### PR TITLE
fix(core): recover executing melts from refresh

### DIFF
--- a/.changeset/melt-refresh-recovers-executing.md
+++ b/.changeset/melt-refresh-recovers-executing.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Recover executing melt operations from `manager.ops.melt.refresh()` so long-running
+clients can resolve stuck melts without waiting for a startup recovery sweep.

--- a/bun.lock
+++ b/bun.lock
@@ -17,22 +17,22 @@
     },
     "packages/adapter-tests": {
       "name": "@cashu/coco-adapter-tests",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "fake-bolt11": "^0.1.0",
       },
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
       },
       "peerDependencies": {
         "@cashu/cashu-ts": "^3.3.0",
-        "@cashu/coco-core": "^1.0.0-rc.2",
+        "@cashu/coco-core": "^1.0.0-rc.5",
         "typescript": "^5",
       },
     },
     "packages/core": {
       "name": "@cashu/coco-core",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "@cashu/cashu-ts": "^3.5.0",
         "@noble/curves": "^2.0.1",
@@ -40,7 +40,7 @@
         "@scure/bip32": "^2.0.1",
       },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.2",
+        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
         "typescript-eslint": "^8.40.0",
       },
       "peerDependencies": {
@@ -55,7 +55,7 @@
     },
     "packages/expo-sqlite": {
       "name": "@cashu/coco-expo-sqlite",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0-rc.2",
       },
@@ -67,7 +67,7 @@
     },
     "packages/indexeddb": {
       "name": "@cashu/coco-indexeddb",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "dexie": "^4.0.8",
       },
@@ -84,9 +84,9 @@
     },
     "packages/react": {
       "name": "@cashu/coco-react",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "@eslint/js": "^9.33.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.10",
@@ -105,13 +105,13 @@
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.2",
+        "@cashu/coco-core": "1.0.0-rc.5",
         "react": "^19",
       },
     },
     "packages/sqlite-bun": {
       "name": "@cashu/coco-sqlite-bun",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0-rc.2",
       },
@@ -122,7 +122,7 @@
     },
     "packages/sqlite3": {
       "name": "@cashu/coco-sqlite",
-      "version": "1.0.0-rc.2",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
       },

--- a/packages/core/api/MeltOpsApi.ts
+++ b/packages/core/api/MeltOpsApi.ts
@@ -111,12 +111,18 @@ export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMeth
    * Re-checks a melt operation and returns its latest persisted state.
    *
    * Pending operations are actively checked with the service before the updated
