### PR TITLE
feat(agents): add repo-specific release workflow skills

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -66,7 +66,8 @@ stops before pushing the commit and tag to `origin`.
   `bunx changeset version`.
 - It validates that every package in the fixed release group shares the same
   version, checks that the derived release tag is ahead of the latest repo tag,
-  and prints shell-ready variables such as `NEW_RELEASE_TAG`.
+  detects whether the latest release tag is signed, and prints shell-ready
+  variables such as `NEW_RELEASE_TAG`.
 
 ## Workflow
 
@@ -121,12 +122,14 @@ to skip the push step while still creating the local release commit and tag.
 
    ```bash
    eval "$(.agents/skills/cut-release/scripts/derive-release-metadata.sh)"
-   printf '%s\n' "$NEW_PACKAGE_VERSION" "$NEW_RELEASE_TAG" "$COMMIT_MESSAGE"
+   printf '%s\n' \
+     "$NEW_PACKAGE_VERSION" "$NEW_RELEASE_TAG" "$LAST_TAG_SIGNED" "$COMMIT_MESSAGE"
    ```
 
    The script exports:
    - `LAST_TAG`
    - `LAST_TAG_TYPE`
+   - `LAST_TAG_SIGNED`
    - `NEW_PACKAGE_VERSION`
    - `NEW_RELEASE_TAG`
    - `COMMIT_MESSAGE`
@@ -160,7 +163,14 @@ to skip the push step while still creating the local release commit and tag.
    git cat-file -t "refs/tags/$LAST_TAG"
    ```
 
-   If the latest tag is an annotated tag object, create an annotated tag:
+   If the latest tag is a signed annotated tag object, create a signed tag:
+
+   ```bash
+   git tag -s "$NEW_RELEASE_TAG" -m "$NEW_RELEASE_TAG"
+   ```
+
+   If the latest tag is an unsigned annotated tag object, create an unsigned
+   annotated tag:
 
    ```bash
    git tag -a "$NEW_RELEASE_TAG" -m "$NEW_RELEASE_TAG"
@@ -172,15 +182,15 @@ to skip the push step while still creating the local release commit and tag.
    git tag "$NEW_RELEASE_TAG"
    ```
 
-   In the current repo state, annotated tags are expected.
+   In the current repo state, signed annotated tags are expected. Preserve that
+   style when `LAST_TAG_TYPE=tag` and `LAST_TAG_SIGNED=true`.
 
 10. Finish in normal mode or dry-run mode.
 
 Normal mode:
 
 ```bash
-git push origin master
-git push origin "$NEW_RELEASE_TAG"
+git push --atomic origin master "refs/tags/$NEW_RELEASE_TAG"
 ```
 
 Dry-run mode: stop before pushing and show the local result instead.

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -82,16 +82,7 @@ to skip the push step while still creating the local release commit and tag.
 
    If the tree is not clean, stop.
 
-2. Confirm there are pending changesets to consume.
-
-   ```bash
-   find .changeset -maxdepth 1 -type f -name '*.md' \
-     ! -name 'README.md' | sort
-   ```
-
-   If this is empty, stop rather than creating a no-op version commit.
-
-3. Confirm this worktree is already on `master`.
+2. Confirm this worktree is already on `master`.
 
    ```bash
    git branch --show-current
@@ -101,7 +92,7 @@ to skip the push step while still creating the local release commit and tag.
    release from a dedicated `master` worktree rather than switching branches in
    place.
 
-4. Sync `master` to the remote release base.
+3. Sync `master` to the remote release base.
 
    ```bash
    git fetch origin master --tags
@@ -110,6 +101,15 @@ to skip the push step while still creating the local release commit and tag.
    ```
 
    If `master` cannot fast-forward cleanly, stop and surface the conflict.
+
+4. Confirm there are pending changesets to consume from the synced release base.
+
+   ```bash
+   find .changeset -maxdepth 1 -type f -name '*.md' \
+     ! -name 'README.md' | sort
+   ```
+
+   If this is empty, stop rather than creating a no-op version commit.
 
 5. Apply the pending changesets.
 

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: cut-release
-description: Cut a coco release from master by fast-forwarding master, running `bunx changeset version`, verifying the fixed package versions and changelogs, deriving the release commit/tag name from the latest repo tag, committing the versioned files, creating the tag, and pushing both the commit and tag.
+description: Cut a coco release from a dedicated `master` worktree by fast-forwarding `master`, running `bunx changeset version`, verifying the fixed package versions and changelogs, deriving the release commit/tag name from the latest repo tag, committing the versioned files, creating the tag, and pushing both the commit and tag.
 ---
 
 # Cut Release
 
 ## Purpose
 
