### PR TITLE
refactor(core): remove WalletApi balance helpers

### DIFF
--- a/.changeset/remove-walletapi-balance-helpers.md
+++ b/.changeset/remove-walletapi-balance-helpers.md
@@ -1,0 +1,15 @@
+---
+'@cashu/coco-core': patch
+---
+
+Remove the legacy scalar and breakdown balance helpers from `WalletApi`.
+
+`wallet.balances.byMint()` and `wallet.balances.total()` are now the only
+balance surface on `WalletApi`. The following methods have been removed:
+`getBalance`, `getBalances`, `getTrustedBalances`, `getSpendableBalance`,
+`getSpendableBalances`, `getTrustedSpendableBalances`, `getBalanceBreakdown`,
+`getBalancesBreakdown`, `getTrustedBalancesBreakdown`, `getBalancesByMint`,
+and `getBalanceTotal`. Migrate to `wallet.balances.byMint(scope?)` and
+`wallet.balances.total(scope?)`, which return structured `spendable`,
+`reserved`, and `total` values and accept an optional `{ mintUrls, trustedOnly }`
+scope.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -789,7 +789,9 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
       it('should execute a melt operation (may skip swap if exact amount)', async () => {
         const invoice = createFakeInvoice(20);
-        const balanceBefore = await mgr!.wallet.getBalanceBreakdown(mintUrl);
+        const getMintBalance = async () =>
+          (await mgr!.wallet.balances.byMint({ mintUrls: [mintUrl] }))[mintUrl]!;
+        const balanceBefore = await getMintBalance();
         const prepared = await mgr!.ops.melt.prepare({
           mintUrl,
           method: 'bolt11',
@@ -799,7 +801,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(prepared.quoteId).toBeDefined();
         expect(prepared.amount).toBeGreaterThan(0);
 
-        const balanceAfterPrepare = await mgr!.wallet.getBalanceBreakdown(mintUrl);
+        const balanceAfterPrepare = await getMintBalance();
         expect(balanceAfterPrepare.reserved).toBeGreaterThan(0);
         expect(balanceAfterPrepare.total).toBe(balanceBefore.total);
 
@@ -815,7 +817,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           throw new Error(`Expected finalized melt result, got ${result.state}`);
         }
 
-        const balanceAfterExecute = await mgr!.wallet.getBalanceBreakdown(mintUrl);
+        const balanceAfterExecute = await getMintBalance();
         const expectedTotal =
           balanceBefore.total - result.amount - result.swap_fee - result.effectiveFee!;
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -216,25 +216,11 @@ In-memory reference implementations are provided under `repositories/memory/` fo
 - `receive(token: Token | string): Promise<void>`
 - `balances.byMint(scope?: { mintUrls?: string[]; trustedOnly?: boolean }): Promise<BalancesByMint>`
 - `balances.total(scope?: { mintUrls?: string[]; trustedOnly?: boolean }): Promise<BalanceSnapshot>`
-- `getBalancesByMint(scope?: { mintUrls?: string[]; trustedOnly?: boolean }): Promise<BalancesByMint>`
-- `getBalanceTotal(scope?: { mintUrls?: string[]; trustedOnly?: boolean }): Promise<BalanceSnapshot>`
 - `restore(mintUrl: string): Promise<void>`
 - `sweep(mintUrl: string, bip39seed: Uint8Array): Promise<void>`
 - `decodeToken(tokenString: string, mintUrl?: string): Promise<Token>`
 - `encodeToken(token: Token, opts?: { version?: 3 | 4 }): string`
 - `encodePaymentRequest(paymentRequest: PaymentRequest, version?: 'creqA' | 'creqB'): string`
-
-Compatibility helpers retained for callers that want scalar values:
-
-- `getBalance(mintUrl: string): Promise<number>`
-- `getBalances(): Promise<{ [mintUrl: string]: number }>`
-- `getTrustedBalances(): Promise<{ [mintUrl: string]: number }>`
-- `getSpendableBalance(mintUrl: string): Promise<number>`
-- `getSpendableBalances(): Promise<{ [mintUrl: string]: number }>`
-- `getTrustedSpendableBalances(): Promise<{ [mintUrl: string]: number }>`
-- `getBalanceBreakdown(mintUrl: string): Promise<BalanceBreakdown>` legacy alias for `ready/reserved/total`
-- `getBalancesBreakdown(): Promise<BalancesBreakdownByMint>` legacy alias for `ready/reserved/total`
-- `getTrustedBalancesBreakdown(): Promise<BalancesBreakdownByMint>` legacy alias for `ready/reserved/total`
 
 ### AuthApi
 

--- a/packages/core/api/WalletApi.ts
+++ b/packages/core/api/WalletApi.ts
@@ -12,13 +12,6 @@ import type {
   TransactionService,
   TokenService,
 } from '@core/services';
-import type {
-  BalanceBreakdown,
-  BalanceQuery,
-  BalanceSnapshot,
-  BalancesBreakdownByMint,
-  BalancesByMint,
-} from '../types';
 import type { ReceiveOperationService } from '../operations/receive/ReceiveOperationService';
 import type { Logger } from '../logging/Logger.ts';
 import { WalletBalancesApi } from './WalletBalancesApi.ts';
@@ -63,50 +56,6 @@ export class WalletApi {
    */
   async receive(token: Token | string): Promise<void> {
     return this.receiveOperationService.receive(token);
-  }
-
-  async getBalance(mintUrl: string): Promise<number> {
-    return this.proofService.getBalance(mintUrl);
-  }
-
-  async getBalances(): Promise<{ [mintUrl: string]: number }> {
-    return this.proofService.getBalances();
-  }
-
-  async getTrustedBalances(): Promise<{ [mintUrl: string]: number }> {
-    return this.proofService.getTrustedBalances();
-  }
-
-  async getSpendableBalance(mintUrl: string): Promise<number> {
-    return this.proofService.getSpendableBalance(mintUrl);
-  }
-
-  async getSpendableBalances(): Promise<{ [mintUrl: string]: number }> {
-    return this.proofService.getSpendableBalances();
-  }
-
-  async getTrustedSpendableBalances(): Promise<{ [mintUrl: string]: number }> {
-    return this.proofService.getTrustedSpendableBalances();
-  }
-
-  async getBalanceBreakdown(mintUrl: string): Promise<BalanceBreakdown> {
-    return this.proofService.getBalanceBreakdown(mintUrl);
-  }
-
-  async getBalancesBreakdown(): Promise<BalancesBreakdownByMint> {
-    return this.proofService.getBalancesBreakdown();
-  }
-
-  async getTrustedBalancesBreakdown(): Promise<BalancesBreakdownByMint> {
-    return this.proofService.getTrustedBalancesBreakdown();
-  }
-
-  async getBalancesByMint(scope?: BalanceQuery): Promise<BalancesByMint> {
-    return this.proofService.getBalancesByMint(scope);
-  }
-
-  async getBalanceTotal(scope?: BalanceQuery): Promise<BalanceSnapshot> {
-    return this.proofService.getBalanceTotal(scope);
   }
 
   // Restoration logic is delegated to WalletRestoreService

--- a/packages/core/test/unit/WalletApi.test.ts
+++ b/packages/core/test/unit/WalletApi.test.ts
@@ -152,14 +152,6 @@ describe('WalletApi - Trust Enforcement', () => {
         reserved: 5,
         total: 15,
       });
-      await expect(walletApi.getBalancesByMint()).resolves.toEqual({
-        [testMintUrl]: { spendable: 10, reserved: 5, total: 15 },
-      });
-      await expect(walletApi.getBalanceTotal()).resolves.toEqual({
-        spendable: 10,
-        reserved: 5,
-        total: 15,
-      });
     });
 
     it('should reject tokens from untrusted mints', async () => {

--- a/packages/docs/starting/migrating-from-alpha.md
+++ b/packages/docs/starting/migrating-from-alpha.md
@@ -127,21 +127,23 @@ Breaking `WalletApi` balance changes:
 
 - Alpha balance APIs only exposed scalar totals such as
   `wallet.getBalance(mintUrl)` and `wallet.getBalances()`
-- The current release line keeps those scalar helpers, but also adds a
-  canonical structured balance surface so apps can distinguish `spendable`,
-  `reserved`, and `total`
-- The preferred structured entrypoints are:
-  `wallet.balances.byMint(scope?)`,
-  `wallet.balances.total(scope?)`,
-  `wallet.getBalancesByMint(scope?)`, and
-  `wallet.getBalanceTotal(scope?)`
-- `wallet.getSpendableBalance()`,
-  `wallet.getSpendableBalances()`, and
-  `wallet.getTrustedSpendableBalances()` are explicit opt-in helpers for the
-  narrower spendable-only view
-- `wallet.getBalanceBreakdown()`, `wallet.getBalancesBreakdown()`, and
-  `wallet.getTrustedBalancesBreakdown()` still exist as legacy compatibility
-  aliases using the older `ready/reserved/total` naming
+- v1 standardizes on a single structured balance surface so apps can
+  distinguish `spendable`, `reserved`, and `total`
+- Use these entrypoints:
+  `wallet.balances.byMint(scope?)` and
+  `wallet.balances.total(scope?)`
+- All scalar and breakdown helpers are removed, including
+  `wallet.getBalance()`,
+  `wallet.getBalances()`,
+  `wallet.getTrustedBalances()`,
+  `wallet.getSpendableBalance()`,
+  `wallet.getSpendableBalances()`,
+  `wallet.getTrustedSpendableBalances()`,
+  `wallet.getBalanceBreakdown()`,
+  `wallet.getBalancesBreakdown()`,
+  `wallet.getTrustedBalancesBreakdown()`,
+  `wallet.getBalancesByMint()`, and
+  `wallet.getBalanceTotal()`
 
 Use these forms after migrating:
 
@@ -159,11 +161,6 @@ await manager.ops.melt.prepare({
 const balancesByMint = await manager.wallet.balances.byMint();
 const trustedBalancesByMint = await manager.wallet.balances.byMint({ trustedOnly: true });
 const total = await manager.wallet.balances.total();
-
-// compatibility helpers still exist if you only want totals
-const balance = await manager.wallet.getBalance(mintUrl);
-const balances = await manager.wallet.getBalances();
-const trustedBalances = await manager.wallet.getTrustedBalances();
 ```
 
 Notes:

--- a/packages/docs/starting/migrating-from-alpha.md
+++ b/packages/docs/starting/migrating-from-alpha.md
@@ -125,10 +125,9 @@ Removed `WalletApi` compatibility wrappers:
 
 Breaking `WalletApi` balance changes:
 
-- Alpha balance APIs only exposed scalar totals such as
-  `wallet.getBalance(mintUrl)` and `wallet.getBalances()`
-- v1 standardizes on a single structured balance surface so apps can
-  distinguish `spendable`, `reserved`, and `total`
+- Alpha exposed only scalar balance totals; v1 removes them in favor of a
+  single structured balance surface that distinguishes `spendable`,
+  `reserved`, and `total`
 - Use these entrypoints:
   `wallet.balances.byMint(scope?)` and
   `wallet.balances.total(scope?)`


### PR DESCRIPTION
## Summary
- remove deprecated `WalletApi` balance helper methods and keep `wallet.balances.*` as the canonical balance API
- update adapter tests and migration docs to use the structured balance surface
- remove obsolete balance helper references from the core README and `WalletApi` unit coverage

## Why
Legacy balance helper aliases were still exposed and documented after the structured balance API became the standard surface. This change removes the deprecated helpers so the public API, tests, and migration guidance all describe the same interface.

## Impact
- consumers should use `wallet.balances.byMint()` and `wallet.balances.total()`
- scalar and breakdown helper calls on `WalletApi` are no longer available

## Validation
- targeted build, typecheck, and test runs passed for the affected packages