### PR TITLE
feat(core): introduce opaque storage adapters

### DIFF
--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -1,12 +1,13 @@
-import type { Mint, Keyset, CoreProof, Repositories, MeltOperation } from 'coco-cashu-core';
+import type { Mint, Keyset, CoreProof, MeltOperation, CocoStorage } from 'coco-cashu-core';
+import { getStorageRepositories, withStorageTransaction } from 'coco-cashu-core/adapter';
 
-type TransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
-  repositories: TRepositories;
+type TransactionFactory<TStorage extends CocoStorage = CocoStorage> = () => Promise<{
+  repositories: TStorage;
   dispose(): Promise<void>;
 }>;
 
-type ContractOptions<TRepositories extends Repositories = Repositories> = {
-  createRepositories: TransactionFactory<TRepositories>;
+type ContractOptions<TStorage extends CocoStorage = CocoStorage> = {
+  createRepositories: TransactionFactory<TStorage>;
 };
 
 export async function runRepositoryTransactionContract(
@@ -17,10 +18,10 @@ export async function runRepositoryTransactionContract(
 
   describe('repository transactions contract', () => {
     it('commits all repositories together', async () => {
-      const { repositories, dispose } = await options.createRepositories();
+      const { repositories: storage, dispose } = await options.createRepositories();
       try {
         let committed = false;
-        await repositories.withTransaction(async (tx) => {
+        await withStorageTransaction(storage, async (tx) => {
           await tx.mintRepository.addOrUpdateMint(createDummyMint());
           await tx.keysetRepository.addKeyset(createDummyKeyset());
           await tx.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
@@ -29,6 +30,7 @@ export async function runRepositoryTransactionContract(
         });
 
         expect(committed).toBe(true);
+        const repositories = getStorageRepositories(storage);
         const stored = await repositories.proofRepository.getAllReadyProofs();
         expect(stored.length).toBeGreaterThan(0);
         const operation = await repositories.meltOperationRepository.getById('melt-op');
@@ -39,15 +41,16 @@ export async function runRepositoryTransactionContract(
     });
 
     it('rolls back commits on error', async () => {
-      const { repositories, dispose } = await options.createRepositories();
+      const { repositories: storage, dispose } = await options.createRepositories();
       try {
         await expectThrows(async () => {
-          await repositories.withTransaction(async (tx) => {
+          await withStorageTransaction(storage, async (tx) => {
             await tx.mintRepository.addOrUpdateMint(createDummyMint());
             throw new Error('boom');
           });
         }, expect);
 
+        const repositories = getStorageRepositories(storage);
         const mints = await repositories.mintRepository.getAllMints();
         expect(mints.length).toBe(0);
       } finally {

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -1,5 +1,6 @@
-import type { Repositories, Manager, Logger } from 'coco-cashu-core';
+import type { CocoStorage, Manager, Logger, ProofRepository } from 'coco-cashu-core';
 import { initializeCoco, getEncodedToken, ConsoleLogger } from 'coco-cashu-core';
+import { getStorageRepositories } from 'coco-cashu-core/adapter';
 import {
   Mint,
   Wallet,
@@ -44,9 +45,9 @@ type ExpectApi = {
   };
 };
 
-export type IntegrationTestOptions<TRepositories extends Repositories = Repositories> = {
+export type IntegrationTestOptions<TStorage extends CocoStorage = CocoStorage> = {
   createRepositories: () => Promise<{
-    repositories: TRepositories;
+    repositories: TStorage;
     dispose(): Promise<void>;
   }>;
   mintUrl: string;
@@ -107,8 +108,8 @@ function waitForSendHistoryState(
   });
 }
 
-export async function runIntegrationTests<TRepositories extends Repositories = Repositories>(
-  options: IntegrationTestOptions<TRepositories>,
+export async function runIntegrationTests<TStorage extends CocoStorage = CocoStorage>(
+  options: IntegrationTestOptions<TStorage>,
   runner: IntegrationTestRunner,
 ): Promise<void> {
   const { describe, it, beforeEach, afterEach, expect } = runner;
@@ -140,7 +141,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -176,7 +177,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -203,7 +204,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -237,7 +238,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
             processors: {
@@ -307,7 +308,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
             processors: {
@@ -347,7 +348,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         repositoriesDispose = dispose;
         mgr = await initializeCoco({
-          repo: repositories,
+          storage: repositories,
           seedGetter,
           logger,
         });
@@ -555,7 +556,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         repositoriesDispose = dispose;
         mgr = await initializeCoco({
-          repo: repositories,
+          storage: repositories,
           seedGetter,
           logger,
           watchers: {
@@ -583,7 +584,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         await mgr!.wallet.receive(token);
 
-        const proofRepository = (mgr as any).proofRepository as Repositories['proofRepository'];
+        const proofRepository = (mgr as any).proofRepository as ProofRepository;
         const proofService = (mgr as any).proofService as {
           checkInflightProofs: () => Promise<void>;
         };
@@ -606,14 +607,16 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
     describe('Melt Quote Workflow', () => {
       let repositoriesDispose: (() => Promise<void>) | undefined;
-      let repositories: Repositories | undefined;
+      let repositories: CocoStorage | undefined;
+
+      const adapterRepositories = () => getStorageRepositories(repositories!);
 
       beforeEach(async () => {
         const created = await createRepositories();
         repositories = created.repositories;
         repositoriesDispose = created.dispose;
         mgr = await initializeCoco({
-          repo: created.repositories,
+          storage: created.repositories,
           seedGetter,
           logger,
         });
@@ -645,7 +648,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(meltQuote.quote).toBeDefined();
         expect(meltQuote.amount).toBeGreaterThan(0);
 
-        const stored = await repositories!.meltQuoteRepository.getMeltQuote(
+        const stored = await adapterRepositories().meltQuoteRepository.getMeltQuote(
           mintUrl,
           meltQuote.quote,
         );
@@ -713,7 +716,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         await Promise.all([paidEventPromise, stateChangedEventPromise]);
 
-        const storedQuote = await repositories!.meltQuoteRepository.getMeltQuote(
+        const storedQuote = await adapterRepositories().meltQuoteRepository.getMeltQuote(
           mintUrl,
           meltQuote.quote,
         );
@@ -733,7 +736,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         expect(prepared.quoteId).toBeDefined();
 
-        const stored = await repositories!.meltOperationRepository.getByQuoteId(
+        const stored = await adapterRepositories().meltOperationRepository.getByQuoteId(
           mintUrl,
           prepared.quoteId,
         );
@@ -746,7 +749,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(executed?.mintUrl).toBe(mintUrl);
         expect(executed?.quoteId).toBe(prepared.quoteId);
 
-        const operationAfterExecute = await repositories!.meltOperationRepository.getById(
+        const operationAfterExecute = await adapterRepositories().meltOperationRepository.getById(
           executed!.id,
         );
         expect(operationAfterExecute).toBeDefined();
@@ -756,7 +759,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           let pendingResult = await mgr!.quotes.checkPendingMeltByQuote(mintUrl, prepared.quoteId);
           expect(pendingResult).toBeDefined();
 
-          const operationAfterCheck = await repositories!.meltOperationRepository.getById(
+          const operationAfterCheck = await adapterRepositories().meltOperationRepository.getById(
             executed!.id,
           );
           expect(operationAfterCheck).toBeDefined();
@@ -765,7 +768,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
             pendingResult = await mgr!.quotes.checkPendingMeltByQuote(mintUrl, prepared.quoteId);
           }
 
-          const operationAfterRetry = await repositories!.meltOperationRepository.getById(
+          const operationAfterRetry = await adapterRepositories().meltOperationRepository.getById(
             executed!.id,
           );
           expect(operationAfterRetry).toBeDefined();
@@ -796,7 +799,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         repositoriesDispose = dispose;
         mgr = await initializeCoco({
-          repo: repositories,
+          storage: repositories,
           seedGetter,
           logger,
         });
@@ -885,7 +888,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         repositoriesDispose = dispose;
         mgr = await initializeCoco({
-          repo: repositories,
+          storage: repositories,
           seedGetter,
           logger,
           watchers: {
@@ -1085,7 +1088,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         repositoriesDispose = dispose;
         mgr = await initializeCoco({
-          repo: repositories,
+          storage: repositories,
           seedGetter,
           logger,
           watchers: {
@@ -1259,7 +1262,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1290,7 +1293,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1321,7 +1324,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1379,7 +1382,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
             watchers: {
@@ -1423,7 +1426,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1452,7 +1455,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
             watchers: {
@@ -1487,7 +1490,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           mgr = undefined;
 
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
             watchers: {
@@ -1524,7 +1527,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1579,7 +1582,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1604,7 +1607,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1629,7 +1632,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1652,7 +1655,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1679,7 +1682,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1701,7 +1704,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1732,7 +1735,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1776,7 +1779,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         try {
           // First manager generates keypairs
           const mgr1 = await initializeCoco({
-            repo: repo1,
+            storage: repo1,
             seedGetter: sharedSeedGetter,
             logger,
           });
@@ -1789,7 +1792,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
           // Second manager with same seed generates keypairs
           const mgr2 = await initializeCoco({
-            repo: repo2,
+            storage: repo2,
             seedGetter: sharedSeedGetter,
             logger,
           });
@@ -1813,7 +1816,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -1857,7 +1860,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         try {
           // First manager: generate a keypair to discover what the first derived key will be
           const mgr1 = await initializeCoco({
-            repo: repo1,
+            storage: repo1,
             seedGetter: sharedSeedGetter,
             logger,
           });
@@ -1870,7 +1873,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
           // Second manager: add the key first (without derivation index), then generate
           const mgr2 = await initializeCoco({
-            repo: repo2,
+            storage: repo2,
             seedGetter: sharedSeedGetter,
             logger,
           });
@@ -1904,14 +1907,14 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
     describe('P2PK (Pay-to-Public-Key)', () => {
       let repositoriesDispose: (() => Promise<void>) | undefined;
-      let repositories: Repositories | undefined;
+      let repositories: CocoStorage | undefined;
 
       beforeEach(async () => {
         const created = await createRepositories();
         repositories = created.repositories;
         repositoriesDispose = created.dispose;
         mgr = await initializeCoco({
-          repo: created.repositories,
+          storage: created.repositories,
           seedGetter,
           logger,
         });
@@ -2166,7 +2169,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         mgr = undefined;
 
         mgr = await initializeCoco({
-          repo: repositories!,
+          storage: repositories!,
           seedGetter,
           logger,
           watchers: {
@@ -2282,7 +2285,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         try {
           mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
             logger,
           });
@@ -2366,7 +2369,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const { repositories, dispose } = await createRepositories();
         repositoriesDispose = dispose;
         mgr = await initializeCoco({
-          repo: repositories,
+          storage: repositories,
           seedGetter,
           logger,
         });

--- a/packages/adapter-tests/src/migrations.ts
+++ b/packages/adapter-tests/src/migrations.ts
@@ -1,4 +1,5 @@
-import { initializeCoco, type Repositories } from 'coco-cashu-core';
+import { initializeCoco, type CocoStorage } from 'coco-cashu-core';
+import { getStorageRepositories } from 'coco-cashu-core/adapter';
 
 /**
  * Test runner interface for migration tests.
@@ -31,13 +32,13 @@ type MigrationExpectApi = {
  * Options for running migration tests.
  * Each adapter provides its specific implementations.
  */
-export type MigrationTestOptions<TRepositories extends Repositories = Repositories> = {
+export type MigrationTestOptions<TStorage extends CocoStorage = CocoStorage> = {
   /**
    * Create fresh repositories with ALL migrations applied.
    * Used for creating realistic test data via Core API.
    */
   createRepositories: () => Promise<{
-    repositories: TRepositories;
+    repositories: TStorage;
     dispose: () => Promise<void>;
   }>;
 
@@ -49,7 +50,7 @@ export type MigrationTestOptions<TRepositories extends Repositories = Repositori
    * For IndexedDB, stopBeforeId is the version number as a string like '8'.
    */
   createRepositoriesAtMigration: (stopBeforeId: string) => Promise<{
-    repositories: TRepositories;
+    repositories: TStorage;
     dispose: () => Promise<void>;
     /**
      * Run remaining migrations (from stopBeforeId onwards).
@@ -113,8 +114,8 @@ export type MigrationTestOptions<TRepositories extends Repositories = Repositori
  * }, { describe, it, expect, beforeEach, afterEach });
  * ```
  */
-export function runMigrationTests<TRepositories extends Repositories = Repositories>(
-  options: MigrationTestOptions<TRepositories>,
+export function runMigrationTests<TStorage extends CocoStorage = CocoStorage>(
+  options: MigrationTestOptions<TStorage>,
   runner: MigrationTestRunner,
 ): void {
   const { describe, it, expect, beforeEach, afterEach } = runner;
@@ -140,17 +141,18 @@ export function runMigrationTests<TRepositories extends Repositories = Repositor
         const { repositories, dispose } = await createRepositories();
 
         try {
+          const repoSet = getStorageRepositories(repositories);
           const seedGetter = createSeedGetter();
 
           const mgr = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
           });
 
           const testMintUrl = 'https://migration-test.mint';
 
           // Add a mint
-          await repositories.mintRepository.addOrUpdateMint({
+          await repoSet.mintRepository.addOrUpdateMint({
             mintUrl: testMintUrl,
             name: 'Migration Test Mint',
             mintInfo: {
@@ -166,7 +168,7 @@ export function runMigrationTests<TRepositories extends Repositories = Repositor
           });
 
           // Add keyset
-          await repositories.keysetRepository.addKeyset({
+          await repoSet.keysetRepository.addKeyset({
             mintUrl: testMintUrl,
             id: 'test-keyset-001',
             unit: 'sat',
@@ -176,7 +178,7 @@ export function runMigrationTests<TRepositories extends Repositories = Repositor
           });
 
           // Add proofs (user's money!)
-          await repositories.proofRepository.saveProofs(testMintUrl, [
+          await repoSet.proofRepository.saveProofs(testMintUrl, [
             {
               id: 'test-keyset-001',
               amount: 100,
@@ -196,14 +198,13 @@ export function runMigrationTests<TRepositories extends Repositories = Repositor
           ]);
 
           // Add counter
-          await repositories.counterRepository.setCounter(testMintUrl, 'test-keyset-001', 10);
+          await repoSet.counterRepository.setCounter(testMintUrl, 'test-keyset-001', 10);
 
           // Record state before
-          const mintsBefore = await repositories.mintRepository.getAllMints();
-          const keysetsBefore =
-            await repositories.keysetRepository.getKeysetsByMintUrl(testMintUrl);
-          const proofsBefore = await repositories.proofRepository.getAllReadyProofs();
-          const counterBefore = await repositories.counterRepository.getCounter(
+          const mintsBefore = await repoSet.mintRepository.getAllMints();
+          const keysetsBefore = await repoSet.keysetRepository.getKeysetsByMintUrl(testMintUrl);
+          const proofsBefore = await repoSet.proofRepository.getAllReadyProofs();
+          const counterBefore = await repoSet.counterRepository.getCounter(
             testMintUrl,
             'test-keyset-001',
           );
@@ -212,15 +213,15 @@ export function runMigrationTests<TRepositories extends Repositories = Repositor
 
           // Re-initialize (simulates app restart after update)
           const mgr2 = await initializeCoco({
-            repo: repositories,
+            storage: repositories,
             seedGetter,
           });
 
           // Verify ALL data survived
-          const mintsAfter = await repositories.mintRepository.getAllMints();
-          const keysetsAfter = await repositories.keysetRepository.getKeysetsByMintUrl(testMintUrl);
-          const proofsAfter = await repositories.proofRepository.getAllReadyProofs();
-          const counterAfter = await repositories.counterRepository.getCounter(
+          const mintsAfter = await repoSet.mintRepository.getAllMints();
+          const keysetsAfter = await repoSet.keysetRepository.getKeysetsByMintUrl(testMintUrl);
+          const proofsAfter = await repoSet.proofRepository.getAllReadyProofs();
+          const counterAfter = await repoSet.counterRepository.getCounter(
             testMintUrl,
             'test-keyset-001',
           );

--- a/packages/adapter-tests/tsconfig.json
+++ b/packages/adapter-tests/tsconfig.json
@@ -14,6 +14,12 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "coco-cashu-core": ["../core/index.ts"],
+      "coco-cashu-core/adapter": ["../core/adapter.ts"],
+      "@core/*": ["../core/*"]
+    },
 
     // Best practices
     "strict": true,

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -1,10 +1,6 @@
-import type {
-  Repositories,
-  MintQuoteRepository,
-  SendOperationRepository,
-  MeltOperationRepository,
-  ReceiveOperationRepository,
-} from './repositories';
+import type { RepositorySet } from './repositories';
+import type { CocoStorage } from './storage/index.ts';
+import { getStorageRepositories } from './storage/adapter.ts';
 import {
   CounterService,
   MintService,
@@ -50,8 +46,8 @@ import type { Plugin, ServiceMap, PluginExtensions } from './plugins/types.ts';
  * Configuration options for initializing the Coco Cashu manager
  */
 export interface CocoConfig {
-  /** Repository implementations for data persistence */
-  repo: Repositories;
+  /** Storage implementation for data persistence */
+  storage: CocoStorage;
   /** Function that returns the wallet seed as Uint8Array */
   seedGetter: () => Promise<Uint8Array>;
   /** Optional logger instance (defaults to NullLogger) */
@@ -117,13 +113,13 @@ export interface CocoConfig {
 
 /**
  * Initializes and configures a new Coco Cashu manager instance
- * @param config - Configuration options including repositories, seed, and optional features
+ * @param config - Configuration options including storage, seed, and optional features
  * @returns A fully initialized Manager instance
  */
 export async function initializeCoco(config: CocoConfig): Promise<Manager> {
-  await config.repo.init();
+  await config.storage.init();
   const coco = new Manager(
-    config.repo,
+    config.storage,
     config.seedGetter,
     config.logger,
     config.webSocketFactory,
@@ -187,7 +183,6 @@ export class Manager {
   private mintQuoteService: MintQuoteService;
   private mintQuoteWatcher?: MintQuoteWatcherService;
   private mintQuoteProcessor?: MintQuoteProcessor;
-  private mintQuoteRepository: MintQuoteRepository;
   private proofStateWatcher?: ProofStateWatcherService;
   private meltQuoteService: MeltQuoteService;
   private historyService: HistoryService;
@@ -197,12 +192,8 @@ export class Manager {
   private transactionService: TransactionService;
   private paymentRequestService: PaymentRequestService;
   private sendOperationService: SendOperationService;
-  private sendOperationRepository: SendOperationRepository;
   private meltOperationService: MeltOperationService;
-  private meltOperationRepository: MeltOperationRepository;
   private receiveOperationService: ReceiveOperationService;
-  private receiveOperationRepository: ReceiveOperationRepository;
-  private proofRepository: Repositories['proofRepository'];
   private readonly pluginHost: PluginHost = new PluginHost();
   private subscriptionsPaused = false;
   private originalWatcherConfig: CocoConfig['watchers'];
@@ -210,7 +201,7 @@ export class Manager {
   private readonly mintRequestProvider: MintRequestProvider;
   private readonly mintAdapter: MintAdapter;
   constructor(
-    repositories: Repositories,
+    storage: CocoStorage,
     seedGetter: () => Promise<Uint8Array>,
     logger?: Logger,
     webSocketFactory?: WebSocketFactory,
@@ -237,6 +228,7 @@ export class Manager {
     if (plugins && plugins.length > 0) {
       for (const p of plugins) this.pluginHost.use(p);
     }
+    const repositories = getStorageRepositories(storage);
     const core = this.buildCoreServices(repositories, seedGetter);
     this.mintService = core.mintService;
     this.walletService = core.walletService;
@@ -246,19 +238,14 @@ export class Manager {
     this.seedService = core.seedService;
     this.counterService = core.counterService;
     this.mintQuoteService = core.mintQuoteService;
-    this.mintQuoteRepository = core.mintQuoteRepository;
     this.meltQuoteService = core.meltQuoteService;
     this.historyService = core.historyService;
     this.transactionService = core.transactionService;
     this.paymentRequestService = core.paymentRequestService;
     this.sendOperationService = core.sendOperationService;
     this.tokenService = core.tokenService;
-    this.sendOperationRepository = core.sendOperationRepository;
     this.receiveOperationService = core.receiveOperationService;
-    this.receiveOperationRepository = core.receiveOperationRepository;
     this.meltOperationService = core.meltOperationService;
-    this.meltOperationRepository = core.meltOperationRepository;
-    this.proofRepository = repositories.proofRepository;
     const apis = this.buildApis();
     this.mint = apis.mint;
     this.wallet = apis.wallet;
@@ -374,7 +361,6 @@ export class Manager {
       ? this.logger.child({ module: 'MintQuoteWatcherService' })
       : this.logger;
     this.mintQuoteWatcher = new MintQuoteWatcherService(
-      this.mintQuoteRepository,
       this.subscriptions,
       this.mintService,
       this.mintQuoteService,
@@ -433,7 +419,6 @@ export class Manager {
       this.subscriptions,
       this.mintService,
       this.proofService,
-      this.proofRepository,
       this.eventBus,
       watcherLogger,
       { watchExistingInflightOnStart: options?.watchExistingInflightOnStart ?? true },
@@ -557,7 +542,7 @@ export class Manager {
   }
 
   private buildCoreServices(
-    repositories: Repositories,
+    repositories: RepositorySet,
     seedGetter: () => Promise<Uint8Array>,
   ): {
     mintService: MintService;
@@ -569,17 +554,13 @@ export class Manager {
     walletRestoreService: WalletRestoreService;
     keyRingService: KeyRingService;
     mintQuoteService: MintQuoteService;
-    mintQuoteRepository: MintQuoteRepository;
     meltQuoteService: MeltQuoteService;
     historyService: HistoryService;
     transactionService: TransactionService;
     paymentRequestService: PaymentRequestService;
     sendOperationService: SendOperationService;
-    sendOperationRepository: SendOperationRepository;
     receiveOperationService: ReceiveOperationService;
-    receiveOperationRepository: ReceiveOperationRepository;
     meltOperationService: MeltOperationService;
-    meltOperationRepository: MeltOperationRepository;
   } {
     const mintLogger = this.getChildLogger('MintService');
     const walletLogger = this.getChildLogger('WalletService');
@@ -642,7 +623,6 @@ export class Manager {
       mintQuoteLogger,
     );
     const mintQuoteService = quotesService;
-    const mintQuoteRepository = repositories.mintQuoteRepository;
 
     const meltQuoteService = new MeltQuoteService(
       mintService,
@@ -686,7 +666,6 @@ export class Manager {
       sendOperationLogger,
       mintScopedLock,
     );
-    const sendOperationRepository = repositories.sendOperationRepository;
 
     const tokenService = new TokenService(mintService, tokenLogger);
 
@@ -702,7 +681,6 @@ export class Manager {
       this.eventBus,
       receiveOperationLogger,
     );
-    const receiveOperationRepository = repositories.receiveOperationRepository;
 
     const meltOperationLogger = this.getChildLogger('MeltOperationService');
     const meltHandlerProvider = new MeltHandlerProvider({
@@ -720,7 +698,6 @@ export class Manager {
       meltOperationLogger,
       mintScopedLock,
     );
-    const meltOperationRepository = repositories.meltOperationRepository;
 
     const paymentRequestLogger = this.getChildLogger('PaymentRequestService');
     const paymentRequestService = new PaymentRequestService(
@@ -739,17 +716,13 @@ export class Manager {
       walletRestoreService,
       keyRingService,
       mintQuoteService,
-      mintQuoteRepository,
       meltQuoteService,
       historyService,
       transactionService,
       paymentRequestService,
       sendOperationService,
-      sendOperationRepository,
       receiveOperationService,
-      receiveOperationRepository,
       meltOperationService,
-      meltOperationRepository,
     };
   }
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -47,16 +47,16 @@ bun install
 ## Quick start
 
 ```ts
-import { initializeCoco, MemoryRepositories, ConsoleLogger } from 'coco-cashu-core';
+import { initializeCoco, MemoryStorage, ConsoleLogger } from 'coco-cashu-core';
 
 // Provide a deterministic 64-byte seed for wallet key derivation
 const seedGetter = async () => seed;
 
-const repos = new MemoryRepositories();
+const storage = new MemoryStorage();
 const logger = new ConsoleLogger('example', { level: 'info' });
 
 const manager = await initializeCoco({
-  repo: repos,
+  storage,
   seedGetter,
   logger,
 });
@@ -110,7 +110,7 @@ await manager.disableProofStateWatcher();
 
 `initializeCoco` sets up repositories, plugins, watchers, and processors for you. You can configure it via `CocoConfig`:
 
-- `repo`: `Repositories` implementation (required)
+- `storage`: `CocoStorage` implementation (required)
 - `seedGetter`: async seed provider (required)
 - `logger`: optional logger (defaults to `NullLogger`)
 - `webSocketFactory`: optional WebSocket factory

--- a/packages/core/adapter.ts
+++ b/packages/core/adapter.ts
@@ -1,0 +1,28 @@
+export type {
+  MintRepository,
+  KeysetRepository,
+  CounterRepository,
+  ProofRepository,
+  MintQuoteRepository,
+  KeyRingRepository,
+  MeltQuoteRepository,
+  HistoryRepository,
+  SendOperationRepository,
+  MeltOperationRepository,
+  ReceiveOperationRepository,
+  RepositorySet,
+  Repositories,
+  RepositoryTransactionScope,
+} from './repositories/index.ts';
+export {
+  STORAGE_ACCESS,
+  createInternalStorageAdapter,
+  getStorageAccess,
+  getStorageRepositories,
+  withStorageTransaction,
+} from './storage/adapter.ts';
+export type {
+  StorageAccess,
+  InternalStorageAdapter,
+  CreateStorageAdapterOptions,
+} from './storage/adapter.ts';

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,11 +1,28 @@
 export * from './Manager.ts';
-export * from './repositories/index.ts';
 export * from './models/index.ts';
 export * from './api/index.ts';
 export * from './services/index.ts';
 export * from './operations/index.ts';
+export type {
+  MintRepository,
+  KeysetRepository,
+  CounterRepository,
+  ProofRepository,
+  MintQuoteRepository,
+  KeyRingRepository,
+  MeltQuoteRepository,
+  HistoryRepository,
+  SendOperationRepository,
+  MeltOperationRepository,
+  ReceiveOperationRepository,
+  RepositorySet,
+  Repositories,
+  RepositoryTransactionScope,
+} from './repositories/index.ts';
 export type { CoreProof, ProofState } from './types.ts';
 export { type Logger, ConsoleLogger } from './logging/index.ts';
+export type { CocoStorage } from './storage/index.ts';
+export { MemoryStorage } from './storage/index.ts';
 export { getEncodedToken, getDecodedToken } from '@cashu/cashu-ts';
 export { SubscriptionManager } from './infra/SubscriptionManager.ts';
 export { WsConnectionManager } from './infra/WsConnectionManager.ts';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./adapter": {
+      "types": "./dist/adapter.d.ts",
+      "import": "./dist/adapter.js",
+      "require": "./dist/adapter.cjs"
     }
   },
   "files": [

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -208,7 +208,7 @@ export interface ReceiveOperationRepository {
   delete(id: string): Promise<void>;
 }
 
-interface RepositoriesBase {
+export interface RepositorySet {
   mintRepository: MintRepository;
   keyRingRepository: KeyRingRepository;
   counterRepository: CounterRepository;
@@ -222,11 +222,6 @@ interface RepositoriesBase {
   receiveOperationRepository: ReceiveOperationRepository;
 }
 
-export interface Repositories extends RepositoriesBase {
-  init(): Promise<void>;
-  withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
-}
+export type Repositories = RepositorySet;
 
-export type RepositoryTransactionScope = RepositoriesBase;
-
-export * from './memory';
+export type RepositoryTransactionScope = RepositorySet;

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -1,6 +1,6 @@
 import type {
-  Repositories,
   RepositoryTransactionScope,
+  RepositorySet,
   MintRepository,
   KeysetRepository,
   KeyRingRepository,
@@ -13,6 +13,11 @@ import type {
   MeltOperationRepository,
   ReceiveOperationRepository,
 } from '..';
+import {
+  STORAGE_ACCESS,
+  type InternalStorageAdapter,
+  type StorageAccess,
+} from '../../storage/adapter.ts';
 import { MemoryMintRepository } from './MemoryMintRepository';
 import { MemoryKeysetRepository } from './MemoryKeysetRepository';
 import { MemoryKeyRingRepository } from './MemoryKeyRingRepository';
@@ -25,7 +30,7 @@ import { MemorySendOperationRepository } from './MemorySendOperationRepository';
 import { MemoryMeltOperationRepository } from './MemoryMeltOperationRepository';
 import { MemoryReceiveOperationRepository } from './MemoryReceiveOperationRepository';
 
-export class MemoryRepositories implements Repositories {
+export class MemoryRepositories implements RepositorySet, InternalStorageAdapter {
   mintRepository: MintRepository;
   keyRingRepository: KeyRingRepository;
   counterRepository: CounterRepository;
@@ -58,5 +63,13 @@ export class MemoryRepositories implements Repositories {
 
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
     return fn(this);
+  }
+
+  [STORAGE_ACCESS](): StorageAccess {
+    return {
+      repositories: this,
+      withTransaction: async <T>(fn: (repos: RepositoryTransactionScope) => Promise<T>) =>
+        this.withTransaction(fn),
+    };
   }
 }

--- a/packages/core/services/MintQuoteService.ts
+++ b/packages/core/services/MintQuoteService.ts
@@ -1,4 +1,5 @@
 import type { MintQuoteRepository } from '../repositories';
+import type { MintQuote } from '../models/MintQuote';
 import type { MintService } from './MintService';
 import type { WalletService } from './WalletService';
 import type { ProofService } from './ProofService';
@@ -200,5 +201,9 @@ export class MintQuoteService {
       this.logger?.error('Failed to requeue PAID mint quotes', { mintUrl, err });
     }
     return { requeued };
+  }
+
+  async getPendingMintQuotes(): Promise<MintQuote[]> {
+    return this.mintQuoteRepo.getPendingMintQuotes();
   }
 }

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -479,6 +479,14 @@ export class ProofService {
     return this.proofRepository.getProofsByKeysetId(mintUrl, keysetId);
   }
 
+  async getInflightProofs(mintUrls?: string[]): Promise<CoreProof[]> {
+    return this.proofRepository.getInflightProofs(mintUrls);
+  }
+
+  async getProofBySecret(mintUrl: string, secret: string): Promise<CoreProof | null> {
+    return this.proofRepository.getProofBySecret(mintUrl, secret);
+  }
+
   async hasProofsForKeyset(mintUrl: string, keysetId: string): Promise<boolean> {
     if (!mintUrl || mintUrl.trim().length === 0) {
       throw new ProofValidationError('mintUrl is required');

--- a/packages/core/services/watchers/MintQuoteWatcherService.ts
+++ b/packages/core/services/watchers/MintQuoteWatcherService.ts
@@ -1,6 +1,5 @@
 import type { EventBus, CoreEvents } from '@core/events';
 import type { Logger } from '../../logging/Logger.ts';
-import type { MintQuoteRepository } from '../../repositories';
 import type { SubscriptionManager, UnsubscribeHandler } from '@core/infra/SubscriptionManager.ts';
 import type { MintQuoteResponse } from '@cashu/cashu-ts';
 import type { MintQuoteService } from '../MintQuoteService';
@@ -18,7 +17,6 @@ export interface MintQuoteWatcherOptions {
 }
 
 export class MintQuoteWatcherService {
-  private readonly repo: MintQuoteRepository;
   private readonly subs: SubscriptionManager;
   private readonly mintService: MintService;
   private readonly quotes: MintQuoteService;
@@ -33,7 +31,6 @@ export class MintQuoteWatcherService {
   private offUntrusted?: () => void;
 
   constructor(
-    repo: MintQuoteRepository,
     subs: SubscriptionManager,
     mintService: MintService,
     quotes: MintQuoteService,
@@ -41,7 +38,6 @@ export class MintQuoteWatcherService {
     logger?: Logger,
     options: MintQuoteWatcherOptions = { watchExistingPendingOnStart: true },
   ) {
-    this.repo = repo;
     this.subs = subs;
     this.mintService = mintService;
     this.quotes = quotes;
@@ -97,7 +93,7 @@ export class MintQuoteWatcherService {
     if (this.options.watchExistingPendingOnStart) {
       // Also watch any quotes that are not ISSUED yet (only for trusted mints)
       try {
-        const pending = await this.repo.getPendingMintQuotes();
+        const pending = await this.quotes.getPendingMintQuotes();
         const byMint = new Map<string, string[]>();
         for (const q of pending) {
           let arr = byMint.get(q.mintUrl);

--- a/packages/core/services/watchers/ProofStateWatcherService.ts
+++ b/packages/core/services/watchers/ProofStateWatcherService.ts
@@ -5,7 +5,6 @@ import type { MintService } from '../MintService';
 import type { ProofService } from '../ProofService';
 import type { SendOperationService } from '../../operations/send/SendOperationService';
 import { getSendProofSecrets, hasPreparedData } from '../../operations/send/SendOperation';
-import type { ProofRepository } from '../../repositories';
 import { buildYHexMapsForSecrets } from '../../utils.ts';
 
 type ProofKey = string; // `${mintUrl}::${secret}`
@@ -31,7 +30,6 @@ export class ProofStateWatcherService {
   private readonly subs: SubscriptionManager;
   private readonly mintService: MintService;
   private readonly proofs: ProofService;
-  private readonly proofRepository: ProofRepository;
   private readonly bus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
   private readonly options: ProofStateWatcherOptions;
@@ -48,7 +46,6 @@ export class ProofStateWatcherService {
     subs: SubscriptionManager,
     mintService: MintService,
     proofs: ProofService,
-    proofRepository: ProofRepository,
     bus: EventBus<CoreEvents>,
     logger?: Logger,
     options: ProofStateWatcherOptions = { watchExistingInflightOnStart: true },
@@ -56,7 +53,6 @@ export class ProofStateWatcherService {
     this.subs = subs;
     this.mintService = mintService;
     this.proofs = proofs;
-    this.proofRepository = proofRepository;
     this.bus = bus;
     this.logger = logger;
     this.options = options;
@@ -297,7 +293,7 @@ export class ProofStateWatcherService {
     await this.proofs.checkInflightProofs();
     if (!this.running) return;
 
-    const inflightProofs = await this.proofRepository.getInflightProofs();
+    const inflightProofs = await this.proofs.getInflightProofs();
     if (!this.running || inflightProofs.length === 0) return;
 
     const byMint = new Map<string, string[]>();
@@ -368,7 +364,7 @@ export class ProofStateWatcherService {
 
     try {
       // Look up the specific proof that was just spent
-      const spentProof = await this.proofRepository.getProofBySecret(mintUrl, secret);
+      const spentProof = await this.proofs.getProofBySecret(mintUrl, secret);
       // Check both usedByOperationId (for exact match sends) and createdByOperationId (for swap sends)
       const operationId = spentProof?.usedByOperationId || spentProof?.createdByOperationId;
       if (!operationId) return;
@@ -386,7 +382,7 @@ export class ProofStateWatcherService {
       // Check state of all send proofs
       let allSpent = true;
       for (const sendSecret of sendProofSecrets) {
-        const proof = await this.proofRepository.getProofBySecret(mintUrl, sendSecret);
+        const proof = await this.proofs.getProofBySecret(mintUrl, sendSecret);
         if (!proof || proof.state !== 'spent') {
           allSpent = false;
           break;

--- a/packages/core/storage/MemoryStorage.ts
+++ b/packages/core/storage/MemoryStorage.ts
@@ -1,0 +1,19 @@
+import { MemoryRepositories } from '../repositories/memory/MemoryRepositories.ts';
+import type { RepositoryTransactionScope } from '../repositories/index.ts';
+import { STORAGE_ACCESS, type InternalStorageAdapter } from './adapter.ts';
+
+export class MemoryStorage implements InternalStorageAdapter {
+  readonly #repositories = new MemoryRepositories();
+
+  async init(): Promise<void> {
+    await this.#repositories.init();
+  }
+
+  [STORAGE_ACCESS]() {
+    return {
+      repositories: this.#repositories,
+      withTransaction: async <T>(fn: (repos: RepositoryTransactionScope) => Promise<T>) =>
+        this.#repositories.withTransaction(fn),
+    };
+  }
+}

--- a/packages/core/storage/adapter.ts
+++ b/packages/core/storage/adapter.ts
@@ -1,0 +1,44 @@
+import type { RepositorySet, RepositoryTransactionScope } from '../repositories/index.ts';
+import {
+  STORAGE_ACCESS,
+  type CocoStorage,
+  type CreateStorageAdapterOptions,
+  type InternalStorageAdapter,
+  type StorageAccess,
+} from './types.ts';
+
+export { STORAGE_ACCESS };
+export type { StorageAccess, InternalStorageAdapter, CreateStorageAdapterOptions };
+
+export function createInternalStorageAdapter(
+  options: CreateStorageAdapterOptions,
+): InternalStorageAdapter {
+  return {
+    init: options.init,
+    [STORAGE_ACCESS]: () => ({
+      repositories: options.repositories,
+      withTransaction: options.withTransaction,
+    }),
+  };
+}
+
+export function getStorageAccess(storage: CocoStorage): StorageAccess {
+  const getAccess = (storage as Partial<InternalStorageAdapter>)[STORAGE_ACCESS];
+  if (typeof getAccess !== 'function') {
+    throw new Error(
+      'Invalid Coco storage adapter. Use a storage implementation built for this core version.',
+    );
+  }
+  return getAccess.call(storage);
+}
+
+export function getStorageRepositories(storage: CocoStorage): RepositorySet {
+  return getStorageAccess(storage).repositories;
+}
+
+export function withStorageTransaction<T>(
+  storage: CocoStorage,
+  fn: (repos: RepositoryTransactionScope) => Promise<T>,
+): Promise<T> {
+  return getStorageAccess(storage).withTransaction(fn);
+}

--- a/packages/core/storage/index.ts
+++ b/packages/core/storage/index.ts
@@ -1,0 +1,3 @@
+export type { CocoStorage } from './types.ts';
+
+export { MemoryStorage } from './MemoryStorage.ts';

--- a/packages/core/storage/types.ts
+++ b/packages/core/storage/types.ts
@@ -1,0 +1,22 @@
+import type { RepositorySet, RepositoryTransactionScope } from '../repositories/index.ts';
+
+export const STORAGE_ACCESS = Symbol('coco-cashu.storage-access');
+
+export interface StorageAccess {
+  repositories: RepositorySet;
+  withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
+}
+
+export interface CocoStorage {
+  init(): Promise<void>;
+}
+
+export interface InternalStorageAdapter extends CocoStorage {
+  [STORAGE_ACCESS](): StorageAccess;
+}
+
+export interface CreateStorageAdapterOptions {
+  init(): Promise<void>;
+  repositories: RepositorySet;
+  withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
+}

--- a/packages/core/test/integration/PauseResumeIntegration.test.ts
+++ b/packages/core/test/integration/PauseResumeIntegration.test.ts
@@ -13,7 +13,7 @@ describe('Pause/Resume Integration Test', () => {
   beforeEach(async () => {
     const repositories = new MemoryRepositories();
     manager = await initializeCoco({
-      repo: repositories,
+      storage: repositories,
       seedGetter,
       logger: new NullLogger(),
       // Use faster intervals for testing
@@ -152,7 +152,7 @@ describe('Pause/Resume Integration Test', () => {
     // Create new manager with some watchers disabled
     const repositories = new MemoryRepositories();
     manager = await initializeCoco({
-      repo: repositories,
+      storage: repositories,
       seedGetter,
       logger: new NullLogger(),
       watchers: {

--- a/packages/core/test/integration/ReceiveOperationIntegration.test.ts
+++ b/packages/core/test/integration/ReceiveOperationIntegration.test.ts
@@ -36,13 +36,13 @@ describe('ReceiveOperationService integration', () => {
     };
 
     sender = await initializeCoco({
-      repo: senderRepos,
+      storage: senderRepos,
       seedGetter: makeSeedGetter(),
       ...baseConfig,
     });
 
     receiver = await initializeCoco({
-      repo: receiverRepos,
+      storage: receiverRepos,
       seedGetter: makeSeedGetter(),
       ...baseConfig,
     });

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -6,13 +6,13 @@ import { NullLogger } from '../../logging';
 describe('initializeCoco', () => {
   let repositories: MemoryRepositories;
   let seedGetter: () => Promise<Uint8Array>;
-  let baseConfig: Pick<CocoConfig, 'repo' | 'seedGetter'>;
+  let baseConfig: Pick<CocoConfig, 'storage' | 'seedGetter'>;
 
   beforeEach(() => {
     repositories = new MemoryRepositories();
     seedGetter = async () => new Uint8Array(32);
     baseConfig = {
-      repo: repositories,
+      storage: repositories,
       seedGetter,
     };
   });
@@ -44,7 +44,7 @@ describe('initializeCoco', () => {
 
       await initializeCoco({
         ...baseConfig,
-        repo: mockRepo,
+        storage: mockRepo,
       });
 
       expect(initSpy).toHaveBeenCalled();

--- a/packages/core/test/unit/ProofStateWatcherService.test.ts
+++ b/packages/core/test/unit/ProofStateWatcherService.test.ts
@@ -5,7 +5,6 @@ import { ProofStateWatcherService } from '../../services/watchers/ProofStateWatc
 import type { SubscriptionManager } from '../../infra/SubscriptionManager.ts';
 import type { MintService } from '../../services/MintService.ts';
 import type { ProofService } from '../../services/ProofService.ts';
-import type { ProofRepository } from '../../repositories/index.ts';
 import type { CoreProof } from '../../types.ts';
 import { NullLogger } from '../../logging/NullLogger.ts';
 
@@ -46,10 +45,8 @@ describe('ProofStateWatcherService', () => {
 
     const proofService = {
       checkInflightProofs,
-    } as unknown as ProofService;
-    const proofRepository = {
       getInflightProofs,
-    } as unknown as ProofRepository;
+    } as unknown as ProofService;
     const subs = {} as SubscriptionManager;
     const mintService = {
       isTrustedMint: mock(async () => true),
@@ -59,7 +56,6 @@ describe('ProofStateWatcherService', () => {
       subs,
       mintService,
       proofService,
-      proofRepository,
       bus,
       new NullLogger(),
     );
@@ -86,10 +82,8 @@ describe('ProofStateWatcherService', () => {
 
     const proofService = {
       checkInflightProofs,
-    } as unknown as ProofService;
-    const proofRepository = {
       getInflightProofs,
-    } as unknown as ProofRepository;
+    } as unknown as ProofService;
     const subs = {} as SubscriptionManager;
     const mintService = {
       isTrustedMint: mock(async () => true),
@@ -99,7 +93,6 @@ describe('ProofStateWatcherService', () => {
       subs,
       mintService,
       proofService,
-      proofRepository,
       bus,
       new NullLogger(),
       { watchExistingInflightOnStart: false },

--- a/packages/core/test/unit/WalletApi.test.ts
+++ b/packages/core/test/unit/WalletApi.test.ts
@@ -13,7 +13,8 @@ import { UnknownMintError } from '../../models/Error';
 import { getEncodedToken, OutputData } from '@cashu/cashu-ts';
 import type { Proof } from '@cashu/cashu-ts';
 import { ReceiveOperationService } from '../../operations/receive/ReceiveOperationService';
-import { MemoryProofRepository, MemoryReceiveOperationRepository } from '@core/repositories';
+import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository.ts';
+import { MemoryReceiveOperationRepository } from '../../repositories/memory/MemoryReceiveOperationRepository.ts';
 import { TokenService } from '../../services/TokenService';
 import type { MintAdapter } from '../../infra/MintAdapter';
 

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig([
   {
-    entry: ['./index.ts'],
+    entry: ['./index.ts', './adapter.ts'],
     platform: 'neutral',
     target: 'esnext',
     format: ['esm', 'cjs'],

--- a/packages/docs/examples/node.md
+++ b/packages/docs/examples/node.md
@@ -41,15 +41,15 @@ export function cachedSeedGetter() {
 
 ### Persistence
 
-We are going to use sqlite3 to persist our wallet data. Coco expects a repository implementation when instantiating. The `coco-cashu-sqlite3` package helps us bridge sqlite3 to coco
+We are going to use sqlite3 to persist our wallet data. Coco expects a storage adapter when instantiating. The `coco-cashu-sqlite3` package helps us bridge sqlite3 to coco
 
 ```ts
-// repo.ts
+// storage.ts
 import { SqliteRepositories } from 'coco-cashu-sqlite3';
 import { Database } from 'sqlite3';
 
 const db = new Database('./coco.db');
-export const repo = new SqliteRepositories({ database: db });
+export const storage = new SqliteRepositories({ database: db });
 ```
 
 ### Websockets
@@ -70,12 +70,12 @@ Now that we have all the parts prepared we can bring them together and instantia
 
 ```ts
 import { initializeCoco } from 'coco-cashu-core';
-import { repo } from './repo.ts';
+import { storage } from './storage.ts';
 import { websocketFactory } from './websocket.ts';
 import { cachedSeedGetter } from './seedgetter.ts';
 
 export const coco = await initializeCoco({
-  repo: repo,
+  storage,
   seedGetter: cachedSeedGetter(),
   websocketFactory: websocketFactory,
 });

--- a/packages/docs/pages/bip39.md
+++ b/packages/docs/pages/bip39.md
@@ -14,7 +14,7 @@ async function seedGetter(): Promise<Uint8Array> {
 }
 
 const coco = await initializeCoco({
-  repo, // See storage adapters to learn more
+  storage, // See storage adapters to learn more
   seedGetter,
 });
 ```

--- a/packages/docs/pages/coco-config.md
+++ b/packages/docs/pages/coco-config.md
@@ -4,7 +4,7 @@ Coco can be configured using a configuration object `CocoConfig`
 
 ```ts
 export interface CocoConfig {
-  repo: Repositories;
+  storage: CocoStorage;
   seedGetter: () => Promise<Uint8Array>;
   logger?: Logger;
   webSocketFactory?: WebSocketFactory;
@@ -30,7 +30,7 @@ export interface CocoConfig {
 }
 ```
 
-- repo: A storage adapter that satisfies the `Repositories` interface. See [Storage Adapters](./storage-adapters.md) for more information
+- storage: A storage adapter that satisfies the `CocoStorage` contract. See [Storage Adapters](./storage-adapters.md) for more information
 - seedGetter: An asynchronous function that returns a BIP-39 conforming seed as `Uint8Array`. See [BIP-39](./bip39.md) for more information.
 - logger (optional): An implementation of the Logger interface that Coco will use to log
 - webSocketFactory (optional): A factory function that should return a `WebSocketLike` instance that will be used by Coco to establish websocket connections. If the global `WebSocket` is not present and `webSocketFactory` is undefined coco will fallback to polling.

--- a/packages/docs/pages/plugins.md
+++ b/packages/docs/pages/plugins.md
@@ -42,7 +42,7 @@ Pass plugins to `initializeCoco()` via the `plugins` config option:
 import { initializeCoco } from 'coco-cashu-core';
 
 const manager = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
   plugins: [myPlugin],
 });
@@ -114,7 +114,7 @@ After initialization, access the extension via `manager.ext`:
 
 ```ts
 const manager = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
   plugins: [myPlugin],
 });

--- a/packages/docs/pages/react-overview.md
+++ b/packages/docs/pages/react-overview.md
@@ -26,7 +26,7 @@ export function App() {
 
   useEffect(() => {
     let cancelled = false;
-    void initializeCoco({ repo, seedGetter })
+    void initializeCoco({ storage, seedGetter })
       .then((instance) => {
         if (!cancelled) setManager(instance);
       })

--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -3,10 +3,10 @@
 Coco is built in a platform agnostic way. As we can not assume anything about the presence of a certain storage API (e.g. IndexedDB), coco exposes a storage interface that needs to be satisfied when instantiating.
 
 ```ts
-const repo = new ExpoSqliteRepositories({ database: db }); // Implements the Repositories interface
-await repo.init(); // Ensures schema and applies migrations
+const storage = new ExpoSqliteRepositories({ database: db });
+await storage.init(); // Ensures schema and applies migrations
 const coco = await initializeCoco({
-  repo, // <-- pass the storage implementation
+  storage,
   seedGetter,
   // other params
 });
@@ -30,9 +30,9 @@ Usage:
 import { initializeCoco } from 'coco-cashu-core';
 import { IndexedDbRepositories } from 'coco-cashu-indexeddb';
 
-const repo = new IndexedDbRepositories({ name: 'your-db-name' });
+const storage = new IndexedDbRepositories({ name: 'your-db-name' });
 const coco = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
 });
 ```
@@ -57,9 +57,9 @@ import { openDatabaseAsync } from 'expo-sqlite';
 // First we create an expo-sqlite client
 const db = await openDatabaseAsync('coco-demo.db');
 // Then we pass it to our storage implementation
-const repo = new ExpoSqliteRepositories({ database: db });
+const storage = new ExpoSqliteRepositories({ database: db });
 const coco = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
 });
 ```
@@ -83,9 +83,9 @@ import { Database } from 'sqlite3';
 // First we create a sqlite3 client
 const db = new Database('./test.db');
 // Then we pass it to our storage implementation
-const repo = new SqliteRepositories({ database: db });
+const storage = new SqliteRepositories({ database: db });
 const coco = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
 });
 ```
@@ -110,9 +110,9 @@ import { Database } from 'bun:sqlite';
 // First we create a bun:sqlite client
 const db = new Database('./test.db');
 // Then we pass it to our storage implementation
-const repo = new SqliteRepositories({ database: db });
+const storage = new SqliteRepositories({ database: db });
 const coco = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
 });
 ```

--- a/packages/docs/pages/watchers-processors.md
+++ b/packages/docs/pages/watchers-processors.md
@@ -12,7 +12,7 @@ To disable them during initialization with `initializeCoco()`:
 
 ```ts
 const coco = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
   watchers: {
     mintQuoteWatcher: { disabled: true },

--- a/packages/docs/starting/adding-mints.md
+++ b/packages/docs/starting/adding-mints.md
@@ -11,7 +11,7 @@ Coco uses a trust-based security model for mints. Wallet operations (receiving, 
 You can fetch and cache mint information without trusting it:
 
 ```ts
-const coco = await initializeCoco({ repo, seedGetter });
+const coco = await initializeCoco({ storage, seedGetter });
 
 const mintUrl = 'https://minturl.com';
 

--- a/packages/docs/starting/start-here.md
+++ b/packages/docs/starting/start-here.md
@@ -7,9 +7,10 @@ Coco is a TypeScript library that simplifies the development of Cashu applicatio
 To get started all you got to do is create a Coco `Manager` instance. This instance will be your entry-point to your Coco Cashu wallet.
 
 ```ts
-import { initializeCoco } from 'coco-cashu-core';
+import { initializeCoco, MemoryStorage } from 'coco-cashu-core';
 
-const coco = await initializeCoco({ repo, seedGetter });
+const storage = new MemoryStorage();
+const coco = await initializeCoco({ storage, seedGetter });
 
 // After initialization you can start to use your coco wallet
 const balances = await coco.wallet.getBalances();
@@ -20,14 +21,15 @@ const balances = await coco.wallet.getBalances();
 In order to work properly coco requires you to supply a BIP39 conforming seed. Coco will never persist that seed, so you need to supply it via a `seedGetter` function. This function is expected to be passed when instantiating coco and will be called automatically when coco needs the key to derive new secrets from it
 
 ```ts
-import { initializeCoco } from 'coco-cashu-core';
+import { initializeCoco, MemoryStorage } from 'coco-cashu-core';
 
 async function seedGetter(): Uint8Array {
   // add your implementation here
   // e.g. reading a mnemonic from SecureStorage and converting it to a BIP-39 seed
 }
 
-const coco = await initializeCoco({ seedGetter });
+const storage = new MemoryStorage();
+const coco = await initializeCoco({ storage, seedGetter });
 
 // Before receiving tokens, you need to add and trust the mint
 await coco.mint.addMint('https://mint.url', { trusted: true });
@@ -46,9 +48,9 @@ By default coco uses an in-memory store that will be lost as soon as the process
 import { initializeCoco } from 'coco-cashu-core';
 import { IndexedDbRespositories } from 'coco-cashu-indexeddb';
 
-const repo = new IndexedDbRepositories({ name: 'coco' });
+const storage = new IndexedDbRepositories({ name: 'coco' });
 const coco = await initializeCoco({
-  repo,
+  storage,
 });
 
 // Add and trust a mint before performing wallet operations

--- a/packages/docs/starting/subscriptions.md
+++ b/packages/docs/starting/subscriptions.md
@@ -12,7 +12,7 @@ import { initializeCoco } from 'coco-cashu-core';
 import { WebSocket } from 'ws';
 
 const coco = await initializeCoco({
-  repo,
+  storage,
   seedGetter,
   webSocketFactory: (url) => new WebSocket(url),
 });

--- a/packages/sqlite-bun/README.md
+++ b/packages/sqlite-bun/README.md
@@ -11,12 +11,17 @@ npm install coco-cashu-sqlite-bun
 ## Usage
 
 ```typescript
-import { SqliteRepositories } from 'coco-cashu-sqlite-bun';
+import { SqliteStorage } from 'coco-cashu-sqlite-bun';
+import { initializeCoco } from 'coco-cashu-core';
 import { Database } from 'bun:sqlite';
 
 const database = new Database(':memory:');
-const repositories = new SqliteRepositories({ database });
-await repositories.init();
+const storage = new SqliteStorage({ database });
+
+const coco = await initializeCoco({
+  storage,
+  seedGetter,
+});
 ```
 
 ## Differences from coco-cashu-sqlite3

--- a/packages/sqlite-bun/src/index.ts
+++ b/packages/sqlite-bun/src/index.ts
@@ -1,17 +1,10 @@
 import type {
-  Repositories,
-  MintRepository,
-  KeysetRepository,
-  KeyRingRepository,
-  CounterRepository,
-  ProofRepository,
-  MintQuoteRepository,
-  MeltQuoteRepository,
-  SendOperationRepository,
-  MeltOperationRepository,
-  ReceiveOperationRepository,
+  InternalStorageAdapter,
+  RepositorySet,
   RepositoryTransactionScope,
-} from 'coco-cashu-core';
+  StorageAccess,
+} from 'coco-cashu-core/adapter';
+import { createInternalStorageAdapter, STORAGE_ACCESS } from 'coco-cashu-core/adapter';
 import { SqliteDb, type SqliteDbOptions } from './db.ts';
 import { ensureSchema, ensureSchemaUpTo, MIGRATIONS, type Migration } from './schema.ts';
 import { SqliteMintRepository } from './repositories/MintRepository.ts';
@@ -26,78 +19,52 @@ import { SqliteSendOperationRepository } from './repositories/SendOperationRepos
 import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 
-export interface SqliteRepositoriesOptions extends SqliteDbOptions {}
+export interface SqliteStorageOptions extends SqliteDbOptions {}
 
-export class SqliteRepositories implements Repositories {
-  readonly mintRepository: MintRepository;
-  readonly keyRingRepository: KeyRingRepository;
-  readonly counterRepository: CounterRepository;
-  readonly keysetRepository: KeysetRepository;
-  readonly proofRepository: ProofRepository;
-  readonly mintQuoteRepository: MintQuoteRepository;
-  readonly meltQuoteRepository: MeltQuoteRepository;
-  readonly historyRepository: SqliteHistoryRepository;
-  readonly sendOperationRepository: SendOperationRepository;
-  readonly meltOperationRepository: MeltOperationRepository;
-  readonly receiveOperationRepository: ReceiveOperationRepository;
+export type SqliteRepositoriesOptions = SqliteStorageOptions;
+
+function createRepositories(db: SqliteDb): RepositorySet {
+  return {
+    mintRepository: new SqliteMintRepository(db),
+    keyRingRepository: new SqliteKeyRingRepository(db),
+    counterRepository: new SqliteCounterRepository(db),
+    keysetRepository: new SqliteKeysetRepository(db),
+    proofRepository: new SqliteProofRepository(db),
+    mintQuoteRepository: new SqliteMintQuoteRepository(db),
+    meltQuoteRepository: new SqliteMeltQuoteRepository(db),
+    historyRepository: new SqliteHistoryRepository(db),
+    sendOperationRepository: new SqliteSendOperationRepository(db),
+    meltOperationRepository: new SqliteMeltOperationRepository(db),
+    receiveOperationRepository: new SqliteReceiveOperationRepository(db),
+  };
+}
+
+export class SqliteStorage implements InternalStorageAdapter {
   readonly db: SqliteDb;
+  readonly #adapter: InternalStorageAdapter;
 
-  constructor(options: SqliteRepositoriesOptions) {
+  constructor(options: SqliteStorageOptions) {
     this.db = new SqliteDb(options);
-    this.mintRepository = new SqliteMintRepository(this.db);
-    this.keyRingRepository = new SqliteKeyRingRepository(this.db);
-    this.counterRepository = new SqliteCounterRepository(this.db);
-    this.keysetRepository = new SqliteKeysetRepository(this.db);
-    this.proofRepository = new SqliteProofRepository(this.db);
-    this.mintQuoteRepository = new SqliteMintQuoteRepository(this.db);
-    this.meltQuoteRepository = new SqliteMeltQuoteRepository(this.db);
-    this.historyRepository = new SqliteHistoryRepository(this.db);
-    this.sendOperationRepository = new SqliteSendOperationRepository(this.db);
-    this.meltOperationRepository = new SqliteMeltOperationRepository(this.db);
-    this.receiveOperationRepository = new SqliteReceiveOperationRepository(this.db);
+    this.#adapter = createInternalStorageAdapter({
+      init: async () => ensureSchema(this.db),
+      repositories: createRepositories(this.db),
+      withTransaction: async <T>(fn: (repos: RepositoryTransactionScope) => Promise<T>) => {
+        return this.db.transaction(async (txDb) => fn(createRepositories(txDb)));
+      },
+    });
   }
 
   async init(): Promise<void> {
-    await ensureSchema(this.db);
+    await this.#adapter.init();
   }
 
-  async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
-    return this.db.transaction(async (txDb) => {
-      const scopedRepositories: RepositoryTransactionScope = {
-        mintRepository: new SqliteMintRepository(txDb),
-        keyRingRepository: new SqliteKeyRingRepository(txDb),
-        counterRepository: new SqliteCounterRepository(txDb),
-        keysetRepository: new SqliteKeysetRepository(txDb),
-        proofRepository: new SqliteProofRepository(txDb),
-        mintQuoteRepository: new SqliteMintQuoteRepository(txDb),
-        meltQuoteRepository: new SqliteMeltQuoteRepository(txDb),
-        historyRepository: new SqliteHistoryRepository(txDb),
-        sendOperationRepository: new SqliteSendOperationRepository(txDb),
-        meltOperationRepository: new SqliteMeltOperationRepository(txDb),
-        receiveOperationRepository: new SqliteReceiveOperationRepository(txDb),
-      };
-
-      return fn(scopedRepositories);
-    });
+  [STORAGE_ACCESS](): StorageAccess {
+    return this.#adapter[STORAGE_ACCESS]();
   }
 }
 
-export {
-  SqliteDb,
-  ensureSchema,
-  ensureSchemaUpTo,
-  MIGRATIONS,
-  SqliteMintRepository,
-  SqliteKeyRingRepository,
-  SqliteKeysetRepository,
-  SqliteCounterRepository,
-  SqliteProofRepository,
-  SqliteMintQuoteRepository,
-  SqliteMeltQuoteRepository,
-  SqliteHistoryRepository,
-  SqliteSendOperationRepository,
-  SqliteMeltOperationRepository,
-  SqliteReceiveOperationRepository,
-};
+export { SqliteStorage as SqliteRepositories };
+
+export { SqliteDb, ensureSchema, ensureSchemaUpTo, MIGRATIONS };
 
 export type { Migration };

--- a/packages/sqlite-bun/src/test/SendOperationRepository.test.ts
+++ b/packages/sqlite-bun/src/test/SendOperationRepository.test.ts
@@ -5,7 +5,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 // @ts-ignore bun:sqlite types are provided by the runtime in this workspace.
 import { Database } from 'bun:sqlite';
 import type { PendingSendOperation, RollingBackSendOperation } from 'coco-cashu-core';
-import { SqliteRepositories } from '../index.ts';
+import { getStorageRepositories } from 'coco-cashu-core/adapter';
+import { SqliteStorage } from '../index.ts';
 
 function makeRollingBackOperation(): RollingBackSendOperation {
   return {
@@ -52,11 +53,11 @@ function makePendingP2pkOperation(): PendingSendOperation {
 
 describe('SqliteSendOperationRepository', () => {
   let database: Database;
-  let repositories: SqliteRepositories;
+  let repositories: SqliteStorage;
 
   beforeEach(async () => {
     database = new Database(':memory:');
-    repositories = new SqliteRepositories({ database });
+    repositories = new SqliteStorage({ database });
     await repositories.init();
   });
 
@@ -66,21 +67,23 @@ describe('SqliteSendOperationRepository', () => {
 
   it('loads rolling_back operations from repository read methods', async () => {
     const operation = makeRollingBackOperation();
+    const repoSet = getStorageRepositories(repositories);
 
-    await repositories.sendOperationRepository.create(operation);
+    await repoSet.sendOperationRepository.create(operation);
 
-    expect(await repositories.sendOperationRepository.getById(operation.id)).toEqual(operation);
-    expect(await repositories.sendOperationRepository.getByState('rolling_back')).toEqual([
+    expect(await repoSet.sendOperationRepository.getById(operation.id)).toEqual(operation);
+    expect(await repoSet.sendOperationRepository.getByState('rolling_back')).toEqual([
       operation,
     ]);
-    expect(await repositories.sendOperationRepository.getPending()).toEqual([operation]);
+    expect(await repoSet.sendOperationRepository.getPending()).toEqual([operation]);
   });
 
   it('round-trips persisted tokens for pending P2PK operations', async () => {
     const operation = makePendingP2pkOperation();
+    const repoSet = getStorageRepositories(repositories);
 
-    await repositories.sendOperationRepository.create(operation);
+    await repoSet.sendOperationRepository.create(operation);
 
-    expect(await repositories.sendOperationRepository.getById(operation.id)).toEqual(operation);
+    expect(await repoSet.sendOperationRepository.getById(operation.id)).toEqual(operation);
   });
 });

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -6,7 +6,8 @@ import {
   createDummyKeyset,
   createDummyProof,
 } from 'coco-cashu-adapter-tests';
-import { SqliteRepositories as Repositories } from '../index.ts';
+import { getStorageRepositories, withStorageTransaction } from 'coco-cashu-core/adapter';
+import { SqliteStorage } from '../index.ts';
 
 function createDeferred<T = void>() {
   let resolve!: (value: T) => void;
@@ -20,7 +21,7 @@ function createDeferred<T = void>() {
 
 async function createRepositories() {
   const database = new Database(':memory:');
-  const repositories = new Repositories({ database });
+  const repositories = new SqliteStorage({ database });
   await repositories.init();
   return {
     repositories,
@@ -41,15 +42,16 @@ describe('sqlite-bun adapter transactions', () => {
   it('commits across repositories', async () => {
     const { repositories, dispose } = await createRepositories();
     try {
-      await repositories.withTransaction(async (tx) => {
+      const repoSet = getStorageRepositories(repositories);
+      await withStorageTransaction(repositories, async (tx) => {
         await tx.mintRepository.addOrUpdateMint(createDummyMint());
         await tx.keysetRepository.addKeyset(createDummyKeyset());
         await tx.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
       });
 
-      const mints = await repositories.mintRepository.getAllMints();
+      const mints = await repoSet.mintRepository.getAllMints();
       expect(mints.length).toBe(1);
-      const proofs = await repositories.proofRepository.getAllReadyProofs();
+      const proofs = await repoSet.proofRepository.getAllReadyProofs();
       expect(proofs.length).toBe(1);
     } finally {
       await dispose();
@@ -61,7 +63,7 @@ describe('sqlite-bun adapter transactions', () => {
     try {
       let didThrow = false;
       try {
-        await repositories.withTransaction(async (tx) => {
+        await withStorageTransaction(repositories, async (tx) => {
           await tx.mintRepository.addOrUpdateMint(createDummyMint());
           await tx.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
           throw new Error('boom');
@@ -71,9 +73,10 @@ describe('sqlite-bun adapter transactions', () => {
       }
       expect(didThrow).toBe(true);
 
-      const mints = await repositories.mintRepository.getAllMints();
+      const repoSet = getStorageRepositories(repositories);
+      const mints = await repoSet.mintRepository.getAllMints();
       expect(mints.length).toBe(0);
-      const proofs = await repositories.proofRepository.getAllReadyProofs();
+      const proofs = await repoSet.proofRepository.getAllReadyProofs();
       expect(proofs.length).toBe(0);
     } finally {
       await dispose();
@@ -90,7 +93,7 @@ describe('sqlite-bun adapter transactions', () => {
       const mintA = { ...createDummyMint(), mintUrl: 'https://mint-a.test' };
       const mintB = { ...createDummyMint(), mintUrl: 'https://mint-b.test' };
 
-      const firstPromise = repositories.withTransaction(async (tx) => {
+      const firstPromise = withStorageTransaction(repositories, async (tx) => {
         await tx.mintRepository.addOrUpdateMint(mintA);
         firstEntered.resolve();
         await releaseFirst.promise;
@@ -98,7 +101,7 @@ describe('sqlite-bun adapter transactions', () => {
 
       await firstEntered.promise;
 
-      const secondPromise = repositories.withTransaction(async (tx) => {
+      const secondPromise = withStorageTransaction(repositories, async (tx) => {
         secondStarted.resolve();
         await tx.mintRepository.addOrUpdateMint(mintB);
       });
@@ -116,7 +119,7 @@ describe('sqlite-bun adapter transactions', () => {
 
       await Promise.all([firstPromise, secondPromise]);
 
-      const mints = await repositories.mintRepository.getAllMints();
+      const mints = await getStorageRepositories(repositories).mintRepository.getAllMints();
       expect(mints).toHaveLength(2);
       expect(mints.map((m) => m.mintUrl).sort()).toEqual([
         'https://mint-a.test',

--- a/packages/sqlite-bun/src/test/integration.test.ts
+++ b/packages/sqlite-bun/src/test/integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach, expect as bunExpect } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runIntegrationTests, type IntegrationTestRunner } from 'coco-cashu-adapter-tests';
-import { SqliteRepositories } from '../index.ts';
+import { SqliteStorage } from '../index.ts';
 import { ConsoleLogger, type Logger } from 'coco-cashu-core';
 
 // Cast bun's expect to match the adapter-tests expectation type
@@ -25,7 +25,7 @@ function getTestLogger(): Logger | undefined {
 
 async function createRepositories() {
   const database = new Database(':memory:');
-  const repositories = new SqliteRepositories({ database });
+  const repositories = new SqliteStorage({ database });
   await repositories.init();
   return {
     repositories,

--- a/packages/sqlite-bun/tsconfig.json
+++ b/packages/sqlite-bun/tsconfig.json
@@ -14,6 +14,12 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "coco-cashu-core": ["../core/index.ts"],
+      "coco-cashu-core/adapter": ["../core/adapter.ts"],
+      "@core/*": ["../core/*"]
+    },
 
     // Best practices
     "strict": true,


### PR DESCRIPTION
## Summary
- replace direct repository-bag injection with an opaque `CocoStorage` contract in core
- add an adapter-only internal storage entrypoint so adapters can still access repositories and transactions without exposing them through the app-facing API
- migrate `coco-cashu-sqlite-bun` and related tests/docs to the new storage-based initialization flow
- 
## Why
The framework is intended to be used through `Manager` and the public APIs it exposes. Previously, consumers had easy access to individual repositories because storage adapters surfaced the full repository bag directly. This change narrows the public boundary while still preserving a supported path for adapter authors.

## What Changed
- added an internal storage adapter boundary in `packages/core`
- kept root `CocoStorage` minimal and app-facing
- moved internal adapter access behind the adapter-only subpath
- removed remaining direct repository plumbing from `Manager`
- updated watcher bootstrapping to go through services
- migrated `sqlite-bun` as the proof-of-concept adapter
- updated docs and examples from `repo` to `storage`

## Follow-ups
- migrate `sqlite3`, `indexeddb`, and `expo-sqlite` to the same internal storage adapter pattern