-Run the git-side release flow for `cashubtc/coco` from `master`:
+Run the git-side release flow for `cashubtc/coco` from a dedicated `master`
+worktree:
 sync `master` with `origin/master`, apply pending changesets, verify the fixed
 release group was bumped together, derive the release commit/tag name from the
 latest repo tag, commit the versioned files, create the release tag, and push
@@ -31,6 +32,12 @@ stops before pushing the commit and tag to `origin`.
 
 - Start from a clean worktree. If `git status -sb` shows changes, stop and tell
   the user instead of trying to carry local edits through the release.
+- Do not switch a feature worktree to `master` just to cut the release. This
+  repo commonly uses one worktree per feature branch, so repurposing the
+  current worktree can fail or disturb ongoing work.
+- If the current branch is not `master`, stop and tell the user to rerun the
+  release from a dedicated `master` worktree, or create one only if the user
+  explicitly asks you to do that.
 - Use non-interactive git commands only.
 - Networked git commands often need escalation. Request approval for `git fetch`,
   `git pull`, and `git push` when sandboxing blocks them.
@@ -84,24 +91,33 @@ to skip the push step while still creating the local release commit and tag.
 
    If this is empty, stop rather than creating a no-op version commit.
 
-3. Sync `master` to the remote release base.
+3. Confirm this worktree is already on `master`.
+
+   ```bash
+   git branch --show-current
+   ```
+
+   If the current branch is not `master`, stop and tell the user to rerun the
+   release from a dedicated `master` worktree rather than switching branches in
+   place.
+
+4. Sync `master` to the remote release base.
 
    ```bash
    git fetch origin master --tags
-   git checkout master
    git pull --ff-only origin master
    git status -sb
    ```
 
    If `master` cannot fast-forward cleanly, stop and surface the conflict.
 
-4. Apply the pending changesets.
+5. Apply the pending changesets.
 
    ```bash
    bunx changeset version
    ```
 
-5. Validate the release metadata and derive the release tag.
+6. Validate the release metadata and derive the release tag.
 
    ```bash
    eval "$(.agents/skills/cut-release/scripts/derive-release-metadata.sh)"
@@ -109,14 +125,13 @@ to skip the push step while still creating the local release commit and tag.
    ```
 
    The script exports:
-
    - `LAST_TAG`
    - `LAST_TAG_TYPE`
    - `NEW_PACKAGE_VERSION`
    - `NEW_RELEASE_TAG`
    - `COMMIT_MESSAGE`
 
-6. Verify the versioned files look right before committing.
+7. Verify the versioned files look right before committing.
 
    ```bash
    git diff --name-only
@@ -124,21 +139,20 @@ to skip the push step while still creating the local release commit and tag.
    ```
 
    Expect versioning changes in:
-
    - `.changeset/` including consumed changeset deletions and `pre.json`
    - `packages/*/package.json`
    - `packages/*/CHANGELOG.md`
 
    If unrelated files changed, stop and inspect before committing.
 
-7. Commit the versioning output with the repo’s release commit format.
+8. Commit the versioning output with the repo’s release commit format.
 
    ```bash
    git add .changeset packages/*/package.json packages/*/CHANGELOG.md
    git commit -m "$COMMIT_MESSAGE"
    ```
 
-8. Reuse the latest tag style.
+9. Reuse the latest tag style.
 
    Inspect the latest tag object type:
 
@@ -160,29 +174,29 @@ to skip the push step while still creating the local release commit and tag.
 
    In the current repo state, annotated tags are expected.
 
-9. Finish in normal mode or dry-run mode.
+10. Finish in normal mode or dry-run mode.
 
-   Normal mode:
+Normal mode:
 
-   ```bash
-   git push origin master
-   git push origin "$NEW_RELEASE_TAG"
-   ```
+```bash
+git push origin master
+git push origin "$NEW_RELEASE_TAG"
+```
 
-   Dry-run mode: stop before pushing and show the local result instead.
+Dry-run mode: stop before pushing and show the local result instead.
 
-   ```bash
-   git status -sb
-   git log --decorate --oneline -1
-   git show --stat --decorate --no-patch HEAD
-   git tag --list "$NEW_RELEASE_TAG"
-   ```
+```bash
+git status -sb
+git log --decorate --oneline -1
+git show --stat --decorate --no-patch HEAD
+git tag --list "$NEW_RELEASE_TAG"
+```
 
