### PR TITLE
feat(core): persist operation ids on history entries

### DIFF
--- a/.changeset/calm-squids-wait.md
+++ b/.changeset/calm-squids-wait.md
@@ -1,0 +1,11 @@
+---
+'@cashu/coco-core': patch
+---
+
+Expose operation ids on history entries so consumers can act on the underlying
+operation directly.
+
+History entries now persist their linked `operationId` where available, and the
+core history API adds `getOperationIdForHistoryEntry()` for callers that only
+have a history entry id. This makes flows like reclaiming a send from a history
+item straightforward with the existing `manager.ops.*` APIs.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -963,11 +963,29 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(sendEntry).toBeDefined();
         expect(sendEntry!.type).toBe('send');
         if (sendEntry!.type === 'send') {
+          expect(await mgr!.history.getOperationIdForHistoryEntry(sendEntry.id)).toBe(operation.id);
           expect(sendEntry.operationId).toBeDefined();
           expect(sendEntry.state).toBe('pending');
           expect(sendEntry.amount).toBe(sendAmount);
           expect(sendEntry.token).toBeDefined();
           expect(sendEntry.token!.proofs.length).toBeGreaterThan(0);
+        }
+      });
+
+      it('should store operationId for mint history entries', async () => {
+        const pendingMint = await prepareMintOperation(mgr!, mintUrl, 21);
+
+        const history = await mgr!.history.getPaginatedHistory(0, 20);
+        const mintEntry = history.find(
+          (entry) => entry.type === 'mint' && entry.quoteId === pendingMint.quoteId,
+        );
+
+        expect(mintEntry).toBeDefined();
+        if (mintEntry?.type === 'mint') {
+          expect(mintEntry.operationId).toBe(pendingMint.id);
+          expect(await mgr!.history.getOperationIdForHistoryEntry(mintEntry.id)).toBe(
+            pendingMint.id,
+          );
         }
       });
 
@@ -991,8 +1009,31 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         expect(meltEntry).toBeDefined();
         if (meltEntry?.type === 'melt') {
+          expect(meltEntry.operationId).toBe(prepared.id);
+          expect(await mgr!.history.getOperationIdForHistoryEntry(meltEntry.id)).toBe(prepared.id);
           expect(meltEntry.state).toBe('UNPAID');
           expect(meltEntry.amount).toBe(prepared.amount);
+        }
+      });
+
+      it('should store operationId for receive history entries created via ops.receive', async () => {
+        const preparedSend = await mgr!.ops.send.prepare({ mintUrl, amount: 18 });
+        const { token } = await mgr!.ops.send.execute(preparedSend.id);
+
+        const preparedReceive = await mgr!.ops.receive.prepare({ token });
+        const finalizedReceive = await mgr!.ops.receive.execute(preparedReceive.id);
+
+        const history = await mgr!.history.getPaginatedHistory(0, 20);
+        const receiveEntry = history.find(
+          (entry) => entry.type === 'receive' && entry.operationId === finalizedReceive.id,
+        );
+
+        expect(receiveEntry).toBeDefined();
+        if (receiveEntry?.type === 'receive') {
+          expect(await mgr!.history.getOperationIdForHistoryEntry(receiveEntry.id)).toBe(
+            finalizedReceive.id,
+          );
+          expect(receiveEntry.amount).toBe(finalizedReceive.amount);
         }
       });
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -260,6 +260,7 @@ Compatibility helpers retained for callers that want scalar values:
 
 - `getPaginatedHistory(offset?: number, limit?: number): Promise<HistoryEntry[]>`
 - `getHistoryEntryById(id: string): Promise<HistoryEntry | null>`
+- `getOperationIdForHistoryEntry(id: string): Promise<string | null>`
 
 ### KeyRingApi
 
@@ -302,7 +303,7 @@ include:
 - `send:pending` → `{ mintUrl, operationId, operation, token }`
 - `send:finalized` → `{ mintUrl, operationId, operation }`
 - `send:rolled-back` → `{ mintUrl, operationId, operation }`
-- `receive:created` → `{ mintUrl, token }`
+- `receive:created` → `{ mintUrl, token, operationId? }`
 - `history:updated` → `{ mintUrl, entry }`
 - `melt-op:prepared` → `{ mintUrl, operationId, operation }`
 - `melt-op:pending` → `{ mintUrl, operationId, operation }`

--- a/packages/core/api/HistoryApi.ts
+++ b/packages/core/api/HistoryApi.ts
@@ -15,4 +15,8 @@ export class HistoryApi {
   async getHistoryEntryById(id: string): Promise<HistoryEntry | null> {
     return this.historyService.getHistoryEntryById(id);
   }
+
+  async getOperationIdForHistoryEntry(id: string): Promise<string | null> {
+    return this.historyService.getOperationIdForHistoryEntry(id);
+  }
 }

