### PR TITLE
fix: repair SQLite migration compatibility

### DIFF
--- a/.changeset/quiet-mirrors-repair.md
+++ b/.changeset/quiet-mirrors-repair.md
@@ -1,0 +1,8 @@
+---
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+---
+
+Repair SQLite migration compatibility for databases that were opened by adapters with swapped
+send/receive operation migration IDs.

--- a/.github/workflows/expo-sqlite-integration-tests.yml
+++ b/.github/workflows/expo-sqlite-integration-tests.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build local test dependencies
+        run: |
+          cd packages/core && bun run build && cd ../..
+          cd packages/adapter-tests && bun run build && cd ../..
+
       - name: Run expo-sqlite local adapter tests
         run: |
           cd packages/expo-sqlite

--- a/.github/workflows/expo-sqlite-integration-tests.yml
+++ b/.github/workflows/expo-sqlite-integration-tests.yml
@@ -24,5 +24,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Run expo-sqlite local adapter tests
+        run: |
+          cd packages/expo-sqlite
+          bun test \
+            src/test/MintOperationRepository.test.ts \
+            src/test/SendOperationRepository.test.ts \
+            src/test/MeltOperationRepository.test.ts \
+            src/test/contract.test.ts \
+            src/test/schema.test.ts
+
       - name: Run expo-sqlite integration tests
         run: ./scripts/test-integration.sh expo-sqlite

--- a/.github/workflows/sqlite-bun-integration-tests.yml
+++ b/.github/workflows/sqlite-bun-integration-tests.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build local test dependencies
+        run: |
+          cd packages/core && bun run build && cd ../..
+          cd packages/adapter-tests && bun run build && cd ../..
+
       - name: Run sqlite-bun local adapter tests
         run: |
           cd packages/sqlite-bun

--- a/.github/workflows/sqlite-bun-integration-tests.yml
+++ b/.github/workflows/sqlite-bun-integration-tests.yml
@@ -24,5 +24,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Run sqlite-bun local adapter tests
+        run: |
+          cd packages/sqlite-bun
+          bun test \
+            src/test/MintOperationRepository.test.ts \
+            src/test/SendOperationRepository.test.ts \
+            src/test/MeltOperationRepository.test.ts \
+            src/test/contract.test.ts \
+            src/test/schema.test.ts
+
       - name: Run sqlite-bun integration tests
         run: ./scripts/test-integration.sh sqlite-bun

--- a/.github/workflows/sqlite3-integration-tests.yml
+++ b/.github/workflows/sqlite3-integration-tests.yml
@@ -24,5 +24,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Run sqlite3 local adapter tests
+        run: |
+          cd packages/sqlite3
+          bun run vitest run \
+            src/test/MintOperationRepository.test.ts \
+            src/test/SendOperationRepository.test.ts \
+            src/test/MeltOperationRepository.test.ts \
+            src/test/contract.test.ts \
+            src/test/schema.test.ts
+
       - name: Run sqlite3 integration tests
         run: ./scripts/test-integration.sh sqlite3

--- a/.github/workflows/sqlite3-integration-tests.yml
+++ b/.github/workflows/sqlite3-integration-tests.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build local test dependencies
+        run: |
+          cd packages/core && bun run build && cd ../..
+          cd packages/adapter-tests && bun run build && cd ../..
+
       - name: Run sqlite3 local adapter tests
         run: |
           cd packages/sqlite3

--- a/packages/expo-sqlite/src/schema.ts
+++ b/packages/expo-sqlite/src/schema.ts
@@ -7,6 +7,74 @@ interface Migration {
   run?: (db: ExpoSqliteDb) => Promise<void>;
 }
 