-10. Report the release result.
+11. Report the release result.
 
-   Include the new package version, new tag, commit SHA, and whether you pushed
-   or intentionally stopped in dry-run mode. If any step was skipped or
-   blocked, say so plainly.
+Include the new package version, new tag, commit SHA, and whether you pushed
+or intentionally stopped in dry-run mode. If any step was skipped or
+blocked, say so plainly.
 
 ## Notes
 

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: cut-release
+description: Cut a coco release from master by fast-forwarding master, running `bunx changeset version`, verifying the fixed package versions and changelogs, deriving the release commit/tag name from the latest repo tag, committing the versioned files, creating the tag, and pushing both the commit and tag.
+---
+
+# Cut Release
+
+## Purpose
+
+Run the git-side release flow for `cashubtc/coco` from `master`:
+sync `master` with `origin/master`, apply pending changesets, verify the fixed
+release group was bumped together, derive the release commit/tag name from the
+latest repo tag, commit the versioned files, create the release tag, and push
+both the branch update and the tag.
+
+This skill does not create a GitHub Release. In this repo, npm publishing is
+handled later by `.github/workflows/publish.yml` when a GitHub release is
+created.
+
+It also supports a dry-run mode that performs the same local release steps but
+stops before pushing the commit and tag to `origin`.
+
+## When to Trigger
+
+- The user asks to cut, version, tag, or push a repo release.
+- The user asks for a release dry run, preview, rehearsal, or `--dry-run`.
+- Use it after the release-worthy changes are already merged and the repo has
+  pending changesets ready to version.
+
+## Safety
+
+- Start from a clean worktree. If `git status -sb` shows changes, stop and tell
+  the user instead of trying to carry local edits through the release.
+- Use non-interactive git commands only.
+- Networked git commands often need escalation. Request approval for `git fetch`,
+  `git pull`, and `git push` when sandboxing blocks them.
+- Do not create an empty release. If there are no pending changeset markdown
+  files under `.changeset/` other than repo metadata like `README.md`, stop.
+- In dry-run mode, still create the local release commit and tag. Only the push
+  step is skipped.
+
+## Repo-specific facts
+
+- Changesets is configured with `baseBranch: "master"` in `.changeset/config.json`.
+- Published packages are released as one fixed group:
+  `@cashu/coco-core`, `@cashu/coco-indexeddb`, `@cashu/coco-expo-sqlite`,
+  `@cashu/coco-sqlite`, `@cashu/coco-sqlite-bun`,
+  `@cashu/coco-adapter-tests`, and `@cashu/coco-react`.
+- Recent release commits use `version: <tag>`.
+- Recent release tags use the annotated `stable-v<major>.RC<rc>` format, for
+  example `stable-v1.RC3`.
+- Package manifests currently use semver prerelease versions like
+  `1.0.0-rc.3`. The helper script below maps that package version to the repo
+  tag format and refuses to guess if the tag scheme changes.
+
+## Bundled helper
+
+- Run `.agents/skills/cut-release/scripts/derive-release-metadata.sh` after
+  `bunx changeset version`.
+- It validates that every package in the fixed release group shares the same
+  version, checks that the derived release tag is ahead of the latest repo tag,
+  and prints shell-ready variables such as `NEW_RELEASE_TAG`.
+
+## Workflow
+
+Before running the steps below, decide whether the user requested dry-run mode.
+Treat `dry run`, `dry-run`, `--dry-run`, `preview`, or `rehearsal` as a request
+to skip the push step while still creating the local release commit and tag.
+
+1. Confirm the worktree is clean.
+
+   ```bash
+   git status -sb
+   ```
+
+   If the tree is not clean, stop.
+
+2. Confirm there are pending changesets to consume.
+
+   ```bash
+   find .changeset -maxdepth 1 -type f -name '*.md' \
+     ! -name 'README.md' | sort
+   ```
+
+   If this is empty, stop rather than creating a no-op version commit.
+
+3. Sync `master` to the remote release base.
+
+   ```bash
+   git fetch origin master --tags
+   git checkout master
+   git pull --ff-only origin master
+   git status -sb
+   ```
+
+   If `master` cannot fast-forward cleanly, stop and surface the conflict.
+
+4. Apply the pending changesets.
+
+   ```bash
+   bunx changeset version
+   ```
+
+5. Validate the release metadata and derive the release tag.
+
+   ```bash
+   eval "$(.agents/skills/cut-release/scripts/derive-release-metadata.sh)"
+   printf '%s\n' "$NEW_PACKAGE_VERSION" "$NEW_RELEASE_TAG" "$COMMIT_MESSAGE"
+   ```
+
+   The script exports:
+
+   - `LAST_TAG`
+   - `LAST_TAG_TYPE`
+   - `NEW_PACKAGE_VERSION`
+   - `NEW_RELEASE_TAG`
+   - `COMMIT_MESSAGE`
+
+6. Verify the versioned files look right before committing.
+
+   ```bash
+   git diff --name-only
+   git diff --stat
+   ```
+
+   Expect versioning changes in:
+
+   - `.changeset/` including consumed changeset deletions and `pre.json`
+   - `packages/*/package.json`
+   - `packages/*/CHANGELOG.md`
+
+   If unrelated files changed, stop and inspect before committing.
+
+7. Commit the versioning output with the repo’s release commit format.
+
+   ```bash
+   git add .changeset packages/*/package.json packages/*/CHANGELOG.md
+   git commit -m "$COMMIT_MESSAGE"
+   ```
+
+8. Reuse the latest tag style.
+
+   Inspect the latest tag object type:
+
+   ```bash
+   git cat-file -t "refs/tags/$LAST_TAG"
+   ```
+
+   If the latest tag is an annotated tag object, create an annotated tag:
+
+   ```bash
+   git tag -a "$NEW_RELEASE_TAG" -m "$NEW_RELEASE_TAG"
+   ```
+
+   If the latest tag points directly at a commit, use a lightweight tag instead:
+
+   ```bash
+   git tag "$NEW_RELEASE_TAG"
+   ```
+
+   In the current repo state, annotated tags are expected.
+
+9. Finish in normal mode or dry-run mode.
+
+   Normal mode:
+
+   ```bash
+   git push origin master
+   git push origin "$NEW_RELEASE_TAG"
+   ```
+
+   Dry-run mode: stop before pushing and show the local result instead.
+
+   ```bash
+   git status -sb
+   git log --decorate --oneline -1
+   git show --stat --decorate --no-patch HEAD
+   git tag --list "$NEW_RELEASE_TAG"
+   ```
+
+10. Report the release result.
+
+   Include the new package version, new tag, commit SHA, and whether you pushed
+   or intentionally stopped in dry-run mode. If any step was skipped or
+   blocked, say so plainly.
+
+## Notes
+
+- Do not rewrite history or amend older release commits unless the user
+  explicitly asks.
+- If the helper script fails because the tag format changed, stop and inspect
+  the latest release tag manually instead of inventing a new naming scheme.
+- A dry run leaves the local `master` branch one release commit ahead with the
+  new local tag present. Do not clean that up unless the user explicitly asks.

