### PR TITLE
chore: enable Codecov carryforward flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## Description

This pull request adds root Codecov configuration so path-filtered coverage workflows can safely skip unchanged test suites without producing missing-flag coverage drops.

## Problem

PRs that trigger only some coverage workflows can upload fewer Codecov flags than the base commit. In PR #149, `core-integration` uploaded but `core-unit` did not, causing Codecov to compare against a missing flag even though all changed coverable lines were covered.

## Summary

- Add `codecov.yml` with `flag_management.default_rules.carryforward: true`.
- Allow Codecov to carry forward previously uploaded flags for legitimate partial CI runs.
- Leave workflow path filters unchanged.

## Verification

- `curl --data-binary @codecov.yml https://api.codecov.io/validate`
- `bun run test:coverage:core`
- `git diff --no-index --check /dev/null codecov.yml`

## Changeset

- No changeset added; this is CI/Codecov configuration only and does not affect published package runtime behavior.