### PR TITLE
chore: add topological build script for automatic dependency ordering

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - 'packages/**'
       - 'scripts/build.ts'
+      - 'package.json'
       - '.github/workflows/build-packages.yml'
   pull_request:
     paths:
       - 'packages/**'
       - 'scripts/build.ts'
+      - 'package.json'
       - '.github/workflows/build-packages.yml'
 
 jobs:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -28,21 +28,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build packages in dependency order
-        run: |
-          # Build core first (base dependency)
-          cd packages/core && bun run build && cd ../..
-
-          # Build adapter-tests (depends on core)
-          cd packages/adapter-tests && bun run build && cd ../..
-
-          # Build storage adapters (depend on core and adapter-tests)
-          cd packages/indexeddb && bun run build && cd ../..
-          cd packages/expo-sqlite && bun run build && cd ../..
-          cd packages/sqlite3 && bun run build && cd ../..
-          cd packages/sqlite-bun && bun run build && cd ../..
-
-          # Build react (depends on core)
-          cd packages/react && bun run build && cd ../..
+        run: bun run build
 
       - name: Typecheck packages in dependency order
         run: bun run typecheck

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -6,10 +6,12 @@ on:
       - master
     paths:
       - 'packages/**'
+      - 'scripts/build.ts'
       - '.github/workflows/build-packages.yml'
   pull_request:
     paths:
       - 'packages/**'
