### PR TITLE
docs: refresh README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A modular, TypeScript-first toolkit for building Cashu wallets and applications.
 
-> ⚠️ Alpha software: This library is under active development and APIs may change. Use with caution in production and pin versions.
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
 
 coco provides a complete foundation for Cashu development with a storage-agnostic
 core that handles proof management, mint synchronization, quote lifecycle,
@@ -31,15 +32,14 @@ Native via `@cashu/coco-expo-sqlite`.
         │  • Repository Interfaces         │
         │  • Plugin System (lifecycle)     │
         │                                  │
-        └────┬──────────┬──────────┬───────┘
-             │          │          │
-      depends│   depends│   depends│
-             ▼          ▼          ▼
-      ┌──────────┐ ┌──────────┐ ┌──────────┐
-      │ SQLite3  │ │ IndexedDB│ │  Expo    │
-      │ Adapter  │ │ Adapter  │ │  SQLite  │
-      └──────────┘ └──────────┘ └──────────┘
-         (Node)       (Web)       (Mobile)
+        └────┬──────────────┬──────────┬────────────┘
+             │              │          │
+      depends│       depends│   depends│
+             ▼              ▼          ▼
+   ┌────────────────┐ ┌──────────┐ ┌──────────────┐
+   │ SQLite Adapters│ │ IndexedDB│ │ Expo SQLite  │
+   │   Node + Bun   │ │ Adapter  │ │   Adapter    │
+   └────────────────┘ └──────────┘ └──────────────┘
 ```
 
 ## Packages
@@ -53,6 +53,7 @@ Native via `@cashu/coco-expo-sqlite`.
 - `@cashu/coco-expo-sqlite` — Expo SQLite adapter for React Native and Expo.
 - `@cashu/coco-sqlite-bun` — Bun adapter built on `bun:sqlite`.
 - `@cashu/coco-adapter-tests` — reusable storage adapter contract test helpers.
+- `packages/docs` — VitePress documentation site for the repository.
 
 ## Philosophy
 
@@ -69,7 +70,17 @@ The core exposes a minimal plugin API to hook into lifecycle events with access 
 
 ## Development
 
-Use TypeScript for type checking and `tsdown` to build packages. See `packages/core/README.md` for API details and usage.
+This repo uses Bun workspaces. Most packages build with `tsdown`; the React
+package builds with `tsc -b` and Vite, and the docs site uses VitePress.
+
+```bash
+bun install
+bun run build
+bun run typecheck
+bun run docs:dev
+```
+
+See `packages/core/README.md` for API details and package-level usage.
 
 ## Contributing
 

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -1,5 +1,8 @@
 # @cashu/coco-adapter-tests
 
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
+
 This package exports reusable test helpers that verify whether a storage adapter
 conforms to the `Repositories` contract from `@cashu/coco-core`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,12 +2,14 @@
 
 Modular, storage-agnostic core for working with Cashu mints and wallets.
 
-> ⚠️ Alpha software: This library is under active development and APIs may change. Use with caution in production and pin versions.
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
 
 - **Storage-agnostic**: Repositories are interfaces; bring your own persistence.
 - **Typed Event Bus**: Subscribe to mint, proof, quote, and counter events with strong types.
 - **High-level APIs**: `MintApi`, `WalletApi`, `AuthApi`, `PaymentRequestsApi`,
-  `SubscriptionApi`, and `manager.ops.*` for common flows.
+  `SubscriptionApi`, `HistoryApi`, `KeyRingApi`, and `manager.ops.*` for common
+  flows.
 - **Background watchers**: Optional services to track quote/payment and proof states.
 
 ## Install
@@ -18,7 +20,7 @@ npm install @cashu/coco-core
 
 For a real application you will usually install a storage adapter alongside the
 core package, for example `@cashu/coco-sqlite`, `@cashu/coco-indexeddb`, or
-`@cashu/coco-expo-sqlite`.
+`@cashu/coco-expo-sqlite`. Bun applications can use `@cashu/coco-sqlite-bun`.
 
 ## Protocol Support
 

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -1,0 +1,35 @@
+# @cashu/coco-expo-sqlite
+
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
+
+Expo SQLite storage adapter for Coco in React Native and Expo applications.
+
+## Install
+
+```bash
+npm install @cashu/coco-core @cashu/coco-expo-sqlite
+npx expo install expo-sqlite
+```
+
+## Usage
+
+```ts
+import { initializeCoco } from '@cashu/coco-core';
+import { ExpoSqliteRepositories } from '@cashu/coco-expo-sqlite';
+import { openDatabaseAsync } from 'expo-sqlite';
+
+const database = await openDatabaseAsync('coco.db');
+const repositories = new ExpoSqliteRepositories({ database });
+await repositories.init();
+
+const manager = await initializeCoco({
+  repo: repositories,
+  seedGetter,
+});
+```
+
+## Notes
+
+- Pass an already opened `expo-sqlite` database instance via the `database` option.
+- The adapter ensures schema creation and migrations when you call `init()`.

--- a/packages/indexeddb/README.md
+++ b/packages/indexeddb/README.md
@@ -1,0 +1,32 @@
+# @cashu/coco-indexeddb
+
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
+
+IndexedDB storage adapter for Coco in browser and worker environments.
+
+## Install
+
+```bash
+npm install @cashu/coco-core @cashu/coco-indexeddb
+```
+
+## Usage
+
+```ts
+import { initializeCoco } from '@cashu/coco-core';
+import { IndexedDbRepositories } from '@cashu/coco-indexeddb';
+
+const repositories = new IndexedDbRepositories({ name: 'coco' });
+await repositories.init();
+
+const manager = await initializeCoco({
+  repo: repositories,
+  seedGetter,
+});
+```
+
+## Notes
+
+- Pass `name` to control the IndexedDB database name. The default is `coco_cashu`.
+- This adapter is intended for environments where IndexedDB is available.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,7 +1,7 @@
 # @cashu/coco-react
 
-> ⚠️ Release candidate: the React API is stabilizing for v1, but breaking
-> changes may still land before the final 1.0 release.
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
 
 React hooks and providers for integrating a Coco `Manager` into React
 applications.

--- a/packages/sqlite-bun/README.md
+++ b/packages/sqlite-bun/README.md
@@ -1,10 +1,11 @@
 # @cashu/coco-sqlite-bun
 
-> ⚠️ Alpha software: This library is under active development and APIs may change. Use with caution in production and pin versions.
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
 
 SQLite adapter for Coco using Bun's built-in `bun:sqlite` module.
 
-## Installation
+## Install
 
 ```bash
 bun add @cashu/coco-core @cashu/coco-sqlite-bun
