### PR TITLE
feat: migrate to cashu-ts v4

### DIFF
--- a/.changeset/cashu-ts-v4.md
+++ b/.changeset/cashu-ts-v4.md
@@ -1,0 +1,10 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-adapter-tests': major
+---
+
+Upgrade `@cashu/cashu-ts` to `4.1.0` and adapt core wallet flows to the v4
+`Amount` API while preserving coco's numeric repository and operation models.
+
+Token encoding now follows cashu-ts v4 options, so `WalletApi.encodeToken`
+accepts `removeDleq` instead of the removed v3/v4 `version` selector.

--- a/bun.lock
+++ b/bun.lock
@@ -17,30 +17,30 @@
     },
     "packages/adapter-tests": {
       "name": "@cashu/coco-adapter-tests",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "fake-bolt11": "^0.1.0",
       },
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
       },
       "peerDependencies": {
-        "@cashu/cashu-ts": "^3.3.0",
-        "@cashu/coco-core": "^1.0.0-rc.2",
+        "@cashu/cashu-ts": "4.1.0",
+        "@cashu/coco-core": "^1.0.0-rc.5",
         "typescript": "^5",
       },
     },
     "packages/core": {
       "name": "@cashu/coco-core",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
-        "@cashu/cashu-ts": "^3.5.0",
+        "@cashu/cashu-ts": "4.1.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@scure/bip32": "^2.0.1",
       },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.2",
+        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
         "typescript-eslint": "^8.40.0",
       },
       "peerDependencies": {
@@ -55,38 +55,43 @@
     },
     "packages/expo-sqlite": {
       "name": "@cashu/coco-expo-sqlite",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
+      "dependencies": {
+        "@cashu/cashu-ts": "4.1.0",
+      },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.2",
+        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "expo-sqlite": "*",
         "typescript": "^5",
       },
     },
     "packages/indexeddb": {
       "name": "@cashu/coco-indexeddb",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
+        "@cashu/cashu-ts": "4.1.0",
         "dexie": "^4.0.8",
       },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.2",
+        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
         "@vitest/browser": "^3.2.4",
         "playwright": "^1.52.0",
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "typescript": "^5",
       },
     },
     "packages/react": {
       "name": "@cashu/coco-react",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/cashu-ts": "4.1.0",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "@eslint/js": "^9.33.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.10",
@@ -105,34 +110,38 @@
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "react": "^19",
       },
     },
     "packages/sqlite-bun": {
       "name": "@cashu/coco-sqlite-bun",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
+      "dependencies": {
+        "@cashu/cashu-ts": "4.1.0",
+      },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.2",
+        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "typescript": "^5",
       },
     },
     "packages/sqlite3": {
       "name": "@cashu/coco-sqlite",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
+        "@cashu/cashu-ts": "4.1.0",
         "better-sqlite3": "^12.6.2",
       },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.2",
+        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
         "@types/better-sqlite3": "^7.6.12",
         "vitest": "^2.1.9",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "typescript": "^5",
       },
     },
@@ -377,7 +386,7 @@
 
     "@babel/types": ["@babel/types@8.0.0-beta.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-beta.4", "@babel/helper-validator-identifier": "^8.0.0-beta.4" } }, "sha512-xjk2xqYp25ePzAs0I08hN2lrbUDDQFfCjwq6MIEa8HwHa0WK8NfNtdvtXod8Ku2CbE1iui7qwWojGvjQiyrQeA=="],
 
-    "@cashu/cashu-ts": ["@cashu/cashu-ts@3.5.0", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/base": "^2.0.0", "@scure/bip32": "^2.0.1" } }, "sha512-LVOfCY1ZjQ+/f/CwekCeH+QRjN9SaHp8rTUjf8f4feHxT9Bqn/Bw+qYfNhaBKLWrqS19DMK/q/ern3AQ2MCq9w=="],
+    "@cashu/cashu-ts": ["@cashu/cashu-ts@4.1.0", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/base": "^2.0.0", "@scure/bip32": "^2.0.1" } }, "sha512-QlqacjFDtkcODmK+JeXhocgSMghYDSahuR8YB2DsB0F9EeZvbxEfw5S1NV4EdUWCWbdtoOOkHze7GfGhYJUk7A=="],
 
     "@cashu/coco-adapter-tests": ["@cashu/coco-adapter-tests@workspace:packages/adapter-tests"],
 

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@cashu/coco-core": "^1.0.0-rc.5",
     "typescript": "^5",
-    "@cashu/cashu-ts": "^3.3.0"
+    "@cashu/cashu-ts": "4.1.0"
   },
   "dependencies": {
     "fake-bolt11": "^0.1.0"

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -6,6 +6,7 @@ import type {
   MeltOperation,
   AuthSession,
 } from '@cashu/coco-core';
+import { Amount } from '@cashu/cashu-ts';
 
 type TransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
   repositories: TRepositories;
@@ -305,8 +306,8 @@ export async function runAuthSessionRepositoryContract(
           refreshToken: 'refresh-xyz',
           scope: 'read write',
           batPool: [
-            { id: 'proof-1', amount: 1, secret: 's1', C: 'C1' },
-            { id: 'proof-2', amount: 2, secret: 's2', C: 'C2' },
+            { id: 'proof-1', amount: Amount.from(1), secret: 's1', C: 'C1' },
+            { id: 'proof-2', amount: Amount.from(2), secret: 's2', C: 'C2' },
           ] as AuthSession['batPool'],
         });
         await repo.saveSession(session);
@@ -317,6 +318,8 @@ export async function runAuthSessionRepositoryContract(
         expect(result!.scope).toBe('read write');
         expect(result!.batPool).toBeDefined();
         expect(result!.batPool!).toHaveLength(2);
+        expect(result!.batPool![0]!.amount.equals(1)).toBe(true);
+        expect(result!.batPool![1]!.amount.equals(2)).toBe(true);
       } finally {
         await dispose();
       }

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -262,16 +262,20 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       return async () => seed;
     };
 
-    beforeEach(async () => {
-      seedGetter = await createSeedGetter();
-    });
-
-    afterEach(async () => {
+    const disposeManager = async () => {
       if (mgr) {
         await mgr.pauseSubscriptions();
         await mgr.dispose();
         mgr = undefined;
       }
+    };
+
+    beforeEach(async () => {
+      seedGetter = await createSeedGetter();
+    });
+
+    afterEach(async () => {
+      await disposeManager();
     });
 
     describe('Mint Management', () => {
@@ -482,6 +486,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -688,6 +693,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -742,6 +748,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -945,6 +952,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -1107,6 +1115,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -1309,6 +1318,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -1713,7 +1723,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           }
           await dispose();
         }
-      }, 20000);
+      }, 30000);
     });
 
     describe('Full Workflow Integration', () => {
@@ -2114,6 +2124,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;
@@ -2558,6 +2569,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       });
 
       afterEach(async () => {
+        await disposeManager();
         if (repositoriesDispose) {
           await repositoriesDispose();
           repositoriesDispose = undefined;

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -4,6 +4,8 @@ import {
   Mint,
   Wallet,
   OutputData,
+  sumProofs,
+  type AmountLike,
   type OutputConfig,
   PaymentRequest,
   PaymentRequestTransportType,
@@ -15,7 +17,7 @@ import {
 } from '@cashu/cashu-ts';
 import { createFakeInvoice } from 'fake-bolt11';
 
-export type OutputDataFactory = (amount: number, keys: MintKeys | HasKeysetKeys) => OutputData;
+export type OutputDataFactory = (amount: AmountLike, keys: MintKeys | HasKeysetKeys) => OutputData;
 
 export type IntegrationTestRunner = {
   describe(name: string, fn: () => void): void;
@@ -495,7 +497,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           mgr!.once('send:pending', (payload) => {
             expect(payload.mintUrl).toBe(mintUrl);
             expect(payload.token.proofs.length).toBeGreaterThan(0);
-            const tokenAmount = payload.token.proofs.reduce((sum, p) => sum + p.amount, 0);
+            const tokenAmount = sumProofs(payload.token.proofs).toNumber();
             expect(tokenAmount).toBeGreaterThanOrEqual(sendAmount);
             resolve(payload);
           });
@@ -586,9 +588,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         const op = await mgr!.ops.receive.execute(prepOp.id);
 
-        const tokenAmount = token.proofs.reduce((sum: number, proof: { amount: number }) => {
-          return sum + proof.amount;
-        }, 0);
+        const tokenAmount = sumProofs(token.proofs).toNumber();
         expect(op.state).toBe('finalized');
 
         expect(await getMintSpendableBalance(mgr!, mintUrl)).toBeGreaterThan(preBalance);
@@ -626,8 +626,8 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(decodedToken.mint).toBe(token.mint);
         expect(decodedToken.proofs).toHaveLength(token.proofs.length);
 
-        const decodedAmount = decodedToken.proofs.reduce((sum, proof) => sum + proof.amount, 0);
-        const tokenAmount = token.proofs.reduce((sum, proof) => sum + proof.amount, 0);
+        const decodedAmount = sumProofs(decodedToken.proofs).toNumber();
+        const tokenAmount = sumProofs(token.proofs).toNumber();
         expect(decodedAmount).toBe(tokenAmount);
       });
 
@@ -2642,7 +2642,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(receivedToken!.mint).toBe(mintUrl);
         expect(receivedToken!.proofs.length).toBeGreaterThan(0);
 
-        const tokenAmount = receivedToken!.proofs.reduce((sum, p) => sum + p.amount, 0);
+        const tokenAmount = sumProofs(receivedToken!.proofs).toNumber();
         expect(tokenAmount).toBeGreaterThanOrEqual(30);
 
         // Balance should have decreased
@@ -2679,7 +2679,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(receivedToken).toBeDefined();
         expect(receivedToken!.mint).toBe(mintUrl);
 
-        const tokenAmount = receivedToken!.proofs.reduce((sum, p) => sum + p.amount, 0);
+        const tokenAmount = sumProofs(receivedToken!.proofs).toNumber();
         expect(tokenAmount).toBeGreaterThanOrEqual(25);
       });
 

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -14,6 +14,7 @@ import {
   type HasKeysetKeys,
   parseP2PKSecret,
   type Secret,
+  JSONInt,
 } from '@cashu/cashu-ts';
 import { createFakeInvoice } from 'fake-bolt11';
 
@@ -78,6 +79,51 @@ const watcherTestSubscriptions = {
   slowPollingIntervalMs: 50,
   fastPollingIntervalMs: 50,
 };
+
+type TestWalletOptions = ConstructorParameters<typeof Wallet>[1];
+
+async function browserSafeMintRequest<T>(options: {
+  endpoint: string;
+  requestBody?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  method?: string;
+}): Promise<T> {
+  const body =
+    options.requestBody === undefined ? undefined : JSONInt.stringify(options.requestBody);
+  const headers = new Headers({
+    Accept: 'application/json, text/plain, */*',
+    ...(options.headers ?? {}),
+  });
+
+  if (body !== undefined) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  const response = await fetch(options.endpoint, {
+    method: options.method ?? (body === undefined ? 'GET' : 'POST'),
+    headers,
+    body,
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text || `HTTP ${response.status}`);
+  }
+  if (!text) {
+    throw new Error('Empty response body');
+  }
+
+  return JSONInt.parse(text) as T;
+}
+
+function createTestMint(mintUrl: string): Mint {
+  return new Mint(mintUrl, { customRequest: browserSafeMintRequest });
+}
+
+function createTestWallet(mintUrl: string, options?: TestWalletOptions): Wallet {
+  return new Wallet(createTestMint(mintUrl), options);
+}
 
 function waitForEvent<TPayload = unknown>(
   manager: Manager,
@@ -876,7 +922,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
             effectiveFee?: number;
             finalizedData?: { preimage?: string };
           };
-          const meltQuote = await new Mint(mintUrl).checkMeltQuoteBolt11(prepared.quoteId);
+          const meltQuote = await createTestMint(mintUrl).checkMeltQuoteBolt11(prepared.quoteId);
           const expectedPreimage = meltQuote.payment_preimage ?? undefined;
           expect(settlement.changeAmount).toBeDefined();
           expect(settlement.effectiveFee).toBeDefined();
@@ -911,7 +957,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
               effectiveFee?: number;
               finalizedData?: { preimage?: string };
             };
-            const meltQuote = await new Mint(mintUrl).checkMeltQuoteBolt11(refreshed.quoteId);
+            const meltQuote = await createTestMint(mintUrl).checkMeltQuoteBolt11(refreshed.quoteId);
             const expectedPreimage = meltQuote.payment_preimage ?? undefined;
             expect(operationAfterRetry!.state).toBe('finalized');
             expect(settlement.changeAmount).toBeDefined();
@@ -2138,7 +2184,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect(keypair.publicKeyHex).toBeDefined();
 
         // Create a sender wallet with cashu-ts
-        const senderWallet = new Wallet(new Mint(mintUrl));
+        const senderWallet = createTestWallet(mintUrl);
         await senderWallet.loadMint();
 
         // Fund the sender wallet
@@ -2199,7 +2245,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         expect('secretKey' in keypair).toBe(false);
 
         // Create a sender wallet with cashu-ts
-        const senderWallet = new Wallet(new Mint(mintUrl));
+        const senderWallet = createTestWallet(mintUrl);
         await senderWallet.loadMint();
 
         // Fund the sender wallet
