### PR TITLE
fix(core): added startup recovery for melts

### DIFF
--- a/.changeset/great-weeks-punch.md
+++ b/.changeset/great-weeks-punch.md
@@ -1,0 +1,5 @@
+---
+'coco-cashu-core': patch
+---
+
+Fix: Added missing startup recovery for MeltOperations

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -148,6 +148,9 @@ export async function initializeCoco(config: CocoConfig): Promise<Manager> {
   // Recover any pending send operations from previous session
   await coco.recoverPendingSendOperations();
 
+  // Recover any pending melt operations from previous session
+  await coco.recoverPendingMeltOperations();
+
   return coco;
 }
 
@@ -420,6 +423,10 @@ export class Manager {
 
   async recoverPendingSendOperations(): Promise<void> {
     await this.sendOperationService.recoverPendingOperations();
+  }
+
+  async recoverPendingMeltOperations(): Promise<void> {
+    await this.meltOperationService.recoverPendingOperations();
   }
 
   async pauseSubscriptions(): Promise<void> {


### PR DESCRIPTION
When the melt saga was added, the recovery method was not added the the initialization helper.