### PR TITLE
feat(core): added missing quotes utils to QuotesApi

### DIFF
--- a/.changeset/clear-cycles-slide.md
+++ b/.changeset/clear-cycles-slide.md
@@ -1,0 +1,5 @@
+---
+'coco-cashu-core': patch
+---
+
+feat: Added missing util method to QuotesApi (rollback, getPending/getPrepared)

--- a/packages/core/api/QuotesApi.ts
+++ b/packages/core/api/QuotesApi.ts
@@ -1,6 +1,7 @@
 import type { MeltQuoteBolt11Response, MintQuoteBolt11Response } from '@cashu/cashu-ts';
 import type {
   FinalizedMeltOperation,
+  MeltOperation,
   MeltOperationService,
   PendingMeltOperation,
   PendingCheckResult,
@@ -82,6 +83,38 @@ export class QuotesApi {
     }
 
     return this.meltOperationService.checkPendingOperation(operation.id);
+  }
+
+  /**
+   * Rollback (abort) a prepared melt operation.
+   * Reclaims reserved proofs and cancels the operation.
+   * Only works for operations in 'prepared' or 'pending' states.
+   */
+  async rollbackMelt(operationId: string, reason?: string): Promise<void> {
+    return this.meltOperationService.rollback(operationId, reason);
+  }
+
+  /**
+   * Get a melt operation by its ID.
+   */
+  async getMeltOperation(operationId: string): Promise<MeltOperation | null> {
+    return this.meltOperationService.getOperation(operationId);
+  }
+
+  /**
+   * Get all pending melt operations.
+   * Pending operations are in 'executing' or 'pending' state.
+   */
+  async getPendingMeltOperations(): Promise<MeltOperation[]> {
+    return this.meltOperationService.getPendingOperations();
+  }
+
+  /**
+   * Get all prepared melt operations.
+   * Prepared operations are ready to be executed or rolled back.
+   */
+  async getPreparedMeltOperations(): Promise<PreparedMeltOperation[]> {
+    return this.meltOperationService.getPreparedOperations();
   }
 
   async addMintQuote(

--- a/packages/core/operations/melt/MeltOperationService.ts
+++ b/packages/core/operations/melt/MeltOperationService.ts
@@ -693,4 +693,9 @@ export class MeltOperationService {
   async getPendingOperations(): Promise<MeltOperation[]> {
     return this.meltOperationRepository.getPending();
   }
+
+  async getPreparedOperations(): Promise<PreparedMeltOperation[]> {
+    const ops = await this.meltOperationRepository.getByState('prepared');
+    return ops.filter((op): op is PreparedMeltOperation => op.state === 'prepared');
+  }
 }


### PR DESCRIPTION
##Summary
- Exposes missing melt-operation utility methods on QuotesApi so consumers can fully manage the melt lifecycle from the API layer.
- Adds support for fetching prepared melt operations in MeltOperationService and wires it through to QuotesApi.
## What Changed
- packages/core/api/QuotesApi.ts
  - Added rollbackMelt(operationId, reason?)
  - Added getMeltOperation(operationId)
  - Added getPendingMeltOperations()
  - Added getPreparedMeltOperations()
- packages/core/operations/melt/MeltOperationService.ts
  - Added getPreparedOperations() using repository state query + type narrowing to PreparedMeltOperation[]