@@ -12,7 +13,7 @@ bun add @cashu/coco-core @cashu/coco-sqlite-bun
 
 ## Usage
 
-```typescript
+```ts
 import { initializeCoco } from '@cashu/coco-core';
 import { SqliteRepositories } from '@cashu/coco-sqlite-bun';
 import { Database } from 'bun:sqlite';
@@ -27,12 +28,11 @@ const manager = await initializeCoco({
 });
 ```
 
-## Differences from @cashu/coco-sqlite
+## Notes
 
-- Uses `bun:sqlite` instead of `better-sqlite3`
-- Designed specifically for Bun runtime
-- Uses `bun:test` for testing instead of vitest
-- No external SQLite dependencies required
+- Uses `bun:sqlite` instead of `better-sqlite3`.
+- Designed specifically for Bun runtime.
+- No external SQLite dependency is required.
 
 ## Testing
 

--- a/packages/sqlite3/README.md
+++ b/packages/sqlite3/README.md
@@ -1,6 +1,7 @@
 # @cashu/coco-sqlite
 
-> ⚠️ Alpha software: This library is under active development and APIs may change. Use with caution in production and pin versions.
+> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
+> still land before the final 1.0 release. Pin versions in production.
 
 Node storage adapter for Coco built on `better-sqlite3`.
 


### PR DESCRIPTION
## Summary

This updates the repository README set to match the current package layout and release state.

- align release-stage wording across the published package READMEs
- refresh the root README development and architecture overview
- add missing READMEs for `@cashu/coco-indexeddb` and `@cashu/coco-expo-sqlite`
- keep package install and usage snippets consistent with current package names and exports

## Why

A few README files had drifted out of sync with the current v1 release-candidate state, and two published packages referenced `README.md` in `package.json` without the file being present.

## Validation

- reviewed the current package manifests and exported entry points
- checked the README set for consistency after the edits
- no code or test changes; tests not run because this is a docs-only update
