### PR TITLE
chore: align package entry metadata

### DIFF
--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@cashu/coco-adapter-tests",
-  "module": "index.ts",
   "version": "1.0.0-rc.5",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@cashu/coco-core",
   "version": "1.0.0-rc.5",
   "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "module": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/cashubtc/coco",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "docs",
-  "module": "index.ts",
   "type": "module",
   "private": true,
   "peerDependencies": {

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@cashu/coco-expo-sqlite",
   "version": "1.0.0-rc.5",
-  "module": "index.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@cashu/coco-indexeddb",
   "version": "1.0.0-rc.5",
-  "module": "index.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@cashu/coco-react",
   "version": "1.0.0-rc.5",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/sqlite-bun/package.json
+++ b/packages/sqlite-bun/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@cashu/coco-sqlite-bun",
   "version": "1.0.0-rc.5",
-  "module": "index.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/sqlite3/package.json
+++ b/packages/sqlite3/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@cashu/coco-sqlite",
   "version": "1.0.0-rc.5",
-  "module": "index.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed
- point published package entry fields at built `dist` artifacts instead of source `index.ts` files
- normalize `module` entries to `dist/index.js` where the build emits `.js`
- add missing `main` and `types` fields for packages that publish build output
- remove the stray `module` field from the private docs package

## Why
Several package manifests were still advertising source files or outdated output filenames. That leaves the published metadata out of sync with the actual build artifacts and can break consumer resolution depending on the toolchain.

## Impact
Consumers of the published packages get consistent `main` / `module` / `types` metadata that matches the generated files.

## Validation
- `bun run build`