--- a/.agents/skills/cut-release/agents/openai.yaml
+++ b/.agents/skills/cut-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Cut Release'
+  short_description: 'Version, tag, and push a coco release from master'
+  default_prompt: 'Use $cut-release to sync master, run changeset version, verify the coco package version bump, derive the release tag from the latest repo tag, commit the release, create the tag, and either push both or stop before push in dry-run mode.'

--- a/.agents/skills/cut-release/agents/openai.yaml
+++ b/.agents/skills/cut-release/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'Cut Release'
   short_description: 'Version, tag, and push a coco release from master'
-  default_prompt: 'Use $cut-release to sync master, run changeset version, verify the coco package version bump, derive the release tag from the latest repo tag, commit the release, create the tag, and either push both or stop before push in dry-run mode.'
+  default_prompt: 'Use $cut-release to sync master, run changeset version, verify the coco package version bump, derive the release tag from the latest repo tag, commit the release, preserve the latest tag signing style, and either atomically push both refs or stop before push in dry-run mode.'

--- a/.agents/skills/cut-release/scripts/derive-release-metadata.sh
+++ b/.agents/skills/cut-release/scripts/derive-release-metadata.sh
@@ -40,6 +40,11 @@ fi
 new_package_version="$unique_versions"
 last_tag="$(git describe --tags --abbrev=0)"
 last_tag_type="$(git cat-file -t "refs/tags/$last_tag" 2>/dev/null || echo commit)"
