### PR TITLE
fix(core): prevent duplicate plugin initialization

### DIFF
--- a/.changeset/fix-plugin-initialization-idempotency.md
+++ b/.changeset/fix-plugin-initialization-idempotency.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': patch
+---
+
+Prevent plugins from initializing twice through `initializeCoco()`, and make
+plugin lifecycle hooks idempotent across repeated or concurrent init and ready
+calls.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -310,7 +310,6 @@ export class Manager {
     };
     this.eventBus.on('auth-session:updated', clearWalletCache);
     this.eventBus.on('auth-session:deleted', clearWalletCache);
-
   }
 
   on<E extends keyof CoreEvents>(

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -311,33 +311,6 @@ export class Manager {
     this.eventBus.on('auth-session:updated', clearWalletCache);
     this.eventBus.on('auth-session:deleted', clearWalletCache);
 
-    // Initialize plugins asynchronously to keep constructor sync
-    const services: ServiceMap = {
-      mintService: this.mintService,
-      walletService: this.walletService,
-      proofService: this.proofService,
-      keyRingService: this.keyRingService,
-      seedService: this.seedService,
-      walletRestoreService: this.walletRestoreService,
-      counterService: this.counterService,
-      meltQuoteService: this.meltQuoteService,
-      historyService: this.historyService,
-      sendOperationService: this.sendOperationService,
-      receiveOperationService: this.receiveOperationService,
-      paymentRequestService: this.paymentRequestService,
-      meltOperationService: this.meltOperationService,
-      mintOperationService: this.mintOperationService,
-      tokenService: this.tokenService,
-      subscriptions: this.subscriptions,
-      eventBus: this.eventBus,
-      logger: this.logger,
-    };
-    void this.pluginHost
-      .init(services)
-      .then(() => this.pluginHost.ready())
-      .catch((err) => {
-        this.logger.error('Plugin system initialization failed', err);
-      });
   }
 
   on<E extends keyof CoreEvents>(

--- a/packages/core/plugins/PluginHost.ts
+++ b/packages/core/plugins/PluginHost.ts
@@ -5,6 +5,10 @@ export class PluginHost {
   private readonly plugins: Plugin[] = [];
   private readonly cleanups: Array<() => void | Promise<void>> = [];
   private readonly extensions: Record<string, unknown> = {};
+  private readonly initializedPlugins = new WeakSet<Plugin>();
+  private readonly readyPlugins = new WeakSet<Plugin>();
+  private readonly initPromises = new WeakMap<Plugin, Promise<void>>();
+  private readonly readyPromises = new WeakMap<Plugin, Promise<void>>();
   private services?: ServiceMap;
   private initialized = false;
   private readyPhase = false;
@@ -12,8 +16,11 @@ export class PluginHost {
   use(plugin: Plugin): void {
     this.plugins.push(plugin);
     if (this.initialized && this.services) {
-      void this.runInit(plugin, this.services);
-      if (this.readyPhase) void this.runReady(plugin, this.services);
+      const services = this.services;
+      const initPromise = this.ensureInitialized(plugin, services);
+      if (this.readyPhase) {
+        void initPromise.then(() => this.ensureReady(plugin, services));
+      }
     }
   }
 
@@ -21,7 +28,7 @@ export class PluginHost {
     this.services = services;
     this.initialized = true;
     for (const p of this.plugins) {
-      await this.runInit(p, services);
+      await this.ensureInitialized(p, services);
     }
   }
 
@@ -29,7 +36,7 @@ export class PluginHost {
     if (!this.services) return;
     this.readyPhase = true;
     for (const p of this.plugins) {
-      await this.runReady(p, this.services);
+      await this.ensureReady(p, this.services);
     }
   }
 
@@ -63,6 +70,49 @@ export class PluginHost {
    */
   getExtensions(): Record<string, unknown> {
     return this.extensions;
+  }
+
+  private async ensureInitialized(plugin: Plugin, services: ServiceMap): Promise<void> {
+    if (this.initializedPlugins.has(plugin)) return;
+
+    const existing = this.initPromises.get(plugin);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const promise = this.runInit(plugin, services)
+      .then(() => {
+        this.initializedPlugins.add(plugin);
+      })
+      .finally(() => {
+        this.initPromises.delete(plugin);
+      });
+
+    this.initPromises.set(plugin, promise);
+    await promise;
+  }
+
+  private async ensureReady(plugin: Plugin, services: ServiceMap): Promise<void> {
+    await this.ensureInitialized(plugin, services);
+    if (this.readyPlugins.has(plugin)) return;
+
+    const existing = this.readyPromises.get(plugin);
+    if (existing) {
+      await existing;
+      return;
+    }
+
+    const promise = this.runReady(plugin, services)
+      .then(() => {
+        this.readyPlugins.add(plugin);
+      })
+      .finally(() => {
+        this.readyPromises.delete(plugin);
+      });
+
+    this.readyPromises.set(plugin, promise);
+    await promise;
   }
 
   private async runInit(plugin: Plugin, services: ServiceMap): Promise<void> {

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -88,6 +88,38 @@ describe('initializeCoco', () => {
       await manager.disableProofStateWatcher();
       await manager.disableMintOperationProcessor();
     });
+
+    it('should initialize plugins once before returning', async () => {
+      const counters = { init: 0, ready: 0 };
+      const extension = { ok: true };
+
+      const manager = await initializeCoco({
+        ...baseConfig,
+        plugins: [
+          {
+            name: 'plugin-init',
+            required: [],
+            onInit: (ctx) => {
+              counters.init += 1;
+              ctx.registerExtension('pluginInit', extension);
+            },
+            onReady: () => {
+              counters.ready += 1;
+            },
+          },
+        ],
+        watchers: {
+          mintOperationWatcher: { disabled: true },
+          proofStateWatcher: { disabled: true },
+        },
+        processors: {
+          mintOperationProcessor: { disabled: true },
+        },
+      });
+
+      expect(counters).toEqual({ init: 1, ready: 1 });
+      expect((manager.ext as Record<string, unknown>).pluginInit).toBe(extension);
+    });
   });
 
   describe('watchers configuration', () => {

--- a/packages/core/test/unit/PluginHost.test.ts
+++ b/packages/core/test/unit/PluginHost.test.ts
@@ -71,6 +71,50 @@ describe('PluginHost', () => {
     expect(order).toEqual(['init', 'ready']);
   });
 
+  it('does not rerun hooks when init and ready are called repeatedly', async () => {
+    const calls = { init: 0, ready: 0 };
+    const plugin: Plugin<['logger']> = {
+      name: 'idempotent',
+      required: ['logger'],
+      onInit: () => {
+        calls.init += 1;
+      },
+      onReady: () => {
+        calls.ready += 1;
+      },
+    };
+
+    host.use(plugin);
+    await host.init(services);
+    await host.init(services);
+    await host.ready();
+    await host.ready();
+
+    expect(calls).toEqual({ init: 1, ready: 1 });
+  });
+
+  it('coalesces concurrent init and ready calls', async () => {
+    const calls = { init: 0, ready: 0 };
+    const plugin: Plugin<['logger']> = {
+      name: 'concurrent',
+      required: ['logger'],
+      onInit: async () => {
+        calls.init += 1;
+        await Promise.resolve();
+      },
+      onReady: async () => {
+        calls.ready += 1;
+        await Promise.resolve();
+      },
+    };
+
+    host.use(plugin);
+    await Promise.all([host.init(services), host.init(services)]);
+    await Promise.all([host.ready(), host.ready()]);
+
+    expect(calls).toEqual({ init: 1, ready: 1 });
+  });
+
   it('supports only return-style cleanup from onInit', async () => {
     const flags = { cleaned: 0 };
     const plugin: Plugin<['logger']> = {
@@ -123,22 +167,29 @@ describe('PluginHost', () => {
 
   it('late registration after init+ready runs both hooks', async () => {
     const order: string[] = [];
+    let resolveReady!: () => void;
+    const readyPromise = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+
     await host.init(services);
     await host.ready();
     const plugin: Plugin<['logger']> = {
       name: 'late',
       required: ['logger'],
-      onInit: () => {
+      onInit: async () => {
         order.push('init');
+        await Promise.resolve();
       },
       onReady: () => {
         order.push('ready');
+        resolveReady();
       },
     };
+
     host.use(plugin);
-    // hooks execute automatically on use()
-    // give microtask queue a tick to settle any async voids
-    await Promise.resolve();
+    await readyPromise;
+
     expect(order).toEqual(['init', 'ready']);
   });
 


### PR DESCRIPTION
This pull request fixes plugin startup so `initializeCoco()` is the single awaited owner of initial plugin lifecycle execution, then hardens `PluginHost` against repeated or concurrent lifecycle calls.

## Problem

Plugins could run `onInit` and `onReady` twice because the `Manager` constructor started plugin initialization asynchronously while `initializeCoco()` also awaited `initPlugins()`. Plugins registering extensions could fail with duplicate extension keys, and side-effectful plugins could duplicate listeners, timers, or clients.

## Summary

- Removed constructor-started plugin initialization from `Manager`.
- Added Manager regression coverage for one-time plugin initialization and extension registration.
- Added per-plugin init/ready tracking and in-flight promise coalescing in `PluginHost`.
- Added repeated, concurrent, and late-registration lifecycle tests.
- Added `.changeset/fix-plugin-initialization-idempotency.md` for `@cashu/coco-core`.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/PluginHost.test.ts test/unit/Manager.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`

## Changeset

- Added `.changeset/fix-plugin-initialization-idempotency.md`