--- a/packages/core/api/HistoryApi.ts
+++ b/packages/core/api/HistoryApi.ts
@@ -17,6 +17,6 @@ export class HistoryApi {
   }
 
   async getOperationIdForHistoryEntry(id: string): Promise<string | null> {
-    return this.historyService.getOperationIdForHistoryEntry(id);
+    return this.historyService.getHistoryEntryById(id).then((entry) => entry?.operationId ?? null);
   }
 }

--- a/packages/core/api/HistoryApi.ts
+++ b/packages/core/api/HistoryApi.ts
@@ -17,6 +17,9 @@ export class HistoryApi {
   }
 
   async getOperationIdForHistoryEntry(id: string): Promise<string | null> {
-    return this.historyService.getHistoryEntryById(id).then((entry) => entry?.operationId ?? null);
+    return this.historyService.getHistoryEntryById(id).then((entry) => {
+      const operationId = entry?.operationId?.trim();
+      return operationId ? operationId : null;
+    });
   }
 }

--- a/packages/core/events/types.ts
+++ b/packages/core/events/types.ts
@@ -38,7 +38,7 @@ export interface CoreEvents {
   'send:finalized': { mintUrl: string; operationId: string; operation: SendOperation };
   /** Emitted when send operation is rolled back */
   'send:rolled-back': { mintUrl: string; operationId: string; operation: SendOperation };
-  'receive:created': { mintUrl: string; token: Token };
+  'receive:created': { mintUrl: string; token: Token; operationId?: string };
   'history:updated': { mintUrl: string; entry: HistoryEntry };
   'melt-op:prepared': { mintUrl: string; operationId: string; operation: MeltOperation };
   'melt-op:pending': { mintUrl: string; operationId: string; operation: MeltOperation };

--- a/packages/core/models/History.ts
+++ b/packages/core/models/History.ts
@@ -7,6 +7,7 @@ type BaseHistoryEntry = {
   mintUrl: string;
   unit: string;
   metadata?: Record<string, string>;
+  operationId?: string;
 };
 
 export type MintHistoryEntry = BaseHistoryEntry & {

--- a/packages/core/operations/receive/ReceiveOperationService.ts
+++ b/packages/core/operations/receive/ReceiveOperationService.ts
@@ -632,6 +632,7 @@ export class ReceiveOperationService {
     await this.eventBus.emit('receive:created', {
       mintUrl: executing.mintUrl,
       token: { mint: executing.mintUrl, proofs: executing.inputProofs },
+      operationId: executing.id,
     });
 
     this.logger?.info('Receive operation finalized', {

--- a/packages/core/services/HistoryService.ts
+++ b/packages/core/services/HistoryService.ts
@@ -83,21 +83,22 @@ export class HistoryService {
     return this.historyRepository.getHistoryEntryById(id);
   }
 
-  async getOperationIdForHistoryEntry(historyId: string): Promise<string | null> {
-    const entry = await this.historyRepository.getHistoryEntryById(historyId);
-
-    return entry?.operationId ?? null;
-  }
-
   /**
-   * @deprecated Prefer getOperationIdForHistoryEntry(), which returns null for legacy entries.
+   * Get the operationId for a send history entry.
+   * @throws Error if entry not found or is not a send entry
    */
   async getOperationIdFromHistoryEntry(historyId: string): Promise<string> {
-    const operationId = await this.getOperationIdForHistoryEntry(historyId);
-    if (!operationId) {
-      throw new Error(`History entry ${historyId} has no associated operationId`);
+    const entry = await this.historyRepository.getHistoryEntryById(historyId);
+
+    if (!entry) {
+      throw new Error(`History entry ${historyId} not found`);
     }
-    return operationId;
+
+    if (entry.type !== 'send') {
+      throw new Error(`History entry ${historyId} is not a send entry`);
+    }
+
+    return entry.operationId;
   }
 
   async handleSendPrepared(mintUrl: string, operationId: string, operation: SendOperation) {

--- a/packages/core/services/HistoryService.ts
+++ b/packages/core/services/HistoryService.ts
@@ -70,8 +70,8 @@ export class HistoryService {
     this.eventBus.on('send:rolled-back', ({ mintUrl, operationId }) => {
       this.handleSendStateChanged(mintUrl, operationId, 'rolledBack');
     });
-    this.eventBus.on('receive:created', ({ mintUrl, token }) => {
-      this.handleReceiveCreated(mintUrl, token);
+    this.eventBus.on('receive:created', ({ mintUrl, token, operationId }) => {
+      this.handleReceiveCreated(mintUrl, token, operationId);
     });
   }
 
@@ -83,22 +83,21 @@ export class HistoryService {
     return this.historyRepository.getHistoryEntryById(id);
   }
 
-  /**
-   * Get the operationId for a send history entry.
-   * @throws Error if entry not found or is not a send entry
-   */
-  async getOperationIdFromHistoryEntry(historyId: string): Promise<string> {
+  async getOperationIdForHistoryEntry(historyId: string): Promise<string | null> {
     const entry = await this.historyRepository.getHistoryEntryById(historyId);
 
-    if (!entry) {
-      throw new Error(`History entry ${historyId} not found`);
-    }
+    return entry?.operationId ?? null;
+  }
 
-    if (entry.type !== 'send') {
-      throw new Error(`History entry ${historyId} is not a send entry`);
+  /**
+   * @deprecated Prefer getOperationIdForHistoryEntry(), which returns null for legacy entries.
+   */
+  async getOperationIdFromHistoryEntry(historyId: string): Promise<string> {
+    const operationId = await this.getOperationIdForHistoryEntry(historyId);
+    if (!operationId) {
+      throw new Error(`History entry ${historyId} has no associated operationId`);
     }
-
-    return entry.operationId;
+    return operationId;
   }
 
   async handleSendPrepared(mintUrl: string, operationId: string, operation: SendOperation) {
@@ -164,7 +163,7 @@ export class HistoryService {
     }
   }
 
-  async handleReceiveCreated(mintUrl: string, token: Token) {
+  async handleReceiveCreated(mintUrl: string, token: Token, operationId?: string) {
     const entry: Omit<ReceiveHistoryEntry, 'id'> = {
       type: 'receive',
       createdAt: Date.now(),
@@ -172,6 +171,7 @@ export class HistoryService {
       amount: token.proofs.reduce((acc, proof) => acc + proof.amount, 0),
       mintUrl,
       token,
+      operationId,
     };
     try {
       const entryRes = await this.historyRepository.addHistoryEntry(entry);
@@ -201,6 +201,7 @@ export class HistoryService {
         });
         return;
       }
+      entry.operationId = operationId;
       entry.state = state;
       await this.historyRepository.updateHistoryEntry(entry);
       await this.handleHistoryUpdated(mintUrl, { ...entry, state });
@@ -267,6 +268,7 @@ export class HistoryService {
     const entry: Omit<MeltHistoryEntry, 'id'> = {
       type: 'melt',
       mintUrl,
+      operationId: operation.id,
       quoteId: operation.quoteId,
       amount: operation.amount,
       state,
@@ -277,6 +279,7 @@ export class HistoryService {
     try {
       if (existing) {
         existing.amount = entry.amount;
+        existing.operationId = entry.operationId;
         existing.state = entry.state;
         existing.unit = entry.unit;
         const updated = await this.historyRepository.updateHistoryEntry(existing);
@@ -305,6 +308,7 @@ export class HistoryService {
     const entry: Omit<MintHistoryEntry, 'id'> = {
       type: 'mint',
       mintUrl,
+      operationId: operation.id,
       unit: operation.unit,
       paymentRequest: operation.request,
       quoteId: operation.quoteId,
@@ -316,6 +320,7 @@ export class HistoryService {
     try {
       const existing = await this.historyRepository.getMintHistoryEntry(mintUrl, operation.quoteId);
       if (existing) {
+        existing.operationId = entry.operationId;
         existing.unit = entry.unit;
         existing.paymentRequest = entry.paymentRequest;
         existing.state = entry.state;

--- a/packages/core/test/unit/HistoryApi.test.ts
+++ b/packages/core/test/unit/HistoryApi.test.ts
@@ -39,4 +39,22 @@ describe('HistoryApi', () => {
     await expect(api.getOperationIdForHistoryEntry('history-2')).resolves.toBeNull();
     expect(historyService.getHistoryEntryById).toHaveBeenCalledWith('history-2');
   });
+
+  it('normalizes blank operationId lookups from the history service to null', async () => {
+    (
+      historyService.getHistoryEntryById as unknown as ReturnType<typeof mock>
+    ).mockResolvedValueOnce({
+      id: 'history-3',
+      type: 'send',
+      mintUrl: 'https://mint.test',
+      operationId: '   ',
+      amount: 10,
+      state: 'pending',
+      unit: 'sat',
+      createdAt: Date.now(),
+    } as HistoryEntry);
+
+    await expect(api.getOperationIdForHistoryEntry('history-3')).resolves.toBeNull();
+    expect(historyService.getHistoryEntryById).toHaveBeenCalledWith('history-3');
+  });
 });

--- a/packages/core/test/unit/HistoryApi.test.ts
+++ b/packages/core/test/unit/HistoryApi.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { HistoryApi } from '../../api/HistoryApi';
+import type { HistoryEntry } from '../../models/History';
+import type { HistoryService } from '../../services';
+
+describe('HistoryApi', () => {
+  let api: HistoryApi;
+  let historyService: HistoryService;
+
+  beforeEach(() => {
+    historyService = {
+      getPaginatedHistory: mock(async () => []),
+      getHistoryEntryById: mock(async () => null),
+    } as unknown as HistoryService;
+
+    api = new HistoryApi(historyService);
+  });
+
+  it('delegates operationId lookups to the history service', async () => {
+    (
+      historyService.getHistoryEntryById as unknown as ReturnType<typeof mock>
+    ).mockResolvedValueOnce({
+      id: 'history-1',
+      type: 'melt',
+      mintUrl: 'https://mint.test',
+      quoteId: 'quote-1',
+      operationId: 'operation-1',
+      amount: 10,
+      state: 'UNPAID',
+      unit: 'sat',
+      createdAt: Date.now(),
+    } as HistoryEntry);
+
+    await expect(api.getOperationIdForHistoryEntry('history-1')).resolves.toBe('operation-1');
+    expect(historyService.getHistoryEntryById).toHaveBeenCalledWith('history-1');
+  });
+
+  it('preserves null operationId lookups from the history service', async () => {
+    await expect(api.getOperationIdForHistoryEntry('history-2')).resolves.toBeNull();
+    expect(historyService.getHistoryEntryById).toHaveBeenCalledWith('history-2');
+  });
+});

--- a/packages/core/test/unit/HistoryService.test.ts
+++ b/packages/core/test/unit/HistoryService.test.ts
@@ -526,38 +526,4 @@ describe('HistoryService', () => {
       expect(entry.operationId).toBeUndefined();
     });
   });
-
-  describe('operation lookup', () => {
-    it('returns the stored operationId for operation-backed history entries', async () => {
-      const entry = await mockRepo.addHistoryEntry({
-        type: 'melt',
-        mintUrl: 'https://mint.test',
-        quoteId: 'quote-1',
-        operationId: 'melt-op-1',
-        amount: 50,
-        state: 'UNPAID',
-        unit: 'sat',
-        createdAt: Date.now(),
-      } as Omit<MeltHistoryEntry, 'id'>);
-
-      await expect(service.getOperationIdForHistoryEntry(entry.id)).resolves.toBe('melt-op-1');
-    });
-
-    it('returns null for legacy history entries without an operationId', async () => {
-      const entry = await mockRepo.addHistoryEntry({
-        type: 'receive',
-        mintUrl: 'https://mint.test',
-        amount: 42,
-        unit: 'sat',
-        token: receiveToken,
-        createdAt: Date.now(),
-      } as Omit<ReceiveHistoryEntry, 'id'>);
-
-      await expect(service.getOperationIdForHistoryEntry(entry.id)).resolves.toBeNull();
-    });
-
-    it('returns null when the history entry does not exist', async () => {
-      await expect(service.getOperationIdForHistoryEntry('missing-id')).resolves.toBeNull();
-    });
-  });
 });

--- a/packages/core/test/unit/HistoryService.test.ts
+++ b/packages/core/test/unit/HistoryService.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, beforeEach, expect } from 'bun:test';
+import type { Token } from '@cashu/cashu-ts';
 import { HistoryService } from '../../services/HistoryService';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { HistoryRepository } from '../../repositories';
-import type { HistoryEntry, MeltHistoryEntry, MintHistoryEntry } from '../../models/History';
+import type {
+  HistoryEntry,
+  MeltHistoryEntry,
+  MintHistoryEntry,
+  ReceiveHistoryEntry,
+  SendHistoryEntry,
+} from '../../models/History';
 import type {
   FinalizedMeltOperation,
   PendingMeltOperation,
@@ -18,6 +25,11 @@ describe('HistoryService', () => {
   let eventBus: EventBus<CoreEvents>;
   let historyEntries: Map<string, HistoryEntry>;
   let historyUpdateEvents: Array<{ mintUrl: string; entry: HistoryEntry }>;
+  const receiveToken = {
+    mint: 'https://mint.test',
+    unit: 'sat',
+    proofs: [{ id: 'keyset-1', amount: 42, secret: 'secret-1', C: 'C-1' }],
+  } as Token;
 
   const makePendingOperation = (
     quoteId: string,
@@ -135,15 +147,23 @@ describe('HistoryService', () => {
       async getPaginatedHistoryEntries(): Promise<HistoryEntry[]> {
         return Array.from(historyEntries.values());
       },
-      async getSendHistoryEntry(): Promise<null> {
+      async getSendHistoryEntry(
+        mintUrl: string,
+        operationId: string,
+      ): Promise<SendHistoryEntry | null> {
+        for (const entry of historyEntries.values()) {
+          if (
+            entry.type === 'send' &&
+            entry.mintUrl === mintUrl &&
+            entry.operationId === operationId
+          ) {
+            return entry;
+          }
+        }
         return null;
       },
-      async getReceiveHistoryEntry(): Promise<null> {
-        return null;
-      },
-      async updateHistoryEntryState(): Promise<void> {},
-      async getHistoryEntryById(): Promise<null> {
-        return null;
+      async getHistoryEntryById(id: string): Promise<HistoryEntry | null> {
+        return historyEntries.get(id) ?? null;
       },
       async updateHistoryEntry(entry: HistoryEntry): Promise<HistoryEntry> {
         historyEntries.set(entry.id, entry);
@@ -196,6 +216,7 @@ describe('HistoryService', () => {
       expect(entry.state).toBe('UNPAID');
       expect(entry.unit).toBe(operation.unit);
       expect(entry.paymentRequest).toBe(operation.request);
+      expect(entry.operationId).toBe(operation.id);
       expect(historyUpdateEvents.length).toBe(1);
     });
 
@@ -228,6 +249,7 @@ describe('HistoryService', () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       const entry = Array.from(historyEntries.values())[0] as MintHistoryEntry;
+      expect(entry.operationId).toBe(operation.id);
       expect(entry.state).toBe('PAID');
       expect(historyUpdateEvents.length).toBe(1);
       expect(historyUpdateEvents[0]?.entry.type).toBe('mint');
@@ -262,6 +284,7 @@ describe('HistoryService', () => {
       expect(historyEntries.size).toBe(1);
       const entry = Array.from(historyEntries.values())[0] as MintHistoryEntry;
       expect(entry.amount).toBe(operation.amount);
+      expect(entry.operationId).toBe(operation.id);
       expect(entry.paymentRequest).toBe(operation.request);
       expect(entry.state).toBe('PAID');
       expect(historyUpdateEvents.length).toBe(1);
@@ -286,6 +309,7 @@ describe('HistoryService', () => {
       expect(entry.mintUrl).toBe(operation.mintUrl);
       expect(entry.quoteId).toBe(operation.quoteId);
       expect(entry.amount).toBe(operation.amount);
+      expect(entry.operationId).toBe(operation.id);
       expect(entry.state).toBe('UNPAID');
       expect(entry.unit).toBe('sat');
       expect(historyUpdateEvents.length).toBe(1);
@@ -333,6 +357,7 @@ describe('HistoryService', () => {
       expect(historyEntries.size).toBe(1);
       const entry = Array.from(historyEntries.values())[0] as MeltHistoryEntry;
       expect(entry.amount).toBe(operation.amount);
+      expect(entry.operationId).toBe(operation.id);
       expect(entry.state).toBe('PENDING');
       expect(historyUpdateEvents.length).toBe(1);
       expect(historyUpdateEvents[0]?.entry.type).toBe('melt');
@@ -381,6 +406,7 @@ describe('HistoryService', () => {
       const entry = Array.from(historyEntries.values())[0] as MeltHistoryEntry;
       expect(entry.quoteId).toBe(operation.quoteId);
       expect(entry.amount).toBe(operation.amount);
+      expect(entry.operationId).toBe(operation.id);
       expect(entry.state).toBe('PAID');
       expect(historyUpdateEvents.length).toBe(1);
     });
@@ -467,6 +493,71 @@ describe('HistoryService', () => {
 
       expect(historyUpdateEvents.length).toBe(1);
       expect(historyUpdateEvents[0]?.entry.type).toBe('melt');
+    });
+  });
+
+  describe('receive operations', () => {
+    it('creates history entry with operationId for operation-backed receives', async () => {
+      await eventBus.emit('receive:created', {
+        mintUrl: 'https://mint.test',
+        token: receiveToken,
+        operationId: 'receive-op-1',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(historyEntries.size).toBe(1);
+      const entry = Array.from(historyEntries.values())[0] as ReceiveHistoryEntry;
+      expect(entry.type).toBe('receive');
+      expect(entry.amount).toBe(42);
+      expect(entry.unit).toBe('sat');
+      expect(entry.operationId).toBe('receive-op-1');
+    });
+
+    it('keeps legacy receives without an operationId', async () => {
+      await eventBus.emit('receive:created', {
+        mintUrl: 'https://mint.test',
+        token: receiveToken,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const entry = Array.from(historyEntries.values())[0] as ReceiveHistoryEntry;
+      expect(entry.operationId).toBeUndefined();
+    });
+  });
+
+  describe('operation lookup', () => {
+    it('returns the stored operationId for operation-backed history entries', async () => {
+      const entry = await mockRepo.addHistoryEntry({
+        type: 'melt',
+        mintUrl: 'https://mint.test',
+        quoteId: 'quote-1',
+        operationId: 'melt-op-1',
+        amount: 50,
+        state: 'UNPAID',
+        unit: 'sat',
+        createdAt: Date.now(),
+      } as Omit<MeltHistoryEntry, 'id'>);
+
+      await expect(service.getOperationIdForHistoryEntry(entry.id)).resolves.toBe('melt-op-1');
+    });
+
+    it('returns null for legacy history entries without an operationId', async () => {
+      const entry = await mockRepo.addHistoryEntry({
+        type: 'receive',
+        mintUrl: 'https://mint.test',
+        amount: 42,
+        unit: 'sat',
+        token: receiveToken,
+        createdAt: Date.now(),
+      } as Omit<ReceiveHistoryEntry, 'id'>);
+
+      await expect(service.getOperationIdForHistoryEntry(entry.id)).resolves.toBeNull();
+    });
+
+    it('returns null when the history entry does not exist', async () => {
+      await expect(service.getOperationIdForHistoryEntry('missing-id')).resolves.toBeNull();
     });
   });
 });

--- a/packages/docs/pages/send-operations.md
+++ b/packages/docs/pages/send-operations.md
@@ -73,8 +73,9 @@ await coco.ops.send.cancel(prepared.id);
 After executing a send, if the recipient never claims the token:
 
 ```ts
-// Get the operation (from history or stored operationId)
-const operation = await coco.ops.send.get(operationId);
+// Resolve the operationId from a history entry, then load the operation
+const operationId = await coco.history.getOperationIdForHistoryEntry(historyEntry.id);
+const operation = operationId ? await coco.ops.send.get(operationId) : null;
 
 if (operation?.state === 'pending') {
   // Reclaim the proofs

--- a/packages/expo-sqlite/src/repositories/HistoryRepository.ts
+++ b/packages/expo-sqlite/src/repositories/HistoryRepository.ts
@@ -128,10 +128,12 @@ export class ExpoHistoryRepository {
         quoteId = history.quoteId;
         state = history.state;
         paymentRequest = history.paymentRequest;
+        operationId = history.operationId ?? null;
         break;
       case 'melt':
         quoteId = history.quoteId;
         state = history.state;
+        operationId = history.operationId ?? null;
         break;
       case 'send':
         tokenJson = history.token ? JSON.stringify(history.token as SendToken) : null;
@@ -140,6 +142,7 @@ export class ExpoHistoryRepository {
         break;
       case 'receive':
         tokenJson = history.token ? JSON.stringify(history.token as ReceiveToken) : null;
+        operationId = history.operationId ?? null;
         break;
     }
 
@@ -201,7 +204,7 @@ export class ExpoHistoryRepository {
       paymentRequest = history.paymentRequest;
 
       await this.db.run(
-        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, paymentRequest = ?, metadata = ?
+        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, paymentRequest = ?, metadata = ?, operationId = ?
          WHERE mintUrl = ? AND quoteId = ? AND type = 'mint'`,
         [
           history.unit,
@@ -209,6 +212,7 @@ export class ExpoHistoryRepository {
           state,
           paymentRequest,
           history.metadata ? JSON.stringify(history.metadata) : null,
+          history.operationId ?? null,
           history.mintUrl,
           history.quoteId,
         ],
@@ -227,13 +231,14 @@ export class ExpoHistoryRepository {
       state = history.state;
 
       await this.db.run(
-        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, metadata = ?
+        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, metadata = ?, operationId = ?
          WHERE mintUrl = ? AND quoteId = ? AND type = 'melt'`,
         [
           history.unit,
           history.amount,
           state,
           history.metadata ? JSON.stringify(history.metadata) : null,
+          history.operationId ?? null,
           history.mintUrl,
           history.quoteId,
         ],
@@ -323,6 +328,7 @@ export class ExpoHistoryRepository {
         type: 'mint',
         paymentRequest: row.paymentRequest ?? '',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MintQuoteState,
         amount: row.amount,
       };
@@ -332,6 +338,7 @@ export class ExpoHistoryRepository {
         ...base,
         type: 'melt',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MeltQuoteState,
         amount: row.amount,
       };
@@ -351,6 +358,7 @@ export class ExpoHistoryRepository {
       ...base,
       type: 'receive',
       amount: row.amount,
+      operationId: row.operationId ?? undefined,
       token,
     } satisfies HistoryEntry;
   }

--- a/packages/indexeddb/src/repositories/HistoryRepository.ts
+++ b/packages/indexeddb/src/repositories/HistoryRepository.ts
@@ -102,6 +102,7 @@ export class IdbHistoryRepository {
         unit: history.unit,
         amount: history.amount,
         metadata: history.metadata ?? null,
+        operationId: history.operationId ?? null,
         state: history.state,
         paymentRequest: history.paymentRequest,
       };
@@ -120,6 +121,7 @@ export class IdbHistoryRepository {
         unit: history.unit,
         amount: history.amount,
         metadata: history.metadata ?? null,
+        operationId: history.operationId ?? null,
         state: history.state,
       };
       await coll.update(row.id, updated);
@@ -181,10 +183,12 @@ export class IdbHistoryRepository {
     } as any;
     if (history.type === 'mint') {
       base.quoteId = history.quoteId;
+      base.operationId = history.operationId ?? null;
       base.state = history.state as MintQuoteState;
       base.paymentRequest = history.paymentRequest;
     } else if (history.type === 'melt') {
       base.quoteId = history.quoteId;
+      base.operationId = history.operationId ?? null;
       base.state = history.state as MeltQuoteState;
     } else if (history.type === 'send') {
       base.tokenJson = history.token ? JSON.stringify(history.token as SendToken) : null;
@@ -192,6 +196,7 @@ export class IdbHistoryRepository {
       base.state = history.state;
     } else if (history.type === 'receive') {
       base.tokenJson = history.token ? JSON.stringify(history.token as ReceiveToken) : null;
+      base.operationId = history.operationId ?? null;
     }
     return base;
   }
@@ -210,6 +215,7 @@ export class IdbHistoryRepository {
         type: 'mint',
         paymentRequest: row.paymentRequest ?? '',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MintQuoteState,
         amount: row.amount,
       };
@@ -219,6 +225,7 @@ export class IdbHistoryRepository {
         ...base,
         type: 'melt',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MeltQuoteState,
         amount: row.amount,
       };
@@ -238,6 +245,7 @@ export class IdbHistoryRepository {
       ...base,
       type: 'receive',
       amount: row.amount,
+      operationId: row.operationId ?? undefined,
       token,
     } satisfies HistoryEntry;
   }

--- a/packages/sqlite-bun/src/repositories/HistoryRepository.ts
+++ b/packages/sqlite-bun/src/repositories/HistoryRepository.ts
@@ -79,12 +79,14 @@ export class SqliteHistoryRepository implements HistoryRepository {
         quoteId = h.quoteId;
         state = h.state;
         paymentRequest = h.paymentRequest;
+        operationId = h.operationId ?? null;
         break;
       }
       case 'melt': {
         const h = history as Omit<MeltHistoryEntry, 'id'>;
         quoteId = h.quoteId;
         state = h.state;
+        operationId = h.operationId ?? null;
         break;
       }
       case 'send': {
@@ -97,6 +99,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
       case 'receive': {
         const h = history as Omit<ReceiveHistoryEntry, 'id'>;
         tokenJson = h.token ? JSON.stringify(h.token as ReceiveToken) : null;
+        operationId = h.operationId ?? null;
         break;
       }
     }
@@ -167,7 +170,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
       paymentRequest = h.paymentRequest;
 
       await this.db.run(
-        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, paymentRequest = ?, metadata = ?
+        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, paymentRequest = ?, metadata = ?, operationId = ?
          WHERE mintUrl = ? AND quoteId = ? AND type = 'mint'`,
         [
           history.unit,
@@ -175,6 +178,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
           state,
           paymentRequest,
           history.metadata ? JSON.stringify(history.metadata) : null,
+          h.operationId ?? null,
           history.mintUrl,
           h.quoteId,
         ],
@@ -194,13 +198,14 @@ export class SqliteHistoryRepository implements HistoryRepository {
       state = h.state;
 
       await this.db.run(
-        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, metadata = ?
+        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, metadata = ?, operationId = ?
          WHERE mintUrl = ? AND quoteId = ? AND type = 'melt'`,
         [
           history.unit,
           history.amount,
           state,
           history.metadata ? JSON.stringify(history.metadata) : null,
+          h.operationId ?? null,
           history.mintUrl,
           h.quoteId,
         ],
@@ -281,6 +286,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
         type: 'mint',
         paymentRequest: row.paymentRequest ?? '',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MintQuoteState,
         amount: row.amount,
       };
@@ -290,6 +296,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
         ...base,
         type: 'melt',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MeltQuoteState,
         amount: row.amount,
       };
@@ -309,6 +316,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
       ...base,
       type: 'receive',
       amount: row.amount,
+      operationId: row.operationId ?? undefined,
       token,
     } satisfies HistoryEntry;
   }

--- a/packages/sqlite3/src/repositories/HistoryRepository.ts
+++ b/packages/sqlite3/src/repositories/HistoryRepository.ts
@@ -79,12 +79,14 @@ export class SqliteHistoryRepository implements HistoryRepository {
         quoteId = h.quoteId;
         state = h.state;
         paymentRequest = h.paymentRequest;
+        operationId = h.operationId ?? null;
         break;
       }
       case 'melt': {
         const h = history as Omit<MeltHistoryEntry, 'id'>;
         quoteId = h.quoteId;
         state = h.state;
+        operationId = h.operationId ?? null;
         break;
       }
       case 'send': {
@@ -97,6 +99,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
       case 'receive': {
         const h = history as Omit<ReceiveHistoryEntry, 'id'>;
         tokenJson = h.token ? JSON.stringify(h.token as ReceiveToken) : null;
+        operationId = h.operationId ?? null;
         break;
       }
     }
@@ -168,6 +171,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
 
       await this.db.run(
         `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, paymentRequest = ?, metadata = ?
+            , operationId = ?
          WHERE mintUrl = ? AND quoteId = ? AND type = 'mint'`,
         [
           history.unit,
@@ -175,6 +179,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
           state,
           paymentRequest,
           history.metadata ? JSON.stringify(history.metadata) : null,
+          h.operationId ?? null,
           history.mintUrl,
           h.quoteId,
         ],
@@ -194,13 +199,14 @@ export class SqliteHistoryRepository implements HistoryRepository {
       state = h.state;
 
       await this.db.run(
-        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, metadata = ?
+        `UPDATE coco_cashu_history SET unit = ?, amount = ?, state = ?, metadata = ?, operationId = ?
          WHERE mintUrl = ? AND quoteId = ? AND type = 'melt'`,
         [
           history.unit,
           history.amount,
           state,
           history.metadata ? JSON.stringify(history.metadata) : null,
+          h.operationId ?? null,
           history.mintUrl,
           h.quoteId,
         ],
@@ -281,6 +287,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
         type: 'mint',
         paymentRequest: row.paymentRequest ?? '',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MintQuoteState,
         amount: row.amount,
       };
@@ -290,6 +297,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
         ...base,
         type: 'melt',
         quoteId: row.quoteId ?? '',
+        operationId: row.operationId ?? undefined,
         state: (row.state ?? 'UNPAID') as MeltQuoteState,
         amount: row.amount,
       };
@@ -309,6 +317,7 @@ export class SqliteHistoryRepository implements HistoryRepository {
       ...base,
       type: 'receive',
       amount: row.amount,
+      operationId: row.operationId ?? undefined,
       token,
     } satisfies HistoryEntry;
   }


### PR DESCRIPTION
## What changed

This updates history entries to carry a direct `operationId` for all future operation-backed flows, not just sends.

- added nullable `operationId` support to mint, melt, and receive history entries
- added `HistoryApi.getOperationIdForHistoryEntry()` returning `string | null`
- persisted and hydrated `operationId` across the history repositories
- emitted `operationId` on operation-backed `receive:created` events
- added unit and adapter coverage for the new behavior
- updated docs to describe the new lookup flow

## Why

History currently only supports direct operation lookup for send entries. Mint and melt rely on quote-based correlation, and receive entries do not carry a direct operation link. That makes it harder for consumers to reliably move from a history item to the underlying operation.

This change makes the link explicit for newly created operation-backed history entries while keeping legacy entries safe: if a history row does not have an `operationId`, the lookup returns `null`.

## Impact

Consumers can now resolve operation-backed history entries through a uniform nullable lookup and then load the underlying operation via the typed ops APIs.

Legacy history rows remain supported without backfill or migration pressure.

## Validation

- `bun test packages/core/test/unit/HistoryService.test.ts packages/core/test/unit/ReceiveOperationService.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-adapter-tests' typecheck`

## Commit breakdown

- `feat(core): persist operation ids on history entries`
- `test(adapter-tests): cover history operation lookup`
- `docs(core): document history operation lookup`