@@ -2256,7 +2302,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       it('should fail to receive P2PK token without the private key', async () => {
         // Create a sender wallet with cashu-ts
         const senderSeed = crypto.getRandomValues(new Uint8Array(64));
-        const senderWallet = new Wallet(new Mint(mintUrl), {
+        const senderWallet = createTestWallet(mintUrl, {
           bip39seed: senderSeed,
         });
         await senderWallet.loadMint();
@@ -2412,7 +2458,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
         const keypair2 = await mgr!.keyring.generateKeyPair();
 
         // Create sender wallet
-        const senderWallet = new Wallet(new Mint(mintUrl));
+        const senderWallet = createTestWallet(mintUrl);
         await senderWallet.loadMint();
         const keyset = senderWallet.keyChain.getCheapestKeyset();
 
@@ -2481,7 +2527,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
           // Create a separate wallet with a different seed that has funds
           const toBeSweptSeed = crypto.getRandomValues(new Uint8Array(64));
-          const baseWallet = new Wallet(new Mint(mintUrl), {
+          const baseWallet = createTestWallet(mintUrl, {
             bip39seed: toBeSweptSeed,
           });
           await baseWallet.loadMint();

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -61,6 +61,7 @@ import {
 import { SubscriptionApi } from './api/SubscriptionApi.ts';
 import { PluginHost } from './plugins/PluginHost.ts';
 import type { Plugin, ServiceMap, PluginExtensions } from './plugins/types.ts';
+import { Amount } from '@cashu/cashu-ts';
 
 /**
  * Configuration options for initializing the Coco Cashu manager
@@ -492,7 +493,7 @@ export class Manager {
       try {
         const operation = await this.mintOperationService.importQuote(
           quote.mintUrl,
-          quote,
+          { ...quote, amount: Amount.from(quote.amount) },
           'bolt11',
           {},
         );

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -219,7 +219,7 @@ In-memory reference implementations are provided under `repositories/memory/` fo
 - `restore(mintUrl: string): Promise<void>`
 - `sweep(mintUrl: string, bip39seed: Uint8Array): Promise<void>`
 - `decodeToken(tokenString: string, mintUrl?: string): Promise<Token>`
-- `encodeToken(token: Token, opts?: { version?: 3 | 4 }): string`
+- `encodeToken(token: Token, opts?: { removeDleq?: boolean }): string`
 - `encodePaymentRequest(paymentRequest: PaymentRequest, version?: 'creqA' | 'creqB'): string`
 
 ### AuthApi

--- a/packages/core/api/SubscriptionApi.ts
+++ b/packages/core/api/SubscriptionApi.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '../logging/Logger.ts';
 import { SubscriptionManager } from '../infra/SubscriptionManager.ts';
 import type { SubscriptionKind } from '../infra/SubscriptionProtocol.ts';
+import type { MeltQuoteState, MintQuoteState } from '@cashu/cashu-ts';
 
 export class SubscriptionApi {
   private readonly subs: SubscriptionManager;
@@ -12,21 +13,41 @@ export class SubscriptionApi {
   }
 
   async awaitMintQuotePaid(mintUrl: string, quoteId: string): Promise<unknown> {
-    return this.awaitFirstNotification(mintUrl, 'bolt11_mint_quote', [quoteId]);
+    return this.awaitFirstMatchingNotification(
+      mintUrl,
+      'bolt11_mint_quote',
+      [quoteId],
+      (payload) => {
+        const state = (payload as { state?: MintQuoteState }).state;
+        return state === 'PAID' || state === 'ISSUED';
+      },
+    );
   }
 
   async awaitMeltQuotePaid(mintUrl: string, quoteId: string): Promise<unknown> {
-    return this.awaitFirstNotification(mintUrl, 'bolt11_melt_quote', [quoteId]);
+    return this.awaitFirstMatchingNotification(
+      mintUrl,
+      'bolt11_melt_quote',
+      [quoteId],
+      (payload) => {
+        const state = (payload as { state?: MeltQuoteState }).state;
+        return state === 'PAID';
+      },
+    );
   }
 
-  private async awaitFirstNotification(
+  private async awaitFirstMatchingNotification(
     mintUrl: string,
     kind: SubscriptionKind,
     filters: string[],
+    predicate: (payload: unknown) => boolean,
   ): Promise<unknown> {
     return new Promise<unknown>(async (resolve, reject) => {
       try {
         const { unsubscribe } = await this.subs.subscribe(mintUrl, kind, filters, (payload) => {
+          if (!predicate(payload)) {
+            return;
+          }
           try {
             resolve(payload);
           } finally {

--- a/packages/core/api/WalletApi.ts
+++ b/packages/core/api/WalletApi.ts
@@ -139,10 +139,10 @@ export class WalletApi {
    * Encode a token to a string.
    * @param token - The token to encode
    * @param opts - Optional encoding options
-   * @param opts.version - Token version (3 for cashuA, 4 for cashuB). Defaults to 4 if keyset allows it.
+   * @param opts.removeDleq - Remove DLEQ proofs from the encoded token.
    * @returns Encoded token string
    */
-  encodeToken(token: Token, opts?: { version?: 3 | 4 }): string {
+  encodeToken(token: Token, opts?: { removeDleq?: boolean }): string {
     return getEncodedToken(token, opts);
   }
 

--- a/packages/core/infra/MintAdapter.ts
+++ b/packages/core/infra/MintAdapter.ts
@@ -3,12 +3,13 @@ import {
   type CheckStatePayload,
   type Keys,
   OutputData,
-  type Proof,
+  type ProofLike,
   type MeltQuoteBolt11Response,
   type MeltQuoteBolt12Response,
   type GetKeysetsResponse,
   type AuthProvider,
   type MintQuoteBolt11Response,
+  normalizeProofAmounts,
 } from '@cashu/cashu-ts';
 import type { MintInfo } from '../types';
 import type { MintRequestProvider } from './MintRequestProvider.ts';
@@ -105,23 +106,31 @@ export class MintAdapter {
 
   async customMeltBolt11(
     mintUrl: string,
-    proofsToSend: Proof[],
+    proofsToSend: ProofLike[],
     changeOutputs: OutputData[],
     quoteId: string,
   ): Promise<MeltQuoteBolt11Response> {
     const cashuMint = this.getCashuMint(mintUrl);
     const blindedMessages = changeOutputs.map((output) => output.blindedMessage);
-    return cashuMint.meltBolt11({ quote: quoteId, inputs: proofsToSend, outputs: blindedMessages });
+    return cashuMint.meltBolt11({
+      quote: quoteId,
+      inputs: normalizeProofAmounts(proofsToSend),
+      outputs: blindedMessages,
+    });
   }
 
   async customMeltBolt12(
     mintUrl: string,
-    proofsToSend: Proof[],
+    proofsToSend: ProofLike[],
     changeOutputs: OutputData[],
     quoteId: string,
   ): Promise<MeltQuoteBolt12Response> {
     const cashuMint = this.getCashuMint(mintUrl);
     const blindedMessages = changeOutputs.map((output) => output.blindedMessage);
-    return cashuMint.meltBolt12({ quote: quoteId, inputs: proofsToSend, outputs: blindedMessages });
+    return cashuMint.meltBolt12({
+      quote: quoteId,
+      inputs: normalizeProofAmounts(proofsToSend),
+      outputs: blindedMessages,
+    });
   }
 }

--- a/packages/core/infra/RequestRateLimiter.ts
+++ b/packages/core/infra/RequestRateLimiter.ts
@@ -1,3 +1,4 @@
+import { JSONInt } from '@cashu/cashu-ts';
 import type { Logger } from '../logging/Logger.ts';
 import { HttpResponseError, NetworkError, MintOperationError } from '../models/Error';
 
@@ -88,14 +89,14 @@ export class RequestRateLimiter {
     let body: unknown | undefined = undefined;
     if (requestBody !== undefined) {
       finalHeaders.set('Content-Type', 'application/json');
-      body = JSON.stringify(requestBody);
+      body = JSONInt.stringify(requestBody);
     }
 
     // Log request payload
     this.logger?.debug('Mint request', {
       method: init.method || 'GET',
       endpoint,
-      requestBody: requestBody ? JSON.stringify(requestBody, null, 2) : undefined,
+      requestBody: requestBody ? JSONInt.stringify(requestBody, undefined, 2) : undefined,
     });
 
     let response: Response;

--- a/packages/core/infra/handlers/melt/MeltBolt11Handler.ts
+++ b/packages/core/infra/handlers/melt/MeltBolt11Handler.ts
@@ -1,4 +1,9 @@
-import type { OutputConfig, Proof, SerializedBlindedSignature } from '@cashu/cashu-ts';
+import type {
+  OutputConfig,
+  Proof,
+  ProofLike,
+  SerializedBlindedSignature,
+} from '@cashu/cashu-ts';
 import { MintOperationError } from '@core/models';
 import type {
   BasePrepareContext,
@@ -15,6 +20,7 @@ import type {
   RollbackContext,
 } from '@core/operations/melt';
 import {
+  amountToNumber,
   computeYHexForSecrets,
   deserializeOutputData,
   mapProofToCoreProof,
@@ -30,6 +36,7 @@ import {
   sumProofs,
   type MeltQuoteData,
 } from './MeltBolt11Handler.utils.ts';
+import type { CoreProof } from '@core/types';
 
 export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
   // ============================================================================
@@ -48,7 +55,8 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
     meltAmount: number,
     changeProofs?: SerializedBlindedSignature[],
   ): { changeAmount: number; effectiveFee: number } {
-    const changeAmount = changeProofs?.reduce((sum, p) => sum + p.amount, 0) ?? 0;
+    const changeAmount =
+      changeProofs?.reduce((sum, p) => sum + amountToNumber(p.amount), 0) ?? 0;
     const effectiveFee = meltInputAmount - meltAmount - changeAmount;
     return { changeAmount, effectiveFee };
   }
@@ -71,7 +79,7 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
     }
 
     return deserializeOutputData(operation.swapOutputData).send.reduce(
-      (sum, output) => sum + output.blindedMessage.amount,
+      (sum, output) => sum + amountToNumber(output.blindedMessage.amount),
       0,
     );
   }
@@ -104,7 +112,13 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
     const { mintUrl, id: operationId } = ctx.operation;
     ctx.logger?.debug('Preparing bolt11 melt operation', { operationId, mintUrl });
 
-    const quote = await ctx.wallet.createMeltQuote(ctx.operation.methodData.invoice);
+    const remoteQuote = await ctx.wallet.createMeltQuoteBolt11(ctx.operation.methodData.invoice);
+    const quote: MeltQuoteData = {
+      quote: remoteQuote.quote,
+      amount: amountToNumber(remoteQuote.amount),
+      fee_reserve: amountToNumber(remoteQuote.fee_reserve),
+      unit: remoteQuote.unit,
+    };
     const { amount, fee_reserve } = quote;
     const totalAmount = amount + fee_reserve;
 
@@ -196,7 +210,7 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
     const selectedAmount = sumProofs(selectedProofs);
     const inputSecrets = selectedProofs.map((p) => p.secret);
 
-    const swapFee = ctx.wallet.getFeesForProofs(selectedProofs);
+    const swapFee = amountToNumber(ctx.wallet.getFeesForProofs(selectedProofs));
     const sendAmount = totalAmount;
     const keepAmount = selectedAmount - sendAmount - swapFee;
 
@@ -328,7 +342,7 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
       change?: SerializedBlindedSignature[];
       payment_preimage?: string | null;
     },
-    proofsToMelt: Proof[],
+    proofsToMelt: ProofLike[],
   ): Promise<ExecutionResult<'bolt11'>> {
     const { mintUrl } = ctx.operation;
     const { state, change, payment_preimage: paymentPreimage } = response;
@@ -372,7 +386,7 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
   /**
    * Retrieve the input proofs reserved for this operation.
    */
-  private async getInputProofs(ctx: ExecuteContext<'bolt11'>): Promise<Proof[]> {
+  private async getInputProofs(ctx: ExecuteContext<'bolt11'>): Promise<CoreProof[]> {
     const { mintUrl, id: operationId } = ctx.operation;
     const proofs = await ctx.proofRepository.getProofsByOperationId(mintUrl, operationId);
     if (proofs.length !== ctx.operation.inputProofSecrets.length) {
@@ -385,7 +399,10 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
    * Execute the pre-melt swap to get exact-amount proofs.
    * Returns the "send" proofs from the swap which will be used for the melt.
    */
-  private async executeSwap(ctx: ExecuteContext<'bolt11'>, inputProofs: Proof[]): Promise<Proof[]> {
+  private async executeSwap(
+    ctx: ExecuteContext<'bolt11'>,
+    inputProofs: ProofLike[],
+  ): Promise<Proof[]> {
     const { swapOutputData, inputProofSecrets, id: operationId, mintUrl } = ctx.operation;
 
     if (!swapOutputData) {
@@ -393,7 +410,10 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
     }
 
     const swapData = deserializeOutputData(swapOutputData);
-    const sendAmount = swapData.send.reduce((a, c) => a + c.blindedMessage.amount, 0);
+    const sendAmount = swapData.send.reduce(
+      (amount, output) => amount + amountToNumber(output.blindedMessage.amount),
+      0,
+    );
     const { wallet } = await ctx.walletService.getWalletWithActiveKeysetId(mintUrl);
 
     ctx.logger?.debug('Executing pre-melt swap', {
@@ -710,7 +730,7 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
    */
   private async recoverExecutingWithLocalSwapProofs(
     ctx: RecoverExecutingContext<'bolt11'>,
-    swapSendProofs: Proof[],
+    swapSendProofs: CoreProof[],
   ): Promise<ExecutionResult<'bolt11'>> {
     const { operation } = ctx;
     const { mintUrl, id: operationId } = operation;
@@ -800,7 +820,9 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
    * Find swap send proofs that were saved locally during the swap.
    * Returns empty array if proofs don't exist (crash before save).
    */
-  private async findLocalSwapSendProofs(ctx: RecoverExecutingContext<'bolt11'>): Promise<Proof[]> {
+  private async findLocalSwapSendProofs(
+    ctx: RecoverExecutingContext<'bolt11'>,
+  ): Promise<CoreProof[]> {
     const { swapOutputData, id: operationId, mintUrl } = ctx.operation;
     if (!swapOutputData) return [];
 

--- a/packages/core/infra/handlers/melt/MeltBolt11Handler.ts
+++ b/packages/core/infra/handlers/melt/MeltBolt11Handler.ts
@@ -1,9 +1,4 @@
-import type {
-  OutputConfig,
-  Proof,
-  ProofLike,
-  SerializedBlindedSignature,
-} from '@cashu/cashu-ts';
+import type { OutputConfig, Proof, ProofLike, SerializedBlindedSignature } from '@cashu/cashu-ts';
 import { MintOperationError } from '@core/models';
 import type {
   BasePrepareContext,
@@ -55,8 +50,7 @@ export class MeltBolt11Handler implements MeltMethodHandler<'bolt11'> {
     meltAmount: number,
     changeProofs?: SerializedBlindedSignature[],
   ): { changeAmount: number; effectiveFee: number } {
-    const changeAmount =
-      changeProofs?.reduce((sum, p) => sum + amountToNumber(p.amount), 0) ?? 0;
+    const changeAmount = changeProofs?.reduce((sum, p) => sum + amountToNumber(p.amount), 0) ?? 0;
     const effectiveFee = meltInputAmount - meltAmount - changeAmount;
     return { changeAmount, effectiveFee };
   }

--- a/packages/core/infra/handlers/melt/MeltBolt11Handler.utils.ts
+++ b/packages/core/infra/handlers/melt/MeltBolt11Handler.utils.ts
@@ -1,4 +1,5 @@
 import type { Proof } from '@cashu/cashu-ts';
+import { sumProofAmounts } from '@core/utils';
 import type {
   ExecutingMeltOperation,
   FinalizeResult,
@@ -50,7 +51,7 @@ export const SWAP_THRESHOLD_RATIO = 1.1;
  * Calculate the total amount of a proof set.
  */
 export function sumProofs(proofs: Proof[]): number {
-  return proofs.reduce((sum, p) => sum + p.amount, 0);
+  return sumProofAmounts(proofs);
 }
 
 /**

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -11,7 +11,12 @@ import type {
   PendingMintCheckResult,
 } from '@core/operations/mint';
 import { MintOperationError } from '../../../models/Error';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
+import {
+  amountToNumber,
+  deserializeOutputData,
+  mapProofToCoreProof,
+  serializeOutputData,
+} from '@core/utils';
 import type { MintQuoteBolt11Response } from '@cashu/cashu-ts';
 
 export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
@@ -20,14 +25,15 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
   ): Promise<PendingMintOperation<'bolt11'> & MintMethodMeta<'bolt11'>> {
     const quote =
       ctx.importedQuote ?? (await ctx.wallet.createMintQuoteBolt11(ctx.operation.amount));
+    const quoteAmount = amountToNumber(quote.amount);
 
-    if (!quote.amount || quote.amount <= 0) {
+    if (quoteAmount <= 0) {
       throw new Error(`Mint quote ${quote.quote} has invalid amount`);
     }
 
-    if (quote.amount !== ctx.operation.amount) {
+    if (quoteAmount !== ctx.operation.amount) {
       throw new Error(
-        `Mint quote ${quote.quote} amount ${quote.amount} does not match requested amount ${ctx.operation.amount}`,
+        `Mint quote ${quote.quote} amount ${quoteAmount} does not match requested amount ${ctx.operation.amount}`,
       );
     }
 
@@ -40,7 +46,7 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
       ctx.operation.mintUrl,
       {
-        keep: quote.amount,
+        keep: quoteAmount,
         send: 0,
       },
     );
@@ -52,7 +58,7 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     return {
       ...ctx.operation,
       quoteId: quote.quote,
-      amount: quote.amount,
+      amount: quoteAmount,
       unit: quote.unit,
       request: quote.request,
       expiry: quote.expiry,

--- a/packages/core/infra/handlers/send/DefaultSendHandler.ts
+++ b/packages/core/infra/handlers/send/DefaultSendHandler.ts
@@ -1,4 +1,4 @@
-import type { Token, Proof, OutputConfig } from '@cashu/cashu-ts';
+import { normalizeProofAmounts, type Token, type Proof, type OutputConfig } from '@cashu/cashu-ts';
 import type {
   SendMethodHandler,
   BasePrepareContext,
@@ -15,10 +15,12 @@ import type {
 } from '../../../operations/send/SendOperation';
 import { getSendProofSecrets, getKeepProofSecrets } from '../../../operations/send/SendOperation';
 import {
+  amountToNumber,
   mapProofToCoreProof,
   serializeOutputData,
   deserializeOutputData,
   getSecretsFromSerializedOutputData,
+  sumProofAmounts,
 } from '../../../utils';
 import type { CoreProof } from '../../../types';
 
@@ -36,7 +38,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
 
     // Try exact match first (no swap needed)
     const exactProofs = await proofService.selectProofsToSend(mintUrl, amount, false);
-    const exactAmount = exactProofs.reduce((acc: number, p: Proof) => acc + p.amount, 0);
+    const exactAmount = sumProofAmounts(exactProofs);
     const needsSwap = exactAmount !== amount || exactProofs.length === 0;
 
     let selectedProofs: Proof[];
@@ -56,8 +58,8 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
 
       const selected = await proofService.selectProofsToSend(mintUrl, amount, true);
       selectedProofs = selected;
-      const selectedAmount = selectedProofs.reduce((acc: number, p: Proof) => acc + p.amount, 0);
-      fee = wallet.getFeesForProofs(selectedProofs);
+      const selectedAmount = sumProofAmounts(selectedProofs);
+      fee = amountToNumber(wallet.getFeesForProofs(selectedProofs));
       const keepAmount = selectedAmount - amount - fee;
 
       // Use ProofService to create outputs and increment counters
@@ -99,7 +101,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
       error: operation.error,
       needsSwap,
       fee,
-      inputAmount: selectedProofs.reduce((acc: number, p: Proof) => acc + p.amount, 0),
+      inputAmount: sumProofAmounts(selectedProofs),
       inputProofSecrets: inputSecrets,
       outputData: serializedOutputData,
       method: operation.method,
@@ -123,7 +125,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
     const { operation, wallet, reservedProofs, proofService, logger } = ctx;
     const { mintUrl, amount, needsSwap, inputProofSecrets } = operation;
 
-    const inputProofs = reservedProofs.filter((p: Proof) => inputProofSecrets.includes(p.secret));
+    const inputProofs = reservedProofs.filter((p) => inputProofSecrets.includes(p.secret));
 
     if (inputProofs.length !== inputProofSecrets.length) {
       throw new Error('Could not find all reserved proofs');
@@ -134,7 +136,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
 
     if (!needsSwap) {
       // Exact match - just use the proofs directly
-      sendProofs = inputProofs;
+      sendProofs = normalizeProofAmounts(inputProofs);
       logger?.debug('Executing exact match send', {
         operationId: operation.id,
         proofCount: sendProofs.length,
@@ -247,8 +249,8 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
         );
 
         if (sendProofs.length > 0) {
-          const totalAmount = sendProofs.reduce((acc: number, p: CoreProof) => acc + p.amount, 0);
-          const fee = wallet.getFeesForProofs(sendProofs);
+          const totalAmount = sumProofAmounts(sendProofs);
+          const fee = amountToNumber(wallet.getFeesForProofs(sendProofs));
           const reclaimAmount = totalAmount - fee;
 
           if (reclaimAmount > 0) {
@@ -260,7 +262,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
 
             // Swap to reclaim
             const keep = await wallet.receive(
-              { mint: mintUrl, proofs: sendProofs, unit: wallet.unit },
+              { mint: mintUrl, proofs: normalizeProofAmounts(sendProofs), unit: wallet.unit },
               undefined,
               { type: 'custom', data: outputResult.keep },
             );

--- a/packages/core/infra/handlers/send/P2pkSendHandler.ts
+++ b/packages/core/infra/handlers/send/P2pkSendHandler.ts
@@ -1,4 +1,10 @@
-import { type Token, type Proof, type OutputConfig, OutputData } from '@cashu/cashu-ts';
+import {
+  normalizeProofAmounts,
+  type Token,
+  type Proof,
+  type OutputConfig,
+  OutputData,
+} from '@cashu/cashu-ts';
 import type {
   SendMethodHandler,
   BasePrepareContext,
@@ -16,10 +22,12 @@ import type {
 import { getSendProofSecrets, getKeepProofSecrets } from '../../../operations/send/SendOperation';
 import { ProofValidationError } from '../../../models/Error';
 import {
+  amountToNumber,
   mapProofToCoreProof,
   serializeOutputData,
   deserializeOutputData,
   getSecretsFromSerializedOutputData,
+  sumProofAmounts,
 } from '../../../utils';
 import type { CoreProof } from '../../../types';
 
@@ -45,8 +53,8 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
     // P2PK always requires a swap to lock proofs to the pubkey
     // Select proofs including fees
     const selected = await proofService.selectProofsToSend(mintUrl, amount, true);
-    const selectedAmount = selected.reduce((acc: number, p: Proof) => acc + p.amount, 0);
-    const fee = wallet.getFeesForProofs(selected);
+    const selectedAmount = sumProofAmounts(selected);
+    const fee = amountToNumber(wallet.getFeesForProofs(selected));
     const keepAmount = selectedAmount - amount - fee;
 
     // Use ProofService to create outputs and increment counters
@@ -122,7 +130,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
       throw new Error('P2PK send requires a pubkey in methodData');
     }
 
-    const inputProofs = reservedProofs.filter((p: Proof) => inputProofSecrets.includes(p.secret));
+    const inputProofs = reservedProofs.filter((p) => inputProofSecrets.includes(p.secret));
 
     if (inputProofs.length !== inputProofSecrets.length) {
       throw new Error('Could not find all reserved proofs');
@@ -286,7 +294,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
       });
     }
 
-    let sendProofs: Proof[] = existingProofs.filter((p: CoreProof) =>
+    let sendProofs: Array<CoreProof | Proof> = existingProofs.filter((p: CoreProof) =>
       outputSecrets.sendSecrets.includes(p.secret),
     );
     if (sendProofs.length === 0 && operation.outputData.send.length > 0) {
@@ -319,7 +327,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
     if (sendProofs.length > 0) {
       token = {
         mint: operation.mintUrl,
-        proofs: sendProofs,
+        proofs: normalizeProofAmounts(sendProofs),
         unit: wallet.unit,
       };
     } else if (outputSecrets.sendSecrets.length > 0) {

--- a/packages/core/models/MeltQuote.ts
+++ b/packages/core/models/MeltQuote.ts
@@ -1,5 +1,7 @@
 import type { MeltQuoteBolt11Response } from '@cashu/cashu-ts';
 
-export interface MeltQuote extends MeltQuoteBolt11Response {
+export interface MeltQuote extends Omit<MeltQuoteBolt11Response, 'amount' | 'fee_reserve'> {
+  amount: number;
+  fee_reserve: number;
   mintUrl: string;
 }

--- a/packages/core/models/MintQuote.ts
+++ b/packages/core/models/MintQuote.ts
@@ -1,5 +1,6 @@
 import type { MintQuoteBolt11Response } from '@cashu/cashu-ts';
 
-export interface MintQuote extends MintQuoteBolt11Response {
+export interface MintQuote extends Omit<MintQuoteBolt11Response, 'amount'> {
+  amount: number;
   mintUrl: string;
 }

--- a/packages/core/operations/melt/MeltMethodHandler.ts
+++ b/packages/core/operations/melt/MeltMethodHandler.ts
@@ -1,4 +1,5 @@
-import type { Wallet, Proof } from '@cashu/cashu-ts';
+import type { Proof, Wallet } from '@cashu/cashu-ts';
+import type { CoreProof } from '../../types';
 import type { ProofRepository } from '../../repositories';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
@@ -64,7 +65,7 @@ export interface PreparedContext<M extends MeltMethod = MeltMethod> extends Base
 export interface ExecuteContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
   operation: ExecutingMeltOperation & MeltMethodMeta<M>;
   wallet: Wallet;
-  reservedProofs: Proof[];
+  reservedProofs: CoreProof[];
 }
 
 export interface PendingContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {

--- a/packages/core/operations/mint/MintOperation.ts
+++ b/packages/core/operations/mint/MintOperation.ts
@@ -41,7 +41,7 @@ interface MintIntentData {
 interface MintQuoteSnapshot {
   quoteId: string;
   request: string;
-  expiry: number;
+  expiry: number | null;
   pubkey?: string;
 }
 

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -30,7 +30,7 @@ import type { ProofService } from '../../services/ProofService';
 import type { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
-import { generateSubId, mapProofToCoreProof } from '../../utils';
+import { amountToNumber, generateSubId, mapProofToCoreProof } from '../../utils';
 import {
   OperationInProgressError,
   NetworkError,
@@ -193,7 +193,8 @@ export class MintOperationService {
     methodData: MintMethodData = {},
     options?: { skipMintLock?: boolean },
   ): Promise<PendingMintOperation> {
-    if (!quote.amount || quote.amount <= 0) {
+    const quoteAmount = amountToNumber(quote.amount);
+    if (quoteAmount <= 0) {
       throw new ProofValidationError(`Mint quote ${quote.quote} has invalid amount`);
     }
 
@@ -215,7 +216,7 @@ export class MintOperationService {
 
     const initOperation = await this.init(
       mintUrl,
-      { amount: quote.amount, unit: quote.unit },
+      { amount: quoteAmount, unit: quote.unit },
       method,
       methodData,
       { quoteId: quote.quote },

--- a/packages/core/operations/receive/ReceiveOperationService.ts
+++ b/packages/core/operations/receive/ReceiveOperationService.ts
@@ -13,6 +13,8 @@ import {
   serializeOutputData,
   deserializeOutputData,
   computeYHexForSecrets,
+  amountToNumber,
+  sumProofAmounts,
 } from '../../utils';
 import {
   UnknownMintError,
@@ -145,7 +147,7 @@ export class ReceiveOperationService {
       throw new ProofValidationError('Token contains no proofs');
     }
 
-    const amount = preparedProofs.reduce((acc, proof) => acc + proof.amount, 0);
+    const amount = sumProofAmounts(preparedProofs);
     if (!Number.isFinite(amount) || amount <= 0) {
       this.logger?.warn('Token has invalid or non-positive amount', { mintUrl, amount });
       throw new ProofValidationError('Token amount must be a positive integer');
@@ -209,7 +211,7 @@ export class ReceiveOperationService {
 
     const { mintUrl } = operation;
     const { wallet } = await this.walletService.getWalletWithActiveKeysetId(mintUrl);
-    const fee = wallet.getFeesForProofs(operation.inputProofs);
+    const fee = amountToNumber(wallet.getFeesForProofs(operation.inputProofs));
     const keepAmount = operation.amount - fee;
 
     if (!Number.isFinite(keepAmount) || keepAmount <= 0) {

--- a/packages/core/operations/send/SendMethodHandler.ts
+++ b/packages/core/operations/send/SendMethodHandler.ts
@@ -1,4 +1,5 @@
-import type { Wallet, Proof, Token } from '@cashu/cashu-ts';
+import type { Wallet, Token } from '@cashu/cashu-ts';
+import type { CoreProof } from '../../types';
 import type { ProofRepository } from '../../repositories';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
@@ -57,7 +58,7 @@ export interface PreparedContext extends BaseHandlerDeps {
 export interface ExecuteContext extends BaseHandlerDeps {
   operation: ExecutingSendOperation;
   wallet: Wallet;
-  reservedProofs: Proof[];
+  reservedProofs: CoreProof[];
 }
 
 export interface PendingContext extends BaseHandlerDeps {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@cashu/cashu-ts": "^3.5.0",
+    "@cashu/cashu-ts": "4.1.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@scure/bip32": "^2.0.1"

--- a/packages/core/services/AuthService.ts
+++ b/packages/core/services/AuthService.ts
@@ -1,6 +1,7 @@
 import {
   AuthManager,
   Mint,
+  normalizeProofAmounts,
   type AuthProvider,
   type OIDCAuth,
   type TokenResponse,
@@ -148,7 +149,7 @@ export class AuthService {
     auth.setCAT(session.accessToken);
 
     if (session.batPool?.length) {
-      auth.importPool(session.batPool, 'replace');
+      auth.importPool(normalizeProofAmounts(session.batPool), 'replace');
     }
 
     if (session.refreshToken) {

--- a/packages/core/services/HistoryService.ts
+++ b/packages/core/services/HistoryService.ts
@@ -17,6 +17,7 @@ import type { MintQuoteState } from '@core/models/MintQuoteState';
 import type { Logger } from '@core/logging';
 import type { ReceiveOperation } from '@core/operations/receive/ReceiveOperation';
 import type { SendOperation } from '@core/operations/send/SendOperation';
+import { amountToNumber } from '@core/utils';
 
 export class HistoryService {
   private readonly historyRepository: HistoryRepository;
@@ -277,7 +278,7 @@ export class HistoryService {
       type: 'melt',
       createdAt: Date.now(),
       unit: quote.unit,
-      amount: quote.amount,
+      amount: amountToNumber(quote.amount),
       mintUrl,
       quoteId,
       state: quote.state,

--- a/packages/core/services/MeltQuoteService.ts
+++ b/packages/core/services/MeltQuoteService.ts
@@ -1,4 +1,9 @@
-import type { MeltQuoteBolt11Response, MeltQuoteState, OutputConfig } from '@cashu/cashu-ts';
+import {
+  Amount,
+  type MeltQuoteBolt11Response,
+  type MeltQuoteState,
+  type OutputConfig,
+} from '@cashu/cashu-ts';
 import type { Logger } from '../logging/Logger';
 import type { MintService } from './MintService';
 import type { ProofService } from './ProofService';
@@ -6,7 +11,7 @@ import type { WalletService } from './WalletService';
 import type { EventBus } from '../events/EventBus';
 import type { CoreEvents } from '../events/types';
 import type { MeltQuoteRepository } from '../repositories';
-import { mapProofToCoreProof } from '@core/utils';
+import { amountToNumber, mapProofToCoreProof, sumProofAmounts } from '@core/utils';
 import { UnknownMintError } from '../models/Error';
 
 export class MeltQuoteService {
@@ -54,7 +59,12 @@ export class MeltQuoteService {
     try {
       const { wallet } = await this.walletService.getWalletWithActiveKeysetId(mintUrl);
       const quote = await wallet.createMeltQuoteBolt11(invoice);
-      await this.meltQuoteRepo.addMeltQuote({ ...quote, mintUrl });
+      await this.meltQuoteRepo.addMeltQuote({
+        ...quote,
+        amount: amountToNumber(quote.amount),
+        fee_reserve: amountToNumber(quote.fee_reserve),
+        mintUrl,
+      });
       await this.eventBus.emit('melt-quote:created', { mintUrl, quoteId: quote.quote, quote });
       return quote;
     } catch (err) {
@@ -85,13 +95,18 @@ export class MeltQuoteService {
         this.logger?.warn('Melt quote not found', { mintUrl, quoteId });
         throw new Error('Quote not found');
       }
+      const cashuQuote = {
+        ...quote,
+        amount: Amount.from(quote.amount),
+        fee_reserve: Amount.from(quote.fee_reserve),
+      };
       const { wallet } = await this.walletService.getWalletWithActiveKeysetId(mintUrl);
 
-      let targetAmount = quote.amount + quote.fee_reserve;
+      let targetAmount = amountToNumber(quote.amount) + amountToNumber(quote.fee_reserve);
       const selectedProofs = await this.proofService.selectProofsToSend(mintUrl, targetAmount);
-      const selectedInputFee = wallet.getFeesForProofs(selectedProofs);
+      const selectedInputFee = amountToNumber(wallet.getFeesForProofs(selectedProofs));
       targetAmount = targetAmount + selectedInputFee;
-      const selectedAmount = selectedProofs.reduce((acc, proof) => acc + proof.amount, 0);
+      const selectedAmount = sumProofAmounts(selectedProofs);
       if (selectedAmount < targetAmount) {
         this.logger?.warn('Insufficient proofs to cover melt amount with fee', {
           mintUrl,
@@ -114,7 +129,7 @@ export class MeltQuoteService {
           selectedProofs.map((proof) => proof.secret),
           'inflight',
         );
-        const { change } = await wallet.meltProofsBolt11(quote, selectedProofs);
+        const { change } = await wallet.meltProofsBolt11(cashuQuote, selectedProofs);
         await this.proofService.saveProofs(mintUrl, mapProofToCoreProof(mintUrl, 'ready', change));
         await this.proofService.setProofState(
           mintUrl,
@@ -129,8 +144,9 @@ export class MeltQuoteService {
           targetAmount,
           selectedProofs,
         });
-        const swapFees = wallet.getFeesForProofs(selectedProofs);
-        const totalSendAmount = quote.amount + quote.fee_reserve + swapFees;
+        const swapFees = amountToNumber(wallet.getFeesForProofs(selectedProofs));
+        const totalSendAmount =
+          amountToNumber(quote.amount) + amountToNumber(quote.fee_reserve) + swapFees;
         if (selectedAmount < totalSendAmount) {
           this.logger?.warn('Insufficient proofs after fee calculation', {
             mintUrl,
@@ -141,11 +157,11 @@ export class MeltQuoteService {
           });
           throw new Error('Insufficient proofs to pay melt quote after fees');
         }
-        const sendAmount = quote.amount + quote.fee_reserve;
+        const sendAmount = amountToNumber(quote.amount) + amountToNumber(quote.fee_reserve);
         const keepAmount = selectedAmount - sendAmount - swapFees;
 
         // Create deterministic blank outputs for receiving change and reserve counters
-        const changeDelta = sendAmount - quote.amount;
+        const changeDelta = sendAmount - amountToNumber(quote.amount);
         const blankOutputs = await this.proofService.createBlankOutputs(changeDelta, mintUrl);
 
         const outputData = await this.proofService.createOutputsAndIncrementCounters(
@@ -189,7 +205,7 @@ export class MeltQuoteService {
           'inflight',
         );
 
-        const { change } = await wallet.meltProofsBolt11(quote, send, undefined, {
+        const { change } = await wallet.meltProofsBolt11(cashuQuote, send, undefined, {
           type: 'custom',
           data: blankOutputs,
         });
@@ -201,7 +217,7 @@ export class MeltQuoteService {
         );
       }
       await this.setMeltQuoteState(mintUrl, quoteId, 'PAID');
-      await this.eventBus.emit('melt-quote:paid', { mintUrl, quoteId, quote });
+      await this.eventBus.emit('melt-quote:paid', { mintUrl, quoteId, quote: cashuQuote });
     } catch (err) {
       this.logger?.error('Failed to pay melt quote', { mintUrl, quoteId, err });
       throw err;

--- a/packages/core/services/PaymentRequestService.ts
+++ b/packages/core/services/PaymentRequestService.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@core/logging';
-import { PaymentRequest, PaymentRequestTransportType, type Token } from '@cashu/cashu-ts';
+import { JSONInt, PaymentRequest, PaymentRequestTransportType, type Token } from '@cashu/cashu-ts';
+import { amountToNumber } from '@core/utils';
 import { PaymentRequestError } from '../models/Error';
 import type { ProofService } from '../services';
 import type {
@@ -86,7 +87,10 @@ export class PaymentRequestService {
       paymentRequest: decodedPaymentRequest,
       payableMints,
       allowedMints,
-      amount: decodedPaymentRequest.amount,
+      amount:
+        decodedPaymentRequest.amount === undefined
+          ? undefined
+          : amountToNumber(decodedPaymentRequest.amount),
       transport,
     };
   }
@@ -141,7 +145,7 @@ export class PaymentRequestService {
         const response = await fetch(transaction.request.transport.url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(token),
+          body: JSONInt.stringify(token),
         });
         this.logger?.debug('HTTP payment request completed', {
           mintUrl: transaction.sendOperation.mintUrl,
@@ -195,7 +199,7 @@ export class PaymentRequestService {
 
   private async findMatchingMints(paymentRequest: PaymentRequest): Promise<string[]> {
     const balances = await this.proofService.getBalancesByMint({ trustedOnly: true });
-    const amount = paymentRequest.amount ?? 0;
+    const amount = paymentRequest.amount === undefined ? 0 : amountToNumber(paymentRequest.amount);
     const mintRequirement = paymentRequest.mints;
     const matchingMints: string[] = [];
     for (const [mintUrl, balance] of Object.entries(balances)) {

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -23,7 +23,13 @@ import type { MintService } from './MintService';
 import type { Logger } from '../logging/Logger.ts';
 import type { SeedService } from './SeedService.ts';
 import type { KeyRingService } from './KeyRingService.ts';
-import { deserializeOutputData, mapProofToCoreProof, type SerializedOutputData } from '../utils';
+import {
+  amountToNumber,
+  deserializeOutputData,
+  mapProofToCoreProof,
+  sumProofAmounts,
+  type SerializedOutputData,
+} from '../utils';
 import type { Keyset } from '@core/models/Keyset.ts';
 
 export class ProofService {
@@ -66,12 +72,14 @@ export class ProofService {
     let denominations = splitAmount(sendAmount, keys.keys);
 
     // Calculate receiver fees (sender pays fees)
-    let receiveFee = wallet.getFeesForKeyset(denominations.length, keysetId);
+    let receiveFee = amountToNumber(wallet.getFeesForKeyset(denominations.length, keysetId));
     let receiveFeeAmounts = splitAmount(receiveFee, keys.keys);
 
     // Iterate until fee calculation stabilizes
     while (
-      wallet.getFeesForKeyset(denominations.length + receiveFeeAmounts.length, keysetId) >
+      amountToNumber(
+        wallet.getFeesForKeyset(denominations.length + receiveFeeAmounts.length, keysetId),
+      ) >
       receiveFee
     ) {
       receiveFee++;
@@ -597,7 +605,7 @@ export class ProofService {
     includeFees: boolean = true,
   ): Promise<Proof[]> {
     const proofs = await this.proofRepository.getAvailableProofs(mintUrl);
-    const totalAmount = proofs.reduce((acc, proof) => acc + proof.amount, 0);
+    const totalAmount = sumProofAmounts(proofs);
     if (totalAmount < amount) {
       throw new ProofValidationError('Not enough proofs to send');
     }

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -79,8 +79,7 @@ export class ProofService {
     while (
       amountToNumber(
         wallet.getFeesForKeyset(denominations.length + receiveFeeAmounts.length, keysetId),
-      ) >
-      receiveFee
+      ) > receiveFee
     ) {
       receiveFee++;
       receiveFeeAmounts = splitAmount(receiveFee, keys.keys);

--- a/packages/core/services/WalletRestoreService.ts
+++ b/packages/core/services/WalletRestoreService.ts
@@ -1,5 +1,5 @@
 import { type Proof, Mint, Wallet, type OutputConfig } from '@cashu/cashu-ts';
-import { mapProofToCoreProof } from '@core/utils';
+import { amountToNumber, mapProofToCoreProof, sumProofAmounts } from '@core/utils';
 import type { ProofService } from './ProofService';
 import type { CounterService } from './CounterService';
 import type { Logger } from '../logging/Logger.ts';
@@ -98,8 +98,8 @@ export class WalletRestoreService {
       return;
     }
 
-    const sweepFee = sweepWallet.getFeesForProofs(checkedProofs.ready);
-    const sweepAmount = checkedProofs.ready.reduce((acc, proof) => acc + proof.amount, 0);
+    const sweepFee = amountToNumber(sweepWallet.getFeesForProofs(checkedProofs.ready));
+    const sweepAmount = sumProofAmounts(checkedProofs.ready);
     const sweepTotalAmount = sweepAmount - sweepFee;
 
     if (sweepTotalAmount < 0) {

--- a/packages/core/services/WalletService.ts
+++ b/packages/core/services/WalletService.ts
@@ -138,7 +138,6 @@ export class WalletService {
 
     const cache: KeyChainCache = {
       mintUrl: mint.mintUrl,
-      unit: DEFAULT_UNIT,
       keysets: keysetCache,
     };
 

--- a/packages/core/services/watchers/MintOperationWatcherService.ts
+++ b/packages/core/services/watchers/MintOperationWatcherService.ts
@@ -1,7 +1,7 @@
 import type { EventBus, CoreEvents } from '@core/events';
 import type { Logger } from '../../logging/Logger.ts';
 import type { SubscriptionManager, UnsubscribeHandler } from '@core/infra/SubscriptionManager.ts';
-import type { MintQuoteResponse } from '@cashu/cashu-ts';
+import type { MintQuoteBolt11Response } from '@cashu/cashu-ts';
 import type { MintService } from '../MintService';
 import type { MintOperationService, PendingMintOperation } from '@core/operations/mint';
 
@@ -238,7 +238,7 @@ export class MintOperationWatcherService {
         const operationIdByQuote = new Map(
           batch.map((operation) => [operation.quoteId, operation.id]),
         );
-        const { subId, unsubscribe } = await this.subs.subscribe<MintQuoteResponse>(
+        const { subId, unsubscribe } = await this.subs.subscribe<MintQuoteBolt11Response>(
           mintUrl,
           'bolt11_mint_quote',
           quoteIds,

--- a/packages/core/test/integration/ReceiveOperationIntegration.test.ts
+++ b/packages/core/test/integration/ReceiveOperationIntegration.test.ts
@@ -5,6 +5,7 @@ import { MemoryRepositories } from '../../repositories/memory/index.ts';
 import type { ReceiveOperationRepository } from '../../repositories/index.ts';
 import type { FinalizedReceiveOperation } from '@core/operations/receive/ReceiveOperation.ts';
 import type { ReceiveOperationService } from '../../operations/receive/ReceiveOperationService.ts';
+import { sumProofAmounts } from '../../utils.ts';
 
 describe('ReceiveOperationService integration', () => {
   let sender: Manager;
@@ -69,6 +70,7 @@ describe('ReceiveOperationService integration', () => {
       method: 'bolt11',
       methodData: {},
     });
+    await sender.subscription.awaitMintQuotePaid(mintUrl, pendingMint.quoteId);
     await sender.ops.mint.execute(pendingMint.id);
 
     const preparedSend = await sender.ops.send.prepare({ mintUrl, amount: 30 });
@@ -89,7 +91,7 @@ describe('ReceiveOperationService integration', () => {
     expect(finalized.length).toBe(1);
     const op = finalized[0] as FinalizedReceiveOperation;
 
-    const tokenAmount = token.proofs.reduce((sum, proof) => sum + proof.amount, 0);
+    const tokenAmount = sumProofAmounts(token.proofs);
     expect(op?.amount).toBe(tokenAmount);
     expect(op?.outputData).toBeDefined();
   }, 30000);

--- a/packages/core/test/unit/DefaultSendHandler.test.ts
+++ b/packages/core/test/unit/DefaultSendHandler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
-import { type Proof, type Wallet, type OutputConfig } from '@cashu/cashu-ts';
+import { Amount, type Proof, type Wallet, type OutputConfig } from '@cashu/cashu-ts';
 import { DefaultSendHandler } from '../../infra/handlers/send/DefaultSendHandler';
+import { amountToNumber } from '../../utils';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
@@ -38,7 +39,7 @@ describe('DefaultSendHandler', () => {
 
   const makeProof = (secret: string, amount = 10, overrides?: Partial<Proof>): Proof =>
     ({
-      amount,
+      amount: Amount.from(amount),
       C: `C_${secret}`,
       id: keysetId,
       secret,
@@ -126,7 +127,7 @@ describe('DefaultSendHandler', () => {
     mockWallet = {
       selectProofsToSend: mock((proofs: Proof[], amount: number, includeFees: boolean) => {
         if (!includeFees) {
-          const exact = proofs.find((proof) => proof.amount === amount);
+          const exact = proofs.find((proof) => amountToNumber(proof.amount) === amount);
           if (exact) {
             return { send: [exact], keep: proofs.filter((proof) => proof.secret !== exact.secret) };
           }
@@ -137,7 +138,7 @@ describe('DefaultSendHandler', () => {
         for (const proof of proofs) {
           if (total >= amount) break;
           send.push(proof);
-          total += proof.amount;
+          total += amountToNumber(proof.amount);
         }
 
         return {
@@ -225,11 +226,11 @@ describe('DefaultSendHandler', () => {
 
   const buildExecuteContext = (
     operation: ExecutingSendOperation,
-    reservedProofs: Proof[] = [],
+    reservedProofs: Array<CoreProof | Proof> = [],
   ): ExecuteContext => ({
     operation,
     wallet: mockWallet,
-    reservedProofs,
+    reservedProofs: reservedProofs as CoreProof[],
     proofRepository,
     proofService,
     walletService,

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -4,7 +4,7 @@ import { SeedService } from '../../services/SeedService.ts';
 import { MemoryKeyRingRepository } from '../../repositories/memory/MemoryKeyRingRepository.ts';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { schnorr } from '@noble/curves/secp256k1.js';
-import type { Proof } from '@cashu/cashu-ts';
+import { Amount, type Proof } from '@cashu/cashu-ts';
 
 // Mock seed for deterministic testing
 const MOCK_SEED = new Uint8Array(64);
@@ -334,7 +334,7 @@ describe('KeyRingService', () => {
 
       const proof: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'my-secret-string',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
@@ -357,7 +357,7 @@ describe('KeyRingService', () => {
 
       const proof: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'my-secret-string',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
@@ -373,7 +373,7 @@ describe('KeyRingService', () => {
 
       const proof: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'test-secret',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
@@ -404,7 +404,7 @@ describe('KeyRingService', () => {
     it('throws when keypair not found', async () => {
       const proof: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'my-secret-string',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
@@ -419,7 +419,7 @@ describe('KeyRingService', () => {
     it('includes public key preview in error message', async () => {
       const proof: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'my-secret-string',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
@@ -436,14 +436,14 @@ describe('KeyRingService', () => {
 
       const proof1: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'secret-1',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
 
       const proof2: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: 'secret-2',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };
@@ -459,7 +459,7 @@ describe('KeyRingService', () => {
 
       const proof: Proof = {
         id: 'keyset123',
-        amount: 64,
+        amount: Amount.from(64),
         secret: '',
         C: '0000000000000000000000000000000000000000000000000000000000000000',
       };

--- a/packages/core/test/unit/MeltBolt11Handler.test.ts
+++ b/packages/core/test/unit/MeltBolt11Handler.test.ts
@@ -1,4 +1,4 @@
-import type { Proof, SerializedBlindedSignature, Wallet } from '@cashu/cashu-ts';
+import { Amount, type Proof, type SerializedBlindedSignature, type Wallet } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
@@ -49,7 +49,7 @@ describe('MeltBolt11Handler', () => {
 
   const makeProof = (secret: string, amount = 10, overrides?: Partial<Proof>): Proof =>
     ({
-      amount,
+      amount: Amount.from(amount),
       C: `C_${secret}`,
       id: keysetId,
       secret,
@@ -165,11 +165,11 @@ describe('MeltBolt11Handler', () => {
 
     // Mock wallet
     mockWallet = {
-      createMeltQuote: mock(() =>
+      createMeltQuoteBolt11: mock(() =>
         Promise.resolve({
           quote: 'quote-123',
-          amount: 100,
-          fee_reserve: 10,
+          amount: Amount.from(100),
+          fee_reserve: Amount.from(10),
           unit: 'sat',
         }),
       ),
@@ -272,11 +272,11 @@ describe('MeltBolt11Handler', () => {
 
   const buildExecuteContext = (
     operation: ExecutingMeltOperation & MeltMethodMeta<'bolt11'>,
-    reservedProofs: Proof[] = [],
+    reservedProofs: Array<CoreProof | Proof> = [],
   ): ExecuteContext<'bolt11'> => ({
     operation,
     wallet: mockWallet,
-    reservedProofs,
+    reservedProofs: reservedProofs as CoreProof[],
     proofRepository,
     proofService,
     walletService,
@@ -661,7 +661,7 @@ describe('MeltBolt11Handler', () => {
         );
 
         const changeSignatures: SerializedBlindedSignature[] = [
-          { id: keysetId, amount: 10, C_: 'C_change' },
+          { id: keysetId, amount: Amount.from(10), C_: 'C_change' },
         ];
         (mintAdapter.customMeltBolt11 as Mock<any>).mockImplementation(() =>
           Promise.resolve({ state: 'PAID', change: changeSignatures }),
@@ -692,7 +692,7 @@ describe('MeltBolt11Handler', () => {
       });
 
       const changeSignatures: SerializedBlindedSignature[] = [
-        { id: keysetId, amount: 5, C_: 'C_change' },
+        { id: keysetId, amount: Amount.from(5), C_: 'C_change' },
       ];
       (mintAdapter.checkMeltQuote as Mock<any>).mockImplementation(() =>
         Promise.resolve({
@@ -906,7 +906,7 @@ describe('MeltBolt11Handler', () => {
         });
 
         const changeSignatures: SerializedBlindedSignature[] = [
-          { id: keysetId, amount: 5, C_: 'C_change' },
+          { id: keysetId, amount: Amount.from(5), C_: 'C_change' },
         ];
         (mintAdapter.checkMeltQuoteState as Mock<any>).mockImplementation(() =>
           Promise.resolve('PAID'),

--- a/packages/core/test/unit/MeltQuoteService.test.ts
+++ b/packages/core/test/unit/MeltQuoteService.test.ts
@@ -6,7 +6,7 @@ import type { MeltQuoteRepository } from '../../repositories';
 import type { MintService } from '../../services/MintService';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
-import { OutputData, type Proof } from '@cashu/cashu-ts';
+import { Amount, OutputData, type Proof } from '@cashu/cashu-ts';
 import type { MeltQuote } from '../../models/MeltQuote';
 
 describe('MeltQuoteService.payMeltQuote', () => {
@@ -23,7 +23,7 @@ describe('MeltQuoteService.payMeltQuote', () => {
 
   const makeProof = (amount: number, secret: string): Proof =>
     ({
-      amount,
+      amount: Amount.from(amount),
       secret,
       C: 'C_' as any,
       id: 'keyset-1',
@@ -138,7 +138,10 @@ describe('MeltQuoteService.payMeltQuote', () => {
     expect(setProofStateSpy).toHaveBeenNthCalledWith(2, mintUrl, ['secret-1'], 'spent');
 
     // Verify meltProofsBolt11 was called with selected proofs (not swapped proofs)
-    expect(meltProofsBolt11Spy).toHaveBeenCalledWith(quote, selectedProofs);
+    expect(meltProofsBolt11Spy).toHaveBeenCalledWith(
+      { ...quote, amount: Amount.from(quote.amount), fee_reserve: Amount.from(quote.fee_reserve) },
+      selectedProofs,
+    );
 
     // Verify createOutputsAndIncrementCounters was NOT called (no swap needed)
     expect(mockProofService.createOutputsAndIncrementCounters).not.toHaveBeenCalled();
@@ -257,7 +260,7 @@ describe('MeltQuoteService.payMeltQuote', () => {
 
     // Verify meltProofsBolt11 was called with swapped proofs (not original selected proofs)
     expect(meltProofsBolt11Spy).toHaveBeenCalledWith(
-      quote,
+      { ...quote, amount: Amount.from(quote.amount), fee_reserve: Amount.from(quote.fee_reserve) },
       swappedProofs,
       undefined,
       expectedBlankOutputType,
@@ -356,7 +359,10 @@ describe('MeltQuoteService.payMeltQuote', () => {
     );
 
     // Verify meltProofsBolt11 was called with all selected proofs
-    expect(meltProofsBolt11Spy).toHaveBeenCalledWith(quote, selectedProofs);
+    expect(meltProofsBolt11Spy).toHaveBeenCalledWith(
+      { ...quote, amount: Amount.from(quote.amount), fee_reserve: Amount.from(quote.fee_reserve) },
+      selectedProofs,
+    );
 
     // Verify no swap was performed
     expect(mockProofService.createOutputsAndIncrementCounters).not.toHaveBeenCalled();

--- a/packages/core/test/unit/MintBolt11Handler.test.ts
+++ b/packages/core/test/unit/MintBolt11Handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
-import { OutputData, type MintQuoteBolt11Response, type Wallet } from '@cashu/cashu-ts';
+import { Amount, OutputData, type MintQuoteBolt11Response, type Wallet } from '@cashu/cashu-ts';
 import { MintBolt11Handler } from '../../infra/handlers/mint/MintBolt11Handler';
 import { MintOperationError } from '../../models/Error';
 import { EventBus } from '../../events/EventBus';
@@ -36,7 +36,7 @@ describe('MintBolt11Handler', () => {
     keep: [
       new OutputData(
         {
-          amount: 10,
+          amount: Amount.from(10),
           id: keysetId,
           B_: 'B_out_1',
         },
@@ -62,7 +62,7 @@ describe('MintBolt11Handler', () => {
   const quote: MintQuoteBolt11Response = {
     quote: quoteId,
     request: 'lnbc1test',
-    amount: 10,
+    amount: Amount.from(10),
     unit: 'sat',
     expiry: Math.floor(Date.now() / 1000) + 3600,
     state: 'PAID',
@@ -164,7 +164,7 @@ describe('MintBolt11Handler', () => {
 
       expect((wallet.createMintQuoteBolt11 as Mock<any>).mock.calls).toHaveLength(1);
       expect(result.quoteId).toBe(quoteId);
-      expect(result.amount).toBe(quote.amount);
+      expect(result.amount).toBe(quote.amount.toNumber());
       expect(result.request).toBe(quote.request);
       expect(result.outputData.keep).toHaveLength(1);
       expect(result.outputData.send).toEqual([]);

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
-import { OutputData, type MintQuoteBolt11Response, type Proof } from '@cashu/cashu-ts';
+import { Amount, OutputData, type MintQuoteBolt11Response, type Proof } from '@cashu/cashu-ts';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import { MintOperationService } from '../../operations/mint/MintOperationService';
@@ -43,7 +43,7 @@ describe('MintOperationService', () => {
   const makeProof = (secret: string): Proof =>
     ({
       id: keysetId,
-      amount: 10,
+      amount: Amount.from(10),
       secret,
       C: `C_${secret}`,
     }) as Proof;
@@ -53,7 +53,7 @@ describe('MintOperationService', () => {
       keep: [
         new OutputData(
           {
-            amount: 10,
+            amount: Amount.from(10),
             id: keysetId,
             B_: `B_${secret}`,
           },
@@ -211,7 +211,7 @@ describe('MintOperationService', () => {
     const importedQuote: MintQuoteBolt11Response = {
       quote: 'quote-imported',
       request: 'lnbc1imported',
-      amount: 12,
+      amount: Amount.from(12),
       unit: 'sat',
       expiry: Math.floor(Date.now() / 1000) + 3600,
       state: 'PAID',
@@ -221,7 +221,7 @@ describe('MintOperationService', () => {
       async ({ operation }: { operation: InitMintOperation }) => ({
         ...makePendingOp(operation.id),
         quoteId: importedQuote.quote,
-        amount: importedQuote.amount,
+        amount: importedQuote.amount.toNumber(),
         request: importedQuote.request,
         expiry: importedQuote.expiry,
         lastObservedRemoteState: importedQuote.state,
@@ -244,7 +244,7 @@ describe('MintOperationService', () => {
     const importedQuote: MintQuoteBolt11Response = {
       quote: 'quote-usd',
       request: 'lnbc1imported',
-      amount: 12,
+      amount: Amount.from(12),
       unit: 'usd',
       expiry: Math.floor(Date.now() / 1000) + 3600,
       state: 'PAID',

--- a/packages/core/test/unit/MintOperationWatcherService.test.ts
+++ b/packages/core/test/unit/MintOperationWatcherService.test.ts
@@ -7,7 +7,7 @@ import type { MintService } from '../../services/MintService.ts';
 import type { MintOperationService } from '../../operations/mint/MintOperationService.ts';
 import type { PendingMintOperation } from '../../operations/mint/MintOperation.ts';
 import { NullLogger } from '../../logging/NullLogger.ts';
-import type { MintQuoteResponse } from '@cashu/cashu-ts';
+import { Amount, type MintQuoteBolt11Response } from '@cashu/cashu-ts';
 
 describe('MintOperationWatcherService', () => {
   const mintUrl = 'https://mint.test';
@@ -16,7 +16,7 @@ describe('MintOperationWatcherService', () => {
   let bus: EventBus<CoreEvents>;
   let subscribe: Mock<any>;
   let unsubscribe: Mock<any>;
-  let callback: ((payload: MintQuoteResponse) => Promise<void>) | undefined;
+  let callback: ((payload: MintQuoteBolt11Response) => Promise<void>) | undefined;
 
   const makePendingOperation = (): PendingMintOperation => ({
     id: 'mint-op-1',
@@ -45,7 +45,7 @@ describe('MintOperationWatcherService', () => {
         _mintUrl: string,
         _kind: string,
         _filters: string[],
-        next: (payload: MintQuoteResponse) => Promise<void>,
+        next: (payload: MintQuoteBolt11Response) => Promise<void>,
       ) => {
         callback = next;
         return { subId: 'sub-1', unsubscribe };
@@ -91,7 +91,7 @@ describe('MintOperationWatcherService', () => {
     await callback({
       quote: quoteId,
       request: operation.request,
-      amount: operation.amount,
+      amount: Amount.from(operation.amount),
       unit: operation.unit,
       expiry: operation.expiry,
       state: 'PAID',
@@ -144,7 +144,7 @@ describe('MintOperationWatcherService', () => {
     await callback({
       quote: quoteId,
       request: operation.request,
-      amount: operation.amount,
+      amount: Amount.from(operation.amount),
       unit: operation.unit,
       expiry: operation.expiry,
       state: 'ISSUED',

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -8,7 +8,7 @@ import type {
   PendingMintOperation,
   TerminalMintOperation,
 } from '../../operations/mint/MintOperation.ts';
-import type { MintQuoteBolt11Response } from '@cashu/cashu-ts';
+import { Amount, type MintQuoteBolt11Response } from '@cashu/cashu-ts';
 
 const mintUrl = 'https://mint.test';
 const quoteId = 'quote-1';
@@ -60,7 +60,7 @@ describe('MintOpsApi', () => {
     quote = {
       quote: quoteId,
       request: 'lnbc1test',
-      amount: 10,
+      amount: Amount.from(10),
       unit: 'sat',
       expiry: Math.floor(Date.now() / 1000) + 3600,
       state: 'PAID',

--- a/packages/core/test/unit/P2pkSendHandler.test.ts
+++ b/packages/core/test/unit/P2pkSendHandler.test.ts
@@ -22,12 +22,12 @@ import type {
   RollbackContext,
   RecoverExecutingContext,
 } from '../../operations/send/SendMethodHandler';
-import type { Wallet, Proof, OutputConfig } from '@cashu/cashu-ts';
+import { Amount, type Wallet, type Proof, type OutputConfig } from '@cashu/cashu-ts';
 
 describe('P2pkSendHandler', () => {
   const mintUrl = 'https://mint.test';
   const keysetId = 'keyset-1';
-  const testPubkey = '02abc123def456...'; // Example P2PK pubkey
+  const testPubkey = '02' + '11'.repeat(32);
 
   let handler: P2pkSendHandler;
   let proofRepository: ProofRepository;
@@ -44,7 +44,7 @@ describe('P2pkSendHandler', () => {
 
   const makeProof = (secret: string, amount = 10, overrides?: Partial<Proof>): Proof =>
     ({
-      amount,
+      amount: Amount.from(amount),
       C: `C_${secret}`,
       id: keysetId,
       secret,
@@ -233,11 +233,11 @@ describe('P2pkSendHandler', () => {
 
   const buildExecuteContext = (
     operation: ExecutingSendOperation,
-    reservedProofs: Proof[] = [],
+    reservedProofs: Array<CoreProof | Proof> = [],
   ): ExecuteContext => ({
     operation,
     wallet: mockWallet,
-    reservedProofs,
+    reservedProofs: reservedProofs as CoreProof[],
     proofRepository,
     proofService,
     walletService,
@@ -411,7 +411,7 @@ describe('P2pkSendHandler', () => {
       });
 
       it('should pass the correct pubkey from methodData', async () => {
-        const customPubkey = '03custom_pubkey_hex...';
+        const customPubkey = '03' + '22'.repeat(32);
         const operation = makeExecutingOp('op-1', {
           methodData: { pubkey: customPubkey },
           inputProofSecrets: ['input-1', 'input-2'],

--- a/packages/core/test/unit/PaymentRequestService.test.ts
+++ b/packages/core/test/unit/PaymentRequestService.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { PaymentRequest, PaymentRequestTransportType, type Token } from '@cashu/cashu-ts';
+import { Amount, PaymentRequest, PaymentRequestTransportType, type Token } from '@cashu/cashu-ts';
 import {
   PaymentRequestService,
   type PreparedPaymentRequest,
@@ -40,7 +40,7 @@ describe('PaymentRequestService', () => {
 
   const mockToken: Token = {
     mint: testMintUrl,
-    proofs: [{ id: 'keyset-1', amount: 100, secret: 'secret-1', C: 'C-1' }],
+    proofs: [{ id: 'keyset-1', amount: Amount.from(100), secret: 'secret-1', C: 'C-1' }],
   };
 
   const createMockPreparedSendOperation = (
@@ -234,7 +234,7 @@ describe('PaymentRequestService', () => {
       expect(mockSendOperationService.init).toHaveBeenCalledWith(testMintUrl, 750);
       expect(transaction.request).not.toBe(request);
       expect(transaction.request.amount).toBe(750);
-      expect(transaction.request.paymentRequest.amount).toBe(750);
+      expect(transaction.request.paymentRequest.amount?.toNumber()).toBe(750);
       expect(transaction.request.payableMints).toEqual([testMintUrl]);
     });
 

--- a/packages/core/test/unit/ReceiveOperationService.recovery.test.ts
+++ b/packages/core/test/unit/ReceiveOperationService.recovery.test.ts
@@ -11,7 +11,8 @@ import type { MintService } from '../../services/MintService';
 import { TokenService } from '../../services/TokenService';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
-import type { ProofState as CashuProofState, Proof } from '@cashu/cashu-ts';
+import { Amount, type ProofState as CashuProofState, type Proof } from '@cashu/cashu-ts';
+import { sumProofAmounts } from '../../utils';
 import type { CoreProof } from '../../types';
 import { MintOperationError, ProofValidationError } from '../../models/Error';
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
@@ -40,7 +41,7 @@ describe('ReceiveOperationService - recoverPendingOperations', () => {
   const makeProof = (secret: string): Proof =>
     ({
       id: keysetId,
-      amount: 10,
+      amount: Amount.from(10),
       secret,
       C: `C_${secret}`,
     }) as Proof;
@@ -63,7 +64,7 @@ describe('ReceiveOperationService - recoverPendingOperations', () => {
     state: 'init',
     mintUrl,
     unit: 'sat',
-    amount: proofs.reduce((acc, proof) => acc + proof.amount, 0),
+    amount: sumProofAmounts(proofs),
     inputProofs: proofs,
     createdAt: Date.now() - 10000,
     updatedAt: Date.now() - 10000,
@@ -78,7 +79,7 @@ describe('ReceiveOperationService - recoverPendingOperations', () => {
     state: 'prepared',
     mintUrl,
     unit: 'sat',
-    amount: proofs.reduce((acc, proof) => acc + proof.amount, 0),
+    amount: sumProofAmounts(proofs),
     inputProofs: proofs,
     createdAt: Date.now() - 10000,
     updatedAt: Date.now() - 10000,

--- a/packages/core/test/unit/ReceiveOperationService.test.ts
+++ b/packages/core/test/unit/ReceiveOperationService.test.ts
@@ -13,7 +13,7 @@ import { HistoryService } from '../../services/HistoryService';
 import type { ProofService } from '../../services/ProofService';
 import { TokenService } from '../../services/TokenService';
 import type { WalletService } from '../../services/WalletService';
-import { OutputData, type Proof, type Token } from '@cashu/cashu-ts';
+import { Amount, OutputData, type Proof, type Token } from '@cashu/cashu-ts';
 import {
   MintOperationError,
   NetworkError,
@@ -50,7 +50,7 @@ describe('ReceiveOperationService', () => {
   const makeProof = (secret: string): Proof =>
     ({
       id: keysetId,
-      amount: 10,
+      amount: Amount.from(10),
       secret,
       C: `C_${secret}`,
     }) as Proof;
@@ -59,7 +59,7 @@ describe('ReceiveOperationService', () => {
     secrets.map(
       (secret) =>
         new OutputData(
-          { amount: 10, id: keysetId, B_: `B_${secret}` },
+          { amount: Amount.from(10), id: keysetId, B_: `B_${secret}` },
           BigInt(1),
           new TextEncoder().encode(secret),
         ),
@@ -291,7 +291,7 @@ describe('ReceiveOperationService', () => {
   });
 
   it('init rejects tokens with non-positive amount', async () => {
-    const zeroProof = { ...makeProof('p1'), amount: 0 } as Proof;
+    const zeroProof = { ...makeProof('p1'), amount: Amount.zero() } as Proof;
     const token: Token = { mint: mintUrl, proofs: [zeroProof] } as Token;
 
     expect(service.init(token)).rejects.toThrow(ProofValidationError);

--- a/packages/core/test/unit/RequestRateLimiter.test.ts
+++ b/packages/core/test/unit/RequestRateLimiter.test.ts
@@ -55,6 +55,25 @@ describe('RequestRateLimiter', () => {
     expect(hdrs.get('Content-Type')).toBe('application/json');
   });
 
+  it('serializes bigint values in cashu-ts request payloads', async () => {
+    const calls: Array<{ input: any; init?: any }> = [];
+    // @ts-ignore
+    globalThis.fetch = async (input: any, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const limiter = new RequestRateLimiter();
+
+    await limiter.request({
+      endpoint: 'https://mint.test/v1/swap',
+      method: 'POST',
+      requestBody: { amount: 1n },
+    });
+
+    expect(calls[0]?.init?.body).toBe('{"amount":1}');
+  });
+
   it('throws HttpResponseError with status and message on non-OK responses', async () => {
     // @ts-ignore
     globalThis.fetch = async () => {

--- a/packages/core/test/unit/SendOperationService.recovery.test.ts
+++ b/packages/core/test/unit/SendOperationService.recovery.test.ts
@@ -19,7 +19,12 @@ import type {
   PendingSendOperation,
 } from '../../operations/send/SendOperation';
 import { serializeOutputData } from '../../utils';
-import { OutputData, type Proof, type ProofState as CashuProofState } from '@cashu/cashu-ts';
+import {
+  Amount,
+  OutputData,
+  type Proof,
+  type ProofState as CashuProofState,
+} from '@cashu/cashu-ts';
 
 describe('SendOperationService - recoverPendingOperations', () => {
   const mintUrl = 'https://mint.test';
@@ -624,7 +629,7 @@ describe('SendOperationService - recoverPendingOperations', () => {
       expect(token?.proofs).toEqual([
         expect.objectContaining({
           id: keysetId,
-          amount: 20,
+          amount: Amount.from(20),
           secret: 'send-secret',
           C: 'C_send',
         }),

--- a/packages/core/test/unit/WalletApi.test.ts
+++ b/packages/core/test/unit/WalletApi.test.ts
@@ -7,7 +7,7 @@ import { WalletRestoreService } from '../../services/WalletRestoreService';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import { UnknownMintError } from '../../models/Error';
-import { getEncodedToken, OutputData, PaymentRequest } from '@cashu/cashu-ts';
+import { Amount, getEncodedToken, OutputData, PaymentRequest } from '@cashu/cashu-ts';
 import type { Proof } from '@cashu/cashu-ts';
 import { ReceiveOperationService } from '../../operations/receive/ReceiveOperationService';
 import { MemoryProofRepository, MemoryReceiveOperationRepository } from '@core/repositories';
@@ -28,13 +28,13 @@ describe('WalletApi - Trust Enforcement', () => {
   let mintAdapter: MintAdapter;
 
   const testMintUrl = 'https://mint.test';
-  const keysetId = 'keyset-1';
+  const keysetId = '009a1f293253e41e';
   const testProofs: Proof[] = [
     {
       id: keysetId,
-      amount: 10,
+      amount: Amount.from(10),
       secret: 'secret-1',
-      C: 'C-1',
+      C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
     } as Proof,
   ];
 
@@ -42,7 +42,7 @@ describe('WalletApi - Trust Enforcement', () => {
     secrets.map(
       (secret) =>
         new OutputData(
-          { amount: 10, id: keysetId, B_: `B_${secret}` },
+          { amount: Amount.from(10), id: keysetId, B_: `B_${secret}` },
           BigInt(1),
           new TextEncoder().encode(secret),
         ),
@@ -58,7 +58,7 @@ describe('WalletApi - Trust Enforcement', () => {
 
     mockMintService = {
       isTrustedMint: mock(async (mintUrl: string) => false),
-      addMintByUrl: mock(async () => ({ mint: {}, keysets: [{ id: 'keyset-1' }] })),
+      addMintByUrl: mock(async () => ({ mint: {}, keysets: [{ id: keysetId }] })),
       ensureUpdatedMint: mock(async () => ({
         mint: { url: testMintUrl },
         keysets: [
@@ -315,42 +315,42 @@ describe('WalletApi - Trust Enforcement', () => {
       expect(encodedToken).toBe(getEncodedToken(token));
     });
 
-    it('should encode tokens with V3 when version 3 is specified', () => {
+    it('should encode tokens as cashuB', () => {
       const token = {
         mint: testMintUrl,
         proofs: [
           {
             id: '009a1f293253e41e',
-            amount: 2,
+            amount: Amount.from(2),
             secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
             C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
           } as Proof,
         ],
       };
 
-      const encodedToken = walletApi.encodeToken(token, { version: 3 });
+      const encodedToken = walletApi.encodeToken(token);
 
-      expect(encodedToken).toStartWith('cashuA');
-      expect(encodedToken).toBe(getEncodedToken(token, { version: 3 }));
+      expect(encodedToken).toStartWith('cashuB');
+      expect(encodedToken).toBe(getEncodedToken(token));
     });
 
-    it('should encode tokens with V4 when version 4 is specified', () => {
+    it('should pass token encoding options through', () => {
       const v4Token = {
         mint: testMintUrl,
         proofs: [
           {
             id: '009a1f293253e41e',
-            amount: 2,
+            amount: Amount.from(2),
             secret: '407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837',
             C: '02bc9097997d81afb2cc7346b5e4345a9346bd2a506eb7958598a72f0cf85163ea',
           } as Proof,
         ],
       };
 
-      const encodedToken = walletApi.encodeToken(v4Token, { version: 4 });
+      const encodedToken = walletApi.encodeToken(v4Token, { removeDleq: true });
 
       expect(encodedToken).toStartWith('cashuB');
-      expect(encodedToken).toBe(getEncodedToken(v4Token, { version: 4 }));
+      expect(encodedToken).toBe(getEncodedToken(v4Token, { removeDleq: true }));
     });
   });
 

--- a/packages/core/test/unit/WalletRestoreService.test.ts
+++ b/packages/core/test/unit/WalletRestoreService.test.ts
@@ -5,7 +5,7 @@ import type { CounterService } from '../../services/CounterService';
 import type { WalletService } from '../../services/WalletService';
 import type { MintRequestProvider } from '../../infra/MintRequestProvider';
 import type { Logger } from '../../logging/Logger';
-import { Wallet, type Proof, type ProofState } from '@cashu/cashu-ts';
+import { Amount, Wallet, type Proof, type ProofState } from '@cashu/cashu-ts';
 
 describe('WalletRestoreService', () => {
   const mintUrl = 'https://mint.test';
@@ -21,7 +21,7 @@ describe('WalletRestoreService', () => {
 
   const makeProof = (amount: number, secret: string): Proof =>
     ({
-      amount,
+      amount: Amount.from(amount),
       C: `C_${secret}`,
       id: keysetId,
       secret,
@@ -96,7 +96,7 @@ describe('WalletRestoreService', () => {
       const mockCheckProofsStates = mock(() =>
         Promise.resolve([{ state: 'UNSPENT' } as ProofState, { state: 'UNSPENT' } as ProofState]),
       );
-      const mockGetFeesForProofs = mock(() => 1);
+      const mockGetFeesForProofs = mock(() => Amount.from(1));
 
       Wallet.prototype.batchRestore = mockBatchRestore;
       Wallet.prototype.checkProofsStates = mockCheckProofsStates;
@@ -164,7 +164,7 @@ describe('WalletRestoreService', () => {
           { state: 'UNSPENT' } as ProofState,
         ]),
       );
-      const mockGetFeesForProofs = mock(() => 1);
+      const mockGetFeesForProofs = mock(() => Amount.from(1));
 
       Wallet.prototype.batchRestore = mockBatchRestore;
       Wallet.prototype.checkProofsStates = mockCheckProofsStates;
@@ -237,7 +237,7 @@ describe('WalletRestoreService', () => {
         Promise.resolve([{ state: 'UNSPENT' } as ProofState]),
       );
       // Mock a negative fee to create a negative total (edge case scenario)
-      const mockGetFeesForProofs = mock(() => 10);
+      const mockGetFeesForProofs = mock(() => Amount.from(10));
 
       Wallet.prototype.batchRestore = mockBatchRestore;
       Wallet.prototype.checkProofsStates = mockCheckProofsStates;
@@ -262,7 +262,7 @@ describe('WalletRestoreService', () => {
       const mockCheckProofsStates = mock(() =>
         Promise.resolve([{ state: 'UNSPENT' } as ProofState]),
       );
-      const mockGetFeesForProofs = mock(() => 1);
+      const mockGetFeesForProofs = mock(() => Amount.from(1));
 
       Wallet.prototype.batchRestore = mockBatchRestore;
       Wallet.prototype.checkProofsStates = mockCheckProofsStates;

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -31,7 +31,8 @@ export interface BalanceBreakdown {
  */
 export type BalancesBreakdownByMint = { [mintUrl: string]: BalanceBreakdown };
 
-export interface CoreProof extends Proof {
+export interface CoreProof extends Omit<Proof, 'amount'> {
+  amount: number;
   mintUrl: string;
   state: ProofState;
 

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -1,4 +1,12 @@
-import { hashToCurve, OutputData, type Proof, type Token } from '@cashu/cashu-ts';
+import {
+  Amount,
+  hashToCurve,
+  OutputData,
+  sumProofs,
+  type AmountLike,
+  type Proof,
+  type Token,
+} from '@cashu/cashu-ts';
 import type { CoreProof, ProofState } from './types';
 import type { Logger } from './logging/Logger.ts';
 import { TokenValidationError } from './models/Error.ts';
@@ -37,6 +45,14 @@ export interface SerializedOutputData {
 // OutputData Serialization Functions
 // ============================================================================
 
+export function amountToNumber(amount: AmountLike): number {
+  return Amount.from(amount).toNumber();
+}
+
+export function sumProofAmounts(proofs: Array<{ amount: AmountLike }>): number {
+  return amountToNumber(sumProofs(proofs));
+}
+
 /**
  * Convert a Uint8Array to hex string
  */
@@ -63,7 +79,7 @@ function hexToUint8Array(hex: string): Uint8Array {
 export function serializeOutput(output: OutputData): SerializedOutput {
   return {
     blindedMessage: {
-      amount: output.blindedMessage.amount,
+      amount: amountToNumber(output.blindedMessage.amount),
       id: output.blindedMessage.id,
       B_: output.blindedMessage.B_,
     },
@@ -78,7 +94,7 @@ export function serializeOutput(output: OutputData): SerializedOutput {
 export function deserializeOutput(serialized: SerializedOutput): OutputData {
   return new OutputData(
     {
-      amount: serialized.blindedMessage.amount,
+      amount: Amount.from(serialized.blindedMessage.amount),
       id: serialized.blindedMessage.id,
       B_: serialized.blindedMessage.B_,
     },
@@ -143,6 +159,7 @@ export function mapProofToCoreProof(
 ): CoreProof[] {
   return proofs.map((p) => ({
     ...p,
+    amount: amountToNumber(p.amount),
     mintUrl,
     state,
     createdByOperationId: options?.createdByOperationId,
@@ -264,7 +281,7 @@ export function isValidToken(token: Token): void {
   if (token.proofs.length === 0) {
     throw new TokenValidationError('Token proofs are required');
   }
-  if (token.proofs.some((p) => !p.amount || p.amount <= 0)) {
+  if (token.proofs.some((p) => amountToNumber(p.amount) <= 0)) {
     throw new TokenValidationError('Token proofs must have a positive amount');
   }
 }

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -24,7 +24,9 @@
       "import": "./dist/index.js"
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "@cashu/cashu-ts": "4.1.0"
+  },
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",

--- a/packages/expo-sqlite/src/repositories/AuthSessionRepository.ts
+++ b/packages/expo-sqlite/src/repositories/AuthSessionRepository.ts
@@ -1,3 +1,4 @@
+import { deserializeProofs, serializeProofs } from '@cashu/cashu-ts';
 import type { AuthSessionRepository, AuthSession } from '@cashu/coco-core';
 import { ExpoSqliteDb } from '../db.ts';
 
@@ -17,7 +18,7 @@ function rowToSession(row: AuthSessionRow): AuthSession {
     refreshToken: row.refreshToken ?? undefined,
     expiresAt: row.expiresAt,
     scope: row.scope ?? undefined,
-    batPool: row.batPoolJson ? JSON.parse(row.batPoolJson) : undefined,
+    batPool: row.batPoolJson ? deserializeProofs(row.batPoolJson) : undefined,
   };
 }
 
@@ -53,7 +54,7 @@ export class ExpoAuthSessionRepository implements AuthSessionRepository {
         session.refreshToken ?? null,
         session.expiresAt,
         session.scope ?? null,
-        session.batPool ? JSON.stringify(session.batPool) : null,
+        session.batPool ? JSON.stringify(serializeProofs(session.batPool)) : null,
       ],
     );
   }

--- a/packages/expo-sqlite/src/repositories/SendOperationRepository.ts
+++ b/packages/expo-sqlite/src/repositories/SendOperationRepository.ts
@@ -1,3 +1,4 @@
+import { JSONInt, normalizeProofAmounts, type Token } from '@cashu/cashu-ts';
 import type {
   SendOperationRepository,
   SendOperation,
@@ -25,12 +26,14 @@ interface SendOperationRow {
 }
 
 function parseToken(tokenJson: string | null): unknown {
-  return tokenJson ? JSON.parse(tokenJson) : undefined;
+  if (!tokenJson) return undefined;
+  const token = JSONInt.parse(tokenJson) as Token;
+  return { ...token, proofs: normalizeProofAmounts(token.proofs) };
 }
 
 function serializeToken(operation: SendOperation): string | null {
   const maybeTokenOperation = operation as SendOperation & { token?: unknown };
-  return maybeTokenOperation.token ? JSON.stringify(maybeTokenOperation.token) : null;
+  return maybeTokenOperation.token ? (JSONInt.stringify(maybeTokenOperation.token) ?? null) : null;
 }
 
 function rowToOperation(row: SendOperationRow): SendOperation {

--- a/packages/expo-sqlite/src/test/SendOperationRepository.test.ts
+++ b/packages/expo-sqlite/src/test/SendOperationRepository.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 // @ts-ignore bun:sqlite types are provided by the runtime in this workspace.
 import { Database } from 'bun:sqlite';
+import { Amount } from '@cashu/cashu-ts';
 import type { PendingSendOperation, RollingBackSendOperation } from '@cashu/coco-core';
 import { ExpoSqliteRepositories, type ExpoSqliteRepositoriesOptions } from '../index.ts';
 
@@ -90,7 +91,7 @@ function makePendingP2pkOperation(): PendingSendOperation {
     },
     token: {
       mint: 'https://mint.test',
-      proofs: [{ id: 'keyset-1', amount: 100, secret: 'send-secret', C: 'C_send' }],
+      proofs: [{ id: 'keyset-1', amount: Amount.from(100), secret: 'send-secret', C: 'C_send' }],
       unit: 'sat',
     },
   } as PendingSendOperation;

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -28,6 +28,7 @@
     }
   },
   "dependencies": {
+    "@cashu/cashu-ts": "4.1.0",
     "dexie": "^4.0.8"
   },
   "scripts": {

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -152,7 +152,7 @@ export interface MintQuoteRow {
   request: string;
   amount: number;
   unit: string;
-  expiry: number;
+  expiry: number | null;
   pubkey?: string | null;
 }
 

--- a/packages/indexeddb/src/repositories/AuthSessionRepository.ts
+++ b/packages/indexeddb/src/repositories/AuthSessionRepository.ts
@@ -1,3 +1,4 @@
+import { deserializeProofs, serializeProofs } from '@cashu/cashu-ts';
 import type { AuthSessionRepository, AuthSession } from '@cashu/coco-core';
 import type { IdbDb, AuthSessionRow } from '../lib/db.ts';
 
@@ -19,7 +20,7 @@ export class IdbAuthSessionRepository implements AuthSessionRepository {
       refreshToken: row.refreshToken ?? undefined,
       expiresAt: row.expiresAt,
       scope: row.scope ?? undefined,
-      batPool: row.batPoolJson ? JSON.parse(row.batPoolJson) : undefined,
+      batPool: row.batPoolJson ? deserializeProofs(row.batPoolJson) : undefined,
     };
   }
 
@@ -30,7 +31,7 @@ export class IdbAuthSessionRepository implements AuthSessionRepository {
       refreshToken: session.refreshToken ?? null,
       expiresAt: session.expiresAt,
       scope: session.scope ?? null,
-      batPoolJson: session.batPool ? JSON.stringify(session.batPool) : null,
+      batPoolJson: session.batPool ? JSON.stringify(serializeProofs(session.batPool)) : null,
     };
     await (this.db as any).table('coco_cashu_auth_sessions').put(row);
   }
@@ -49,7 +50,7 @@ export class IdbAuthSessionRepository implements AuthSessionRepository {
       refreshToken: row.refreshToken ?? undefined,
       expiresAt: row.expiresAt,
       scope: row.scope ?? undefined,
-      batPool: row.batPoolJson ? JSON.parse(row.batPoolJson) : undefined,
+      batPool: row.batPoolJson ? deserializeProofs(row.batPoolJson) : undefined,
     }));
   }
 }

--- a/packages/indexeddb/src/repositories/SendOperationRepository.test.ts
+++ b/packages/indexeddb/src/repositories/SendOperationRepository.test.ts
@@ -2,6 +2,7 @@
 
 // @ts-ignore bun:test types are provided by the test runner in this workspace.
 import { describe, expect, it } from 'bun:test';
+import { Amount } from '@cashu/cashu-ts';
 import { IdbSendOperationRepository } from './SendOperationRepository.ts';
 import type { SendOperationRow } from '../lib/db.ts';
 
@@ -94,7 +95,7 @@ describe('IdbSendOperationRepository', () => {
       outputData: { keep: [], send: [] },
       token: {
         mint: 'https://mint.test',
-        proofs: [{ id: 'keyset-1', amount: 100, secret: 'send-secret', C: 'C_send' }],
+        proofs: [{ id: 'keyset-1', amount: Amount.from(100), secret: 'send-secret', C: 'C_send' }],
         unit: 'sat',
       },
     });

--- a/packages/indexeddb/src/repositories/SendOperationRepository.ts
+++ b/packages/indexeddb/src/repositories/SendOperationRepository.ts
@@ -1,3 +1,4 @@
+import { JSONInt, normalizeProofAmounts, type Token } from '@cashu/cashu-ts';
 import type {
   SendOperationRepository,
   SendOperation,
@@ -13,12 +14,14 @@ type LegacySendOperationRow = SendOperationRow & {
 };
 
 function parseToken(row: SendOperationRow): unknown {
-  return row.tokenJson ? JSON.parse(row.tokenJson) : undefined;
+  if (!row.tokenJson) return undefined;
+  const token = JSONInt.parse(row.tokenJson) as Token;
+  return { ...token, proofs: normalizeProofAmounts(token.proofs) };
 }
 
 function serializeToken(operation: SendOperation): string | null {
   const maybeTokenOperation = operation as SendOperation & { token?: unknown };
-  return maybeTokenOperation.token ? JSON.stringify(maybeTokenOperation.token) : null;
+  return maybeTokenOperation.token ? (JSONInt.stringify(maybeTokenOperation.token) ?? null) : null;
 }
 
 function parseMethodData(row: SendOperationRow): SendOperation['methodData'] {

--- a/packages/indexeddb/vitest.config.ts
+++ b/packages/indexeddb/vitest.config.ts
@@ -2,9 +2,15 @@ import { defineConfig } from 'vitest/config';
 
 // Determine which browsers to test based on environment
 // In CI, test all browsers. Locally, default to just chromium for speed.
-const browsers = process.env.CI
-  ? [{ browser: 'chromium' }, { browser: 'firefox' }, { browser: 'webkit' }]
-  : [{ browser: 'chromium' }];
+const browserNames = process.env.VITEST_BROWSER
+  ? process.env.VITEST_BROWSER.split(',').map((browser) => browser.trim())
+  : process.env.CI
+    ? ['chromium', 'firefox', 'webkit']
+    : ['chromium'];
+
+const browsers = browserNames
+  .filter((browser) => browser.length > 0)
+  .map((browser) => ({ browser }));
 
 export default defineConfig({
   test: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,6 +33,7 @@
     "@cashu/coco-core": "1.0.0-rc.5"
   },
   "devDependencies": {
+    "@cashu/cashu-ts": "4.1.0",
     "@testing-library/react": "^16.3.0",
     "@eslint/js": "^9.33.0",
     "@types/react": "^19.1.10",

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -1,4 +1,5 @@
 import type { Manager } from '@cashu/coco-core';
+import { Amount } from '@cashu/cashu-ts';
 import { act, cleanup, renderHook } from '@testing-library/react';
 import { useLayoutEffect } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -73,7 +74,7 @@ const MINT_IMPORT_QUOTE_INPUT: MintOperationImportQuoteInput = {
     request: 'lnbc1importquote',
     expiry: 1_700_000_100_000,
     state: 'UNPAID',
-    amount: 100,
+    amount: Amount.from(100),
     unit: 'sat',
   },
 };

--- a/packages/sqlite-bun/package.json
+++ b/packages/sqlite-bun/package.json
@@ -24,7 +24,9 @@
       "import": "./dist/index.js"
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "@cashu/cashu-ts": "4.1.0"
+  },
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",

--- a/packages/sqlite-bun/src/repositories/AuthSessionRepository.ts
+++ b/packages/sqlite-bun/src/repositories/AuthSessionRepository.ts
@@ -1,3 +1,4 @@
+import { deserializeProofs, serializeProofs } from '@cashu/cashu-ts';
 import type { AuthSessionRepository, AuthSession } from '@cashu/coco-core';
 import { SqliteDb } from '../db.ts';
 
@@ -17,7 +18,7 @@ function rowToSession(row: AuthSessionRow): AuthSession {
     refreshToken: row.refreshToken ?? undefined,
     expiresAt: row.expiresAt,
     scope: row.scope ?? undefined,
-    batPool: row.batPoolJson ? JSON.parse(row.batPoolJson) : undefined,
+    batPool: row.batPoolJson ? deserializeProofs(row.batPoolJson) : undefined,
   };
 }
 
@@ -53,7 +54,7 @@ export class SqliteAuthSessionRepository implements AuthSessionRepository {
         session.refreshToken ?? null,
         session.expiresAt,
         session.scope ?? null,
-        session.batPool ? JSON.stringify(session.batPool) : null,
+        session.batPool ? JSON.stringify(serializeProofs(session.batPool)) : null,
       ],
     );
   }

--- a/packages/sqlite-bun/src/repositories/SendOperationRepository.ts
+++ b/packages/sqlite-bun/src/repositories/SendOperationRepository.ts
@@ -1,3 +1,4 @@
+import { JSONInt, normalizeProofAmounts, type Token } from '@cashu/cashu-ts';
 import type {
   SendOperationRepository,
   SendOperation,
@@ -25,12 +26,14 @@ interface SendOperationRow {
 }
 
 function parseToken(tokenJson: string | null): unknown {
-  return tokenJson ? JSON.parse(tokenJson) : undefined;
+  if (!tokenJson) return undefined;
+  const token = JSONInt.parse(tokenJson) as Token;
+  return { ...token, proofs: normalizeProofAmounts(token.proofs) };
 }
 
 function serializeToken(operation: SendOperation): string | null {
   const maybeTokenOperation = operation as SendOperation & { token?: unknown };
-  return maybeTokenOperation.token ? JSON.stringify(maybeTokenOperation.token) : null;
+  return maybeTokenOperation.token ? (JSONInt.stringify(maybeTokenOperation.token) ?? null) : null;
 }
 
 function rowToOperation(row: SendOperationRow): SendOperation {

--- a/packages/sqlite-bun/src/test/SendOperationRepository.test.ts
+++ b/packages/sqlite-bun/src/test/SendOperationRepository.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 // @ts-ignore bun:sqlite types are provided by the runtime in this workspace.
 import { Database } from 'bun:sqlite';
+import { Amount } from '@cashu/cashu-ts';
 import type { PendingSendOperation, RollingBackSendOperation } from '@cashu/coco-core';
 import { SqliteRepositories } from '../index.ts';
 
@@ -44,7 +45,7 @@ function makePendingP2pkOperation(): PendingSendOperation {
     },
     token: {
       mint: 'https://mint.test',
-      proofs: [{ id: 'keyset-1', amount: 100, secret: 'send-secret', C: 'C_send' }],
+      proofs: [{ id: 'keyset-1', amount: Amount.from(100), secret: 'send-secret', C: 'C_send' }],
       unit: 'sat',
     },
   } as PendingSendOperation;

--- a/packages/sqlite-bun/src/test/integration.test.ts
+++ b/packages/sqlite-bun/src/test/integration.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, beforeEach, afterEach, expect as bunExpect } from 'bun:test';
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  expect as bunExpect,
+  setDefaultTimeout,
+} from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { runIntegrationTests, type IntegrationTestRunner } from '@cashu/coco-adapter-tests';
 import { SqliteRepositories } from '../index.ts';
@@ -8,6 +15,8 @@ import { ConsoleLogger, type Logger } from '@cashu/coco-core';
 const expect = bunExpect as unknown as IntegrationTestRunner['expect'];
 
 const mintUrl = process.env.MINT_URL;
+
+setDefaultTimeout(30_000);
 
 if (!mintUrl) {
   throw new Error('MINT_URL is not set');

--- a/packages/sqlite3/package.json
+++ b/packages/sqlite3/package.json
@@ -27,6 +27,7 @@
     }
   },
   "dependencies": {
+    "@cashu/cashu-ts": "4.1.0",
     "better-sqlite3": "^12.6.2"
   },
   "scripts": {

--- a/packages/sqlite3/src/repositories/AuthSessionRepository.ts
+++ b/packages/sqlite3/src/repositories/AuthSessionRepository.ts
@@ -1,3 +1,4 @@
+import { deserializeProofs, serializeProofs } from '@cashu/cashu-ts';
 import type { AuthSessionRepository, AuthSession } from '@cashu/coco-core';
 import { SqliteDb } from '../db.ts';
 
@@ -17,7 +18,7 @@ function rowToSession(row: AuthSessionRow): AuthSession {
     refreshToken: row.refreshToken ?? undefined,
     expiresAt: row.expiresAt,
     scope: row.scope ?? undefined,
-    batPool: row.batPoolJson ? JSON.parse(row.batPoolJson) : undefined,
+    batPool: row.batPoolJson ? deserializeProofs(row.batPoolJson) : undefined,
   };
 }
 
@@ -53,7 +54,7 @@ export class SqliteAuthSessionRepository implements AuthSessionRepository {
         session.refreshToken ?? null,
         session.expiresAt,
         session.scope ?? null,
-        session.batPool ? JSON.stringify(session.batPool) : null,
+        session.batPool ? JSON.stringify(serializeProofs(session.batPool)) : null,
       ],
     );
   }

--- a/packages/sqlite3/src/repositories/SendOperationRepository.ts
+++ b/packages/sqlite3/src/repositories/SendOperationRepository.ts
@@ -1,3 +1,4 @@
+import { JSONInt, normalizeProofAmounts, type Token } from '@cashu/cashu-ts';
 import type {
   SendOperationRepository,
   SendOperation,
@@ -25,12 +26,14 @@ interface SendOperationRow {
 }
 
 function parseToken(tokenJson: string | null): unknown {
-  return tokenJson ? JSON.parse(tokenJson) : undefined;
+  if (!tokenJson) return undefined;
+  const token = JSONInt.parse(tokenJson) as Token;
+  return { ...token, proofs: normalizeProofAmounts(token.proofs) };
 }
 
 function serializeToken(operation: SendOperation): string | null {
   const maybeTokenOperation = operation as SendOperation & { token?: unknown };
-  return maybeTokenOperation.token ? JSON.stringify(maybeTokenOperation.token) : null;
+  return maybeTokenOperation.token ? (JSONInt.stringify(maybeTokenOperation.token) ?? null) : null;
 }
 
 function rowToOperation(row: SendOperationRow): SendOperation {

--- a/packages/sqlite3/src/test/SendOperationRepository.test.ts
+++ b/packages/sqlite3/src/test/SendOperationRepository.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database, { type Database as BetterSqlite3Database } from 'better-sqlite3';
+import { Amount } from '@cashu/cashu-ts';
 import type { PendingSendOperation, RollingBackSendOperation } from '@cashu/coco-core';
 import { SqliteRepositories } from '../index.ts';
 
@@ -40,7 +41,7 @@ function makePendingP2pkOperation(): PendingSendOperation {
     },
     token: {
       mint: 'https://mint.test',
-      proofs: [{ id: 'keyset-1', amount: 100, secret: 'send-secret', C: 'C_send' }],
+      proofs: [{ id: 'keyset-1', amount: Amount.from(100), secret: 'send-secret', C: 'C_send' }],
       unit: 'sat',
     },
   } as PendingSendOperation;

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -224,7 +224,20 @@ run_test() {
             unset VITE_TEST_LOG_LEVEL
         fi
 
-        if [ -n "$test_pattern" ]; then
+        if [ "$CI" = "true" ]; then
+            for browser in chromium firefox webkit; do
+                log_test "Running browser instance: $browser"
+                export VITEST_BROWSER="$browser"
+                if [ -n "$test_pattern" ]; then
+                    bun run test:browser -- --testNamePattern="$test_pattern" || test_result=$?
+                else
+                    bun run test:browser || test_result=$?
+                fi
+                if [ $test_result -ne 0 ]; then
+                    break
+                fi
+            done
+        elif [ -n "$test_pattern" ]; then
             bun run test:browser -- --testNamePattern="$test_pattern" || test_result=$?
         else
             bun run test:browser || test_result=$?
@@ -232,6 +245,7 @@ run_test() {
 
         unset VITE_MINT_URL
         unset VITE_TEST_LOG_LEVEL
+        unset VITEST_BROWSER
     else
         # Standard test command for non-browser packages (uses vitest or bun:test)
         export MINT_URL="$mint_url"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -62,9 +62,14 @@ is_browser_test_package() {
 ensure_playwright_browsers() {
     log_info "Ensuring Playwright browsers are installed..."
     cd "$PROJECT_ROOT"
-    npx playwright install --with-deps chromium firefox webkit 2>/dev/null || {
+    local playwright_bin="$PROJECT_ROOT/packages/indexeddb/node_modules/.bin/playwright"
+    if [ ! -x "$playwright_bin" ]; then
+        playwright_bin="npx playwright"
+    fi
+
+    $playwright_bin install --with-deps chromium firefox webkit 2>/dev/null || {
         log_warn "Failed to install all browsers, trying without deps..."
-        npx playwright install chromium firefox webkit || {
+        $playwright_bin install chromium firefox webkit || {
             log_error "Failed to install Playwright browsers"
             return 1
         }
@@ -95,7 +100,7 @@ start_mint_container() {
     local package_name=$1
     local port=$2
     local container_name="cdk-mint-${package_name}"
-    local mint_url="http://localhost:${port}"
+    local mint_url="http://127.0.0.1:${port}"
 
     log_info "Starting mint container for $package_name on port $port..."
 
@@ -157,7 +162,7 @@ run_test() {
     local test_pattern="${3:-}"
     local log_level="${4:-}"
     local test_file
-    local mint_url="http://localhost:${port}"
+    local mint_url="http://127.0.0.1:${port}"
 
     # Find the test file for this package
     test_file=$(discover_integration_tests | grep "^${package_name}|" | cut -d'|' -f2)


### PR DESCRIPTION
## Description

  This pull request upgrades coco to @cashu/cashu-ts v4.1.0 and adapts core wallet, mint, melt, send, receive, subscription,
  and adapter persistence flows to the v4 Amount API.

  ## Problem

  cashu-ts v4 replaces several numeric fields with Amount, removes token version selection, changes JSON integer handling
  expectations, and allows nullable mint quote expiries. Coco needed explicit boundary conversions to keep existing numeric
  operation and repository models while preserving correct Cashu proof/token serialization.

  ## Summary

  - Updates core flows to convert Amount values at coco boundaries and normalize proof amounts before Cashu operations.
  - Uses v4-safe JSON/proof serialization for mint requests, payment requests, BAT pools, and persisted send tokens.
  - Updates adapter packages, React tests, type fixtures, docs, lockfile, and package manifests for @cashu/cashu-ts 4.1.0.
  - Adds changeset .changeset/cashu-ts-v4.md with major bumps for core and adapter-tests.