### PR TITLE
docs(docs): document operation lifecycles

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -40,6 +40,8 @@ export default defineConfig({
           { text: 'KeyRing (P2PK)', link: '/pages/keyring' },
           { text: 'Watchers & Processors', link: '/pages/watchers-processors' },
           { text: 'Send Operations', link: '/pages/send-operations' },
+          { text: 'Receive Operations', link: '/pages/receive-operations' },
+          { text: 'Mint Operations', link: '/pages/mint-operations' },
           { text: 'Melt Operations', link: '/pages/melt-operations' },
           { text: 'Coco Config', link: '/pages/coco-config' },
           { text: 'Plugins', link: '/pages/plugins' },

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -1,0 +1,116 @@
+# Mint Operations
+
+Mint operations track quote-backed issuance from quote creation through proof
+redemption. They are durable so apps can show an invoice, wait for remote
+payment, recover after crashes, and avoid losing issued proofs.
+
+## API Surface (`coco.ops.mint`)
+
+The canonical API is exposed through `coco.ops.mint`:
+
+- `prepare({ mintUrl, amount, unit?, method, methodData? })` creates a remote
+  quote and persists a pending mint operation
+- `importQuote({ mintUrl, quote, method, methodData? })` tracks an existing
+  quote as a mint operation
+- `execute(operationOrId)` redeems a paid quote and returns the terminal state
+- `checkPayment(operationId)` checks the remote quote state for a pending
+  operation
+- `refresh(operationId)` checks or recovers an operation and returns the latest
+  stored state
+- `finalize(operationId)` executes or recovers the operation until it reaches a
+  terminal state when possible
+- `get(operationId)`, `getByQuote(mintUrl, quoteId)`, `listPending()`, and
+  `listInFlight()` load persisted operation state
+
+## Operation States
+
+Mint operations progress through the following states:
+
+| State | Description |
+| ----- | ----------- |
+| `init` | Local mint intent exists before a quote snapshot is attached |
+| `pending` | Quote and deterministic output data are persisted; payment may settle remotely |
+| `executing` | Quote redemption or recovery is in progress |
+| `finalized` | Quote was issued and proofs were saved or recovered |
+| `failed` | Quote reached a terminal non-issued state, such as expiry |
+
+```
+init -> pending -> executing -> finalized
+          ^          |
+          +----------+-> failed
+```
+
+## Lifecycle Actions
+
+| Action | Valid input state | Resulting state | Use when |
+| ------ | ----------------- | --------------- | -------- |
+| `prepare(...)` | none | `pending` | You need a new quote and invoice request to show the payer. |
+| `importQuote(...)` | none | `pending` | You already have a remote quote and want Coco to track it. |
+| `checkPayment(operationId)` | `pending` | latest remote observation; may queue redemption | You want to update UI after the invoice may have been paid. |
+| `execute(operationOrId)` | `pending` | `finalized` or `failed` | You know the quote is payable and want to redeem it now. |
+| `refresh(operationId)` | any, actively checks `pending` and recovers `executing` | latest stored state | You are showing stale persisted state or a recovery screen. |
+| `finalize(operationId)` | `pending`, `executing`, or terminal | terminal state when possible | You want one explicit call to settle or recover the operation. |
+
+With the default mint watcher and processor enabled, apps usually do not need to
+poll `refresh()` in the happy path. Show the payment request from the pending
+operation, then render the latest operation state from events, hook state, or a
+targeted `checkPayment()` action.
+
+## Prepare -> Pay -> Finalize Flow
+
+```ts
+const pending = await coco.ops.mint.prepare({
+  mintUrl,
+  amount: 100,
+  method: 'bolt11',
+});
+
+showInvoice(pending.request);
+
+const check = await coco.ops.mint.checkPayment(pending.id);
+
+if (check.category === 'ready' || check.category === 'completed') {
+  const terminal = await coco.ops.mint.finalize(pending.id);
+  console.log('Mint operation state:', terminal.state);
+}
+```
+
+## Recovery
+
+`initializeCoco()` runs mint recovery automatically. Pending operations are
+rechecked for trusted mints, and executing operations are recovered by checking
+whether deterministic outputs were saved or can be restored.
+
+Use `refresh(operationId)` when a screen is opened with an old operation id:
+
+```ts
+const operation = await coco.ops.mint.refresh(operationId);
+
+if (operation.state === 'finalized') {
+  console.log('Mint complete');
+}
+
+if (operation.state === 'failed') {
+  console.log('Mint failed:', operation.terminalFailure?.reason ?? operation.error);
+}
+```
+
+## Events
+
+```ts
+coco.on('mint-op:pending', ({ operationId, operation }) => {
+  console.log('Mint pending', operationId, operation.request);
+});
+
+coco.on('mint-op:quote-state-changed', ({ operationId, state }) => {
+  console.log('Quote state changed', operationId, state);
+});
+
+coco.on('mint-op:executing', ({ operationId }) => {
+  console.log('Mint executing', operationId);
+});
+
+coco.on('mint-op:finalized', ({ operationId, operation }) => {
+  console.log('Mint terminal', operationId, operation.state);
+});
+```

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -26,13 +26,13 @@ The canonical API is exposed through `coco.ops.mint`:
 
 Mint operations progress through the following states:
 
-| State | Description |
-| ----- | ----------- |
-| `init` | Local mint intent exists before a quote snapshot is attached |
-| `pending` | Quote and deterministic output data are persisted; payment may settle remotely |
-| `executing` | Quote redemption or recovery is in progress |
-| `finalized` | Quote was issued and proofs were saved or recovered |
-| `failed` | Quote reached a terminal non-issued state, such as expiry |
+| State       | Description                                                                    |
+| ----------- | ------------------------------------------------------------------------------ |
+| `init`      | Local mint intent exists before a quote snapshot is attached                   |
+| `pending`   | Quote and deterministic output data are persisted; payment may settle remotely |
+| `executing` | Quote redemption or recovery is in progress                                    |
+| `finalized` | Quote was issued and proofs were saved or recovered                            |
+| `failed`    | Quote reached a terminal non-issued state, such as expiry                      |
 
 ```
 init -> pending -> executing -> finalized
@@ -42,14 +42,14 @@ init -> pending -> executing -> finalized
 
 ## Lifecycle Actions
 
-| Action | Valid input state | Resulting state | Use when |
-| ------ | ----------------- | --------------- | -------- |
-| `prepare(...)` | none | `pending` | You need a new quote and invoice request to show the payer. |
-| `importQuote(...)` | none | `pending` | You already have a remote quote and want Coco to track it. |
-| `checkPayment(operationId)` | `pending` | latest remote observation; may queue redemption | You want to update UI after the invoice may have been paid. |
-| `execute(operationOrId)` | `pending` | `finalized` or `failed` | You know the quote is payable and want to redeem it now. |
-| `refresh(operationId)` | any, actively checks `pending` and recovers `executing` | latest stored state | You are showing stale persisted state or a recovery screen. |
-| `finalize(operationId)` | `pending`, `executing`, or terminal | terminal state when possible | You want one explicit call to settle or recover the operation. |
+| Action                      | Valid input state                                       | Resulting state                                 | Use when                                                       |
+| --------------------------- | ------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------- |
+| `prepare(...)`              | none                                                    | `pending`                                       | You need a new quote and invoice request to show the payer.    |
+| `importQuote(...)`          | none                                                    | `pending`                                       | You already have a remote quote and want Coco to track it.     |
+| `checkPayment(operationId)` | `pending`                                               | latest remote observation; may queue redemption | You want to update UI after the invoice may have been paid.    |
+| `execute(operationOrId)`    | `pending`                                               | `finalized` or `failed`                         | You know the quote is payable and want to redeem it now.       |
+| `refresh(operationId)`      | any, actively checks `pending` and recovers `executing` | latest stored state                             | You are showing stale persisted state or a recovery screen.    |
+| `finalize(operationId)`     | `pending`, `executing`, or terminal                     | terminal state when possible                    | You want one explicit call to settle or recover the operation. |
 
 With the default mint watcher and processor enabled, apps usually do not need to
 poll `refresh()` in the happy path. Show the payment request from the pending

--- a/packages/docs/pages/react-hooks.md
+++ b/packages/docs/pages/react-hooks.md
@@ -4,15 +4,35 @@ Hooks are built on top of the providers and the core `Manager` API. Make sure
 your component tree is wrapped with `ManagerProvider` or
 `CocoCashuProvider`.
 
-The operation hooks intentionally mirror `manager.ops.*` instead of inventing a
-separate React-only workflow model:
+## Operation Hook Contract
 
-- render from `currentOperation`
-- use `executeResult` for execute-specific output only
-- optionally initialize a hook with an operation or `operationId` on first render
-- hydrate persisted work on mount when initialized with an `operationId`
-- call follow-up methods on the currently bound operation
-- use `status`, `error`, `isLoading`, and `isError` for local hook state
+The operation hooks intentionally mirror `manager.ops.*` instead of inventing a
+separate React-only workflow model. One hook instance owns one active operation.
+
+- `currentOperation` is the authoritative operation record to render from.
+- `executeResult` is only for execute-specific returned data, such as the token
+  returned by `useSendOperation().execute()`.
+- Creation methods such as `prepare(...)` and `importQuote(...)` bind the hook to
+  the operation they create.
+- Follow-up methods such as `execute()`, `checkPayment()`, `finalize()`,
+  `cancel()`, `reclaim()`, and `refresh()` operate on the currently bound
+  operation, so app code should not pass an `operationId` to those methods.
+- The optional hook argument is initial-only. Use it to seed a resume screen from
+  an operation object or load one persisted operation by id on mount.
+- The hooks subscribe to lifecycle events and update the bound operation when the
+  manager emits a newer state for that operation id.
+- `refresh()` is for stale persisted operations, recovery screens, or explicit
+  user refresh actions. It is not needed as happy-path polling.
+- `reset()` clears the hook's local binding, `executeResult`, `status`, and
+  `error`. It does not roll back or delete the persisted operation.
+- `status`, `error`, `isLoading`, and `isError` describe the hook's current local
+  async action. If a second stateful action is started while one is already
+  running, the second call rejects and does not replace the loading/error state
+  from the first action.
+
+For state-machine details, see [Send Operations](./send-operations.md),
+[Receive Operations](./receive-operations.md), [Mint Operations](./mint-operations.md),
+and [Melt Operations](./melt-operations.md).
 
 ## useSendOperation
 
@@ -65,8 +85,11 @@ import { useReceiveOperation } from '@cashu/coco-react';
 
 const { prepare, execute, currentOperation, refresh, cancel } = useReceiveOperation();
 
-await prepare({ token });
-await execute();
+const preparedReceive = await prepare({ token });
+
+if (preparedReceive.state === 'prepared') {
+  await execute();
+}
 ```
 
 ## useMintOperation
@@ -89,8 +112,11 @@ const {
   listInFlight,
 } = useMintOperation();
 
-await prepare({ mintUrl, amount: 100, method: 'bolt11' });
-await checkPayment();
+const pendingMint = await prepare({ mintUrl, amount: 100, method: 'bolt11' });
+
+if (pendingMint.state === 'pending') {
+  await checkPayment();
+}
 ```
 
 `prepare()` and `importQuote()` both create a pending mint operation.
@@ -104,12 +130,15 @@ import { useMeltOperation } from '@cashu/coco-react';
 
 const { prepare, execute, refresh, finalize, reclaim, currentOperation } = useMeltOperation();
 
-await prepare({
+const preparedMelt = await prepare({
   mintUrl,
   method: 'bolt11',
   methodData: { invoice },
 });
-await execute();
+
+if (preparedMelt.state === 'prepared') {
+  await execute();
+}
 ```
 
 ## Derived-data Hooks

--- a/packages/docs/pages/react-overview.md
+++ b/packages/docs/pages/react-overview.md
@@ -15,7 +15,8 @@ package mirrors that model directly with:
 Each hook exposes the same durable-operation story:
 
 - `currentOperation` for the persisted operation state you should render from
-- `executeResult` for the last execute-specific result
+- `executeResult` for the last execute-specific result, not the general
+  operation state
 - optional initial binding via an operation or `operationId` on first render
 - internal mount-time hydration when initialized with an `operationId`
 - no-arg follow-up actions that operate on the currently bound operation
@@ -23,6 +24,9 @@ Each hook exposes the same durable-operation story:
 
 The optional hook argument is initial-only. If your UI stays mounted while the
 target operation changes, remount the hook or component with a new React `key`.
+Use `refresh()` for stale persisted operations or recovery UI, not as normal
+happy-path polling. Lifecycle events update the bound `currentOperation`
+automatically when watchers, processors, or explicit actions move it forward.
 
 ## Installation
 

--- a/packages/docs/pages/receive-operations.md
+++ b/packages/docs/pages/receive-operations.md
@@ -1,0 +1,99 @@
+# Receive Operations
+
+Receive operations turn an encoded Cashu token into proofs stored in the local
+wallet. The operation API makes receiving explicit so apps can review decoded
+token details, recover after crashes, and avoid duplicate receives.
+
+## API Surface (`coco.ops.receive`)
+
+The canonical API is exposed through `coco.ops.receive`:
+
+- `prepare({ token })` decodes and validates a token, calculates fees, and
+  creates deterministic receive outputs
+- `execute(operationOrId)` receives the prepared token and saves the new proofs
+- `get(operationId)` returns a persisted receive operation
+- `listPrepared()` lists receives waiting for user confirmation
+- `listInFlight()` lists receives that may need recovery
+- `refresh(operationId)` recovers an executing receive and returns the latest
+  operation state
+- `cancel(operationId, reason?)` rolls back an `init` or `prepared` receive
+
+## Operation States
+
+Receive operations progress through the following states:
+
+| State | Description |
+| ----- | ----------- |
+| `init` | Token decoded and validated, but outputs are not prepared yet |
+| `prepared` | Fees calculated, output data persisted, ready to execute |
+| `executing` | Receive request is in progress at the mint |
+| `finalized` | New proofs were saved locally |
+| `rolled_back` | Operation was cancelled or could not be recovered |
+
+```
+init -> prepared -> executing -> finalized
+  |        |             |
+  +--------+-------------+-> rolled_back
+```
+
+## Lifecycle Actions
+
+| Action | Valid input state | Resulting state | Use when |
+| ------ | ----------------- | --------------- | -------- |
+| `prepare({ token })` | none | `prepared` | You want to inspect token amount, mint, unit, and fees before receiving. |
+| `execute(operationOrId)` | `prepared` | `finalized` | The user confirmed the receive and proofs should be saved. |
+| `refresh(operationId)` | any, actively recovers `executing` | latest stored state | You are resuming an operation after a crash or stale UI state. |
+| `cancel(operationId, reason?)` | `init`, `prepared` | `rolled_back` or deleted when still `init` | The user abandons the receive before it completes. |
+
+## Prepare -> Execute Flow
+
+```ts
+const prepared = await coco.ops.receive.prepare({ token });
+
+console.log('Amount:', prepared.amount);
+console.log('Mint:', prepared.mintUrl);
+console.log('Fee:', prepared.fee);
+
+if (userConfirmed) {
+  const finalized = await coco.ops.receive.execute(prepared.id);
+  console.log('Received:', finalized.amount);
+} else {
+  await coco.ops.receive.cancel(prepared.id, 'User cancelled receive');
+}
+```
+
+## Recovery
+
+`initializeCoco()` runs receive recovery automatically. Recovery removes stale
+`init` operations, leaves `prepared` operations for user decision, and tries to
+complete or roll back `executing` operations based on mint state.
+
+Use `refresh(operationId)` for explicit recovery UI:
+
+```ts
+const operation = await coco.ops.receive.refresh(operationId);
+
+if (operation.state === 'finalized') {
+  console.log('Receive completed');
+}
+
+if (operation.state === 'rolled_back') {
+  console.log('Receive rolled back:', operation.error);
+}
+```
+
+## Events
+
+```ts
+coco.on('receive-op:prepared', ({ operationId, operation }) => {
+  console.log('Receive prepared', operationId, operation.amount);
+});
+
+coco.on('receive-op:finalized', ({ operationId, operation }) => {
+  console.log('Receive finalized', operationId, operation.amount);
+});
+
+coco.on('receive-op:rolled-back', ({ operationId, operation }) => {
+  console.log('Receive rolled back', operationId, operation.error);
+});
+```

--- a/packages/docs/pages/receive-operations.md
+++ b/packages/docs/pages/receive-operations.md
@@ -22,13 +22,13 @@ The canonical API is exposed through `coco.ops.receive`:
 
 Receive operations progress through the following states:
 
-| State | Description |
-| ----- | ----------- |
-| `init` | Token decoded and validated, but outputs are not prepared yet |
-| `prepared` | Fees calculated, output data persisted, ready to execute |
-| `executing` | Receive request is in progress at the mint |
-| `finalized` | New proofs were saved locally |
-| `rolled_back` | Operation was cancelled or could not be recovered |
+| State         | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `init`        | Token decoded and validated, but outputs are not prepared yet |
+| `prepared`    | Fees calculated, output data persisted, ready to execute      |
+| `executing`   | Receive request is in progress at the mint                    |
+| `finalized`   | New proofs were saved locally                                 |
+| `rolled_back` | Operation was cancelled or could not be recovered             |
 
 ```
 init -> prepared -> executing -> finalized
@@ -38,12 +38,12 @@ init -> prepared -> executing -> finalized
 
 ## Lifecycle Actions
 
-| Action | Valid input state | Resulting state | Use when |
-| ------ | ----------------- | --------------- | -------- |
-| `prepare({ token })` | none | `prepared` | You want to inspect token amount, mint, unit, and fees before receiving. |
-| `execute(operationOrId)` | `prepared` | `finalized` | The user confirmed the receive and proofs should be saved. |
-| `refresh(operationId)` | any, actively recovers `executing` | latest stored state | You are resuming an operation after a crash or stale UI state. |
-| `cancel(operationId, reason?)` | `init`, `prepared` | `rolled_back` or deleted when still `init` | The user abandons the receive before it completes. |
+| Action                         | Valid input state                  | Resulting state                            | Use when                                                                 |
+| ------------------------------ | ---------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------ |
+| `prepare({ token })`           | none                               | `prepared`                                 | You want to inspect token amount, mint, unit, and fees before receiving. |
+| `execute(operationOrId)`       | `prepared`                         | `finalized`                                | The user confirmed the receive and proofs should be saved.               |
+| `refresh(operationId)`         | any, actively recovers `executing` | latest stored state                        | You are resuming an operation after a crash or stale UI state.           |
+| `cancel(operationId, reason?)` | `init`, `prepared`                 | `rolled_back` or deleted when still `init` | The user abandons the receive before it completes.                       |
 
 ## Prepare -> Execute Flow
 

--- a/packages/docs/pages/send-operations.md
+++ b/packages/docs/pages/send-operations.md
@@ -20,17 +20,33 @@ Send operations progress through the following states:
 | `prepared`     | Proofs reserved, fee calculated, ready to execute |
 | `executing`    | Swap in progress (if needed)                      |
 | `pending`      | Token created, waiting for recipient to claim     |
-| `completed`    | Recipient claimed, operation finalized            |
+| `finalized`    | Recipient claimed, operation finalized            |
 | `rolling_back` | Rollback in progress                              |
 | `rolled_back`  | Operation cancelled, proofs reclaimed             |
 
 ```
-init ──► prepared ──► executing ──► pending ──► completed
+init ──► prepared ──► executing ──► pending ──► finalized
   │         │            │            │
   │         │            │            └──► rolling_back ──► rolled_back
   │         │            │                      │
   └─────────┴────────────┴──────────────────────┴──► rolled_back
 ```
+
+## Lifecycle Actions
+
+| Action | Valid input state | Resulting state | Use when |
+| ------ | ----------------- | --------------- | -------- |
+| `prepare({ mintUrl, amount, target? })` | none | `prepared` | You want to reserve proofs and show fees before creating a token. |
+| `execute(operationOrId)` | `prepared` | `pending` | The user confirmed the send and you need the shareable token. |
+| `refresh(operationId)` | any, actively checks `pending` | latest stored state | You are resuming stale persisted state or building recovery UI. |
+| `cancel(operationId)` | `prepared` | `rolled_back` | The user abandons the send before a token is created. |
+| `reclaim(operationId)` | `pending` | `rolled_back` when reclaim is possible | The token was created but should be reclaimed before receipt. |
+| `finalize(operationId)` | `pending` | `finalized` | You know the token was claimed and want to finalize explicitly. |
+
+With the default proof-state watcher enabled, most apps do not need to poll
+`refresh()` during the happy path. Render from the operation returned by
+`execute()` and react to `send:finalized` or history updates when the recipient
+claims the token.
 
 ## Using the Send API
 

--- a/packages/docs/pages/send-operations.md
+++ b/packages/docs/pages/send-operations.md
@@ -34,14 +34,14 @@ init ──► prepared ──► executing ──► pending ──► finalize
 
 ## Lifecycle Actions
 
-| Action | Valid input state | Resulting state | Use when |
-| ------ | ----------------- | --------------- | -------- |
-| `prepare({ mintUrl, amount, target? })` | none | `prepared` | You want to reserve proofs and show fees before creating a token. |
-| `execute(operationOrId)` | `prepared` | `pending` | The user confirmed the send and you need the shareable token. |
-| `refresh(operationId)` | any, actively checks `pending` | latest stored state | You are resuming stale persisted state or building recovery UI. |
-| `cancel(operationId)` | `prepared` | `rolled_back` | The user abandons the send before a token is created. |
-| `reclaim(operationId)` | `pending` | `rolled_back` when reclaim is possible | The token was created but should be reclaimed before receipt. |
-| `finalize(operationId)` | `pending` | `finalized` | You know the token was claimed and want to finalize explicitly. |
+| Action                                  | Valid input state              | Resulting state                        | Use when                                                          |
+| --------------------------------------- | ------------------------------ | -------------------------------------- | ----------------------------------------------------------------- |
+| `prepare({ mintUrl, amount, target? })` | none                           | `prepared`                             | You want to reserve proofs and show fees before creating a token. |
+| `execute(operationOrId)`                | `prepared`                     | `pending`                              | The user confirmed the send and you need the shareable token.     |
+| `refresh(operationId)`                  | any, actively checks `pending` | latest stored state                    | You are resuming stale persisted state or building recovery UI.   |
+| `cancel(operationId)`                   | `prepared`                     | `rolled_back`                          | The user abandons the send before a token is created.             |
+| `reclaim(operationId)`                  | `pending`                      | `rolled_back` when reclaim is possible | The token was created but should be reclaimed before receipt.     |
+| `finalize(operationId)`                 | `pending`                      | `finalized`                            | You know the token was claimed and want to finalize explicitly.   |
 
 With the default proof-state watcher enabled, most apps do not need to poll
 `refresh()` during the happy path. Render from the operation returned by

--- a/packages/docs/starting/minting.md
+++ b/packages/docs/starting/minting.md
@@ -37,3 +37,6 @@ coco.on('mint-op:finalized', (payload) => {
   }
 });
 ```
+
+For the full state machine and action reference, see
+[Mint Operations](../pages/mint-operations.md).

--- a/packages/docs/starting/sending-receiving.md
+++ b/packages/docs/starting/sending-receiving.md
@@ -4,18 +4,23 @@ Cashu tokens can be sent between users as encoded strings. Coco provides simple 
 
 ## Receiving Tokens
 
-To receive a Cashu token, use the `receive` method. The token can be passed as either an encoded string or a parsed `Token` object:
+For app flows that need review, cancellation, or crash recovery, prefer
+`coco.ops.receive.prepare()` and `coco.ops.receive.execute()`. The token can be
+passed as either an encoded string or a parsed `Token` object:
 
 ```ts
-// Receive an encoded token string
-await coco.wallet.receive('cashuBpGF0gaJhaUgA...');
+const prepared = await coco.ops.receive.prepare({ token: 'cashuBpGF0gaJhaUgA...' });
 
-// Or receive a parsed token object
-const token = { mint: 'https://mint.url', proofs: [...] };
-await coco.wallet.receive(token);
+if (userConfirmed) {
+  await coco.ops.receive.execute(prepared.id);
+} else {
+  await coco.ops.receive.cancel(prepared.id);
+}
 ```
 
 > **Note:** The mint must be trusted before receiving tokens. See [Adding a Mint](./adding-mints.md).
+
+For the full receive lifecycle, see [Receive Operations](../pages/receive-operations.md).
 
 ### Events
 
@@ -52,6 +57,7 @@ if (userConfirmed) {
 ```
 
 `coco.ops.send` and `coco.ops.receive` are the canonical workflow APIs.
+For send state details, see [Send Operations](../pages/send-operations.md).
 
 ### Understanding Fees
 
@@ -102,6 +108,7 @@ Use melt operations to pay BOLT11 invoices via `coco.ops.melt`:
 - `refresh(operationId: string): Promise<MeltOperation>`
 
 Finalized melt operations include `changeAmount` and `effectiveFee` when that settlement data is available.
+For the full melt lifecycle, see [Melt Operations](../pages/melt-operations.md).
 
 ## Events
 


### PR DESCRIPTION
## Description

This pull request updates Coco's public docs for durable operation workflows, adding dedicated receive and mint operation references and tightening React hook guidance around bound operations, lifecycle events, and `refresh()`.

## Problem

The docs did not fully explain receive and mint operation state machines, and some lifecycle guidance was easy to misread. Send docs also still referenced `completed` where the current terminal send state is `finalized`.

## Summary

- Adds new `Receive Operations` and `Mint Operations` pages and links them in the VitePress sidebar.
- Updates React hook docs to clarify `currentOperation`, `executeResult`, initial binding, no-arg follow-up actions, event updates, `reset()`, and `refresh()`.
- Updates starting guides and send operation docs to point users at the canonical operation lifecycle references.
- Docs navigation changed; attach a docs preview screenshot if visual review is needed.

## Verification

- `git diff --check`
- `bun run docs:build`

## Changeset

- No changeset added; this is a docs-only update with no package API or runtime behavior change.