+type TableInfoRow = {
+  name: string;
+};
+
+const SEND_OPERATION_METHOD_MIGRATION_IDS = [
+  '012_send_operations_method',
+  '013_send_operations_method',
+] as const;
+
+const RECEIVE_OPERATION_MIGRATION_IDS = [
+  '013_receive_operations',
+  '012_receive_operations',
+] as const;
+
+async function tableExists(db: ExpoSqliteDb, tableName: string): Promise<boolean> {
+  const row = await db.get<{ name: string }>(
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    [tableName],
+  );
+
+  return !!row;
+}
+
+async function getTableColumns(db: ExpoSqliteDb, tableName: string): Promise<Set<string>> {
+  const rows = await db.all<TableInfoRow>(`PRAGMA table_info(${tableName})`);
+  return new Set(rows.map((row) => row.name));
+}
+
+async function insertMigrationIds(db: ExpoSqliteDb, ids: readonly string[]): Promise<void> {
+  const appliedAt = getUnixTimeSeconds();
+
+  for (const id of ids) {
+    await db.run('INSERT OR IGNORE INTO coco_cashu_migrations (id, appliedAt) VALUES (?, ?)', [
+      id,
+      appliedAt,
+    ]);
+  }
+}
+
+async function addSendOperationMethodColumns(db: ExpoSqliteDb): Promise<void> {
+  const columns = await getTableColumns(db, 'coco_cashu_send_operations');
+
+  if (!columns.has('method')) {
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default'`,
+    );
+  }
+
+  if (!columns.has('methodDataJson')) {
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}'`,
+    );
+  }
+}
+
+async function reconcileMigrationAliases(db: ExpoSqliteDb): Promise<void> {
+  if (await tableExists(db, 'coco_cashu_send_operations')) {
+    const sendColumns = await getTableColumns(db, 'coco_cashu_send_operations');
+    if (sendColumns.has('method') && sendColumns.has('methodDataJson')) {
+      await insertMigrationIds(db, SEND_OPERATION_METHOD_MIGRATION_IDS);
+    }
+  }
+
+  if (await tableExists(db, 'coco_cashu_receive_operations')) {
+    await insertMigrationIds(db, RECEIVE_OPERATION_MIGRATION_IDS);
+  }
+}
+
 const MIGRATIONS: readonly Migration[] = [
   {
     id: '001_initial',
@@ -309,10 +377,7 @@ const MIGRATIONS: readonly Migration[] = [
   },
   {
     id: '012_send_operations_method',
-    sql: `
-      ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default';
-      ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}';
-    `,
+    run: addSendOperationMethodColumns,
   },
   {
     id: '013_receive_operations',
@@ -573,6 +638,8 @@ export async function ensureSchemaUpTo(db: ExpoSqliteDb, stopBeforeId?: string):
     );
   `);
 
+  await reconcileMigrationAliases(db);
+
   const appliedRows = await db.all<{ id: string }>(
     'SELECT id FROM coco_cashu_migrations ORDER BY id ASC',
   );
@@ -597,4 +664,6 @@ export async function ensureSchemaUpTo(db: ExpoSqliteDb, stopBeforeId?: string):
       ]);
     });
   }
+
+  await reconcileMigrationAliases(db);
 }

--- a/packages/expo-sqlite/src/test/schema.test.ts
+++ b/packages/expo-sqlite/src/test/schema.test.ts
@@ -1,0 +1,184 @@
+/// <reference types="bun" />
+
+// @ts-ignore bun:test types are provided by the test runner in this workspace.
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+// @ts-ignore bun:sqlite types are provided by the runtime in this workspace.
+import { Database } from 'bun:sqlite';
+import { ExpoSqliteDb, ensureSchemaUpTo } from '../index.ts';
+import type { ExpoSqliteDbOptions } from '../db.ts';
+
+type RunResult = { changes: number; lastInsertRowId: number; lastInsertRowid: number };
+
+class BunExpoSqliteDatabaseShim {
+  private readonly db: Database;
+
+  constructor(filename = ':memory:') {
+    this.db = new Database(filename);
+  }
+
+  async execAsync(sql: string): Promise<void> {
+    const statements = sql
+      .split(';')
+      .map((statement) => statement.trim())
+      .filter(Boolean);
+
+    for (const statementSql of statements) {
+      this.db.prepare(statementSql).run();
+    }
+  }
+
+  async runAsync(sql: string, ...params: any[]): Promise<RunResult> {
+    const result = this.db.prepare(sql).run(...params) as unknown as {
+      changes?: number;
+      lastInsertRowid?: number;
+    };
+
+    const changes = Number(result?.changes ?? 0);
+    const lastInsertRowId = Number(result?.lastInsertRowid ?? 0);
+    return { changes, lastInsertRowId, lastInsertRowid: lastInsertRowId };
+  }
+
+  async getFirstAsync<T = unknown>(sql: string, ...params: any[]): Promise<T | null> {
+    const row = this.db.prepare(sql).get(...params) as T | undefined;
+    return row ?? null;
+  }
+
+  async getAllAsync<T = unknown>(sql: string, ...params: any[]): Promise<T[]> {
+    const rows = this.db.prepare(sql).all(...params) as T[] | undefined;
+    return rows ?? [];
+  }
+
+  async closeAsync(): Promise<void> {
+    this.db.close();
+  }
+}
+
+const RECEIVE_OPERATIONS_SQL = `
+  CREATE TABLE IF NOT EXISTS coco_cashu_receive_operations (
+    id TEXT PRIMARY KEY,
+    mintUrl TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('init', 'prepared', 'executing', 'finalized', 'rolled_back')),
+    createdAt INTEGER NOT NULL,
+    updatedAt INTEGER NOT NULL,
+    error TEXT,
+    fee INTEGER,
+    inputProofsJson TEXT NOT NULL,
+    outputDataJson TEXT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_coco_cashu_receive_operations_state
+    ON coco_cashu_receive_operations(state);
+  CREATE INDEX IF NOT EXISTS idx_coco_cashu_receive_operations_mint
+    ON coco_cashu_receive_operations(mintUrl);
+`;
+
+async function getMigrationIds(db: ExpoSqliteDb): Promise<string[]> {
+  const rows = await db.all<{ id: string }>('SELECT id FROM coco_cashu_migrations ORDER BY id ASC');
+
+  return rows.map((row) => row.id);
+}
+
+async function getColumnNames(db: ExpoSqliteDb, tableName: string): Promise<string[]> {
+  const rows = await db.all<{ name: string }>(`PRAGMA table_info(${tableName})`);
+
+  return rows.map((row) => row.name);
+}
+
+describe('expo-sqlite schema migrations', () => {
+  let database: BunExpoSqliteDatabaseShim;
+  let db: ExpoSqliteDb;
+
+  beforeEach(() => {
+    database = new BunExpoSqliteDatabaseShim();
+    db = new ExpoSqliteDb({
+      database: database as unknown as ExpoSqliteDbOptions['database'],
+    });
+  });
+
+  afterEach(async () => {
+    await database.closeAsync();
+  });
+
+  it('accepts databases with old sqlite-bun swapped migration ids', async () => {
+    await ensureSchemaUpTo(db, '012_send_operations_method');
+    await db.exec(RECEIVE_OPERATIONS_SQL);
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default'`,
+    );
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}'`,
+    );
+    await db.run('INSERT INTO coco_cashu_migrations (id, appliedAt) VALUES (?, ?)', [
+      '012_receive_operations',
+      1,
+    ]);
+    await db.run('INSERT INTO coco_cashu_migrations (id, appliedAt) VALUES (?, ?)', [
+      '013_send_operations_method',
+      1,
+    ]);
+
+    await ensureSchemaUpTo(db);
+
+    expect(await getMigrationIds(db)).toEqual(
+      expect.arrayContaining([
+        '012_send_operations_method',
+        '013_send_operations_method',
+        '012_receive_operations',
+        '013_receive_operations',
+      ]),
+    );
+  });
+
+  it('continues old sqlite-bun databases stopped after receive operations', async () => {
+    await ensureSchemaUpTo(db, '012_send_operations_method');
+    await db.exec(RECEIVE_OPERATIONS_SQL);
+    await db.run('INSERT INTO coco_cashu_migrations (id, appliedAt) VALUES (?, ?)', [
+      '012_receive_operations',
+      1,
+    ]);
+
+    await ensureSchemaUpTo(db);
+
+    expect(await getColumnNames(db, 'coco_cashu_send_operations')).toEqual(
+      expect.arrayContaining(['method', 'methodDataJson', 'tokenJson']),
+    );
+    expect(await getColumnNames(db, 'coco_cashu_receive_operations')).toEqual(
+      expect.arrayContaining(['unit']),
+    );
+    expect(await getMigrationIds(db)).toEqual(
+      expect.arrayContaining([
+        '012_send_operations_method',
+        '013_send_operations_method',
+        '012_receive_operations',
+        '013_receive_operations',
+      ]),
+    );
+  });
+
+  it('backfills legacy aliases for canonical databases', async () => {
+    await ensureSchemaUpTo(db);
+
+    expect(await getMigrationIds(db)).toEqual(
+      expect.arrayContaining([
+        '012_send_operations_method',
+        '013_send_operations_method',
+        '012_receive_operations',
+        '013_receive_operations',
+      ]),
+    );
+  });
+
+  it('adds only missing send method columns for partial schemas', async () => {
+    await ensureSchemaUpTo(db, '012_send_operations_method');
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default'`,
+    );
+
+    await ensureSchemaUpTo(db);
+
+    expect(await getColumnNames(db, 'coco_cashu_send_operations')).toEqual(
+      expect.arrayContaining(['method', 'methodDataJson']),
+    );
+  });
+});

