### PR TITLE
chore: publish docs from stable release tags only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy docs to Github Pages
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: read
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ startsWith(github.ref, 'refs/tags/') && !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,8 @@
 name: Deploy docs to Github Pages
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'packages/docs/**'
-      - '.github/workflows/docs.yml'
-  workflow_dispatch:
+  release:
+    types: [created]
 
 permissions:
   contents: read
@@ -20,6 +15,7 @@ concurrency:
 
 jobs:
   build:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- Update the GitHub Pages docs workflow to run only for `release.published` events.
- Guard the docs build to tag refs and stable releases by skipping `github.event.release.prerelease`.
- Explicitly check out `github.event.release.tag_name` before building.
- Remove the `master` push and manual dispatch triggers so unreleased master docs do not update the live site.

## Verification

- `node_modules/.bin/prettier --check .github/workflows/docs.yml`
- `git diff --check`

## Changeset

- Not added. This is a repository workflow change only.