+      - 'scripts/build.ts'
       - '.github/workflows/build-packages.yml'
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "@changesets/cli": "^2.29.8"
   },
   "scripts": {
-    "build": "bun run --filter='@cashu/coco-core' build && bun run --filter='@cashu/coco-adapter-tests' build && bun run --filter='@cashu/coco-indexeddb' build && bun run --filter='@cashu/coco-expo-sqlite' build && bun run --filter='@cashu/coco-sqlite' build && bun run --filter='@cashu/coco-sqlite-bun' build && bun run --filter='@cashu/coco-react' build",
-    "typecheck": "bun run --filter='@cashu/coco-core' typecheck && bun run --filter='@cashu/coco-adapter-tests' typecheck && bun run --filter='@cashu/coco-indexeddb' typecheck && bun run --filter='@cashu/coco-expo-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite-bun' typecheck && bun run --filter='@cashu/coco-react' typecheck",
-    "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
-    "docs:dev": "vitepress dev packages/docs",
-    "docs:build": "vitepress build packages/docs",
-    "docs:preview": "vitepress preview packages/docs",
-    "format": "prettier . --write",
-    "format:check": "prettier . --check"
-  }
+  "build": "bun scripts/build.ts",
+  "typecheck": "bun run --filter='@cashu/coco-core' typecheck && bun run --filter='@cashu/coco-adapter-tests' typecheck && bun run --filter='@cashu/coco-indexeddb' typecheck && bun run --filter='@cashu/coco-expo-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite-bun' typecheck && bun run --filter='@cashu/coco-react' typecheck",
+  "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
+  "docs:dev": "vitepress dev packages/docs",
+  "docs:build": "vitepress build packages/docs",
+  "docs:preview": "vitepress preview packages/docs",
+  "format": "prettier . --write",
+  "format:check": "prettier . --check"
+}
 }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "@changesets/cli": "^2.29.8"
   },
   "scripts": {
-  "build": "bun scripts/build.ts",
-  "typecheck": "bun run --filter='@cashu/coco-core' typecheck && bun run --filter='@cashu/coco-adapter-tests' typecheck && bun run --filter='@cashu/coco-indexeddb' typecheck && bun run --filter='@cashu/coco-expo-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite-bun' typecheck && bun run --filter='@cashu/coco-react' typecheck",
-  "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
-  "docs:dev": "vitepress dev packages/docs",
-  "docs:build": "vitepress build packages/docs",
-  "docs:preview": "vitepress preview packages/docs",
-  "format": "prettier . --write",
-  "format:check": "prettier . --check"
-}
+    "build": "bun scripts/build.ts",
+    "typecheck": "bun run --filter='@cashu/coco-core' typecheck && bun run --filter='@cashu/coco-adapter-tests' typecheck && bun run --filter='@cashu/coco-indexeddb' typecheck && bun run --filter='@cashu/coco-expo-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite-bun' typecheck && bun run --filter='@cashu/coco-react' typecheck",
+    "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
+    "docs:dev": "vitepress dev packages/docs",
+    "docs:build": "vitepress build packages/docs",
+    "docs:preview": "vitepress preview packages/docs",
+    "format": "prettier . --write",
+    "format:check": "prettier . --check"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "@changesets/cli": "^2.29.8"
   },
   "scripts": {
-    "build": "bun scripts/build.ts",
-    "typecheck": "bun run --filter='@cashu/coco-core' typecheck && bun run --filter='@cashu/coco-adapter-tests' typecheck && bun run --filter='@cashu/coco-indexeddb' typecheck && bun run --filter='@cashu/coco-expo-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite' typecheck && bun run --filter='@cashu/coco-sqlite-bun' typecheck && bun run --filter='@cashu/coco-react' typecheck",
+    "build": "bun scripts/build.ts build",
+    "typecheck": "bun scripts/build.ts typecheck",
     "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
     "docs:dev": "vitepress dev packages/docs",
     "docs:build": "vitepress build packages/docs",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+
+const PACKAGES_DIR = new URL('../packages', import.meta.url).pathname;
+
+type PackageJson = {
+  name: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+async function readPackageJson(packageDir: string): Promise<PackageJson | null> {
+  try {
+    const file = Bun.file(`${PACKAGES_DIR}/${packageDir}/package.json`);
+    return await file.json();
+  } catch {
+    return null;
+  }
+}
+
+function getInternalDeps(pkg: PackageJson): string[] {
+  // peerDependencies define the real build-time requirements
+  // "I need X to exist before I can be used"
+  const buildDeps = {
+    ...pkg.peerDependencies,
+  };
+  return Object.keys(buildDeps).filter((dep) => dep.startsWith('coco-cashu-'));
+}
+
+function topologicalSort(packages: Map<string, string[]>): string[] {
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const result: string[] = [];
+
+  function visit(name: string) {
+    if (visited.has(name)) return;
+    if (visiting.has(name)) {
+      throw new Error(`Circular dependency detected at ${name}`);
+    }
+    visiting.add(name);
+    const deps = packages.get(name) ?? [];
+    for (const dep of deps) {
+      if (packages.has(dep)) {
+        visit(dep);
+      }
+    }
+    visiting.delete(name);
+    visited.add(name);
+    result.push(name);
+  }
+
+  // Sort by number of dependencies first so nodes with no deps are visited first
+  const sorted = [...packages.keys()].sort((a, b) => {
+    return (packages.get(a)?.length ?? 0) - (packages.get(b)?.length ?? 0);
+  });
+
+  for (const name of sorted) {
+    visit(name);
+  }
+
+  return result;
+}
+
+async function main() {
+  const glob = new Bun.Glob('*/package.json');
+  const packageMap = new Map<string, PackageJson>();
+  const nameToDir = new Map<string, string>();
+
+  for await (const file of glob.scan(PACKAGES_DIR)) {
+    const dir = file.split('/')[0];
+    const pkg = await readPackageJson(dir);
+    if (!pkg?.name) continue;
+    if (!pkg.scripts?.build) continue;
+    packageMap.set(pkg.name, pkg);
+    nameToDir.set(pkg.name, dir);
+  }
+
+  // Build dependency graph (only internal deps)
+  const depGraph = new Map<string, string[]>();
+  for (const [name, pkg] of packageMap) {
+    const internalDeps = getInternalDeps(pkg).filter((dep) => packageMap.has(dep));
+    depGraph.set(name, internalDeps);
+  }
+
+  const buildOrder = topologicalSort(depGraph);
+
+  console.log('Build order:');
+  buildOrder.forEach((name, i) => console.log(`  ${i + 1}. ${name}`));
+  console.log('');
+
+  for (const name of buildOrder) {
+    const dir = nameToDir.get(name)!;
+    console.log(`Building ${name}...`);
+    const result = Bun.spawnSync(['bun', 'run', 'build'], {
+      cwd: `${PACKAGES_DIR}/${dir}`,
+      stdout: 'inherit',
+      stderr: 'inherit',
+    });
+    if (result.exitCode !== 0) {
+      console.error(`Failed to build ${name}`);
+      process.exit(1);
+    }
+    console.log(`✓ ${name} built successfully\n`);
+  }
+}
+
+main();

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -25,7 +25,7 @@ function getInternalDeps(pkg: PackageJson): string[] {
   const buildDeps = {
     ...pkg.peerDependencies,
   };
-  return Object.keys(buildDeps).filter((dep) => dep.startsWith('coco-cashu-'));
+  return Object.keys(buildDeps).filter((dep) => dep.startsWith('@cashu/coco-'));
 }
 
 function topologicalSort(packages: Map<string, string[]>): string[] {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,8 +20,19 @@ async function readPackageJson(packageDir: string): Promise<PackageJson | null> 
 }
 
 function getInternalDeps(pkg: PackageJson): string[] {
-  // peerDependencies define the real build-time requirements
-  // "I need X to exist before I can be used"
+  // Build order is derived from peerDependencies only.
+  //
+  // We intentionally exclude devDependencies because they create a circular
+  // relationship in this repo (core <-> adapter-tests):
+  //   - core devDepends on adapter-tests for integration tests
+  //   - adapter-tests devDepends on core to build
+  //
+  // peerDependencies alone produce the correct build order for all current
+  // packages since every package that imports another internal package
+  // declares it as a peerDependency.
+  //
+  // Convention: new packages with build-time dependencies on internal
+  // packages MUST declare them as peerDependencies.
   const buildDeps = {
     ...pkg.peerDependencies,
   };
@@ -63,6 +74,14 @@ function topologicalSort(packages: Map<string, string[]>): string[] {
 }
 
 async function main() {
+  // Accept command argument: 'build' or 'typecheck'
+  // Defaults to 'build' if not specified
+  const command = process.argv[2] ?? 'build';
+  if (command !== 'build' && command !== 'typecheck') {
+    console.error(`Unknown command: ${command}. Use 'build' or 'typecheck'`);
+    process.exit(1);
+  }
+
   const glob = new Bun.Glob('*/package.json');
   const packageMap = new Map<string, PackageJson>();
   const nameToDir = new Map<string, string>();
@@ -71,37 +90,38 @@ async function main() {
     const dir = file.split('/')[0];
     const pkg = await readPackageJson(dir);
     if (!pkg?.name) continue;
-    if (!pkg.scripts?.build) continue;
+    // Skip packages that don't have the requested script
+    if (!pkg.scripts?.[command]) continue;
     packageMap.set(pkg.name, pkg);
     nameToDir.set(pkg.name, dir);
   }
 
-  // Build dependency graph (only internal deps)
+  // Build dependency graph
   const depGraph = new Map<string, string[]>();
   for (const [name, pkg] of packageMap) {
     const internalDeps = getInternalDeps(pkg).filter((dep) => packageMap.has(dep));
     depGraph.set(name, internalDeps);
   }
 
-  const buildOrder = topologicalSort(depGraph);
+  const order = topologicalSort(depGraph);
 
-  console.log('Build order:');
-  buildOrder.forEach((name, i) => console.log(`  ${i + 1}. ${name}`));
+  console.log(`${command} order:`);
+  order.forEach((name, i) => console.log(`  ${i + 1}. ${name}`));
   console.log('');
 
-  for (const name of buildOrder) {
+  for (const name of order) {
     const dir = nameToDir.get(name)!;
-    console.log(`Building ${name}...`);
-    const result = Bun.spawnSync(['bun', 'run', 'build'], {
+    console.log(`Running ${command} for ${name}...`);
+    const result = Bun.spawnSync(['bun', 'run', command], {
       cwd: `${PACKAGES_DIR}/${dir}`,
       stdout: 'inherit',
       stderr: 'inherit',
     });
     if (result.exitCode !== 0) {
-      console.error(`Failed to build ${name}`);
+      console.error(`Failed to ${command} ${name}`);
       process.exit(1);
     }
-    console.log(`✓ ${name} built successfully\n`);
+    console.log(`✓ ${name} ${command} successful\n`);
   }
 }
 


### PR DESCRIPTION
Closes #73

## Problem

The build scripts were manually ordered and brittle:
- Order hardcoded in both `package.json` and `.github/workflows/build-packages.yml`
- Adding a new package requires manually updating both files
- Easy to get wrong order and break builds

## Solution

Added `scripts/build.ts` — a Bun script that:
1. Reads all `package.json` files in `packages/`
2. Builds a dependency graph from `peerDependencies`
3. Sorts packages topologically (dependencies build first)
4. Executes builds in correct order automatically

## Changes

- `scripts/build.ts` — new topological build script
- `package.json` — simplified build script to `bun scripts/build.ts`
- `.github/workflows/build-packages.yml` — simplified to `bun run build`

## Build order output