### PR TITLE
fix(sqlite): isolate root calls during transactions

### DIFF
--- a/.changeset/sqlite-transaction-isolation.md
+++ b/.changeset/sqlite-transaction-isolation.md
@@ -1,0 +1,8 @@
+---
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-adapter-tests': patch
+---
+
+Serialize root repository operations while SQLite adapter transactions are active.

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -14,6 +14,7 @@ type TransactionFactory<TRepositories extends Repositories = Repositories> = () 
 
 type ContractOptions<TRepositories extends Repositories = Repositories> = {
   createRepositories: TransactionFactory<TRepositories>;
+  testConcurrentRootOperationIsolation?: boolean;
 };
 
 export async function runRepositoryTransactionContract(
@@ -61,6 +62,56 @@ export async function runRepositoryTransactionContract(
         await dispose();
       }
     });
+
+    if (options.testConcurrentRootOperationIsolation) {
+      it('does not include concurrent root repository writes in active transactions', async () => {
+        const { repositories, dispose } = await options.createRepositories();
+        try {
+          const transactionEntered = createDeferred();
+          const releaseTransaction = createDeferred();
+          const mintInTransaction = {
+            ...createDummyMint(),
+            mintUrl: 'https://mint-in-transaction.test',
+          };
+          const outsideMint = {
+            ...createDummyMint(),
+            mintUrl: 'https://outside-mint.test',
+          };
+
+          const transactionPromise = repositories.withTransaction(async (tx) => {
+            await tx.mintRepository.addOrUpdateMint(mintInTransaction);
+            transactionEntered.resolve();
+            await releaseTransaction.promise;
+            throw new Error('rollback transaction');
+          });
+
+          await transactionEntered.promise;
+
+          let outsideWriteResolved = false;
+          const outsideWritePromise = repositories.mintRepository
+            .addOrUpdateMint(outsideMint)
+            .then(() => {
+              outsideWriteResolved = true;
+            });
+
+          await Promise.race([
+            outsideWritePromise,
+            new Promise((resolve) => setTimeout(resolve, 25)),
+          ]);
+          expect(outsideWriteResolved).toBe(false);
+
+          releaseTransaction.resolve();
+          await expectThrows(() => transactionPromise, expect);
+          await outsideWritePromise;
+
+          const mints = await repositories.mintRepository.getAllMints();
+          expect(mints).toHaveLength(1);
+          expect(mints[0]?.mintUrl).toBe(outsideMint.mintUrl);
+        } finally {
+          await dispose();
+        }
+      });
+    }
   });
 }
 
@@ -89,6 +140,16 @@ async function expectThrows(fn: () => Promise<void>, expect: Expectation) {
     didThrow = true;
   }
   expect(didThrow).toBe(true);