--- a/packages/sqlite-bun/src/schema.ts
+++ b/packages/sqlite-bun/src/schema.ts
@@ -7,6 +7,74 @@ interface Migration {
   run?: (db: SqliteDb) => Promise<void>;
 }
 
+type TableInfoRow = {
+  name: string;
+};
+
+const SEND_OPERATION_METHOD_MIGRATION_IDS = [
+  '012_send_operations_method',
+  '013_send_operations_method',
+] as const;
+
+const RECEIVE_OPERATION_MIGRATION_IDS = [
+  '013_receive_operations',
+  '012_receive_operations',
+] as const;
+
+async function tableExists(db: SqliteDb, tableName: string): Promise<boolean> {
+  const row = await db.get<{ name: string }>(
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    [tableName],
+  );
+
+  return !!row;
+}
+
+async function getTableColumns(db: SqliteDb, tableName: string): Promise<Set<string>> {
+  const rows = await db.all<TableInfoRow>(`PRAGMA table_info(${tableName})`);
+  return new Set(rows.map((row) => row.name));
+}
+
+async function insertMigrationIds(db: SqliteDb, ids: readonly string[]): Promise<void> {
+  const appliedAt = getUnixTimeSeconds();
+
+  for (const id of ids) {
+    await db.run('INSERT OR IGNORE INTO coco_cashu_migrations (id, appliedAt) VALUES (?, ?)', [
+      id,
+      appliedAt,
+    ]);
+  }
+}
+
+async function addSendOperationMethodColumns(db: SqliteDb): Promise<void> {
+  const columns = await getTableColumns(db, 'coco_cashu_send_operations');
+
+  if (!columns.has('method')) {
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default'`,
+    );
+  }
+
+  if (!columns.has('methodDataJson')) {
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}'`,
+    );
+  }
+}
+
+async function reconcileMigrationAliases(db: SqliteDb): Promise<void> {
+  if (await tableExists(db, 'coco_cashu_send_operations')) {
+    const sendColumns = await getTableColumns(db, 'coco_cashu_send_operations');
+    if (sendColumns.has('method') && sendColumns.has('methodDataJson')) {
+      await insertMigrationIds(db, SEND_OPERATION_METHOD_MIGRATION_IDS);
+    }
+  }
+
+  if (await tableExists(db, 'coco_cashu_receive_operations')) {
+    await insertMigrationIds(db, RECEIVE_OPERATION_MIGRATION_IDS);
+  }
+}
+
 const MIGRATIONS: readonly Migration[] = [
   {
     id: '001_initial',
@@ -308,7 +376,11 @@ const MIGRATIONS: readonly Migration[] = [
     `,
   },
   {
-    id: '012_receive_operations',
+    id: '012_send_operations_method',
+    run: addSendOperationMethodColumns,
+  },
+  {
+    id: '013_receive_operations',
     sql: `
       CREATE TABLE IF NOT EXISTS coco_cashu_receive_operations (
         id TEXT PRIMARY KEY,
@@ -327,13 +399,6 @@ const MIGRATIONS: readonly Migration[] = [
         ON coco_cashu_receive_operations(state);
       CREATE INDEX IF NOT EXISTS idx_coco_cashu_receive_operations_mint
         ON coco_cashu_receive_operations(mintUrl);
-    `,
-  },
-  {
-    id: '013_send_operations_method',
-    sql: `
-      ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default';
-      ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}';
     `,
   },
   {
@@ -579,6 +644,8 @@ export async function ensureSchemaUpTo(db: SqliteDb, stopBeforeId?: string): Pro
     );
   `);
 
+  await reconcileMigrationAliases(db);
+
   const appliedRows = await db.all<{ id: string }>(
     'SELECT id FROM coco_cashu_migrations ORDER BY id ASC',
   );
@@ -602,4 +669,6 @@ export async function ensureSchemaUpTo(db: SqliteDb, stopBeforeId?: string): Pro
       ]);
     });
   }
