### PR TITLE
fix(react): keep receive hook subscriptions bound

### DIFF
--- a/.changeset/few-kiwis-listen.md
+++ b/.changeset/few-kiwis-listen.md
@@ -1,0 +1,10 @@
+---
+'@cashu/coco-react': patch
+---
+
+Fix `useReceiveOperation` so it subscribes to manager events with a bound
+`Manager.on` call, preventing the hook from crashing when receive operation
+listeners are registered.
+
+Add a regression test that uses a `Manager.on` mock with real `this` semantics
+so detached invocation failures are caught in the React hook test suite.

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -149,6 +149,37 @@ function createReceiveManagerMock() {
   };
 }
 
+function createReceiveManagerWithBoundOnMock() {
+  const receive = {
+    prepare: vi.fn(),
+    execute: vi.fn(),
+    get: vi.fn(),
+    listPrepared: vi.fn(),
+    listInFlight: vi.fn(),
+    refresh: vi.fn(),
+    cancel: vi.fn(),
+  };
+  const eventBus = createEventBusMock();
+  type EventBusMock = ReturnType<typeof createEventBusMock>;
+  const manager = {
+    ops: { receive },
+    eventBus,
+    on(
+      this: { eventBus: EventBusMock },
+      event: string,
+      handler: (payload: unknown) => void | Promise<void>,
+    ) {
+      return this.eventBus.on(event, handler);
+    },
+  } as unknown as Manager & { eventBus: EventBusMock };
+
+  return {
+    manager,
+    receive,
+    emit: eventBus.emit,
+  };
+}
+
 function createMintManagerMock() {
   const mint = {
     prepare: vi.fn(),
@@ -885,6 +916,32 @@ describe('useReceiveOperation', () => {
     });
 
     expect(result.current.currentOperation).toEqual(finalized);
+  });
+
+  it('subscribes to receive events without detaching manager.on', async () => {
+    const { manager, receive, emit } = createReceiveManagerWithBoundOnMock();
+    const loaded = createPreparedReceiveOperation({ id: 'receive-op-bound-on' });
+    const finalized = createFinalizedReceiveOperation({ id: loaded.id });
+
+    receive.get.mockResolvedValueOnce(loaded);
+
+    const { result } = renderHook(() => useReceiveOperation(loaded.id), {
+      wrapper: createHookWrapper(manager),
+    });
+
+    await waitForAssertion(() => {
+      expect(result.current.currentOperation).toEqual(loaded);
+    });
+
+    await emit('receive-op:finalized', {
+      mintUrl: loaded.mintUrl,
+      operationId: loaded.id,
+      operation: finalized,
+    });
+
+    await waitForAssertion(() => {
+      expect(result.current.currentOperation).toEqual(finalized);
+    });
   });
 
   it('rejects prepare when the hook is already bound to a receive operation', async () => {

--- a/packages/react/src/lib/hooks/useReceiveOperation.ts
+++ b/packages/react/src/lib/hooks/useReceiveOperation.ts
@@ -14,11 +14,6 @@ import {
 } from './operationHookUtils';
 
 type ReceiveOps = Manager['ops']['receive'];
-type ReceiveOperationEventName =
-  | 'receive-op:prepared'
-  | 'receive-op:finalized'
-  | 'receive-op:rolled-back';
-type ReceiveOperationEventPayload = { operation: ReceiveOperation };
 
 export type ReceiveOperationPrepareInput = Parameters<ReceiveOps['prepare']>[0];
 export type ReceiveOperationPrepareResult = Awaited<ReturnType<ReceiveOps['prepare']>>;
@@ -120,26 +115,15 @@ export function useReceiveOperation(
   useInitialOperationHydration(initialBindingRef.current, hydrateInitialOperation);
 
   useEffect(() => {
-    const onReceiveOperationEvent = manager.on as (
-      event: ReceiveOperationEventName,
-      handler: (payload: ReceiveOperationEventPayload) => void | Promise<void>,
-    ) => () => void;
-
-    const unsubscribePrepared = onReceiveOperationEvent('receive-op:prepared', ({ operation }) => {
+    const unsubscribePrepared = manager.on('receive-op:prepared', ({ operation }) => {
       handleObservedOperation(operation);
     });
-    const unsubscribeFinalized = onReceiveOperationEvent(
-      'receive-op:finalized',
-      ({ operation }) => {
-        handleObservedOperation(operation);
-      },
-    );
-    const unsubscribeRolledBack = onReceiveOperationEvent(
-      'receive-op:rolled-back',
-      ({ operation }) => {
-        handleObservedOperation(operation);
-      },
-    );
+    const unsubscribeFinalized = manager.on('receive-op:finalized', ({ operation }) => {
+      handleObservedOperation(operation);
+    });
+    const unsubscribeRolledBack = manager.on('receive-op:rolled-back', ({ operation }) => {
+      handleObservedOperation(operation);
+    });
 
     return () => {
       unsubscribePrepared();


### PR DESCRIPTION
## Description

This pull request fixes a React receive-operation hook crash caused by registering manager event listeners through a detached `Manager.on` reference.

## Problem

`useReceiveOperation` extracted `manager.on` into a local function before subscribing to receive operation events. Since `Manager.on` is an instance method that uses `this.eventBus`, that detached call lost its binding and could fail as soon as the hook mounted and tried to register listeners.

## Summary

- update `useReceiveOperation` to subscribe with direct `manager.on(...)` calls, matching the other React hooks
- add a regression test that uses a `Manager.on` mock with real `this` semantics so detached invocation failures are caught
- add `.changeset/few-kiwis-listen.md` for a patch release of `@cashu/coco-react`

## Verification

- `bun run test -- src/lib/hooks/operationHooks.test.tsx`
- `bun run typecheck`

## Changeset

- added `.changeset/few-kiwis-listen.md` for `@cashu/coco-react` patch release