-   * operation is returned.
+   * operation is returned. Executing operations are recovered before returning
+   * the updated state.
    */
   async refresh(operationId: string): Promise<MeltOperation> {
     const operation = await this.requireOperation(operationId);
     if (operation.state === 'pending') {
       await this.meltOperationService.checkPendingOperation(operation.id);
+      return this.requireOperation(operationId);
+    }
+
+    if (operation.state === 'executing') {
+      await this.meltOperationService.recoverExecutingOperation(operation);
       return this.requireOperation(operationId);
     }
 

--- a/packages/core/operations/melt/MeltOperationService.ts
+++ b/packages/core/operations/melt/MeltOperationService.ts
@@ -608,54 +608,90 @@ export class MeltOperationService {
    * Delegates to handler for proof cleanup and state determination.
    * Updates operation state based on handler result (finalized, pending, or failed).
    */
-  private async recoverExecutingOperation(op: ExecutingMeltOperation): Promise<void> {
-    const handler = this.handlerProvider.get(op.method);
-    const { wallet } = await this.walletService.getWalletWithActiveKeysetId(op.mintUrl);
-
-    const result = await handler.recoverExecuting({
-      ...this.buildDeps(),
-      operation: op,
-      wallet,
-    });
-
-    switch (result.status) {
-      case 'PAID': {
-        const finalizedOp: FinalizedMeltOperation = {
-          ...result.finalized,
-          state: 'finalized',
-          updatedAt: Date.now(),
-        };
-        await this.meltOperationRepository.update(finalizedOp);
-        await this.eventBus.emit('melt-op:finalized', {
-          mintUrl: finalizedOp.mintUrl,
-          operationId: finalizedOp.id,
-          operation: finalizedOp,
-        });
-        this.logger?.info('Recovered executing operation as finalized', {
-          operationId: op.id,
-        });
-        break;
+  async recoverExecutingOperation(
+    op: ExecutingMeltOperation,
+    options?: { skipLock?: boolean },
+  ): Promise<void> {
+    const releaseLock = options?.skipLock ? undefined : await this.acquireOperationLock(op.id);
+    try {
+      const current = await this.meltOperationRepository.getById(op.id);
+      if (!current) {
+        this.logger?.warn('Melt operation missing during recovery', { operationId: op.id });
+        return;
       }
-      case 'PENDING': {
-        const pendingOp: PendingMeltOperation = {
-          ...result.pending,
-          state: 'pending',
-          updatedAt: Date.now(),
-        };
-        await this.meltOperationRepository.update(pendingOp);
-        await this.eventBus.emit('melt-op:pending', {
-          mintUrl: pendingOp.mintUrl,
-          operationId: pendingOp.id,
-          operation: pendingOp,
-        });
-        this.logger?.info('Recovered executing operation as pending', {
-          operationId: op.id,
-        });
-        break;
+
+      if (
+        current.state === 'finalized' ||
+        current.state === 'failed' ||
+        current.state === 'rolled_back'
+      ) {
+        return;
       }
-      case 'FAILED': {
-        await this.markAsRolledBack(op, result.failed.error ?? 'Recovered: operation failed');
-        break;
+
+      if (current.state !== 'executing') {
+        this.logger?.debug('Melt operation not executing during recovery', {
+          operationId: current.id,
+          state: current.state,
+        });
+        return;
+      }
+
+      const executing = current as ExecutingMeltOperation;
+      const handler = this.handlerProvider.get(executing.method);
+      const { wallet } = await this.walletService.getWalletWithActiveKeysetId(executing.mintUrl);
+
+      const result = await handler.recoverExecuting({
+        ...this.buildDeps(),
+        operation: executing,
+        wallet,
+      });
+
+      switch (result.status) {
+        case 'PAID': {
+          const finalizedOp: FinalizedMeltOperation = {
+            ...result.finalized,
+            state: 'finalized',
+            updatedAt: Date.now(),
+          };
+          await this.meltOperationRepository.update(finalizedOp);
+          await this.eventBus.emit('melt-op:finalized', {
+            mintUrl: finalizedOp.mintUrl,
+            operationId: finalizedOp.id,
+            operation: finalizedOp,
+          });
+          this.logger?.info('Recovered executing operation as finalized', {
+            operationId: executing.id,
+          });
+          break;
+        }
+        case 'PENDING': {
+          const pendingOp: PendingMeltOperation = {
+            ...result.pending,
+            state: 'pending',
+            updatedAt: Date.now(),
+          };
+          await this.meltOperationRepository.update(pendingOp);
+          await this.eventBus.emit('melt-op:pending', {
+            mintUrl: pendingOp.mintUrl,
+            operationId: pendingOp.id,
+            operation: pendingOp,
+          });
+          this.logger?.info('Recovered executing operation as pending', {
+            operationId: executing.id,
+          });
+          break;
+        }
+        case 'FAILED': {
+          await this.markAsRolledBack(
+            executing,
+            result.failed.error ?? 'Recovered: operation failed',
+          );
+          break;
+        }
+      }
+    } finally {
+      if (releaseLock) {
+        releaseLock();
       }
     }
   }
@@ -667,7 +703,7 @@ export class MeltOperationService {
    */
   private async tryRecoverExecutingOperation(op: ExecutingMeltOperation): Promise<void> {
     try {
-      await this.recoverExecutingOperation(op);
+      await this.recoverExecutingOperation(op, { skipLock: true });
       this.logger?.info('Recovered executing operation after failure', { operationId: op.id });
     } catch (recoveryError) {
       this.logger?.warn('Failed to recover executing operation, will retry on next startup', {

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -382,7 +382,7 @@ describe('MeltOperationService', () => {
         failed: { error: 'nope' },
       });
 
-      expect(service.execute('op-6')).rejects.toThrow('nope');
+      await expect(service.execute('op-6')).rejects.toThrow('nope');
       expect(handler.recoverExecuting).toHaveBeenCalled();
     });
   });
@@ -494,6 +494,108 @@ describe('MeltOperationService', () => {
 
       expect(result).toBe('finalize');
       expect((service as any).finalize).toHaveBeenCalledWith('op-11');
+    });
+  });
+
+  describe('recoverExecutingOperation', () => {
+    it('finalizes when handler reports PAID', async () => {
+      const executing = makeExecutingOp('recover-paid');
+      await meltOperationRepository.create(executing);
+      (handler.recoverExecuting as Mock<any>).mockResolvedValue({
+        status: 'PAID',
+        finalized: makeFinalizedOp('recover-paid'),
+      });
+
+      const events: any[] = [];
+      eventBus.on('melt-op:finalized', (payload) => void events.push(payload));
+
+      await service.recoverExecutingOperation(executing);
+
+      const stored = await meltOperationRepository.getById('recover-paid');
+      expect(stored?.state).toBe('finalized');
+      expect(events.length).toBe(1);
+    });
+
+    it('moves to pending when handler reports PENDING', async () => {
+      const executing = makeExecutingOp('recover-pending');
+      await meltOperationRepository.create(executing);
+      (handler.recoverExecuting as Mock<any>).mockResolvedValue({
+        status: 'PENDING',
+        pending: makePendingOp('recover-pending'),
+      });
+
+      const events: any[] = [];
+      eventBus.on('melt-op:pending', (payload) => void events.push(payload));
+
+      await service.recoverExecutingOperation(executing);
+
+      const stored = await meltOperationRepository.getById('recover-pending');
+      expect(stored?.state).toBe('pending');
+      expect(events.length).toBe(1);
+    });
+
+    it('rolls back when handler reports FAILED', async () => {
+      const executing = makeExecutingOp('recover-failed');
+      await meltOperationRepository.create(executing);
+      (handler.recoverExecuting as Mock<any>).mockResolvedValue({
+        status: 'FAILED',
+        failed: { error: 'quote unpaid' },
+      });
+
+      const events: any[] = [];
+      eventBus.on('melt-op:rolled-back', (payload) => void events.push(payload));
+
+      await service.recoverExecutingOperation(executing);
+
+      const stored = await meltOperationRepository.getById('recover-failed');
+      expect(stored?.state).toBe('rolled_back');
+      expect((stored as RolledBackMeltOperation).error).toBe('quote unpaid');
+      expect(events.length).toBe(1);
+    });
+
+    it('ignores operations that are no longer executing', async () => {
+      const staleExecuting = makeExecutingOp('recover-stale');
+      await meltOperationRepository.create(makePendingOp('recover-stale'));
+
+      await service.recoverExecutingOperation(staleExecuting);
+
+      expect(handler.recoverExecuting).not.toHaveBeenCalled();
+      const stored = await meltOperationRepository.getById('recover-stale');
+      expect(stored?.state).toBe('pending');
+    });
+
+    it('throws when recovery is already in progress for the operation', async () => {
+      const executing = makeExecutingOp('recover-locked');
+      await meltOperationRepository.create(executing);
+
+      let releaseRecovery: () => void;
+      const recoveryBlocked = new Promise<void>((resolve) => {
+        releaseRecovery = resolve;
+      });
+      let recoveryStarted: () => void;
+      const recoveryStartedPromise = new Promise<void>((resolve) => {
+        recoveryStarted = resolve;
+      });
+      (handler.recoverExecuting as Mock<any>).mockImplementation(
+        async ({ operation }: { operation: ExecutingMeltOperation }) => {
+          recoveryStarted();
+          await recoveryBlocked;
+          return {
+            status: 'PENDING',
+            pending: makePendingOp(operation.id),
+          };
+        },
+      );
+
+      const first = service.recoverExecutingOperation(executing);
+      await recoveryStartedPromise;
+
+      await expect(service.recoverExecutingOperation(executing)).rejects.toThrow(
+        OperationInProgressError,
+      );
+
+      releaseRecovery!();
+      await first;
     });
   });
 

--- a/packages/core/test/unit/MeltOpsApi.test.ts
+++ b/packages/core/test/unit/MeltOpsApi.test.ts
@@ -148,9 +148,7 @@ describe('MeltOpsApi', () => {
 
     const result = await api.refresh(executingOperation.id);
 
-    expect(meltOperationService.recoverExecutingOperation).toHaveBeenCalledWith(
-      executingOperation,
-    );
+    expect(meltOperationService.recoverExecutingOperation).toHaveBeenCalledWith(executingOperation);
     expect(result).toBe(finalizedOperation);
   });
 

--- a/packages/core/test/unit/MeltOpsApi.test.ts
+++ b/packages/core/test/unit/MeltOpsApi.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type {
+  ExecutingMeltOperation,
   FinalizedMeltOperation,
   MeltOperation,
   PendingMeltOperation,
@@ -47,6 +48,7 @@ describe('MeltOpsApi', () => {
   let api: MeltOpsApi;
   let meltOperationService: MeltOperationService;
   let preparedOperation: PreparedMeltOperation;
+  let executingOperation: ExecutingMeltOperation;
   let pendingOperation: PendingMeltOperation;
 
   beforeEach(() => {
@@ -54,6 +56,10 @@ describe('MeltOpsApi', () => {
     pendingOperation = {
       ...preparedOperation,
       state: 'pending',
+    };
+    executingOperation = {
+      ...preparedOperation,
+      state: 'executing',
     };
 
     meltOperationService = {
@@ -67,6 +73,7 @@ describe('MeltOpsApi', () => {
       rollback: mock(async () => {}),
       finalize: mock(async () => {}),
       recoverPendingOperations: mock(async () => {}),
+      recoverExecutingOperation: mock(async () => {}),
       checkPendingOperation: mock(async () => 'finalize'),
       isOperationLocked: mock(() => false),
       isRecoveryInProgress: mock(() => false),
@@ -126,6 +133,24 @@ describe('MeltOpsApi', () => {
     const result = await api.refresh(pendingOperation.id);
 
     expect(meltOperationService.checkPendingOperation).toHaveBeenCalledWith(pendingOperation.id);
+    expect(result).toBe(finalizedOperation);
+  });
+
+  it('refresh recovers executing operations and re-reads the latest state', async () => {
+    const finalizedOperation: FinalizedMeltOperation = {
+      ...pendingOperation,
+      state: 'finalized',
+      updatedAt: Date.now(),
+    };
+    (meltOperationService.getOperation as unknown as ReturnType<typeof mock>)
+      .mockResolvedValueOnce(executingOperation as MeltOperation)
+      .mockResolvedValueOnce(finalizedOperation as MeltOperation);
+
+    const result = await api.refresh(executingOperation.id);
+
+    expect(meltOperationService.recoverExecutingOperation).toHaveBeenCalledWith(
+      executingOperation,
+    );
     expect(result).toBe(finalizedOperation);
   });
 


### PR DESCRIPTION
## Description

This pull request fixes targeted runtime recovery for executing melt operations.

This pull request resolves #128.

## Problem

Executing melt operations could remain stuck after execute-time recovery failed, because `manager.ops.melt.refresh()` only handled `pending` operations and the executing recovery primitive was private.

## Summary

- Updates `MeltOpsApi.refresh()` to recover `executing` operations and re-read persisted state.
- Makes melt executing recovery public, lock-aware, and safe for stale operation snapshots.
- Adds focused API and service tests for PAID, PENDING, FAILED, stale-state, and lock-contention recovery paths.
- Adds `.changeset/melt-refresh-recovers-executing.md`.
- Unrelated untracked `v4migration.md` remains outside this change.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MeltOpsApi.test.ts test/unit/MeltOperationService.test.ts`
- `bun run typecheck -- --pretty false`
- `bun run --filter='@cashu/coco-core' build`
- `git diff --check`

## Changeset

- Added `.changeset/melt-refresh-recovers-executing.md`