+}
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject } as const;
 }
 
 export function createDummyMint(): Mint {

--- a/packages/expo-sqlite/src/db.ts
+++ b/packages/expo-sqlite/src/db.ts
@@ -26,6 +26,8 @@ interface ExpoSqliteDbRootState {
   currentScope: symbol | null;
   /** Current nesting depth of transactions (1 = top-level, 2+ = nested) */
   scopeDepth: number;
+  /** Number of top-level transactions currently active or queued */
+  pendingTransactionCount: number;
 }
 
 /**
@@ -54,6 +56,7 @@ export class ExpoSqliteDb {
         transactionQueue: Promise.resolve(),
         currentScope: null,
         scopeDepth: 0,
+        pendingTransactionCount: 0,
       } satisfies ExpoSqliteDbRootState;
       this.scopeToken = null;
       this.operationDb = optionsOrRoot.database;
@@ -69,9 +72,16 @@ export class ExpoSqliteDb {
     return this.operationDb;
   }
 
+  private shouldWaitForTransaction(): boolean {
+    return (
+      this.root.pendingTransactionCount > 0 &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    );
+  }
+
   private async waitForActiveTransaction(): Promise<void> {
     while (
-      this.root.currentScope !== null &&
+      this.root.pendingTransactionCount > 0 &&
       (!this.scopeToken || this.root.currentScope !== this.scopeToken)
     ) {
       await this.root.transactionQueue;
@@ -79,25 +89,33 @@ export class ExpoSqliteDb {
   }
 
   async exec(sql: string): Promise<void> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     // execAsync can run multiple statements separated by semicolons
     await (this.operationDb as any).execAsync(sql);
   }
 
   async run(sql: string, params: unknown[] = []): Promise<{ lastID: number; changes: number }> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     const result = await (this.operationDb as any).runAsync(sql, ...(params ?? []));
     return { lastID: result.lastInsertRowId ?? 0, changes: result.changes ?? 0 };
   }
 
   async get<T = unknown>(sql: string, params: unknown[] = []): Promise<T | undefined> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     const row = await (this.operationDb as any).getFirstAsync(sql, ...(params ?? []));
     return (row ?? undefined) as T | undefined;
   }
 
   async all<T = unknown>(sql: string, params: unknown[] = []): Promise<T[]> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     const rows = await (this.operationDb as any).getAllAsync(sql, ...(params ?? []));
     return (rows ?? []) as T[];
   }
@@ -154,6 +172,7 @@ export class ExpoSqliteDb {
     root.transactionQueue = new Promise<void>((resolve) => {
       resolver = resolve;
     });
+    root.pendingTransactionCount++;
 
     try {
       // SERIALIZATION: Wait for the previous transaction to complete
@@ -208,6 +227,7 @@ export class ExpoSqliteDb {
       // This allows the next queued transaction to proceed
       root.scopeDepth = 0;
       root.currentScope = null;
+      root.pendingTransactionCount--;
       resolver(); // Critical: This unblocks the next transaction in the queue
     }
   }

--- a/packages/expo-sqlite/src/db.ts
+++ b/packages/expo-sqlite/src/db.ts
@@ -8,6 +8,11 @@ export interface ExpoSqliteDbOptions {
   database: ExpoSqliteDatabaseLike;
 }
 
+function isWebRuntime(): boolean {
+  const runtime = globalThis as { window?: unknown; document?: unknown };
+  return typeof runtime.window === 'object' && typeof runtime.document === 'object';
+}
+
 /**
  * Shared state for transaction management across all ExpoSqliteDb instances.
  * All instances created from the same root share this state to coordinate transactions.
@@ -33,12 +38,14 @@ interface ExpoSqliteDbRootState {
  */
 export class ExpoSqliteDb {
   private readonly root: ExpoSqliteDbRootState;
+  private readonly operationDb: ExpoSqliteDatabaseLike;
   /** Unique identifier for this instance's transaction scope (null for root instances) */
   private readonly scopeToken: symbol | null;
 
   constructor(
     optionsOrRoot: ExpoSqliteDbOptions | ExpoSqliteDbRootState,
     scopeToken: symbol | null = null,
+    operationDb?: ExpoSqliteDatabaseLike,
   ) {
     if ('database' in optionsOrRoot) {
       // Creating a root instance - initialize the shared state
@@ -49,34 +56,49 @@ export class ExpoSqliteDb {
         scopeDepth: 0,
       } satisfies ExpoSqliteDbRootState;
       this.scopeToken = null;
+      this.operationDb = optionsOrRoot.database;
     } else {
       // Creating a scoped instance - share the root state
       this.root = optionsOrRoot;
       this.scopeToken = scopeToken;
+      this.operationDb = operationDb ?? optionsOrRoot.db;
     }
   }
 
   get raw(): ExpoSqliteDatabaseLike {
-    return this.root.db;
+    return this.operationDb;
+  }
+
+  private async waitForActiveTransaction(): Promise<void> {
+    while (
+      this.root.currentScope !== null &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    ) {
+      await this.root.transactionQueue;
+    }
   }
 
   async exec(sql: string): Promise<void> {
+    await this.waitForActiveTransaction();
     // execAsync can run multiple statements separated by semicolons
-    await (this.root.db as any).execAsync(sql);
+    await (this.operationDb as any).execAsync(sql);
   }
 
   async run(sql: string, params: unknown[] = []): Promise<{ lastID: number; changes: number }> {
-    const result = await (this.root.db as any).runAsync(sql, ...(params ?? []));
+    await this.waitForActiveTransaction();
+    const result = await (this.operationDb as any).runAsync(sql, ...(params ?? []));
     return { lastID: result.lastInsertRowId ?? 0, changes: result.changes ?? 0 };
   }
 
   async get<T = unknown>(sql: string, params: unknown[] = []): Promise<T | undefined> {
-    const row = await (this.root.db as any).getFirstAsync(sql, ...(params ?? []));
+    await this.waitForActiveTransaction();
+    const row = await (this.operationDb as any).getFirstAsync(sql, ...(params ?? []));
     return (row ?? undefined) as T | undefined;
   }
 
   async all<T = unknown>(sql: string, params: unknown[] = []): Promise<T[]> {
-    const rows = await (this.root.db as any).getAllAsync(sql, ...(params ?? []));
+    await this.waitForActiveTransaction();
+    const rows = await (this.operationDb as any).getAllAsync(sql, ...(params ?? []));
     return (rows ?? []) as T[];
   }
 
@@ -122,8 +144,6 @@ export class ExpoSqliteDb {
 
     // NEW TRANSACTION: Create a unique scope token and scoped instance
     const scopeToken = Symbol('expo-sqlite-transaction');
-    const scopedDb = new ExpoSqliteDb(root, scopeToken);
-
     // TRANSACTION QUEUE SETUP:
     // Save reference to the previous transaction's completion promise
     const previousTransaction = root.transactionQueue;
@@ -146,9 +166,18 @@ export class ExpoSqliteDb {
       root.currentScope = scopeToken;
       root.scopeDepth = 1;
 
-      // Prefer withTransactionAsync if available (newer expo-sqlite versions)
-      // This provides better transaction handling with automatic rollback on error
+      // Prefer exclusive transactions when available. Expo documents withTransactionAsync as
+      // interruptible by other async queries, so transaction-scoped operations must use txn.
+      if (typeof dbAny.withExclusiveTransactionAsync === 'function' && !isWebRuntime()) {
+        let result!: T;
+        await dbAny.withExclusiveTransactionAsync(async (txn: ExpoSqliteDatabaseLike) => {
+          result = await fn(new ExpoSqliteDb(root, scopeToken, txn));
+        });
+        return result;
+      }
+
       if (typeof dbAny.withTransactionAsync === 'function') {
+        const scopedDb = new ExpoSqliteDb(root, scopeToken);
         let result!: T;
         await dbAny.withTransactionAsync(async () => {
           result = await fn(scopedDb);
@@ -157,6 +186,7 @@ export class ExpoSqliteDb {
       }
 
       // Fallback to manual BEGIN/COMMIT for older versions
+      const scopedDb = new ExpoSqliteDb(root, scopeToken);
       await dbAny.execAsync('BEGIN');
       try {
         // Execute user code within the transaction

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -60,6 +60,28 @@ class BunExpoSqliteDatabaseShim {
   }
 }
 
+class WebExpoSqliteDatabaseShim extends BunExpoSqliteDatabaseShim {
+  exclusiveTransactionCalls = 0;
+  transactionCalls = 0;
+
+  async withExclusiveTransactionAsync(): Promise<void> {
+    this.exclusiveTransactionCalls++;
+    throw new Error('withExclusiveTransactionAsync is not supported on web');
+  }
+
+  async withTransactionAsync(fn: () => Promise<void>): Promise<void> {
+    this.transactionCalls++;
+    await this.execAsync('BEGIN');
+    try {
+      await fn();
+      await this.execAsync('COMMIT');
+    } catch (error) {
+      await this.execAsync('ROLLBACK');
+      throw error;
+    }
+  }
+}
+
 function createDeferred<T = void>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -87,6 +109,7 @@ async function createRepositories() {
 runRepositoryTransactionContract(
   {
     createRepositories,
+    testConcurrentRootOperationIsolation: true,
   },
   { describe, it, expect },
 );
@@ -185,3 +208,43 @@ describe('expo-sqlite adapter transactions', () => {
     }
   });
 });
+
+describe('expo-sqlite web transaction compatibility', () => {
+  it('uses withTransactionAsync when exclusive transactions are unavailable on web', async () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    Object.defineProperty(globalThis, 'window', { value: {}, configurable: true });
+    Object.defineProperty(globalThis, 'document', { value: {}, configurable: true });
+
+    const database = new WebExpoSqliteDatabaseShim();
+    const repositories = new Repositories({
+      database: database as unknown as ExpoSqliteRepositoriesOptions['database'],
+    });
+
+    try {
+      await repositories.init();
+      database.exclusiveTransactionCalls = 0;
+      database.transactionCalls = 0;
+
+      await repositories.withTransaction(async (tx) => {
+        await tx.mintRepository.addOrUpdateMint(createDummyMint());
+      });
+
+      expect(database.exclusiveTransactionCalls).toBe(0);
+      expect(database.transactionCalls).toBe(1);
+      await expect(repositories.mintRepository.getAllMints()).resolves.toHaveLength(1);
+    } finally {
+      await repositories.db.raw.closeAsync?.();
+      restoreGlobalProperty('window', windowDescriptor);
+      restoreGlobalProperty('document', documentDescriptor);
+    }
+  });
+});
+
+function restoreGlobalProperty(name: string, descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(globalThis, name);
+}

--- a/packages/sqlite-bun/src/db.ts
+++ b/packages/sqlite-bun/src/db.ts
@@ -17,6 +17,8 @@ interface SqliteDbRootState {
   currentScope: symbol | null;
   /** Current nesting depth of transactions (1 = top-level, 2+ = nested) */
   scopeDepth: number;
+  /** Number of top-level transactions currently active or queued */
+  pendingTransactionCount: number;
   /** Cache of prepared statements for frequently-used queries */
   statementCache: Map<string, Statement>;
 }
@@ -45,6 +47,7 @@ export class SqliteDb {
         transactionQueue: Promise.resolve(),
         currentScope: null,
         scopeDepth: 0,
+        pendingTransactionCount: 0,
         statementCache: new Map(),
       } satisfies SqliteDbRootState;
       this.scopeToken = null;
@@ -73,9 +76,16 @@ export class SqliteDb {
     return statement;
   }
 
+  private shouldWaitForTransaction(): boolean {
+    return (
+      this.root.pendingTransactionCount > 0 &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    );
+  }
+
   private async waitForActiveTransaction(): Promise<void> {
     while (
-      this.root.currentScope !== null &&
+      this.root.pendingTransactionCount > 0 &&
       (!this.scopeToken || this.root.currentScope !== this.scopeToken)
     ) {
       await this.root.transactionQueue;
@@ -83,7 +93,9 @@ export class SqliteDb {
   }
 
   async exec(sql: string): Promise<void> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     return new Promise((resolve, reject) => {
       try {
         this.root.db.exec(sql);
@@ -95,7 +107,9 @@ export class SqliteDb {
   }
 
   async run(sql: string, params: any[] = []): Promise<{ lastID: number; changes: number }> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);
@@ -111,7 +125,9 @@ export class SqliteDb {
   }
 
   async get<T = unknown>(sql: string, params: any[] = []): Promise<T | undefined> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);
@@ -124,7 +140,9 @@ export class SqliteDb {
   }
 
   async all<T = unknown>(sql: string, params: any[] = []): Promise<T[]> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);
@@ -190,6 +208,7 @@ export class SqliteDb {
     root.transactionQueue = new Promise<void>((resolve) => {
       resolver = resolve;
     });
+    root.pendingTransactionCount++;
 
     try {
       // SERIALIZATION: Wait for the previous transaction to complete
@@ -227,6 +246,7 @@ export class SqliteDb {
       // This allows the next queued transaction to proceed
       root.scopeDepth = 0;
       root.currentScope = null;
+      root.pendingTransactionCount--;
       resolver(); // Critical: This unblocks the next transaction in the queue
     }
   }

--- a/packages/sqlite-bun/src/db.ts
+++ b/packages/sqlite-bun/src/db.ts
@@ -73,7 +73,17 @@ export class SqliteDb {
     return statement;
   }
 
-  exec(sql: string): Promise<void> {
+  private async waitForActiveTransaction(): Promise<void> {
+    while (
+      this.root.currentScope !== null &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    ) {
+      await this.root.transactionQueue;
+    }
+  }
+
+  async exec(sql: string): Promise<void> {
+    await this.waitForActiveTransaction();
     return new Promise((resolve, reject) => {
       try {
         this.root.db.exec(sql);
@@ -84,7 +94,8 @@ export class SqliteDb {
     });
   }
 
-  run(sql: string, params: any[] = []): Promise<{ lastID: number; changes: number }> {
+  async run(sql: string, params: any[] = []): Promise<{ lastID: number; changes: number }> {
+    await this.waitForActiveTransaction();
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);
@@ -99,7 +110,8 @@ export class SqliteDb {
     });
   }
 
-  get<T = unknown>(sql: string, params: any[] = []): Promise<T | undefined> {
+  async get<T = unknown>(sql: string, params: any[] = []): Promise<T | undefined> {
+    await this.waitForActiveTransaction();
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);
@@ -111,7 +123,8 @@ export class SqliteDb {
     });
   }
 
-  all<T = unknown>(sql: string, params: any[] = []): Promise<T[]> {
+  async all<T = unknown>(sql: string, params: any[] = []): Promise<T[]> {
+    await this.waitForActiveTransaction();
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -35,6 +35,7 @@ async function createRepositories() {
 runRepositoryTransactionContract(
   {
     createRepositories,
+    testConcurrentRootOperationIsolation: true,
   },
   { describe, it, expect },
 );

--- a/packages/sqlite3/src/db.ts
+++ b/packages/sqlite3/src/db.ts
@@ -17,6 +17,8 @@ interface SqliteDbRootState {
   currentScope: symbol | null;
   /** Current nesting depth of transactions (1 = top-level, 2+ = nested) */
   scopeDepth: number;
+  /** Number of top-level transactions currently active or queued */
+  pendingTransactionCount: number;
 }
 
 /**
@@ -43,6 +45,7 @@ export class SqliteDb {
         transactionQueue: Promise.resolve(),
         currentScope: null,
         scopeDepth: 0,
+        pendingTransactionCount: 0,
       } satisfies SqliteDbRootState;
       this.scopeToken = null;
     } else {
@@ -56,9 +59,16 @@ export class SqliteDb {
     return this.root.db;
   }
 
+  private shouldWaitForTransaction(): boolean {
+    return (
+      this.root.pendingTransactionCount > 0 &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    );
+  }
+
   private async waitForActiveTransaction(): Promise<void> {
     while (
-      this.root.currentScope !== null &&
+      this.root.pendingTransactionCount > 0 &&
       (!this.scopeToken || this.root.currentScope !== this.scopeToken)
     ) {
       await this.root.transactionQueue;
@@ -66,12 +76,16 @@ export class SqliteDb {
   }
 
   async exec(sql: string): Promise<void> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     this.root.db.exec(sql);
   }
 
   async run(sql: string, params: any[] = []): Promise<{ lastID: number; changes: number }> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     const result = this.root.db.prepare(sql).run(params);
     return {
       lastID: Number(result.lastInsertRowid),
@@ -80,12 +94,16 @@ export class SqliteDb {
   }
 
   async get<T = unknown>(sql: string, params: any[] = []): Promise<T | undefined> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     return this.root.db.prepare(sql).get(params) as T | undefined;
   }
 
   async all<T = unknown>(sql: string, params: any[] = []): Promise<T[]> {
-    await this.waitForActiveTransaction();
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
     return this.root.db.prepare(sql).all(params) as T[];
   }
 
@@ -143,6 +161,7 @@ export class SqliteDb {
     root.transactionQueue = new Promise<void>((resolve) => {
       resolver = resolve;
     });
+    root.pendingTransactionCount++;
 
     try {
       // SERIALIZATION: Wait for the previous transaction to complete
@@ -175,6 +194,7 @@ export class SqliteDb {
       // This allows the next queued transaction to proceed
       root.scopeDepth = 0;
       root.currentScope = null;
+      root.pendingTransactionCount--;
       resolver(); // Critical: This unblocks the next transaction in the queue
     }
   }

--- a/packages/sqlite3/src/db.ts
+++ b/packages/sqlite3/src/db.ts
@@ -56,11 +56,22 @@ export class SqliteDb {
     return this.root.db;
   }
 
+  private async waitForActiveTransaction(): Promise<void> {
+    while (
+      this.root.currentScope !== null &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    ) {
+      await this.root.transactionQueue;
+    }
+  }
+
   async exec(sql: string): Promise<void> {
+    await this.waitForActiveTransaction();
     this.root.db.exec(sql);
   }
 
   async run(sql: string, params: any[] = []): Promise<{ lastID: number; changes: number }> {
+    await this.waitForActiveTransaction();
     const result = this.root.db.prepare(sql).run(params);
     return {
       lastID: Number(result.lastInsertRowid),
@@ -69,10 +80,12 @@ export class SqliteDb {
   }
 
   async get<T = unknown>(sql: string, params: any[] = []): Promise<T | undefined> {
+    await this.waitForActiveTransaction();
     return this.root.db.prepare(sql).get(params) as T | undefined;
   }
 
   async all<T = unknown>(sql: string, params: any[] = []): Promise<T[]> {
+    await this.waitForActiveTransaction();
     return this.root.db.prepare(sql).all(params) as T[];
   }
 

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -35,6 +35,7 @@ async function createRepositories() {
 runRepositoryTransactionContract(
   {
     createRepositories,
+    testConcurrentRootOperationIsolation: true,
   },
   { describe, it, expect },
 );


### PR DESCRIPTION
## Description

This pull request fixes SQLite transaction isolation by making root repository operations wait while an adapter transaction is active. It also updates the Expo SQLite wrapper to use exclusive transaction handles where available and adds adapter contract coverage for concurrent root writes.

## Problem

SQLite adapters use one connection per repository set. A normal root repository call could run while an unrelated transaction callback was suspended, accidentally joining that open transaction and being committed or rolled back with the wrong operation.

## Summary

- Serialize `exec`, `run`, `get`, and `all` across `sqlite-bun`, `sqlite3`, and `expo-sqlite` when another transaction scope is active.
- Use Expo SQLite exclusive transaction handles on native runtimes, with the web-compatible transaction fallback preserved.
- Add shared adapter contract coverage proving concurrent root writes are not included in active transaction rollbacks.
- Untracked `todo/` audit files remain outside this PR scope.

## Verification

- `git diff --check`
- `bun run --filter='@cashu/coco-adapter-tests' typecheck`
- `bun run --filter='@cashu/coco-sqlite-bun' typecheck`
- `bun run --filter='@cashu/coco-sqlite' typecheck`
- `bun run --filter='@cashu/coco-expo-sqlite' typecheck`
- `bun run --filter='@cashu/coco-sqlite-bun' test -- src/test/contract.test.ts`
- `bun run --filter='@cashu/coco-sqlite' test -- src/test/contract.test.ts`
- `bun --cwd packages/expo-sqlite test src/test/contract.test.ts`
- Full `sqlite-bun` and `expo-sqlite` test commands were also started; both reached the existing `MINT_URL is not set` integration-test gate after the unit/contract tests passed.

## Changeset

- Added `.changeset/sqlite-transaction-isolation.md` for `@cashu/coco-sqlite`, `@cashu/coco-sqlite-bun`, `@cashu/coco-expo-sqlite`, and `@cashu/coco-adapter-tests`.