+last_tag_signed=false
+if [[ "$last_tag_type" == "tag" ]] && \
+  grep -q -- 'BEGIN .* SIGNATURE' < <(git cat-file -p "refs/tags/$last_tag"); then
+  last_tag_signed=true
+fi
 
 if [[ "$new_package_version" =~ ^([0-9]+)\.0\.0-rc\.([0-9]+)$ ]]; then
   new_major="${BASH_REMATCH[1]}"
@@ -69,6 +74,7 @@ commit_message="version: $new_release_tag"
 
 printf 'LAST_TAG=%q\n' "$last_tag"
 printf 'LAST_TAG_TYPE=%q\n' "$last_tag_type"
+printf 'LAST_TAG_SIGNED=%q\n' "$last_tag_signed"
 printf 'NEW_PACKAGE_VERSION=%q\n' "$new_package_version"
 printf 'NEW_RELEASE_TAG=%q\n' "$new_release_tag"
 printf 'COMMIT_MESSAGE=%q\n' "$commit_message"

--- a/.agents/skills/cut-release/scripts/derive-release-metadata.sh
+++ b/.agents/skills/cut-release/scripts/derive-release-metadata.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${1:-$(pwd)}"
+cd "$ROOT_DIR"
+
+package_files=(
+  "packages/core/package.json"
+  "packages/indexeddb/package.json"
+  "packages/expo-sqlite/package.json"
+  "packages/sqlite3/package.json"
+  "packages/sqlite-bun/package.json"
+  "packages/adapter-tests/package.json"
+  "packages/react/package.json"
+)
+
+versions=()
+for file in "${package_files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing package manifest: $file" >&2
+    exit 1
+  fi
+
+  version="$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)",/\1/p' "$file" | head -n 1)"
+  if [[ -z "$version" ]]; then
+    echo "Could not read version from $file" >&2
+    exit 1
+  fi
+  versions+=("$version")
+done
+
+unique_versions="$(printf '%s\n' "${versions[@]}" | sort -u)"
+unique_count="$(printf '%s\n' "$unique_versions" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "$unique_count" != "1" ]]; then
+  echo "Fixed release group does not share one version:" >&2
+  printf '%s\n' "$unique_versions" >&2
+  exit 1
+fi
+
+new_package_version="$unique_versions"
+last_tag="$(git describe --tags --abbrev=0)"
+last_tag_type="$(git cat-file -t "refs/tags/$last_tag" 2>/dev/null || echo commit)"
+
+if [[ "$new_package_version" =~ ^([0-9]+)\.0\.0-rc\.([0-9]+)$ ]]; then
+  new_major="${BASH_REMATCH[1]}"
+  new_rc="${BASH_REMATCH[2]}"
+else
+  echo "Unsupported package version format: $new_package_version" >&2
+  exit 1
+fi
+
+if [[ "$last_tag" =~ ^stable-v([0-9]+)\.RC([0-9]+)$ ]]; then
+  last_major="${BASH_REMATCH[1]}"
+  last_rc="${BASH_REMATCH[2]}"
+else
+  echo "Unsupported repo tag format: $last_tag" >&2
+  exit 1
+fi
+
+new_release_tag="stable-v${new_major}.RC${new_rc}"
+
+if (( new_major < last_major )) || \
+  (( new_major == last_major && new_rc <= last_rc )); then
+  echo "Derived release tag $new_release_tag is not ahead of latest tag $last_tag" >&2
+  exit 1
+fi
+
+commit_message="version: $new_release_tag"
+
+printf 'LAST_TAG=%q\n' "$last_tag"
+printf 'LAST_TAG_TYPE=%q\n' "$last_tag_type"
+printf 'NEW_PACKAGE_VERSION=%q\n' "$new_package_version"
+printf 'NEW_RELEASE_TAG=%q\n' "$new_release_tag"
+printf 'COMMIT_MESSAGE=%q\n' "$commit_message"


### PR DESCRIPTION
  ## Description

  This pull request adds a coco-specific cut-release skill and tightens
  the PR draft helper so release and PR automation follow this repo’s
  master-based workflow.

  ## Summary

  - Adds a cut-release skill for syncing master, running Changesets
    versioning, deriving the repo release tag, committing, tagging, and
    pushing or stopping in dry-run mode.
  - Requires release runs from a dedicated master worktree instead of
    repurposing a feature worktree.
  - Moves the pending changeset check after master is synced so stale
    local worktrees do not produce false no-op releases.
  - Updates the PR draft skill to default PR summaries against origin/
    master instead of a feature branch upstream.