+
+  await reconcileMigrationAliases(db);
 }

--- a/packages/sqlite3/src/schema.ts
+++ b/packages/sqlite3/src/schema.ts
@@ -7,6 +7,74 @@ interface Migration {
   run?: (db: SqliteDb) => Promise<void>;
 }
 
+type TableInfoRow = {
+  name: string;
+};
+
+const SEND_OPERATION_METHOD_MIGRATION_IDS = [
+  '012_send_operations_method',
+  '013_send_operations_method',
+] as const;
+
+const RECEIVE_OPERATION_MIGRATION_IDS = [
+  '013_receive_operations',
+  '012_receive_operations',
+] as const;
+
+async function tableExists(db: SqliteDb, tableName: string): Promise<boolean> {
+  const row = await db.get<{ name: string }>(
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    [tableName],
+  );
+
+  return !!row;
+}
+
+async function getTableColumns(db: SqliteDb, tableName: string): Promise<Set<string>> {
+  const rows = await db.all<TableInfoRow>(`PRAGMA table_info(${tableName})`);
+  return new Set(rows.map((row) => row.name));
+}
+
+async function insertMigrationIds(db: SqliteDb, ids: readonly string[]): Promise<void> {
+  const appliedAt = getUnixTimeSeconds();
+
+  for (const id of ids) {
+    await db.run('INSERT OR IGNORE INTO coco_cashu_migrations (id, appliedAt) VALUES (?, ?)', [
+      id,
+      appliedAt,
+    ]);
+  }
+}
+
+async function addSendOperationMethodColumns(db: SqliteDb): Promise<void> {
+  const columns = await getTableColumns(db, 'coco_cashu_send_operations');
+
+  if (!columns.has('method')) {
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default'`,
+    );
+  }
+
+  if (!columns.has('methodDataJson')) {
+    await db.run(
+      `ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}'`,
+    );
+  }
+}
+
+async function reconcileMigrationAliases(db: SqliteDb): Promise<void> {
+  if (await tableExists(db, 'coco_cashu_send_operations')) {
+    const sendColumns = await getTableColumns(db, 'coco_cashu_send_operations');
+    if (sendColumns.has('method') && sendColumns.has('methodDataJson')) {
+      await insertMigrationIds(db, SEND_OPERATION_METHOD_MIGRATION_IDS);
+    }
+  }
+
+  if (await tableExists(db, 'coco_cashu_receive_operations')) {
+    await insertMigrationIds(db, RECEIVE_OPERATION_MIGRATION_IDS);
+  }
+}
+
 const MIGRATIONS: readonly Migration[] = [
   {
     id: '001_initial',
@@ -309,10 +377,7 @@ const MIGRATIONS: readonly Migration[] = [
   },
   {
     id: '012_send_operations_method',
-    sql: `
-      ALTER TABLE coco_cashu_send_operations ADD COLUMN method TEXT NOT NULL DEFAULT 'default';
-      ALTER TABLE coco_cashu_send_operations ADD COLUMN methodDataJson TEXT NOT NULL DEFAULT '{}';
-    `,
+    run: addSendOperationMethodColumns,
   },
   {
     id: '013_receive_operations',
@@ -579,6 +644,8 @@ export async function ensureSchemaUpTo(db: SqliteDb, stopBeforeId?: string): Pro
     );
   `);
 
+  await reconcileMigrationAliases(db);
+
   const appliedRows = await db.all<{ id: string }>(
     'SELECT id FROM coco_cashu_migrations ORDER BY id ASC',
   );
@@ -602,4 +669,6 @@ export async function ensureSchemaUpTo(db: SqliteDb, stopBeforeId?: string): Pro
       ]);
     });
   }
+
+  await reconcileMigrationAliases(db);
 }

--- a/packages/sqlite3/src/test/schema.test.ts
+++ b/packages/sqlite3/src/test/schema.test.ts
@@ -1,11 +1,6 @@
-/// <reference types="bun" />
-
-// @ts-ignore bun:test types are provided by the test runner in this workspace.
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-// @ts-ignore bun:sqlite types are provided by the runtime in this workspace.
-import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
 import { SqliteDb, ensureSchemaUpTo } from '../index.ts';
-import { SqliteMintOperationRepository } from '../repositories/MintOperationRepository.ts';
 
 const RECEIVE_OPERATIONS_SQL = `
   CREATE TABLE IF NOT EXISTS coco_cashu_receive_operations (
@@ -39,8 +34,8 @@ async function getColumnNames(db: SqliteDb, tableName: string): Promise<string[]
   return rows.map((row) => row.name);
 }
 
-describe('sqlite-bun schema migrations', () => {
-  let database: Database;
+describe('sqlite3 schema migrations', () => {
+  let database: Database.Database;
   let db: SqliteDb;
 
   beforeEach(() => {
@@ -50,69 +45,6 @@ describe('sqlite-bun schema migrations', () => {
 
   afterEach(async () => {
     await db.close();
-  });
-
-  it('upgrades mint operations to allow failed state persistence', async () => {
-    await ensureSchemaUpTo(db, '020_mint_operations_failed_state');
-
-    await db.run(
-      `INSERT INTO coco_cashu_mint_operations
-        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, outputDataJson)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        'mint-op-1',
-        'https://mint.test',
-        'quote-1',
-        'executing',
-        1,
-        2,
-        null,
-        'bolt11',
-        '{}',
-        100,
-        JSON.stringify({ keep: [], send: [] }),
-      ],
-    );
-
-    await ensureSchemaUpTo(db);
-
-    const repository = new SqliteMintOperationRepository(db);
-    await repository.update({
-      id: 'mint-op-1',
-      mintUrl: 'https://mint.test',
-      quoteId: 'quote-1',
-      state: 'failed',
-      createdAt: 1000,
-      updatedAt: 2000,
-      error: 'quote expired',
-      method: 'bolt11',
-      methodData: {},
-      amount: 100,
-      unit: 'sat',
-      request: 'lnbc1test',
-      expiry: 1_730_000_000,
-      outputData: { keep: [], send: [] },
-    });
-
-    expect(await repository.getById('mint-op-1')).toEqual({
-      id: 'mint-op-1',
-      mintUrl: 'https://mint.test',
-      quoteId: 'quote-1',
-      state: 'failed',
-      createdAt: 1000,
-      updatedAt: expect.any(Number),
-      error: 'quote expired',
-      method: 'bolt11',
-      methodData: {},
-      amount: 100,
-      unit: 'sat',
-      request: 'lnbc1test',
-      expiry: 1_730_000_000,
-      pubkey: undefined,
-      lastObservedRemoteState: undefined,
-      lastObservedRemoteStateAt: undefined,
-      outputData: { keep: [], send: [] },
-    });
   });
 
   it('accepts databases with old sqlite-bun swapped migration ids', async () => {


### PR DESCRIPTION
## Description

This pull request fixes cross-adapter SQLite migration compatibility for databases created by adapters that used swapped send/receive operation migration IDs.

## Problem

`@cashu/coco-sqlite-bun` used different 012/013 migration IDs from `@cashu/coco-sqlite` and `@cashu/coco-expo-sqlite`, so opening the same DB across adapters could rerun `ALTER TABLE ... ADD COLUMN method` and fail with duplicate columns.

## Summary

- Canonicalizes sqlite-bun migration 012/013 order to match the other SQLite adapters.
- Adds schema-driven migration alias reconciliation while preserving legacy swapped IDs.
- Makes the send-operation method migration idempotent.
- Adds focused sqlite-bun and sqlite3 tests for swapped, partial, canonical, and partial-column states.
- Adds `.changeset/quiet-mirrors-repair.md` for the three SQLite adapter packages.

## Verification

- `bun test packages/sqlite-bun/src/test/schema.test.ts`
- `bun run vitest run src/test/schema.test.ts --reporter=verbose` in `packages/sqlite3`
- `bun run --filter='@cashu/coco-sqlite-bun' typecheck`
- `bun run --filter='@cashu/coco-sqlite' typecheck`
- `bun run --filter='@cashu/coco-expo-sqlite' typecheck`
- `bun run --filter='@cashu/coco-sqlite-bun' build`
- `bun run --filter='@cashu/coco-sqlite' build`
- `bun run --filter='@cashu/coco-expo-sqlite' build`
- Real generated-entrypoint handoff checks passed for `sqlite-bun -> sqlite3` and `sqlite3 -> sqlite-bun`.

Note: full sqlite package test commands still hit the existing `MINT_URL is not set` integration guard in this local environment.