### PR TITLE
feat: add optimized batch mint finalization

### DIFF
--- a/.changeset/batch-minting.md
+++ b/.changeset/batch-minting.md
@@ -1,0 +1,15 @@
+---
+'@cashu/coco-core': minor
+'@cashu/coco-indexeddb': minor
+'@cashu/coco-expo-sqlite': minor
+'@cashu/coco-sqlite': minor
+'@cashu/coco-sqlite-bun': minor
+'@cashu/coco-adapter-tests': minor
+---
+
+Add optimized BOLT11 batch mint finalization for mints that advertise NUT-29 support.
+
+Mint quote preparation no longer precomputes output data. Single quote finalization now persists
+its output data immediately before minting, while eligible paid quotes can be finalized together
+with consolidated output denominations. Adapters persist batch attempt records and proof batch
+metadata so requesting-state crashes can recover the issued outputs.

--- a/batch-minting-plan-v2.md
+++ b/batch-minting-plan-v2.md
@@ -1,0 +1,718 @@
+# Batch Minting Plan V2
+
+## Context
+
+The original batch minting plan preserved Coco's existing invariant that every prepared mint
+operation already owns the deterministic `outputData` for its own quote amount. That design is
+crash-safe and can reduce HTTP requests, but it misses the main NUT-29 benefit: a batch can create
+one optimized output split for the total amount across many quotes.
+
+Example:
+
+- Three independent 23 sat mints produce `16, 4, 2, 1` each, for 12 proofs total.
+- One 69 sat batch can produce `64, 4, 1`, for 3 proofs total.
+
+That optimization is only possible if output data is created after Coco chooses a concrete
+redemption path. At quote creation time, Coco does not know whether a paid quote will be redeemed
+alone or as part of a larger batch.
+
+CDK's NUT-29 implementation follows this model:
+
+- quote records stay per quote
+- the batch issue saga owns the combined premint secrets / blinded messages
+- the batch request uses outputs for the total amount
+- each quote is marked issued for its own expected amount
+- proofs are stored as outputs of the batch, not as proofs owned by individual quote records
+- recovery replays the batch request first, then falls back to `/restore` using persisted batch output
+  data
+
+For Coco, the equivalent design is a persisted `MintBatchAttempt` that owns consolidated output data.
+
+## Design Goal
+
+Implement NUT-29 in a way that gets both benefits:
+
+- one mint request for multiple paid quotes
+- fewer proofs through an optimized denomination split for the combined amount
+
+The design must preserve Coco's crash-safety boundary:
+
+- after blinded messages may have been submitted to the mint, their output data must be durable
+- recovery must never create a different output set for the same maybe-submitted request
+- ambiguous network failures must not cause unrecoverable proof loss or double finalization
+
+## Revised Mental Model
+
+### Quote operations are not output owners
+
+`MintOperation` should continue to represent one mint quote lifecycle:
+
+- quote creation/import
+- quote amount, unit, method, expiry, request
+- remote state observations
+- whether the quote has been locally redeemed/finalized
+
+Mint operations should not own final mint `outputData` at quote prepare time. The operation should
+carry enough quote metadata to schedule and validate redemption. Output data should be created only
+after Coco knows which redemption path is being used:
+
+- single finalization creates one output set for that quote amount
+- batch finalization creates one output set for the combined batch amount
+
+### Batch attempts own optimized outputs
+
+A `MintBatchAttempt` represents one concrete redemption attempt for a group of quotes:
+
+- the selected operation ids and quote ids
+- the per-quote amounts used in the batch request
+- the total amount
+- the optimized consolidated output data
+- the active keyset and counter range used to produce those outputs
+- state for write-ahead recovery
+
+This mirrors CDK's issue saga shape: once the batch exists, the batch owns the premint secrets.
+
+## Data Model
+
+### MintOperation changes
+
+Adjust pending mint operations so `outputData` is no longer mandatory. In the normal new flow,
+`pending` means "quote known, waiting to be redeemed", not "outputs already prepared".
+
+Recommended shape:
+
+```ts
+interface PendingData {
+  outputData?: SerializedOutputData;
+  batchEligible?: boolean;
+  redeemedByBatchId?: string;
+}
+```
+
+Rules:
+
+- Quote prepare should not create final mint `outputData` for either single or batch-capable methods.
+- Single-operation finalization creates and stores `outputData` immediately before submitting the
+  single quote mint request.
+- Batch finalization creates and stores consolidated output data on `MintBatchAttempt`.
+- `batchEligible` remains only a scheduling hint.
+- `redeemedByBatchId` is set when a batch attempt has claimed or finalized the operation.
+- Existing persisted operations with `outputData` remain valid and should still finalize through the
+  single path or the old compatibility path if needed.
+
+The single path does not need a separate `MintSingleAttempt` entity in the first slice. The
+operation can continue to be the write-ahead record for single redemption, as long as the service
+persists `outputData` on the operation before transitioning to `executing` and before calling the
+mint. Batches need their own entity because one output set belongs to multiple operations.
+
+### MintBatchAttempt
+
+Add a new persisted entity in core and all adapters.
+
+Suggested type:
+
+```ts
+export type MintBatchAttemptState =
+  | 'prepared'
+  | 'requesting'
+  | 'finalized'
+  | 'recovering'
+  | 'failed';
+
+export interface MintBatchAttempt {
+  id: string;
+  mintUrl: string;
+  method: MintMethod;
+  unit: string;
+  operationIds: string[];
+  quoteIds: string[];
+  quoteAmounts: Amount[];
+  totalAmount: Amount;
+  outputData: SerializedOutputData;
+  keysetId: string;
+  counterStart?: number;
+  counterEnd?: number;
+  state: MintBatchAttemptState;
+  error?: string;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt?: number;
+  finalizedAt?: number;
+}
+```
+
+Notes:
+
+- `outputData` is the durable replay/recovery boundary.
+- `quoteAmounts` are required even for bolt11 so recovery can reconstruct the exact request and so
+  each operation can be finalized for its own contribution.
+- `operationIds` and `quoteIds` are kept in the same order as `quoteAmounts`.
+- `keysetId` should be a single active keyset for the first implementation. Mixed-keyset output sets
+  can wait.
+- `counterStart`/`counterEnd` are useful for deterministic recovery if the repo wants CDK-style
+  counter-range re-derivation. If Coco's serialized `outputData` is sufficient for restore, these can
+  be optional but still valuable for audits and migration.
+
+### Repository surface
+
+Add `MintBatchAttemptRepository`:
+
+```ts
+export interface MintBatchAttemptRepository {
+  create(attempt: MintBatchAttempt): Promise<void>;
+  update(attempt: MintBatchAttempt): Promise<void>;
+  getById(id: string): Promise<MintBatchAttempt | null>;
+  getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]>;
+  getByOperationId(operationId: string): Promise<MintBatchAttempt | null>;
+  getPending(): Promise<MintBatchAttempt[]>;
+  delete(id: string): Promise<void>;
+}
+```
+
+Implement it in:
+
+- memory repositories
+- sqlite3
+- sqlite-bun
+- expo-sqlite
+- indexeddb
+
+Adapters should serialize `Amount` and `SerializedOutputData` consistently with existing operation
+repositories.
+
+## Handler Contract
+
+Keep the method-handler boundary, but split quote preparation from output preparation. Quote
+preparation gets the operation to `pending`; single or batch finalization creates the actual blinded
+messages and persists them before the mint request is submitted.
+
+Suggested additions:
+
+```ts
+export interface BatchSupportContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operation: PendingMintOperation<M>;
+  wallet: Wallet;
+}
+
+export interface SingleOutputPrepareContext<M extends MintMethod = MintMethod>
+  extends BaseHandlerDeps {
+  operation: PendingMintOperation<M>;
+  wallet: Wallet;
+}
+
+export interface BatchPrepareContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operations: PendingMintOperation<M>[];
+  totalAmount: Amount;
+  quoteAmounts: Amount[];
+  wallet: Wallet;
+}
+
+export interface BatchExecuteContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  attempt: MintBatchAttempt;
+  operations: PendingMintOperation<M>[];
+  wallet: Wallet;
+}
+
+export interface MintMethodHandler<M extends MintMethod = MintMethod> {
+  prepare(ctx: PrepareContext<M>): Promise<PendingMintOperation<M>>;
+  prepareSingleOutput?(ctx: SingleOutputPrepareContext<M>): Promise<PendingMintOperation<M>>;
+  execute(ctx: ExecuteContext<M>): Promise<MintExecutionResult>;
+  assessBatchSupport?(ctx: BatchSupportContext<M>): Promise<MintBatchSupport> | MintBatchSupport;
+  prepareBatch?(ctx: BatchPrepareContext<M>): Promise<MintBatchAttempt>;
+  executeBatch?(ctx: BatchExecuteContext<M>): Promise<MintBatchExecutionResult>;
+  recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<RecoverExecutingResult>;
+  checkPending(ctx: PendingContext<M>): Promise<PendingMintCheckResult<M>>;
+}
+```
+
+`prepareSingleOutput` creates the output data for one pending operation and returns an updated
+operation ready to persist. It must not submit the mint request.
+
+`prepareBatch` creates the consolidated output data and returns an attempt object ready to persist.
+It must not submit the mint request.
+
+The service, not the handler, persists the returned operation or attempt and owns state
+transitions. That keeps the single and batch paths aligned:
+
+- single: prepare output data, persist it on the operation, mark operation `executing`, call mint
+- batch: prepare output data, persist it on the attempt, mark attempt `requesting`, call mint
+
+## Flow: Quote Creation
+
+1. `MintOperationService.init()` creates an `init` operation.
+2. `MintOperationService.prepare()` calls `handler.prepare(...)`.
+3. For bolt11, `handler.prepare(...)` creates or imports the quote and persists quote metadata.
+4. The handler does not create final mint `outputData`.
+5. The service asks `handler.assessBatchSupport(...)`.
+6. The service persists `batchEligible`.
+7. The operation enters `pending`.
+
+This makes single and batch redemption structurally similar: quote preparation records the payment
+claim, while finalization creates the blinded messages after the concrete redemption path is known.
+
+## Flow: Scheduling
+
+`MintOperationProcessor` still schedules based on paid quote events, but it now has two paths.
+
+### Single path
+
+Use the existing single finalize path when:
+
+- the item is not batch eligible
+- the mint lacks usable NUT-29 support
+- only one ready operation is available and the processor chooses not to wait
+- group validation says the operation must be downgraded
+
+Single finalization should mirror batch write-ahead behavior:
+
+1. Acquire the operation lock and reload the pending operation.
+2. Revalidate trusted mint, quote state, method, and unit.
+3. If the operation has no `outputData`, ask the handler to create single-operation output data for
+   the operation amount.
+4. Persist the operation with that `outputData`.
+5. Transition the operation to `executing` before submitting the mint request.
+6. Submit the single mint request using the persisted output data.
+7. On success, save proofs and finalize as today.
+
+If the process crashes after step 5, recovery uses the persisted operation output data. It must not
+create a fresh output set for the same maybe-submitted single quote request.
+
+### Batch path
+
+When a ready batchable item is selected:
+
+1. Ask `MintService` for current NUT-29 capability and effective max batch size.
+2. Select ready queue items with same `mintUrl`, `method`, and `batchEligible === true`.
+3. Cap by `max_batch_size`.
+4. Call `MintOperationService.finalizeBatch(operationIds)`.
+
+The processor remains method agnostic. It groups by scheduling criteria only. All protocol checks and
+output creation happen in the service/handler.
+
+The processor must also close the existing active-item dedupe gap. Returning an operation to
+`pending` emits `mint-op:pending`; retryable result handling must not duplicate that queue entry.
+
+## Flow: Batch Finalization
+
+`MintOperationService.finalizeBatch(operationIds)` is the correctness boundary.
+
+### Phase 1: lock and reload
+
+1. Sort operation ids deterministically.
+2. Acquire operation locks in sorted order.
+3. Acquire the mint-scoped lock for the mint.
+4. Reload every operation while locks are held.
+5. Validate:
+   - every operation is `pending`
+   - every operation has `batchEligible === true`
+   - same mint, method, and unit
+   - trusted mint
+   - last observed remote state is `PAID`
+   - no operation is already claimed by another batch
+
+### Phase 2: capability and quote validation
+
+1. Load NUT-29 capability from `MintService`.
+2. Enforce effective max batch size.
+3. Run the NUT-29 quote-check endpoint for the concrete quote ids.
+4. Require every response to correspond to the requested quote and to be mintable.
+5. Compute per-quote amounts from the refreshed quote snapshots.
+6. Reject or downgrade operation-local structural issues.
+7. For mint capability absence, max-size overflow, or group-shape problems, return scheduling
+   fallback results without mutating `batchEligible`.
+
+### Phase 3: create and persist batch attempt
+
+1. Ask the handler to prepare the batch.
+2. Handler creates consolidated output data for `sum(quoteAmounts)`.
+3. Service persists `MintBatchAttempt` in `prepared` state.
+4. Service marks each operation as claimed by `redeemedByBatchId`.
+5. Emit a batch prepared/internal event if useful.
+
+At this point no mint request has been submitted. If the process crashes here, recovery can release
+the operation claims or retry the prepared attempt.
+
+### Phase 4: write-ahead transition
+
+Before the network call:
+
+1. Update the attempt to `requesting`.
+2. Set `requestedAt`.
+3. Persist the attempt.
+
+This is write-ahead logging. After this state is durable, recovery must assume the mint may have
+received the request.
+
+### Phase 5: execute batch
+
+1. Call `handler.executeBatch({ attempt, operations, wallet })`.
+2. For bolt11, reconstruct the NUT-29 request from attempt data:
+   - `quotes`
+   - `quote_amounts`
+   - consolidated `outputs`
+   - no NUT-20 signatures in the first slice
+3. Submit `/v1/mint/{method}/batch`.
+4. Validate returned signatures and construct proofs using the attempt output data.
+
+### Phase 6: persist success atomically where possible
+
+On success:
+
+1. Save all returned proofs as ready proofs with metadata:
+   - set `createdByBatchId` to the finalized batch attempt id
+   - leave `createdByOperationId` unset for batch-created proofs
+2. Mark the batch attempt `finalized`.
+3. Mark each mint operation `finalized`.
+4. Set each operation's `lastObservedRemoteState` to `ISSUED`.
+5. Preserve per-operation history with its quote amount.
+6. Add a batch-level history/transaction entry if the history model supports it.
+7. Emit `mint-op:finalized` per operation and a batch finalized event if added.
+
+Proofs should not be split or assigned by operation amount. A 64 sat proof in a 69 sat batch belongs
+to the batch output set, not to one 23 sat quote.
+
+## Bolt11 Handler Details
+
+### `assessBatchSupport`
+
+Return `supported: true` when:
+
+- method is bolt11
+- quote is unlocked
+- unit is supported
+- quote amount is known and positive
+
+For the first slice, locked quotes are explicitly unsupported and should be downgraded to the single
+path. Do not add NUT-20 signing to the batch implementation yet.
+
+### `prepareBatch`
+
+For a group of pending bolt11 operations:
+
+1. Validate same unit and method.
+2. Compute `quoteAmounts` from operation amounts.
+3. Compute `totalAmount`.
+4. Use `ProofService.createOutputsAndIncrementCounters(mintUrl, { keep: totalAmount, send: 0 })`.
+5. Serialize output data as `{ keep, send: [] }`.
+6. Ensure the output total equals `totalAmount`.
+7. Derive/store one keyset id from the created outputs.
+8. Return a `MintBatchAttempt` draft.
+
+This is where denomination optimization happens.
+
+### `executeBatch`
+
+1. Deserialize `attempt.outputData`.
+2. Use `outputData.keep` as consolidated custom outputs.
+3. Build entries from operations/attempt:
+
+```ts
+const entries = operations.map((operation, index) => ({
+  amount: attempt.quoteAmounts[index],
+  quote: {
+    quote: operation.quoteId,
+    ...(operation.pubkey ? { pubkey: operation.pubkey } : {}),
+  },
+}));
+```
+
+4. Call:
+
+```ts
+const preview = await wallet.prepareBatchMint(
+  'bolt11',
+  entries,
+  { keysetId: attempt.keysetId },
+  {
+    type: 'custom',
+    data: outputData.keep,
+  },
+);
+const proofs = await wallet.completeBatchMint(preview);
+```
+
+5. Return the complete proof set for the batch.
+
+The result should be batch-level, not `proofsByOperationId`.
+
+Suggested result:
+
+```ts
+export type MintBatchExecutionResult =
+  | { status: 'ISSUED'; proofs: Proof[] }
+  | { status: 'ALREADY_ISSUED' }
+  | { status: 'FAILED'; error?: string; retryable?: boolean };
+```
+
+## Recovery
+
+Recovery should be state-driven from `MintBatchAttempt`.
+
+### `prepared`
+
+No request was submitted.
+
+Recovery may:
+
+- release operation claims and delete/fail the attempt
+- or retry execution by moving to `requesting`
+
+No proof recovery is needed because the mint should not have seen the output set.
+
+### `requesting`
+
+The request may have reached the mint.
+
+Recovery must not create new output data.
+
+Steps:
+
+1. Check whether all expected output proofs are already saved.
+2. If yes, finalize attempt and operations.
+3. Reconstruct the original batch request from persisted attempt data.
+4. Replay the request if the mint supports cached responses or idempotent behavior.
+5. If replay succeeds, save proofs and finalize.
+6. If replay fails with already-issued or ambiguous status, call `/restore` using persisted output
+   data.
+7. If restore recovers proofs, save and finalize.
+8. If quote check says quotes remain `PAID` and no proofs are recoverable, return the attempt to a
+   retryable state only if it is clear the original request was not accepted. Otherwise keep the
+   attempt in a recoverable failed state and surface an error.
+
+This is stricter than normal single retry. After `requesting`, blind messages may already have been
+accepted by the mint; blindly creating a new attempt risks losing recoverability for the first output
+set.
+
+### `finalized`
+
+No action except idempotent cleanup.
+
+### `failed`
+
+Keep enough data for manual or startup recovery unless the failure happened before the request was
+submitted.
+
+## Error Taxonomy
+
+### Downgrade to single mint
+
+Persist `batchEligible: false` only for operation-local structural problems:
+
+- locked quote without a usable private key in the first implementation
+- unsupported unit
+- invalid quote metadata
+- invalid or incompatible method-local data
+
+### Scheduling fallback without mutating operation eligibility
+
+Do not persist `batchEligible: false` for:
+
+- mint lacks NUT-29
+- group exceeds max batch size
+- group shape is bad
+- mixed keysets caused by the output strategy
+- only one operation is ready
+
+These are scheduler/capability issues, not operation-local facts.
+
+### Retryable before request submission
+
+If quote check or capability refresh fails before the attempt reaches `requesting`, return retryable
+results and keep operations pending.
+
+### Ambiguous after request submission
+
+If the attempt is already `requesting`, recovery must use the persisted attempt and should prefer
+replay/restore. Do not downgrade to single mint and do not create a new output set until recovery has
+proved the old attempt was not accepted.
+
+## Capability Parsing
+
+Add a helper to `MintService`:
+
+```ts
+interface MintBatchCapability {
+  supported: boolean;
+  maxBatchSize: number;
+}
+
+getMintBatchCapability(mintUrl: string, method: MintMethod): Promise<MintBatchCapability>
+```
+
+Rules:
+
+- `nuts[29]` absent or empty means unsupported.
+- `max_batch_size` defaults to an internal cap, likely `100`.
+- if `methods` is omitted, all NUT-04 mint methods are eligible.
+- if `methods` is present, the requested method must be included.
+
+Use this helper in both the processor and `finalizeBatch()`.
+
+## MintAdapter
+
+Add:
+
+```ts
+checkMintQuotesBatch(
+  mintUrl: string,
+  method: MintMethod,
+  quoteIds: string[],
+): Promise<MintQuoteBolt11Response[]>
+```
+
+It should call `POST /v1/mint/quote/{method}/check` through `MintRequestProvider` so auth,
+rate-limiting, and error mapping stay consistent with other mint requests.
+
+## History And Proof Metadata
+
+The existing model often associates proofs with operation ids. Optimized batch proofs break that
+one-to-one assumption.
+
+Required first-slice changes:
+
+- Add `createdByBatchId` to proof metadata.
+- Keep `createdByOperationId` for single-operation mints.
+- For batch-created proofs, set `createdByBatchId` and leave `createdByOperationId` unset.
+- Per-operation history should record quote-level redemption amount.
+- Batch history can record the actual proof set and total amount.
+
+Do not ship the optimized batch path with ownerless batch proofs. Adding `createdByBatchId` in the
+first implementation keeps proof ownership, history, audits, and recovery explicit.
+
+## Migration And Compatibility
+
+Existing pending mint operations may already have `outputData`.
+
+Compatibility rules:
+
+- If a pending operation has `outputData`, it can continue through the single path.
+- Do not batch old operations with precomputed per-operation `outputData` in the optimized path.
+  They are single-only for the first implementation.
+- New operations should avoid precomputing output data, regardless of whether they later finalize
+  through the single or batch path.
+- Repository mappers must tolerate missing `outputData` for pending operations.
+
+This is a breaking internal state-shape change and should be called out in migration notes if public
+types expose `PendingMintOperation.outputData`.
+
+## Implementation Steps
+
+1. Add `MintBatchAttempt` core model and repository interface.
+2. Implement batch attempt repositories in memory, sqlite3, sqlite-bun, expo-sqlite, and indexeddb.
+3. Make pending mint `outputData` optional where needed, preserving single-operation compatibility.
+4. Add required `createdByBatchId` proof metadata support.
+5. Add NUT-29 capability parsing to `MintService`.
+6. Add batch quote-check helper to `MintAdapter`.
+7. Extend `MintMethodHandler` with single-output prepare, batch support, batch prepare, and batch
+   execute hooks.
+8. Change bolt11 prepare so it only prepares quote state and never creates final output data at
+   quote prepare time.
+9. Add single-finalize write-ahead output generation for pending operations without `outputData`.
+10. Add `MintOperationService.finalizeBatch()`.
+11. Add batch-attempt recovery on startup and when stale attempts are discovered.
+12. Update `MintOperationProcessor` to group paid candidates and call `finalizeBatch()`.
+13. Fix active queue dedupe before adding retryable batch result requeueing.
+14. Add bolt11 `prepareBatch()` and `executeBatch()`.
+15. Update history/proof ownership semantics.
+16. Add docs explaining that optimized batch proofs are batch-owned, not quote-owned.
+
+## Tests
+
+### Model and repository tests
+
+- pending mint operations can persist without `outputData`
+- old pending operations with `outputData` still hydrate and remain single-only
+- batch attempts persist and hydrate `Amount`, output data, quote amounts, ids, and state
+- `getByOperationId()` finds the owning attempt
+- adapter contract coverage across all storage adapters
+
+### Capability tests
+
+- missing `nuts[29]` is unsupported
+- omitted `methods` allows bolt11 when NUT-29 exists
+- explicit methods must include bolt11
+- malformed or missing max size falls back to internal cap
+- max size is enforced in processor and service
+
+### Processor tests
+
+- groups ready batchable same-mint/same-method operations
+- does not group different mints, methods, or units
+- falls back to single path when capability is unsupported
+- caps group size
+- dedupes pending events emitted during in-flight recovery/result handling
+- downgraded operation is requeued as non-batchable
+- retryable pre-request failure keeps operations batch eligible
+
+### Service tests
+
+- single finalization creates output data only during finalization
+- single finalization persists output data before calling the mint
+- single finalization transitions to `executing` only after output data has been persisted
+- single recovery after `executing` reuses persisted output data and does not regenerate it
+- `finalizeBatch()` reloads and validates operations under locks
+- rejects stale/non-pending/claimed operations
+- calls batch quote-check before creating outputs
+- creates a batch attempt with output total equal to sum of quote amounts
+- persists attempt before moving to `requesting`
+- does not create new output data after `requesting`
+- on success saves proofs and finalizes every operation
+- on success saves batch proofs with `createdByBatchId` and no `createdByOperationId`
+- batch proofs are not split by operation amount
+- operation-local structural failure downgrades only that operation
+- capability/group-shape failure does not mutate `batchEligible`
+
+### Bolt11 handler tests
+
+- `prepare()` creates/imports quote state but does not call output creation
+- `prepareSingleOutput()` creates outputs for one quote amount
+- `prepareBatch()` creates outputs for total amount, not per-quote amounts
+- three 23 sat quotes produce a total 69 sat output target
+- `executeBatch()` calls `prepareBatchMint('bolt11', ...)` with consolidated custom outputs
+- NUT-20 signing is not attempted in the first slice
+- locked quotes are rejected from batch support and downgraded to single mint
+
+### Recovery tests
+
+- `prepared` attempt can release claims without proof recovery
+- `requesting` attempt replays using persisted outputs
+- replay success saves proofs and finalizes operations
+- replay failure falls back to restore
+- restore success saves proofs and finalizes operations
+- unresolved post-request attempt does not downgrade to single mint
+- startup recovery handles stale batch attempts
+
+## Recommended First Slice
+
+Implement only optimized bolt11 batch minting for unlocked quotes:
+
+- same mint
+- same method `bolt11`
+- same unit `sat`
+- NUT-29 advertised
+- one active keyset
+- locked quotes rejected from batch support
+- old pending operations with precomputed `outputData` treated as single-only
+- batch-created proofs must be saved with `createdByBatchId`
+
+This slice delivers the actual proof-count benefit while keeping the policy surface narrow.
+
+## Superseded Parts Of The Original Plan
+
+The following old-plan ideas should be replaced:
+
+- Do not create final mint `outputData` during quote prepare, even for single mints.
+- Do not reuse each operation's existing `outputData` for optimized batching.
+- Do not return `proofsByOperationId`; optimized batch proofs are not attributable that way.
+- Do not make `ensureOutputsSaved(operation, proofs)` the success path for batches. Add a
+  batch-aware proof persistence path.
+- Do not recover a post-request batch by trying single-operation minting.
+
+The following old-plan ideas remain valid:
+
+- keep the processor method agnostic
+- keep `batchEligible` minimal
+- parse NUT-29 capability in `MintService`
+- use `MintAdapter` for batch quote check
+- keep downgrade reasons out of persisted operation state
+- process one compatible group per processor pass for fairness

--- a/batch-minting-plan.md
+++ b/batch-minting-plan.md
@@ -1,0 +1,464 @@
+# Batch Minting Plan
+
+## Context
+
+`@cashu/cashu-ts@4.1.0` exposes NUT-29 batch minting through the wallet API:
+
+- `wallet.prepareBatchMint(method, entries, config?, outputType?)`
+- `wallet.completeBatchMint(batchPreview)`
+
+The batch preview builds one request with multiple quote ids, per-quote amounts, and one
+consolidated output set. `BatchMintRequest` contains:
+
+- `quotes: string[]`
+- `quote_amounts: bigint[]` (`cashu-ts` sends this even though NUT-29 makes it
+  optional/null for methods that do not require explicit per-quote amounts)
+- `outputs: SerializedBlindedMessage[]`
+- optional NUT-20 quote signatures
+
+NUT-29 adds two wallet-facing endpoints:
+
+- `POST /v1/mint/quote/{method}/check` with `{ quotes: string[] }`, returning quote objects in the
+  same order. Before minting, wallets SHOULD verify all quotes are paid.
+- `POST /v1/mint/{method}/batch`, which requests blind signatures for one consolidated output set.
+
+Both endpoints use all-or-nothing error handling. For the batch mint request, the mint must reject
+the entire batch if the request is empty, contains duplicate/unknown/invalid quotes, mixes methods
+or units, includes quotes that are not mintable, has a bad output/amount balance, or has invalid
+NUT-20 signatures. Mint info can advertise `nuts[29].max_batch_size` and `nuts[29].methods`; when
+`methods` is omitted, every NUT-04 mint method is eligible for batching.
+
+Coco already prepares deterministic `outputData` per mint operation before the quote is paid.
+That persisted output data is the replay-safety boundary we need to preserve.
+
+## Current Coco Flow
+
+The current mint path is intentionally method-oriented:
+
+1. `MintOperationWatcherService` subscribes to pending quote updates. It already batches quote
+   subscriptions by mint, but emits one `mint-op:quote-state-changed` event per quote.
+2. `MintOperationProcessor` enqueues `PAID` operations and drains one queue item at a time.
+3. The processor does not execute method-specific minting directly. Its default handler calls
+   `MintOperationService.finalize(operationId)`.
+4. `MintOperationService.finalize()` loads the operation, transitions `pending -> executing`,
+   resolves the method handler from `operation.method`, and calls `handler.execute(...)`.
+5. `MintBolt11Handler.execute()` deserializes the operation's existing output data and calls
+   `wallet.mintProofsBolt11(...)` for one quote.
+
+The important consequence is that batching should not be added as a bolt11 shortcut in
+`MintOperationProcessor`. The processor only knows queue scheduling. Method-aware execution belongs
+behind the `MintOperationService` / `MintMethodHandler` boundary.
+
+## Goals
+
+- Redeem multiple queued paid mint operations in one mint request when they share a mint and method.
+- Keep the design method agnostic, so future mint methods can opt into batch execution without
+  processor changes.
+- Preserve the existing operation state machine, events, history updates, recovery behavior, and
+  per-operation proof metadata.
+- Reuse existing per-operation deterministic `outputData`; avoid a new batch-operation table or
+  output-data migration for the first implementation.
+- Fall back to single-operation execution when batching is unsupported, unsafe, or only one operation
+  is ready.
+
+## Non-Goals
+
+- Batch quote creation. This plan only batches redemption of already-created, paid quotes.
+- A new persisted "batch operation" aggregate. Each quote remains its own `MintOperation`.
+- Solving locked NUT-20 mint quotes. Existing single execution does not currently carry a private
+  key through mint operations, so locked quote batching should be explicitly skipped until that
+  support exists.
+
+## Proposed Design
+
+### 1. Persist only a minimal batch eligibility flag
+
+Add only a small scheduling hint to pending-or-later mint operations:
+
+```ts
+batchEligible?: boolean;
+```
+
+`batchEligible` should be determined when the operation becomes `pending`, not at `init`. `init`
+does not yet have the quote snapshot, and eligibility should depend only on operation-local facts
+such as quote fields and persisted output data. Mint-wide NUT-29 support and batch-size limits
+belong to mint capability parsing, not operation state.
+
+The service should compute this hint after `handler.prepare(...)` returns the pending operation. For
+imported quotes, that still happens during `importQuote(...)->prepare(...)`, so imported paid quotes
+get the same scheduling hint before they reach the processor.
+
+This flag is a scheduler hint, not a correctness guarantee. It is mainly there to avoid repeatedly
+trying obviously unbatchable operations, such as locked quotes before Coco has a stored signing-key
+path. It should not store an unsupported reason or mint capability fields. `MintOperationService`
+must still reload and revalidate every operation before executing a batch.
+
+### 2. Extend the method handler contract
+
+Add an optional batch capability to `MintMethodHandler`:
+
+```ts
+export interface MintBatchSupport {
+  supported: boolean;
+}
+
+export interface BatchSupportContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operation: PendingMintOperation<M>;
+  wallet: Wallet;
+}
+
+export interface BatchCapabilityContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operations: PendingMintOperation<M>[];
+  wallet: Wallet;
+}
+
+export interface BatchExecuteContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operations: ExecutingMintOperation<M>[];
+  wallet: Wallet;
+}
+
+export type MintBatchExecutionResult =
+  | {
+      status: 'ISSUED';
+      proofsByOperationId: Map<string, Proof[]>;
+    }
+  | {
+      status: 'FAILED';
+      error?: string;
+    };
+
+export interface MintMethodHandler<M extends MintMethod = MintMethod> {
+  prepare(ctx: PrepareContext<M>): Promise<PendingMintOperation<M>>;
+  execute(ctx: ExecuteContext<M>): Promise<MintExecutionResult>;
+  assessBatchSupport?(ctx: BatchSupportContext<M>): Promise<MintBatchSupport> | MintBatchSupport;
+  executeBatch?(ctx: BatchExecuteContext<M>): Promise<MintBatchExecutionResult>;
+  canBatch?(ctx: BatchCapabilityContext<M>): Promise<MintBatchSupport> | MintBatchSupport;
+  recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<RecoverExecutingResult>;
+  checkPending(ctx: PendingContext<M>): Promise<PendingMintCheckResult<M>>;
+}
+```
+
+The exact type names can be adjusted, but the shape should stay per-operation. Even if a method's
+batch endpoint is all-or-nothing, returning proofs by operation id lets the service keep the existing
+proof metadata and finalization events.
+
+`assessBatchSupport` and `canBatch` should be optional. If they are absent, the method does not batch.
+This keeps third-party or future handlers compatible: they can keep implementing only `execute()`.
+
+`assessBatchSupport` answers "should this individual pending operation be scheduled as batchable?"
+`canBatch` answers "is this concrete group still safe to batch right now?" The second check exists
+because persisted scheduling hints can become stale.
+
+### 3. Add a service-level batch finalization API
+
+Add a method on `MintOperationService`, for example:
+
+```ts
+async finalizeBatch(operationIds: string[]): Promise<MintBatchFinalizeResult>
+```
+
+Responsibilities:
+
+- Acquire operation locks in a deterministic order, then reload every operation while the locks are
+  held and validate that batchable candidates are:
+  - `pending`
+  - same `mintUrl`
+  - same `method`
+  - `operation.batchEligible === true`
+  - trusted mint
+  - observed as remotely ready, currently `lastObservedRemoteState === 'PAID'`
+- Resolve the handler using the existing `handlerProvider.get(method)`.
+- Load the current NUT-29 capability for `{ mintUrl, method }` from `MintService` and enforce its
+  effective max batch size.
+- Re-run the handler group-level `canBatch` check before state transitions.
+- Run the NUT-29 batch quote check (`/v1/mint/quote/{method}/check`) for the concrete group when the
+  mint advertises NUT-29 and require the response to be in request order with every quote mintable.
+  If the check is unavailable or fails transiently, return retryable results without moving
+  operations to `executing`.
+- For operations that are no longer locally eligible for batching, persist `batchEligible: false`
+  and return a `downgraded` result to the processor. Keep downgrade details in logs, not in persisted
+  operation state or scheduler control flow. Mint-capability and group-shape failures should not
+  mutate operation eligibility.
+- Transition only the still-batchable group to `executing`, persist each operation, and emit
+  `mint-op:executing` per operation.
+- Use `handler.executeBatch(...)` when:
+  - the handler implements it
+  - there is more than one candidate
+  - `canBatch` allows the group
+- On batch success, save and verify proofs for each operation using the existing
+  `ensureOutputsSaved(operation, proofs)` path, then call `finalizeIssuedOperation(...)` per
+  operation.
+- On batch failure, do not mark the whole group as failed. Use a batch-specific recovery path that
+  checks saved outputs and remote issuance per operation, but does not submit new single-quote mint
+  requests from the service catch path. Return per-operation retry guidance to the processor.
+
+The service should not turn a rejected batch into immediate single-operation finalizations. That would
+bypass the processor's scheduling, retry, and backoff behavior. If an operation needs to be retried
+as a single operation, the service returns a downgrade outcome and the processor requeues it for a
+later turn.
+
+Suggested result shape:
+
+```ts
+type MintBatchFinalizeItemResult =
+  | { operationId: string; status: 'finalized'; operation: FinalizedMintOperation }
+  | { operationId: string; status: 'failed'; operation: FailedMintOperation }
+  | { operationId: string; status: 'downgraded' }
+  | { operationId: string; status: 'retryable'; error: string };
+
+interface MintBatchFinalizeResult {
+  results: MintBatchFinalizeItemResult[];
+}
+```
+
+Use `downgraded` when an item should leave the batch group and run through the single-operation path.
+Use `retryable` for transient or ambiguous failures such as network errors, timeouts, rate limits, or
+a batch request whose submission status is unclear.
+
+### 4. Keep processor batching method agnostic
+
+Change `MintOperationProcessor` from "find one ready item" to "find ready items and process one
+compatible group":
+
+- Keep queue entries as
+  `{ mintUrl, operationId, method, batchEligible, retryCount, nextRetryAt }`.
+- Find all items where `nextRetryAt <= now`.
+- Pick the next ready item.
+- If it is not batchable, run the existing single-operation path for that one item.
+- If it is batchable, ask `MintService` for the current effective NUT-29 limit for
+  `{ mintUrl, method }`, then select matching ready items from the queue with:
+  - same `mintUrl`
+  - same `method`
+  - `batchEligible === true`
+  - within the effective NUT-29 max batch size
+- Call `mintOperations.finalizeBatch(operationIds)` only for that batchable group.
+- Apply result handling per operation:
+  - `finalized` / `failed`: remove from queue
+  - `downgraded`: requeue with `batchEligible: false` so it is processed singly on a later turn
+  - `retryable`: apply existing retry/backoff
+
+The processor should not know whether `bolt11`, `bolt12`, or a future method has a native batch
+endpoint. It only groups by method because cross-method batches are not valid.
+
+Suggested new processor options:
+
+```ts
+export interface MintOperationProcessorOptions {
+  processIntervalMs?: number;
+  maxRetries?: number;
+  baseRetryDelayMs?: number;
+  initialEnqueueDelayMs?: number;
+}
+```
+
+The default max batch size should come from the mint capability helper: use
+`nuts[29].max_batch_size` when advertised, otherwise use a conservative internal cap such as `100`.
+
+### 5. Implement bolt11 as the first batch-capable handler
+
+`MintBolt11Handler.assessBatchSupport()` should set the persisted scheduling hint during prepare:
+
+- `supported: true` when the quote is unlocked, the unit is supported, and the operation's output
+  data can be used in a custom batch output set.
+- `supported: false` when batching is structurally unsupported.
+
+`MintBolt11Handler.canBatch()` should revalidate the concrete group before execution:
+
+- same method and unit
+- all operations still locally eligible for batching
+- all quotes unlocked for the first implementation
+- all custom outputs use a single keyset id that is present in the wallet
+- total custom output amount equals the sum of the per-operation amounts
+- group size within the advertised max
+- mint still advertises NUT-29 support for `bolt11`; an omitted `nuts[29].methods` list means all
+  NUT-04 methods, including `bolt11`, are supported
+
+`MintBolt11Handler.executeBatch()` can then reuse existing per-operation output data:
+
+1. Deserialize each operation's `outputData`.
+2. Take each operation's `keep` outputs. Mint operations currently prepare only keep outputs.
+3. Concatenate all outputs in operation order.
+4. Derive the single `keysetId` from those outputs and fall back if the group uses mixed keysets.
+   NUT-29 itself can carry ids per blinded message, but `cashu-ts` 4.1.0
+   `completeBatchMint()` unblinds the preview with one `keysetId`, so the first implementation should
+   not batch mixed-keyset operation output data.
+5. Build batch entries:
+
+```ts
+const entries = operations.map((operation) => ({
+  amount: operation.amount,
+  quote: {
+    quote: operation.quoteId,
+    ...(operation.pubkey ? { pubkey: operation.pubkey } : {}),
+  },
+}));
+```
+
+6. Call:
+
+```ts
+const preview = await wallet.prepareBatchMint('bolt11', entries, { keysetId }, {
+  type: 'custom',
+  data: allOutputs,
+});
+const proofs = await wallet.completeBatchMint(preview);
+```
+
+7. Split returned proofs back by each operation's output count and return
+   `proofsByOperationId`.
+
+This preserves the deterministic output data Coco already persisted. `cashu-ts` validates that custom
+output total equals the batch amount, and `completeBatchMint()` validates returned signatures against
+the consolidated output data.
+
+Bolt11 should mark operations locally ineligible when:
+
+- the operation has `pubkey` until Coco has a clear locked-quote private-key path
+- operations use units other than `sat` if broader unit support is not implemented yet
+
+The batch attempt should fall back or retry without mutating operation eligibility when:
+
+- the mint does not advertise NUT-29 support for `bolt11`
+- the operation group uses mixed output keysets
+- the group exceeds the mint's advertised `nuts[29].max_batch_size`
+- the mint returns a structural batch-size error such as `BATCH_SIZE_EXCEEDED`; retry with a smaller
+  group if possible before falling back to single-operation processing
+
+Bolt11 should not downgrade for transient request failures.
+
+### 6. Recovery semantics
+
+The current crash-safe sequence is:
+
+`pending -> executing -> save proofs -> finalized`
+
+Batch execution should keep the same sequence per operation:
+
+- All candidates move to `executing` before the batch mint request.
+- If the request succeeds and proofs are returned, each operation persists only the proofs generated
+  from its own output data.
+- If proof persistence fails for one operation after the batch succeeded, recovery should use the
+  existing `recoverProofsFromOutputData()` path for that operation.
+- If the batch request errors, each executing operation should be recovered individually with a
+  no-new-mint recovery mode:
+  - saved outputs already present -> finalize
+  - remote quote is `ISSUED` -> recover proofs from persisted output data and finalize if recovered
+  - remote quote is still `PAID`/`UNPAID` -> transition back to `pending` and let the processor or
+    watcher schedule the next attempt
+- Retrying after a lost batch response is safe because recovery checks saved outputs and remote
+  issuance before another mint attempt.
+
+This means a batch failure can degrade into single-operation retry later, but the service catch path
+must not immediately mint each quote singly. That preserves processor scheduling, backoff, and
+fairness.
+
+## Refined Flow
+
+1. An operation is prepared.
+2. The service asks the method handler to assess batch support and persists the resulting
+   `batchEligible` hint on the pending operation.
+3. The regular flow continues until the quote is paid and the operation is queued in
+   `MintOperationProcessor`.
+4. On schedule, the processor picks the next ready queue item.
+5. If the item is not batchable, the processor runs the existing single-operation finalize path.
+6. If the item is batchable, the processor selects matching ready batchable items from the queue and
+   hands that group to `MintOperationService.finalizeBatch(...)`.
+7. The service reloads the operations, revalidates the group, and hands only still-batchable operations
+   to the method handler's batch execution path.
+8. If one or more operations are no longer structurally batchable, the service persists
+   `batchEligible: false` and returns `downgraded` results.
+9. The processor requeues downgraded operations as non-batchable so they are picked up singly in a
+   later turn.
+10. Transient batch failures remain retryable and use the existing backoff behavior.
+
+## Resolved Design Choices
+
+1. **Batch metadata shape**: keep operation metadata minimal: `operation.batchEligible` only.
+   Do not persist unsupported reasons or mint capability details on each operation.
+2. **Downgrade taxonomy**: persist `batchEligible: false` only for operation-local
+   incompatibilities: unsupported method, locked quote without stored signing key, mixed unit, or
+   invalid persisted output data. Treat missing NUT-29 support, mixed output keyset groups, and
+   batch-size incompatibility as scheduling fallbacks. Treat network errors, timeouts, rate limits,
+   and ambiguous submissions as retryable.
+3. **NUT-29 capability source**: add a small helper in `MintService` (or a nearby utility) that parses
+   the stored mint info consistently. It should treat omitted `nuts[29].methods` as "all NUT-04
+   methods" and expose an effective max batch size from `nuts[29].max_batch_size` or an internal
+   default. `MintOperationProcessor` should use this helper when choosing group size, and
+   `MintOperationService.finalizeBatch()` should revalidate it before execution. If a mint lacks
+   NUT-29 support, the processor should take the existing single-operation path without changing
+   operation eligibility.
+4. **NUT-29 quote checking**: add a `MintAdapter` helper for
+   `POST /v1/mint/quote/{method}/check` until `cashu-ts` exposes one directly. Use the shared
+   `MintRequestProvider` so rate limiting and protocol error handling stay consistent.
+5. **Locked quotes**: skip any `pubkey` quote for batching in the first slice. Add NUT-20 signing only
+   after mint operation method data has an explicit private-key path.
+6. **Queue fairness**: process one compatible group per pass. This matches the current timer model and
+   avoids long processor monopolization when many quotes become paid at once.
+
+## Implementation Steps
+
+1. Add the persisted flat batch eligibility hint to
+   `packages/core/operations/mint/MintOperation.ts` and every adapter repository that serializes mint
+   operations.
+2. Add batch support and batch execution types to
+   `packages/core/operations/mint/MintMethodHandler.ts`.
+3. Add NUT-29 capability and batch quote-check helpers in `MintService` / `MintAdapter`.
+4. During `MintOperationService.prepare()`, call the handler's batch-support assessment after the
+   pending operation is produced and persist the resulting `batchEligible` hint.
+5. Add `MintOperationService.finalizeBatch()` and private helpers for:
+   - loading and validating batch candidates
+   - acquiring and releasing multiple operation locks in deterministic order
+   - loading current NUT-29 max batch size from `MintService`
+   - running the NUT-29 batch quote check before `executing`
+   - downgrading stale locally ineligible operations
+   - transitioning a group to `executing`
+   - finalizing per-operation batch results
+   - recovering a failed batch group without submitting single-quote mint requests
+6. Update `MintOperationProcessor` to queue `batchEligible`, read NUT-29 max batch size from
+   `MintService`, select matching batchable items, and requeue downgraded operations as
+   non-batchable.
+7. Implement `assessBatchSupport`, `canBatch`, and `executeBatch` in `MintBolt11Handler`.
+8. Add focused unit tests:
+   - prepare persists `batchEligible: true` for locally eligible bolt11 operations
+   - prepare persists `batchEligible: false` for locked or otherwise locally ineligible bolt11
+     operations
+   - capability parsing treats omitted `nuts[29].methods` as allowing `bolt11`
+   - processor falls back to single-operation execution when mint capability lacks NUT-29 support
+     without mutating operation eligibility
+   - processor caps group size using `MintService` NUT-29 max batch size instead of operation fields
+   - service uses the NUT-29 batch quote-check endpoint before moving the group to `executing`
+   - processor drains a ready same-mint/same-method group in one service call
+   - processor processes non-batchable ready items singly
+   - processor keeps different mints/methods in separate groups
+   - processor requeues downgraded operations as non-batchable
+   - service transitions all candidates to `executing` before batch execution
+   - service downgrades stale locally ineligible candidates without executing them singly
+   - service saves/finalizes each operation with only its own proofs
+   - batch failure recovers/requeues without marking all operations failed or minting singly
+   - bolt11 handler uses `prepareBatchMint('bolt11', ...)` with custom output data and the derived
+     `keysetId`
+   - bolt11 handler splits returned proofs by operation output counts
+   - bolt11 skips batching when NUT-29 is not advertised or a quote has `pubkey`
+   - bolt11 falls back for mixed-keyset groups
+   - batch-size errors split or fall back without failing operations
+9. Run:
+   - `bun run --filter='@cashu/coco-core' test -- test/unit/MintQuoteProcessor.test.ts`
+   - `bun run --filter='@cashu/coco-core' test -- test/unit/MintOperationService.test.ts`
+   - `bun run --filter='@cashu/coco-core' test -- test/unit/MintBolt11Handler.test.ts`
+   - `bun run --filter='@cashu/coco-core' typecheck`
+
+## Recommended First Slice
+
+Keep the first implementation narrow:
+
+- Add the generic batch handler contract.
+- Persist `batchEligible` on pending mint operations.
+- Add NUT-29 capability parsing and batch quote checking.
+- Add service-level batch finalization.
+- Teach the processor to group ready items by mint and method.
+- Implement bolt11 batching only for unlocked paid quotes on NUT-29-capable mints when the persisted
+  outputs share a keyset.
+- Fall back to existing single-operation behavior for every unsupported case.
+
+This gives the desired win for multiple queued paid bolt11 quotes while preserving the handler-based
+architecture and leaving custom methods free to opt in later.

--- a/batch-minting-plan.md
+++ b/batch-minting-plan.md
@@ -189,13 +189,17 @@ Responsibilities:
   `ensureOutputsSaved(operation, proofs)` path, then call `finalizeIssuedOperation(...)` per
   operation.
 - On batch failure, do not mark the whole group as failed. Use a batch-specific recovery path that
-  checks saved outputs and remote issuance per operation, but does not submit new single-quote mint
-  requests from the service catch path. Return per-operation retry guidance to the processor.
-
-The service should not turn a rejected batch into immediate single-operation finalizations. That would
-bypass the processor's scheduling, retry, and backoff behavior. If an operation needs to be retried
-as a single operation, the service returns a downgrade outcome and the processor requeues it for a
-later turn.
+  checks saved outputs and remote issuance per operation before deciding how each operation should
+  continue.
+- For transient or ambiguous failures such as network errors, timeouts, rate limits, or unclear
+  submission status, unresolved operations should return to `pending` with `batchEligible: true`.
+  The normal pending event may re-enqueue paid quotes, so the processor must either use its own
+  active-item dedupe when also handling retryable results, or make retryable result handling
+  acknowledge that the pending event already owns requeueing. Do not let both paths add duplicate
+  queue entries for the same operation.
+- Only operation-local structural failures should downgrade an operation to single-mint execution.
+  Group-shape failures such as mixed output keysets, mint capability absence, or batch-size limits
+  should fall back, split, shrink, or retry without permanently mutating per-operation eligibility.
 
 Suggested result shape:
 
@@ -213,7 +217,9 @@ interface MintBatchFinalizeResult {
 
 Use `downgraded` when an item should leave the batch group and run through the single-operation path.
 Use `retryable` for transient or ambiguous failures such as network errors, timeouts, rate limits, or
-a batch request whose submission status is unclear.
+a batch request whose submission status is unclear. Retryable results keep the operation's current
+`batchEligible` value. Because returning an operation to `pending` emits `mint-op:pending`, retryable
+requeue handling must be deduplicated against that event path.
 
 ### 4. Keep processor batching method agnostic
 
@@ -235,7 +241,14 @@ compatible group":
 - Apply result handling per operation:
   - `finalized` / `failed`: remove from queue
   - `downgraded`: requeue with `batchEligible: false` so it is processed singly on a later turn
-  - `retryable`: apply existing retry/backoff
+  - `retryable`: apply existing retry/backoff with the existing `batchEligible` value, but dedupe
+    against any `mint-op:pending` event emitted while the batch was recovering
+  - group fallback/split: retry a smaller compatible group or requeue without persisting
+    `batchEligible: false` unless the service identified an operation-local structural issue
+
+Before adding result-driven requeueing, fix the current queue dedupe TODO by tracking active
+operation keys as well as queued keys, or route all result requeues through a helper that can collapse
+duplicates created by recovery events.
 
 The processor should not know whether `bolt11`, `bolt12`, or a future method has a native batch
 endpoint. It only groups by method because cross-method batches are not valid.
@@ -297,10 +310,15 @@ const entries = operations.map((operation) => ({
 6. Call:
 
 ```ts
-const preview = await wallet.prepareBatchMint('bolt11', entries, { keysetId }, {
-  type: 'custom',
-  data: allOutputs,
-});
+const preview = await wallet.prepareBatchMint(
+  'bolt11',
+  entries,
+  { keysetId },
+  {
+    type: 'custom',
+    data: allOutputs,
+  },
+);
 const proofs = await wallet.completeBatchMint(preview);
 ```
 
@@ -323,6 +341,7 @@ The batch attempt should fall back or retry without mutating operation eligibili
 - the group exceeds the mint's advertised `nuts[29].max_batch_size`
 - the mint returns a structural batch-size error such as `BATCH_SIZE_EXCEEDED`; retry with a smaller
   group if possible before falling back to single-operation processing
+- the batch request fails due to network, timeout, rate limit, or ambiguous submission status
 
 Bolt11 should not downgrade for transient request failures.
 
@@ -339,18 +358,18 @@ Batch execution should keep the same sequence per operation:
   from its own output data.
 - If proof persistence fails for one operation after the batch succeeded, recovery should use the
   existing `recoverProofsFromOutputData()` path for that operation.
-- If the batch request errors, each executing operation should be recovered individually with a
-  no-new-mint recovery mode:
+- If the batch request errors, each executing operation should be recovered individually:
   - saved outputs already present -> finalize
   - remote quote is `ISSUED` -> recover proofs from persisted output data and finalize if recovered
-  - remote quote is still `PAID`/`UNPAID` -> transition back to `pending` and let the processor or
-    watcher schedule the next attempt
+  - remote quote is still `PAID`/`UNPAID` or the quote check cannot complete because the mint is
+    offline -> transition back to `pending`
+- For non-structural failures, operations that return to `pending` keep `batchEligible: true`. The
+  normal `mint-op:pending` flow may re-enqueue paid quotes, and the processor should form another
+  batch on a later pass after deduping that event path against retryable result handling.
+- For operation-local structural failures, persist `batchEligible: false` and requeue that operation
+  for single minting. Group-shape failures should not poison per-operation eligibility.
 - Retrying after a lost batch response is safe because recovery checks saved outputs and remote
   issuance before another mint attempt.
-
-This means a batch failure can degrade into single-operation retry later, but the service catch path
-must not immediately mint each quote singly. That preserves processor scheduling, backoff, and
-fairness.
 
 ## Refined Flow
 
@@ -369,7 +388,9 @@ fairness.
    `batchEligible: false` and returns `downgraded` results.
 9. The processor requeues downgraded operations as non-batchable so they are picked up singly in a
    later turn.
-10. Transient batch failures remain retryable and use the existing backoff behavior.
+10. Transient batch failures move unresolved operations back to `pending` with `batchEligible: true`;
+    pending-event and retryable-result requeue paths are deduped, then the processor batches them
+    again on a later pass.
 
 ## Resolved Design Choices
 
@@ -379,7 +400,8 @@ fairness.
    incompatibilities: unsupported method, locked quote without stored signing key, mixed unit, or
    invalid persisted output data. Treat missing NUT-29 support, mixed output keyset groups, and
    batch-size incompatibility as scheduling fallbacks. Treat network errors, timeouts, rate limits,
-   and ambiguous submissions as retryable.
+   and ambiguous submissions as retryable; unresolved operations keep `batchEligible: true` and are
+   re-enqueued for a later batch attempt.
 3. **NUT-29 capability source**: add a small helper in `MintService` (or a nearby utility) that parses
    the stored mint info consistently. It should treat omitted `nuts[29].methods` as "all NUT-04
    methods" and expose an effective max batch size from `nuts[29].max_batch_size` or an internal
@@ -394,6 +416,9 @@ fairness.
    after mint operation method data has an explicit private-key path.
 6. **Queue fairness**: process one compatible group per pass. This matches the current timer model and
    avoids long processor monopolization when many quotes become paid at once.
+7. **Retry requeue ownership**: returning an executing operation to `pending` emits `mint-op:pending`.
+   The implementation must dedupe that event against retryable result handling, for example with an
+   active queue key set. Otherwise a batch recovery can enqueue the same operation twice.
 
 ## Implementation Steps
 
@@ -413,10 +438,12 @@ fairness.
    - downgrading stale locally ineligible operations
    - transitioning a group to `executing`
    - finalizing per-operation batch results
-   - recovering a failed batch group without submitting single-quote mint requests
+   - recovering a failed batch group and re-enqueueing unresolved transient failures as
+     batch-eligible
 6. Update `MintOperationProcessor` to queue `batchEligible`, read NUT-29 max batch size from
    `MintService`, select matching batchable items, and requeue downgraded operations as
-   non-batchable.
+   non-batchable. As part of this change, close the existing active-item dedupe gap so requeue events
+   emitted during in-flight processing cannot duplicate retryable result requeues.
 7. Implement `assessBatchSupport`, `canBatch`, and `executeBatch` in `MintBolt11Handler`.
 8. Add focused unit tests:
    - prepare persists `batchEligible: true` for locally eligible bolt11 operations
@@ -434,12 +461,15 @@ fairness.
    - service transitions all candidates to `executing` before batch execution
    - service downgrades stale locally ineligible candidates without executing them singly
    - service saves/finalizes each operation with only its own proofs
-   - batch failure recovers/requeues without marking all operations failed or minting singly
+   - network batch failure recovers/requeues unresolved operations with `batchEligible: true`
+   - processor dedupes retryable result handling against `mint-op:pending` requeue events
+   - a later processor pass forms another batch for still-eligible requeued operations
+   - operation-local structural failures requeue with `batchEligible: false`
    - bolt11 handler uses `prepareBatchMint('bolt11', ...)` with custom output data and the derived
      `keysetId`
    - bolt11 handler splits returned proofs by operation output counts
    - bolt11 skips batching when NUT-29 is not advertised or a quote has `pubkey`
-   - bolt11 falls back for mixed-keyset groups
+   - bolt11 falls back for mixed-keyset groups without persisting operation-local ineligibility
    - batch-size errors split or fall back without failing operations
 9. Run:
    - `bun run --filter='@cashu/coco-core' test -- test/unit/MintQuoteProcessor.test.ts`

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   testmint:
-    image: cashubtc/mintd:0.15.1
+    image: cashubtc/mintd:v0.16.0
     container_name: cdk-mint
     ports:
       - '3338:3338'

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -211,6 +211,10 @@ function waitForEvent<TPayload = unknown>(
   });
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function waitForSendHistoryState(
   manager: Manager,
   state: string,
@@ -366,6 +370,20 @@ async function awaitMintQuotePaidWithSubscription(
 
   await paidNotificationPromise;
   return (await getLatestPendingMintOperation(manager, pendingMint.id)) ?? pendingMint;
+}
+
+async function waitForPaidMintOperationSnapshot(
+  manager: Manager,
+  operationId: string,
+): Promise<PreparedMintOperation> {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const operation = await getLatestPendingMintOperation(manager, operationId);
+    if (operation?.lastObservedRemoteState === 'PAID') {
+      return operation;
+    }
+    await sleep(25);
+  }
+  throw new Error(`Mint operation ${operationId} did not persist a PAID quote snapshot`);
 }
 
 async function mintAmount(manager: Manager, mintUrl: string, amount: number, unit = 'sat') {
@@ -553,6 +571,81 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           expect(finalizedEvent.operation.quoteId).toBe(pendingMint.quoteId);
 
           expect(await getMintTotalBalance(mgr, mintUrl, testUnit)).toBeGreaterThanOrEqual(100);
+        } finally {
+          if (mgr) {
+            await mgr.pauseSubscriptions();
+            await mgr.dispose();
+            mgr = undefined;
+          }
+          await dispose();
+        }
+      });
+
+      it('should batch redeem paid mint quotes with consolidated output denominations', async () => {
+        const { repositories, dispose } = await createRepositories();
+        try {
+          mgr = await initializeCoco({
+            repo: repositories,
+            seedGetter,
+            logger,
+            processors: {
+              mintOperationProcessor: {
+                disabled: true,
+              },
+            },
+          });
+
+          await mgr.mint.addMint(mintUrl, { trusted: true });
+
+          const pendingMints = await Promise.all([
+            prepareMintOperation(mgr, mintUrl, 23, testUnit),
+            prepareMintOperation(mgr, mintUrl, 23, testUnit),
+            prepareMintOperation(mgr, mintUrl, 23, testUnit),
+          ]);
+          const paidMints = await Promise.all(
+            pendingMints.map(async (pendingMint) => {
+              await awaitMintQuotePaidWithSubscription(mgr!, mintUrl, pendingMint);
+              return waitForPaidMintOperationSnapshot(mgr!, pendingMint.id);
+            }),
+          );
+
+          const operationIds = paidMints.map((operation) => {
+            expect(operation).toBeDefined();
+            expect(operation?.outputData).toBe(undefined);
+            return operation!.id;
+          });
+
+          const mintOperationService = (
+            mgr as unknown as {
+              mintOperationService: {
+                finalizeBatch(operationIds: string[]): Promise<Array<{ state: string }>>;
+              };
+            }
+          ).mintOperationService;
+          const finalized = await mintOperationService.finalizeBatch(operationIds);
+          expect(finalized).toHaveLength(3);
+          for (const operation of finalized) {
+            expect(operation.state).toBe('finalized');
+          }
+
+          const attempts = await Promise.all(
+            operationIds.map((operationId) =>
+              repositories.mintBatchAttemptRepository.getByOperationId(operationId),
+            ),
+          );
+          const [attempt] = attempts;
+          expect(attempt).toBeDefined();
+          expect(attempt?.state).toBe('finalized');
+          for (const currentAttempt of attempts) {
+            expect(currentAttempt?.id).toBe(attempt?.id);
+          }
+
+          const readyProofs = await repositories.proofRepository.getReadyProofs(mintUrl, {
+            unit: testUnit,
+          });
+          const batchProofs = readyProofs.filter((proof) => proof.createdByBatchId === attempt?.id);
+          expect(batchProofs).toHaveLength(3);
+          expect(batchProofs.reduce((sum, proof) => sum + proof.amount.toNumber(), 0)).toBe(69);
         } finally {
           if (mgr) {
             await mgr.pauseSubscriptions();

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -210,6 +210,10 @@ function waitForEvent<TPayload = unknown>(
   });
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function waitForSendHistoryState(
   manager: Manager,
   state: string,
@@ -357,6 +361,20 @@ async function awaitMintQuotePaidWithSubscription(
 
   await paidNotificationPromise;
   return (await getLatestPendingMintOperation(manager, pendingMint.id)) ?? pendingMint;
+}
+
+async function waitForPaidMintOperationSnapshot(
+  manager: Manager,
+  operationId: string,
+): Promise<PreparedMintOperation> {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const operation = await getLatestPendingMintOperation(manager, operationId);
+    if (operation?.lastObservedRemoteState === 'PAID') {
+      return operation;
+    }
+    await sleep(25);
+  }
+  throw new Error(`Mint operation ${operationId} did not persist a PAID quote snapshot`);
 }
 
 async function mintAmount(manager: Manager, mintUrl: string, amount: number, unit: 'sat' = 'sat') {
@@ -540,6 +558,79 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           expect(finalizedEvent.operation.quoteId).toBe(pendingMint.quoteId);
 
           expect(await getMintTotalBalance(mgr, mintUrl)).toBeGreaterThanOrEqual(100);
+        } finally {
+          if (mgr) {
+            await mgr.pauseSubscriptions();
+            await mgr.dispose();
+            mgr = undefined;
+          }
+          await dispose();
+        }
+      });
+
+      it('should batch redeem paid mint quotes with consolidated output denominations', async () => {
+        const { repositories, dispose } = await createRepositories();
+        try {
+          mgr = await initializeCoco({
+            repo: repositories,
+            seedGetter,
+            logger,
+            processors: {
+              mintOperationProcessor: {
+                disabled: true,
+              },
+            },
+          });
+
+          await mgr.mint.addMint(mintUrl, { trusted: true });
+
+          const pendingMints = await Promise.all([
+            prepareMintOperation(mgr, mintUrl, 23),
+            prepareMintOperation(mgr, mintUrl, 23),
+            prepareMintOperation(mgr, mintUrl, 23),
+          ]);
+          const paidMints = await Promise.all(
+            pendingMints.map(async (pendingMint) => {
+              await awaitMintQuotePaidWithSubscription(mgr!, mintUrl, pendingMint);
+              return waitForPaidMintOperationSnapshot(mgr!, pendingMint.id);
+            }),
+          );
+
+          const operationIds = paidMints.map((operation) => {
+            expect(operation).toBeDefined();
+            expect(operation?.outputData).toBe(undefined);
+            return operation!.id;
+          });
+
+          const mintOperationService = (
+            mgr as unknown as {
+              mintOperationService: {
+                finalizeBatch(operationIds: string[]): Promise<Array<{ state: string }>>;
+              };
+            }
+          ).mintOperationService;
+          const finalized = await mintOperationService.finalizeBatch(operationIds);
+          expect(finalized).toHaveLength(3);
+          for (const operation of finalized) {
+            expect(operation.state).toBe('finalized');
+          }
+
+          const attempts = await Promise.all(
+            operationIds.map((operationId) =>
+              repositories.mintBatchAttemptRepository.getByOperationId(operationId),
+            ),
+          );
+          const [attempt] = attempts;
+          expect(attempt).toBeDefined();
+          expect(attempt?.state).toBe('finalized');
+          for (const currentAttempt of attempts) {
+            expect(currentAttempt?.id).toBe(attempt?.id);
+          }
+
+          const readyProofs = await repositories.proofRepository.getReadyProofs(mintUrl);
+          const batchProofs = readyProofs.filter((proof) => proof.createdByBatchId === attempt?.id);
+          expect(batchProofs).toHaveLength(3);
+          expect(batchProofs.reduce((sum, proof) => sum + proof.amount.toNumber(), 0)).toBe(69);
         } finally {
           if (mgr) {
             await mgr.pauseSubscriptions();

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -790,6 +790,7 @@ export class Manager {
     const mintOperationService = new MintOperationService(
       mintHandlerProvider,
       repositories.mintOperationRepository,
+      repositories.mintBatchAttemptRepository,
       repositories.proofRepository,
       proofService,
       mintService,

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -789,6 +789,7 @@ export class Manager {
     const mintOperationService = new MintOperationService(
       mintHandlerProvider,
       repositories.mintOperationRepository,
+      repositories.mintBatchAttemptRepository,
       repositories.proofRepository,
       proofService,
       mintService,

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -9,10 +9,20 @@ import type {
   RecoverExecutingContext,
   PendingContext,
   PendingMintCheckResult,
+  SingleOutputPrepareContext,
+  BatchSupportContext,
+  BatchPrepareContext,
+  BatchExecuteContext,
+  MintBatchExecutionResult,
 } from '@core/operations/mint';
 import { MintOperationError } from '../../../models/Error';
 import { assertSameUnit } from '@core/amounts';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
+import {
+  deserializeOutputData,
+  generateSubId,
+  mapProofToCoreProof,
+  serializeOutputData,
+} from '@core/utils';
 import { Amount, type MintQuoteBolt11Response } from '@cashu/cashu-ts';
 
 export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
@@ -34,19 +44,6 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
 
     assertSameUnit(quote.unit, ctx.operation.unit, `Mint quote ${quote.quote}`);
 
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: quote.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for mint operation');
-    }
-
     return {
       ...ctx.operation,
       quoteId: quote.quote,
@@ -57,8 +54,33 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
       pubkey: quote.pubkey,
       lastObservedRemoteState: quote.state,
       lastObservedRemoteStateAt: Date.now(),
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
       state: 'pending',
+    };
+  }
+
+  async prepareSingleOutput(
+    ctx: SingleOutputPrepareContext<'bolt11'>,
+  ): Promise<PendingMintOperation<'bolt11'> & MintMethodMeta<'bolt11'>> {
+    if (ctx.operation.outputData) {
+      return ctx.operation;
+    }
+
+    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
+      ctx.operation.mintUrl,
+      {
+        keep: { amount: ctx.operation.amount, unit: ctx.operation.unit },
+        send: { amount: Amount.zero(), unit: ctx.operation.unit },
+      },
+    );
+
+    if (outputData.keep.length === 0) {
+      throw new Error('Failed to create deterministic outputs for mint operation');
+    }
+
+    return {
+      ...ctx.operation,
+      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
+      updatedAt: Date.now(),
     };
   }
 
@@ -76,6 +98,89 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
         },
       );
 
+      return { status: 'ISSUED', proofs };
+    } catch (err) {
+      if (err instanceof MintOperationError && err.code === 20002) {
+        return { status: 'ALREADY_ISSUED' };
+      }
+      throw err;
+    }
+  }
+
+  assessBatchSupport(ctx: BatchSupportContext<'bolt11'>): { supported: boolean; reason?: string } {
+    const { operation } = ctx;
+    if (operation.method !== 'bolt11') {
+      return { supported: false, reason: 'unsupported method' };
+    }
+    if (operation.pubkey) {
+      return { supported: false, reason: 'locked quotes are single-only' };
+    }
+    if (!operation.amount || operation.amount.isZero()) {
+      return { supported: false, reason: 'invalid amount' };
+    }
+    if (operation.outputData) {
+      return { supported: false, reason: 'operation already has precomputed output data' };
+    }
+    return { supported: true };
+  }
+
+  async prepareBatch(ctx: BatchPrepareContext<'bolt11'>) {
+    const unit = ctx.operations[0]?.unit ?? 'sat';
+    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
+      ctx.operations[0]?.mintUrl ?? '',
+      {
+        keep: { amount: ctx.totalAmount, unit },
+        send: { amount: Amount.zero(), unit },
+      },
+    );
+
+    if (outputData.keep.length === 0) {
+      throw new Error('Failed to create deterministic outputs for mint batch');
+    }
+
+    const now = Date.now();
+    return {
+      id: generateSubId(),
+      mintUrl: ctx.operations[0]?.mintUrl ?? '',
+      method: 'bolt11' as const,
+      unit,
+      operationIds: ctx.operations.map((operation) => operation.id),
+      quoteIds: ctx.operations.map((operation) => operation.quoteId),
+      quoteAmounts: ctx.quoteAmounts,
+      totalAmount: ctx.totalAmount,
+      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
+      keysetId: ctx.keysetId,
+      state: 'prepared' as const,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async executeBatch(ctx: BatchExecuteContext<'bolt11'>): Promise<MintBatchExecutionResult> {
+    const outputData = deserializeOutputData(ctx.attempt.outputData);
+    const entries = ctx.operations.map((operation, index) => ({
+      amount: ctx.attempt.quoteAmounts[index],
+      quote: {
+        quote: operation.quoteId,
+        amount: operation.amount,
+        unit: operation.unit,
+        request: operation.request,
+        expiry: operation.expiry,
+        ...(operation.pubkey ? { pubkey: operation.pubkey } : {}),
+      },
+    }));
+
+    try {
+      const preview = await (ctx.wallet as any).prepareBatchMint(
+        'bolt11',
+        entries,
+        { keysetId: ctx.attempt.keysetId },
+        {
+          type: 'custom',
+          data: outputData.keep,
+        },
+      );
+      const proofs = await (ctx.wallet as any).completeBatchMint(preview);
       return { status: 'ISSUED', proofs };
     } catch (err) {
       if (err instanceof MintOperationError && err.code === 20002) {

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -9,10 +9,16 @@ import type {
   RecoverExecutingContext,
   PendingContext,
   PendingMintCheckResult,
+  SingleOutputPrepareContext,
+  BatchSupportContext,
+  BatchPrepareContext,
+  BatchExecuteContext,
+  MintBatchExecutionResult,
 } from '@core/operations/mint';
 import { MintOperationError } from '../../../models/Error';
 import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
 import type { MintQuoteBolt11Response } from '@cashu/cashu-ts';
+import { generateSubId } from '@core/utils';
 
 export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
   async prepare(
@@ -37,18 +43,6 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
       );
     }
 
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: quote.amount,
-        send: 0,
-      },
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for mint operation');
-    }
-
     return {
       ...ctx.operation,
       quoteId: quote.quote,
@@ -59,8 +53,33 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
       pubkey: quote.pubkey,
       lastObservedRemoteState: quote.state,
       lastObservedRemoteStateAt: Date.now(),
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
       state: 'pending',
+    };
+  }
+
+  async prepareSingleOutput(
+    ctx: SingleOutputPrepareContext<'bolt11'>,
+  ): Promise<PendingMintOperation<'bolt11'> & MintMethodMeta<'bolt11'>> {
+    if (ctx.operation.outputData) {
+      return ctx.operation;
+    }
+
+    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
+      ctx.operation.mintUrl,
+      {
+        keep: ctx.operation.amount,
+        send: 0,
+      },
+    );
+
+    if (outputData.keep.length === 0) {
+      throw new Error('Failed to create deterministic outputs for mint operation');
+    }
+
+    return {
+      ...ctx.operation,
+      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
+      updatedAt: Date.now(),
     };
   }
 
@@ -78,6 +97,91 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
         },
       );
 
+      return { status: 'ISSUED', proofs };
+    } catch (err) {
+      if (err instanceof MintOperationError && err.code === 20002) {
+        return { status: 'ALREADY_ISSUED' };
+      }
+      throw err;
+    }
+  }
+
+  assessBatchSupport(ctx: BatchSupportContext<'bolt11'>): { supported: boolean; reason?: string } {
+    const { operation } = ctx;
+    if (operation.method !== 'bolt11') {
+      return { supported: false, reason: 'unsupported method' };
+    }
+    if (operation.pubkey) {
+      return { supported: false, reason: 'locked quotes are single-only' };
+    }
+    if (operation.unit !== 'sat') {
+      return { supported: false, reason: 'unsupported unit' };
+    }
+    if (!operation.amount || operation.amount.isZero()) {
+      return { supported: false, reason: 'invalid amount' };
+    }
+    if (operation.outputData) {
+      return { supported: false, reason: 'operation already has precomputed output data' };
+    }
+    return { supported: true };
+  }
+
+  async prepareBatch(ctx: BatchPrepareContext<'bolt11'>) {
+    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
+      ctx.operations[0]?.mintUrl ?? '',
+      {
+        keep: ctx.totalAmount,
+        send: 0,
+      },
+    );
+
+    if (outputData.keep.length === 0) {
+      throw new Error('Failed to create deterministic outputs for mint batch');
+    }
+
+    const now = Date.now();
+    return {
+      id: generateSubId(),
+      mintUrl: ctx.operations[0]?.mintUrl ?? '',
+      method: 'bolt11' as const,
+      unit: ctx.operations[0]?.unit ?? 'sat',
+      operationIds: ctx.operations.map((operation) => operation.id),
+      quoteIds: ctx.operations.map((operation) => operation.quoteId),
+      quoteAmounts: ctx.quoteAmounts,
+      totalAmount: ctx.totalAmount,
+      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
+      keysetId: ctx.keysetId,
+      state: 'prepared' as const,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async executeBatch(ctx: BatchExecuteContext<'bolt11'>): Promise<MintBatchExecutionResult> {
+    const outputData = deserializeOutputData(ctx.attempt.outputData);
+    const entries = ctx.operations.map((operation, index) => ({
+      amount: ctx.attempt.quoteAmounts[index],
+      quote: {
+        quote: operation.quoteId,
+        amount: operation.amount,
+        unit: operation.unit,
+        request: operation.request,
+        expiry: operation.expiry,
+        ...(operation.pubkey ? { pubkey: operation.pubkey } : {}),
+      },
+    }));
+
+    try {
+      const preview = await (ctx.wallet as any).prepareBatchMint(
+        'bolt11',
+        entries,
+        { keysetId: ctx.attempt.keysetId },
+        {
+          type: 'custom',
+          data: outputData.keep,
+        },
+      );
+      const proofs = await (ctx.wallet as any).completeBatchMint(preview);
       return { status: 'ISSUED', proofs };
     } catch (err) {
       if (err instanceof MintOperationError && err.code === 20002) {

--- a/packages/core/operations/index.ts
+++ b/packages/core/operations/index.ts
@@ -3,6 +3,7 @@ export type { MeltMethod, MeltMethodData, MeltMethodInputData } from './melt/Mel
 export { normalizeMeltMethodData } from './melt/MeltMethodHandler.ts';
 export { MeltOperationService } from './melt/MeltOperationService.ts';
 export type { MintOperation, MintOperationState } from './mint/MintOperation.ts';
+export type { MintBatchAttempt, MintBatchAttemptState } from './mint/MintBatchAttempt.ts';
 export type {
   MintMethod,
   MintMethodData,

--- a/packages/core/operations/mint/MintBatchAttempt.ts
+++ b/packages/core/operations/mint/MintBatchAttempt.ts
@@ -1,0 +1,26 @@
+import type { Amount } from '@cashu/cashu-ts';
+import type { SerializedOutputData } from '../../utils';
+import type { MintMethod } from './MintMethodHandler';
+
+export type MintBatchAttemptState = 'prepared' | 'requesting' | 'finalized' | 'recovering' | 'failed';
+
+export interface MintBatchAttempt<M extends MintMethod = MintMethod> {
+  id: string;
+  mintUrl: string;
+  method: M;
+  unit: string;
+  operationIds: string[];
+  quoteIds: string[];
+  quoteAmounts: Amount[];
+  totalAmount: Amount;
+  outputData: SerializedOutputData;
+  keysetId: string;
+  counterStart?: number;
+  counterEnd?: number;
+  state: MintBatchAttemptState;
+  error?: string;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt?: number;
+  finalizedAt?: number;
+}

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -1,4 +1,4 @@
-import type { MintQuoteBolt11Response, Proof, Wallet } from '@cashu/cashu-ts';
+import type { Amount, MintQuoteBolt11Response, Proof, Wallet } from '@cashu/cashu-ts';
 import type { ProofRepository } from '../../repositories';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
@@ -12,6 +12,7 @@ import type {
   MintOperationFailure,
   PendingMintOperation,
 } from './MintOperation';
+import type { MintBatchAttempt } from './MintBatchAttempt';
 import type { MintAdapter } from '../../infra/MintAdapter';
 
 /**
@@ -72,6 +73,31 @@ export interface PendingContext<M extends MintMethod = MintMethod> extends BaseH
   wallet: Wallet;
 }
 
+export interface SingleOutputPrepareContext<M extends MintMethod = MintMethod>
+  extends BaseHandlerDeps {
+  operation: PendingMintOperation<M>;
+  wallet: Wallet;
+}
+
+export interface BatchSupportContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operation: PendingMintOperation<M>;
+  wallet: Wallet;
+}
+
+export interface BatchPrepareContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  operations: PendingMintOperation<M>[];
+  totalAmount: Amount;
+  quoteAmounts: Amount[];
+  wallet: Wallet;
+  keysetId: string;
+}
+
+export interface BatchExecuteContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+  attempt: MintBatchAttempt<M>;
+  operations: PendingMintOperation<M>[];
+  wallet: Wallet;
+}
+
 export type MintExecutionResult =
   | {
       status: 'ISSUED';
@@ -83,6 +109,25 @@ export type MintExecutionResult =
   | {
       status: 'FAILED';
       error?: string;
+    };
+
+export interface MintBatchSupport {
+  supported: boolean;
+  reason?: string;
+}
+
+export type MintBatchExecutionResult =
+  | {
+      status: 'ISSUED';
+      proofs: Proof[];
+    }
+  | {
+      status: 'ALREADY_ISSUED';
+    }
+  | {
+      status: 'FAILED';
+      error?: string;
+      retryable?: boolean;
     };
 
 export type RecoverExecutingResult =
@@ -101,7 +146,11 @@ export interface PendingMintCheckResult<M extends MintMethod = MintMethod> {
 
 export interface MintMethodHandler<M extends MintMethod = MintMethod> {
   prepare(ctx: PrepareContext<M>): Promise<PendingMintOperation<M>>;
+  prepareSingleOutput?(ctx: SingleOutputPrepareContext<M>): Promise<PendingMintOperation<M>>;
   execute(ctx: ExecuteContext<M>): Promise<MintExecutionResult>;
+  assessBatchSupport?(ctx: BatchSupportContext<M>): Promise<MintBatchSupport> | MintBatchSupport;
+  prepareBatch?(ctx: BatchPrepareContext<M>): Promise<MintBatchAttempt<M>>;
+  executeBatch?(ctx: BatchExecuteContext<M>): Promise<MintBatchExecutionResult>;
   recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<RecoverExecutingResult>;
   checkPending(ctx: PendingContext<M>): Promise<PendingMintCheckResult<M>>;
 }

--- a/packages/core/operations/mint/MintOperation.ts
+++ b/packages/core/operations/mint/MintOperation.ts
@@ -6,7 +6,7 @@
  *          +---------+-> failed
  *
  * - init: Local mint intent persisted before prepare has attached a quote snapshot
- * - pending: Deterministic outputData persisted; quote may now settle remotely
+ * - pending: Quote metadata persisted; quote may now settle remotely
  * - executing: Mint or recovery call in progress
  * - finalized: Quote reached terminal ISSUED state; proofs were saved when recoverable
  * - failed: Operation reached a terminal non-issued state (for example, quote expiry)
@@ -53,7 +53,15 @@ interface MintRemoteObservation<M extends MintMethod = MintMethod> {
 }
 
 interface PendingData {
+  outputData?: SerializedOutputData;
+  batchEligible?: boolean;
+  redeemedByBatchId?: string;
+}
+
+interface PreparedData {
   outputData: SerializedOutputData;
+  batchEligible?: boolean;
+  redeemedByBatchId?: string;
 }
 
 export interface InitMintOperation<M extends MintMethod = MintMethod>
@@ -78,7 +86,7 @@ export interface ExecutingMintOperation<M extends MintMethod = MintMethod>
     MintIntentData,
     MintQuoteSnapshot,
     MintRemoteObservation<M>,
-    PendingData {
+    PreparedData {
   state: 'executing';
 }
 
@@ -134,6 +142,9 @@ export function isTerminalOperation<M extends MintMethod>(
 export function getOutputProofSecrets<M extends MintMethod>(
   op: PendingOrLaterOperation<M>,
 ): string[] {
+  if (!op.outputData) {
+    return [];
+  }
   const { keepSecrets, sendSecrets } = getSecretsFromSerializedOutputData(op.outputData);
   return [...keepSecrets, ...sendSecrets];
 }

--- a/packages/core/operations/mint/MintOperation.ts
+++ b/packages/core/operations/mint/MintOperation.ts
@@ -6,7 +6,7 @@
  *          +---------+-> failed
  *
  * - init: Local mint intent persisted before prepare has attached a quote snapshot
- * - pending: Deterministic outputData persisted; quote may now settle remotely
+ * - pending: Quote metadata persisted; quote may now settle remotely
  * - executing: Mint or recovery call in progress
  * - finalized: Quote reached terminal ISSUED state; proofs were saved when recoverable
  * - failed: Operation reached a terminal non-issued state (for example, quote expiry)
@@ -52,7 +52,15 @@ interface MintRemoteObservation<M extends MintMethod = MintMethod> {
 }
 
 interface PendingData {
+  outputData?: SerializedOutputData;
+  batchEligible?: boolean;
+  redeemedByBatchId?: string;
+}
+
+interface PreparedData {
   outputData: SerializedOutputData;
+  batchEligible?: boolean;
+  redeemedByBatchId?: string;
 }
 
 export interface InitMintOperation<M extends MintMethod = MintMethod>
@@ -77,7 +85,7 @@ export interface ExecutingMintOperation<M extends MintMethod = MintMethod>
     MintIntentData,
     MintQuoteSnapshot,
     MintRemoteObservation<M>,
-    PendingData {
+    PreparedData {
   state: 'executing';
 }
 
@@ -133,6 +141,9 @@ export function isTerminalOperation<M extends MintMethod>(
 export function getOutputProofSecrets<M extends MintMethod>(
   op: PendingOrLaterOperation<M>,
 ): string[] {
+  if (!op.outputData) {
+    return [];
+  }
   const { keepSecrets, sendSecrets } = getSecretsFromSerializedOutputData(op.outputData);
   return [...keepSecrets, ...sendSecrets];
 }

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1,5 +1,9 @@
 import type { Proof } from '@cashu/cashu-ts';
-import type { MintOperationRepository, ProofRepository } from '../../repositories';
+import type {
+  MintBatchAttemptRepository,
+  MintOperationRepository,
+  ProofRepository,
+} from '../../repositories';
 import type {
   ExecutingMintOperation,
   FailedMintOperation,
@@ -10,6 +14,7 @@ import type {
   PendingOrLaterOperation,
   TerminalMintOperation,
 } from './MintOperation';
+import type { MintBatchAttempt } from './MintBatchAttempt';
 import {
   createMintOperation,
   getOutputProofSecrets,
@@ -30,7 +35,12 @@ import type { ProofService } from '../../services/ProofService';
 import type { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
-import { generateSubId, mapProofToCoreProof } from '../../utils';
+import {
+  generateSubId,
+  getSecretsFromSerializedOutputData,
+  mapProofToCoreProof,
+  sumAmounts,
+} from '../../utils';
 import {
   OperationInProgressError,
   NetworkError,
@@ -49,6 +59,7 @@ import { OperationIdLock } from '../OperationIdLock';
 export class MintOperationService {
   private readonly handlerProvider: MintHandlerProvider;
   private readonly mintOperationRepository: MintOperationRepository;
+  private readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   private readonly proofRepository: ProofRepository;
   private readonly proofService: ProofService;
   private readonly mintService: MintService;
@@ -64,6 +75,7 @@ export class MintOperationService {
   constructor(
     handlerProvider: MintHandlerProvider,
     mintOperationRepository: MintOperationRepository,
+    mintBatchAttemptRepository: MintBatchAttemptRepository,
     proofRepository: ProofRepository,
     proofService: ProofService,
     mintService: MintService,
@@ -75,6 +87,7 @@ export class MintOperationService {
   ) {
     this.handlerProvider = handlerProvider;
     this.mintOperationRepository = mintOperationRepository;
+    this.mintBatchAttemptRepository = mintBatchAttemptRepository;
     this.proofRepository = proofRepository;
     this.proofService = proofService;
     this.mintService = mintService;
@@ -256,9 +269,17 @@ export class MintOperationService {
           importedQuote: options?.importedQuote as any,
         });
 
+        const batchSupport = handler.assessBatchSupport
+          ? await handler.assessBatchSupport({
+              ...this.buildDeps(),
+              operation: pending as any,
+              wallet,
+            })
+          : { supported: false };
         const pendingOp: PendingMintOperation = {
           ...pending,
           state: 'pending',
+          batchEligible: batchSupport.supported,
           updatedAt: Date.now(),
         };
 
@@ -306,9 +327,38 @@ export class MintOperationService {
         );
       }
 
-      const pendingOp = operation as PendingMintOperation;
+      let pendingOp = operation as PendingMintOperation;
+      const handler = this.handlerProvider.get(pendingOp.method);
+      const { wallet } = await this.walletService.getWalletWithActiveKeysetId(
+        pendingOp.mintUrl,
+        pendingOp.unit,
+      );
+
+      if (!pendingOp.outputData) {
+        if (!handler.prepareSingleOutput) {
+          throw new Error(
+            `Mint method ${pendingOp.method} cannot prepare output data for operation ${pendingOp.id}`,
+          );
+        }
+
+        pendingOp = {
+          ...(await handler.prepareSingleOutput({
+            ...this.buildDeps(),
+            operation: pendingOp as any,
+            wallet,
+          })),
+          updatedAt: Date.now(),
+        } as PendingMintOperation;
+        await this.mintOperationRepository.update(pendingOp);
+      }
+
+      if (!pendingOp.outputData) {
+        throw new Error(`Mint operation ${pendingOp.id} has no output data after preparation`);
+      }
+
       const executing: ExecutingMintOperation = {
         ...pendingOp,
+        outputData: pendingOp.outputData,
         state: 'executing',
         updatedAt: Date.now(),
         error: undefined,
@@ -322,11 +372,6 @@ export class MintOperationService {
       });
 
       try {
-        const handler = this.handlerProvider.get(executing.method);
-        const { wallet } = await this.walletService.getWalletWithActiveKeysetId(
-          executing.mintUrl,
-          executing.unit,
-        );
         const result = await handler.execute({
           ...this.buildDeps(),
           operation: executing as any,
@@ -407,6 +452,150 @@ export class MintOperationService {
     );
   }
 
+  async finalizeBatch(operationIds: string[]): Promise<TerminalMintOperation[]> {
+    const uniqueOperationIds = Array.from(new Set(operationIds)).sort();
+    if (uniqueOperationIds.length === 0) {
+      return [];
+    }
+
+    const releaseLocks: Array<() => void> = [];
+    let releaseMintLock: (() => void) | null = null;
+    try {
+      for (const operationId of uniqueOperationIds) {
+        releaseLocks.push(await this.acquireOperationLock(operationId));
+      }
+
+      const loaded = await Promise.all(
+        uniqueOperationIds.map((operationId) => this.mintOperationRepository.getById(operationId)),
+      );
+      if (loaded.some((operation) => !operation || operation.state !== 'pending')) {
+        throw new Error('Cannot batch finalize: every operation must be pending');
+      }
+
+      const operations = loaded as PendingMintOperation[];
+      const [first] = operations;
+      if (!first) {
+        return [];
+      }
+
+      releaseMintLock = await this.mintScopedLock.acquire(first.mintUrl);
+
+      for (const operation of operations) {
+        if (operation.mintUrl !== first.mintUrl) {
+          throw new Error('Cannot batch finalize operations from different mints');
+        }
+        if (operation.method !== first.method) {
+          throw new Error('Cannot batch finalize operations with different methods');
+        }
+        if (operation.unit !== first.unit) {
+          throw new Error('Cannot batch finalize operations with different units');
+        }
+        if (!operation.batchEligible || operation.outputData || operation.redeemedByBatchId) {
+          throw new Error(`Operation ${operation.id} is not eligible for optimized batch minting`);
+        }
+        if (operation.lastObservedRemoteState !== 'PAID') {
+          throw new Error(`Operation ${operation.id} is not paid`);
+        }
+      }
+
+      if (!(await this.mintService.isTrustedMint(first.mintUrl))) {
+        throw new UnknownMintError(`Mint ${first.mintUrl} is not trusted`);
+      }
+
+      const capability = await this.mintService.getMintBatchCapability(first.mintUrl, first.method);
+      if (!capability.supported) {
+        throw new Error(`Mint ${first.mintUrl} does not support batch minting for ${first.method}`);
+      }
+      if (operations.length > capability.maxBatchSize) {
+        throw new Error(`Batch size ${operations.length} exceeds max ${capability.maxBatchSize}`);
+      }
+
+      const quoteSnapshots = await Promise.all(
+        operations.map((operation) =>
+          this.mintAdapter.checkMintQuoteState(first.mintUrl, operation.quoteId),
+        ),
+      );
+      const quoteAmounts = operations.map((operation, index) => {
+        const quote = quoteSnapshots[index];
+        if (!quote || quote.quote !== operation.quoteId) {
+          throw new Error(`Mint returned unexpected quote snapshot for ${operation.quoteId}`);
+        }
+        if (quote.state !== 'PAID') {
+          throw new Error(`Quote ${operation.quoteId} is not PAID`);
+        }
+        if (!quote.amount || quote.amount.isZero()) {
+          throw new Error(`Quote ${operation.quoteId} has invalid amount`);
+        }
+        return quote.amount;
+      });
+
+      const handler = this.handlerProvider.get(first.method);
+      if (!handler.prepareBatch || !handler.executeBatch) {
+        throw new Error(`Mint method ${first.method} does not implement batch minting`);
+      }
+
+      const { wallet, keysetId } = await this.walletService.getWalletWithActiveKeysetId(
+        first.mintUrl,
+        first.unit,
+      );
+      const totalAmount = sumAmounts(quoteAmounts);
+      let attempt = await handler.prepareBatch({
+        ...this.buildDeps(),
+        operations: operations as any,
+        totalAmount,
+        quoteAmounts,
+        wallet,
+        keysetId,
+      });
+
+      await this.mintBatchAttemptRepository.create(attempt);
+      for (const operation of operations) {
+        await this.mintOperationRepository.update({
+          ...operation,
+          redeemedByBatchId: attempt.id,
+          updatedAt: Date.now(),
+        });
+      }
+
+      attempt = {
+        ...attempt,
+        state: 'requesting',
+        requestedAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      await this.mintBatchAttemptRepository.update(attempt);
+
+      const result = await handler.executeBatch({
+        ...this.buildDeps(),
+        attempt: attempt as any,
+        operations: operations as any,
+        wallet,
+      });
+
+      switch (result.status) {
+        case 'ISSUED':
+          await this.proofService.saveProofs(
+            attempt.mintUrl,
+            mapProofToCoreProof(attempt.mintUrl, 'ready', result.proofs, {
+              unit: attempt.unit,
+              createdByBatchId: attempt.id,
+            }),
+          );
+          return this.finalizeIssuedBatchAttempt(attempt);
+        case 'ALREADY_ISSUED':
+          return this.recoverRequestingBatchAttempt(attempt);
+        case 'FAILED':
+          throw new Error(result.error ?? 'Batch mint execution failed');
+      }
+      throw new Error('Unexpected batch mint execution result');
+    } finally {
+      releaseMintLock?.();
+      for (const release of releaseLocks.reverse()) {
+        release();
+      }
+    }
+  }
+
   async recoverPendingOperations(): Promise<void> {
     if (this.recoveryLock) {
       throw new Error('Recovery is already in progress');
@@ -421,6 +610,7 @@ export class MintOperationService {
       let initCount = 0;
       let pendingCount = 0;
       let executingCount = 0;
+      let batchAttemptCount = 0;
 
       const initOps = await this.mintOperationRepository.getByState('init');
       for (const op of initOps) {
@@ -481,10 +671,39 @@ export class MintOperationService {
         }
       }
 
+      const batchAttempts = await this.mintBatchAttemptRepository.getPending();
+      for (const attempt of batchAttempts) {
+        try {
+          if (attempt.state === 'requesting' || attempt.state === 'recovering') {
+            await this.recoverRequestingBatchAttempt(attempt);
+            batchAttemptCount++;
+          } else if (attempt.state === 'prepared') {
+            await this.mintBatchAttemptRepository.delete(attempt.id);
+            for (const operationId of attempt.operationIds) {
+              const operation = await this.mintOperationRepository.getById(operationId);
+              if (operation?.state === 'pending' && operation.redeemedByBatchId === attempt.id) {
+                await this.mintOperationRepository.update({
+                  ...operation,
+                  redeemedByBatchId: undefined,
+                  updatedAt: Date.now(),
+                });
+              }
+            }
+            batchAttemptCount++;
+          }
+        } catch (e) {
+          this.logger?.error('Error recovering mint batch attempt', {
+            batchAttemptId: attempt.id,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+
       this.logger?.info('Mint operation recovery completed', {
         initOperations: initCount,
         pendingOperations: pendingCount,
         executingOperations: executingCount,
+        batchAttempts: batchAttemptCount,
       });
     } finally {
       this.recoveryLock = null;
@@ -791,6 +1010,96 @@ export class MintOperationService {
     return failed;
   }
 
+  private async finalizeIssuedBatchAttempt(
+    attempt: MintBatchAttempt,
+    error?: string,
+  ): Promise<FinalizedMintOperation[]> {
+    const currentAttempt = await this.mintBatchAttemptRepository.getById(attempt.id);
+    if (!currentAttempt) {
+      throw new Error(`Batch attempt ${attempt.id} not found`);
+    }
+
+    const finalizedAt = Date.now();
+    const finalizedAttempt: MintBatchAttempt = {
+      ...currentAttempt,
+      state: 'finalized',
+      finalizedAt,
+      updatedAt: finalizedAt,
+      error,
+    };
+    await this.mintBatchAttemptRepository.update(finalizedAttempt);
+
+    const finalizedOperations: FinalizedMintOperation[] = [];
+    for (const operationId of finalizedAttempt.operationIds) {
+      const current = await this.mintOperationRepository.getById(operationId);
+      if (!current) {
+        throw new Error(`Operation ${operationId} not found`);
+      }
+      if (current.state === 'finalized') {
+        finalizedOperations.push(current as FinalizedMintOperation);
+        continue;
+      }
+      if (current.state !== 'pending' || current.redeemedByBatchId !== finalizedAttempt.id) {
+        throw new Error(`Cannot finalize batch operation ${operationId} in state ${current.state}`);
+      }
+
+      await this.eventBus.emit('mint-op:quote-state-changed', {
+        mintUrl: current.mintUrl,
+        operationId: current.id,
+        operation: current,
+        quoteId: current.quoteId,
+        state: 'ISSUED',
+      });
+
+      const finalized: FinalizedMintOperation = {
+        ...(current as PendingMintOperation),
+        state: 'finalized',
+        lastObservedRemoteState: 'ISSUED',
+        lastObservedRemoteStateAt: finalizedAt,
+        updatedAt: Date.now(),
+        error,
+      };
+      await this.mintOperationRepository.update(finalized);
+      await this.eventBus.emit('mint-op:finalized', {
+        mintUrl: finalized.mintUrl,
+        operationId: finalized.id,
+        operation: finalized,
+      });
+      finalizedOperations.push(finalized);
+    }
+
+    return finalizedOperations;
+  }
+
+  private async recoverRequestingBatchAttempt(
+    attempt: MintBatchAttempt,
+  ): Promise<FinalizedMintOperation[]> {
+    if (await this.hasSavedBatchOutputs(attempt)) {
+      return this.finalizeIssuedBatchAttempt(attempt);
+    }
+
+    const recovered = await this.proofService.recoverProofsFromOutputData(
+      attempt.mintUrl,
+      attempt.outputData,
+      {
+        unit: attempt.unit,
+        createdByBatchId: attempt.id,
+      },
+    );
+    if (recovered.length > 0 && (await this.hasSavedBatchOutputs(attempt))) {
+      return this.finalizeIssuedBatchAttempt(attempt);
+    }
+
+    const failed: MintBatchAttempt = {
+      ...attempt,
+      state: 'failed',
+      error: `Batch attempt ${attempt.id} could not recover issued proofs`,
+      updatedAt: Date.now(),
+    };
+    await this.mintBatchAttemptRepository.update(failed);
+    throw new Error(failed.error);
+  }
+
   private async transitionToPending(
     op: ExecutingMintOperation,
     error?: string,
@@ -957,6 +1266,23 @@ export class MintOperationService {
 
     for (const secret of outputSecrets) {
       const proof = await this.proofRepository.getProofBySecret(op.mintUrl, secret);
+      if (!proof) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async hasSavedBatchOutputs(attempt: MintBatchAttempt): Promise<boolean> {
+    const { keepSecrets, sendSecrets } = getSecretsFromSerializedOutputData(attempt.outputData);
+    const outputSecrets = [...keepSecrets, ...sendSecrets];
+    if (outputSecrets.length === 0) {
+      return false;
+    }
+
+    for (const secret of outputSecrets) {
+      const proof = await this.proofRepository.getProofBySecret(attempt.mintUrl, secret);
       if (!proof) {
         return false;
       }

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1,5 +1,9 @@
 import type { AmountLike, Proof } from '@cashu/cashu-ts';
-import type { MintOperationRepository, ProofRepository } from '../../repositories';
+import type {
+  MintBatchAttemptRepository,
+  MintOperationRepository,
+  ProofRepository,
+} from '../../repositories';
 import type {
   ExecutingMintOperation,
   FailedMintOperation,
@@ -10,6 +14,7 @@ import type {
   PendingOrLaterOperation,
   TerminalMintOperation,
 } from './MintOperation';
+import type { MintBatchAttempt } from './MintBatchAttempt';
 import {
   createMintOperation,
   getOutputProofSecrets,
@@ -30,7 +35,13 @@ import type { ProofService } from '../../services/ProofService';
 import type { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
-import { generateSubId, mapProofToCoreProof, toAmount } from '../../utils';
+import {
+  generateSubId,
+  getSecretsFromSerializedOutputData,
+  mapProofToCoreProof,
+  sumAmounts,
+  toAmount,
+} from '../../utils';
 import {
   OperationInProgressError,
   NetworkError,
@@ -48,6 +59,7 @@ import { OperationIdLock } from '../OperationIdLock';
 export class MintOperationService {
   private readonly handlerProvider: MintHandlerProvider;
   private readonly mintOperationRepository: MintOperationRepository;
+  private readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   private readonly proofRepository: ProofRepository;
   private readonly proofService: ProofService;
   private readonly mintService: MintService;
@@ -63,6 +75,7 @@ export class MintOperationService {
   constructor(
     handlerProvider: MintHandlerProvider,
     mintOperationRepository: MintOperationRepository,
+    mintBatchAttemptRepository: MintBatchAttemptRepository,
     proofRepository: ProofRepository,
     proofService: ProofService,
     mintService: MintService,
@@ -74,6 +87,7 @@ export class MintOperationService {
   ) {
     this.handlerProvider = handlerProvider;
     this.mintOperationRepository = mintOperationRepository;
+    this.mintBatchAttemptRepository = mintBatchAttemptRepository;
     this.proofRepository = proofRepository;
     this.proofService = proofService;
     this.mintService = mintService;
@@ -262,9 +276,17 @@ export class MintOperationService {
           importedQuote: options?.importedQuote as any,
         });
 
+        const batchSupport = handler.assessBatchSupport
+          ? await handler.assessBatchSupport({
+              ...this.buildDeps(),
+              operation: pending as any,
+              wallet,
+            })
+          : { supported: false };
         const pendingOp: PendingMintOperation = {
           ...pending,
           state: 'pending',
+          batchEligible: batchSupport.supported,
           updatedAt: Date.now(),
         };
 
@@ -312,9 +334,35 @@ export class MintOperationService {
         );
       }
 
-      const pendingOp = operation as PendingMintOperation;
+      let pendingOp = operation as PendingMintOperation;
+      const handler = this.handlerProvider.get(pendingOp.method);
+      const { wallet } = await this.walletService.getWalletWithActiveKeysetId(pendingOp.mintUrl);
+
+      if (!pendingOp.outputData) {
+        if (!handler.prepareSingleOutput) {
+          throw new Error(
+            `Mint method ${pendingOp.method} cannot prepare output data for operation ${pendingOp.id}`,
+          );
+        }
+
+        pendingOp = {
+          ...(await handler.prepareSingleOutput({
+            ...this.buildDeps(),
+            operation: pendingOp as any,
+            wallet,
+          })),
+          updatedAt: Date.now(),
+        } as PendingMintOperation;
+        await this.mintOperationRepository.update(pendingOp);
+      }
+
+      if (!pendingOp.outputData) {
+        throw new Error(`Mint operation ${pendingOp.id} has no output data after preparation`);
+      }
+
       const executing: ExecutingMintOperation = {
         ...pendingOp,
+        outputData: pendingOp.outputData,
         state: 'executing',
         updatedAt: Date.now(),
         error: undefined,
@@ -328,8 +376,6 @@ export class MintOperationService {
       });
 
       try {
-        const handler = this.handlerProvider.get(executing.method);
-        const { wallet } = await this.walletService.getWalletWithActiveKeysetId(executing.mintUrl);
         const result = await handler.execute({
           ...this.buildDeps(),
           operation: executing as any,
@@ -410,6 +456,148 @@ export class MintOperationService {
     );
   }
 
+  async finalizeBatch(operationIds: string[]): Promise<TerminalMintOperation[]> {
+    const uniqueOperationIds = Array.from(new Set(operationIds)).sort();
+    if (uniqueOperationIds.length === 0) {
+      return [];
+    }
+
+    const releaseLocks: Array<() => void> = [];
+    let releaseMintLock: (() => void) | null = null;
+    try {
+      for (const operationId of uniqueOperationIds) {
+        releaseLocks.push(await this.acquireOperationLock(operationId));
+      }
+
+      const loaded = await Promise.all(
+        uniqueOperationIds.map((operationId) => this.mintOperationRepository.getById(operationId)),
+      );
+      if (loaded.some((operation) => !operation || operation.state !== 'pending')) {
+        throw new Error('Cannot batch finalize: every operation must be pending');
+      }
+
+      const operations = loaded as PendingMintOperation[];
+      const [first] = operations;
+      if (!first) {
+        return [];
+      }
+
+      releaseMintLock = await this.mintScopedLock.acquire(first.mintUrl);
+
+      for (const operation of operations) {
+        if (operation.mintUrl !== first.mintUrl) {
+          throw new Error('Cannot batch finalize operations from different mints');
+        }
+        if (operation.method !== first.method) {
+          throw new Error('Cannot batch finalize operations with different methods');
+        }
+        if (operation.unit !== first.unit) {
+          throw new Error('Cannot batch finalize operations with different units');
+        }
+        if (!operation.batchEligible || operation.outputData || operation.redeemedByBatchId) {
+          throw new Error(`Operation ${operation.id} is not eligible for optimized batch minting`);
+        }
+        if (operation.lastObservedRemoteState !== 'PAID') {
+          throw new Error(`Operation ${operation.id} is not paid`);
+        }
+      }
+
+      if (!(await this.mintService.isTrustedMint(first.mintUrl))) {
+        throw new UnknownMintError(`Mint ${first.mintUrl} is not trusted`);
+      }
+
+      const capability = await this.mintService.getMintBatchCapability(first.mintUrl, first.method);
+      if (!capability.supported) {
+        throw new Error(`Mint ${first.mintUrl} does not support batch minting for ${first.method}`);
+      }
+      if (operations.length > capability.maxBatchSize) {
+        throw new Error(`Batch size ${operations.length} exceeds max ${capability.maxBatchSize}`);
+      }
+
+      const quoteSnapshots = await Promise.all(
+        operations.map((operation) =>
+          this.mintAdapter.checkMintQuoteState(first.mintUrl, operation.quoteId),
+        ),
+      );
+      const quoteAmounts = operations.map((operation, index) => {
+        const quote = quoteSnapshots[index];
+        if (!quote || quote.quote !== operation.quoteId) {
+          throw new Error(`Mint returned unexpected quote snapshot for ${operation.quoteId}`);
+        }
+        if (quote.state !== 'PAID') {
+          throw new Error(`Quote ${operation.quoteId} is not PAID`);
+        }
+        if (!quote.amount || quote.amount.isZero()) {
+          throw new Error(`Quote ${operation.quoteId} has invalid amount`);
+        }
+        return quote.amount;
+      });
+
+      const handler = this.handlerProvider.get(first.method);
+      if (!handler.prepareBatch || !handler.executeBatch) {
+        throw new Error(`Mint method ${first.method} does not implement batch minting`);
+      }
+
+      const { wallet, keysetId } = await this.walletService.getWalletWithActiveKeysetId(
+        first.mintUrl,
+      );
+      const totalAmount = sumAmounts(quoteAmounts);
+      let attempt = await handler.prepareBatch({
+        ...this.buildDeps(),
+        operations: operations as any,
+        totalAmount,
+        quoteAmounts,
+        wallet,
+        keysetId,
+      });
+
+      await this.mintBatchAttemptRepository.create(attempt);
+      for (const operation of operations) {
+        await this.mintOperationRepository.update({
+          ...operation,
+          redeemedByBatchId: attempt.id,
+          updatedAt: Date.now(),
+        });
+      }
+
+      attempt = {
+        ...attempt,
+        state: 'requesting',
+        requestedAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      await this.mintBatchAttemptRepository.update(attempt);
+
+      const result = await handler.executeBatch({
+        ...this.buildDeps(),
+        attempt: attempt as any,
+        operations: operations as any,
+        wallet,
+      });
+
+      switch (result.status) {
+        case 'ISSUED':
+          await this.proofService.saveProofs(
+            attempt.mintUrl,
+            mapProofToCoreProof(attempt.mintUrl, 'ready', result.proofs, {
+              createdByBatchId: attempt.id,
+            }),
+          );
+          return this.finalizeIssuedBatchAttempt(attempt);
+        case 'ALREADY_ISSUED':
+          return this.recoverRequestingBatchAttempt(attempt);
+        case 'FAILED':
+          throw new Error(result.error ?? 'Batch mint execution failed');
+      }
+      throw new Error('Unexpected batch mint execution result');
+    } finally {
+      releaseMintLock?.();
+      for (const release of releaseLocks.reverse()) {
+        release();
+      }
+    }
+  }
+
   async recoverPendingOperations(): Promise<void> {
     if (this.recoveryLock) {
       throw new Error('Recovery is already in progress');
@@ -424,6 +612,7 @@ export class MintOperationService {
       let initCount = 0;
       let pendingCount = 0;
       let executingCount = 0;
+      let batchAttemptCount = 0;
 
       const initOps = await this.mintOperationRepository.getByState('init');
       for (const op of initOps) {
@@ -484,10 +673,39 @@ export class MintOperationService {
         }
       }
 
+      const batchAttempts = await this.mintBatchAttemptRepository.getPending();
+      for (const attempt of batchAttempts) {
+        try {
+          if (attempt.state === 'requesting' || attempt.state === 'recovering') {
+            await this.recoverRequestingBatchAttempt(attempt);
+            batchAttemptCount++;
+          } else if (attempt.state === 'prepared') {
+            await this.mintBatchAttemptRepository.delete(attempt.id);
+            for (const operationId of attempt.operationIds) {
+              const operation = await this.mintOperationRepository.getById(operationId);
+              if (operation?.state === 'pending' && operation.redeemedByBatchId === attempt.id) {
+                await this.mintOperationRepository.update({
+                  ...operation,
+                  redeemedByBatchId: undefined,
+                  updatedAt: Date.now(),
+                });
+              }
+            }
+            batchAttemptCount++;
+          }
+        } catch (e) {
+          this.logger?.error('Error recovering mint batch attempt', {
+            batchAttemptId: attempt.id,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+
       this.logger?.info('Mint operation recovery completed', {
         initOperations: initCount,
         pendingOperations: pendingCount,
         executingOperations: executingCount,
+        batchAttempts: batchAttemptCount,
       });
     } finally {
       this.recoveryLock = null;
@@ -789,6 +1007,95 @@ export class MintOperationService {
     return failed;
   }
 
+  private async finalizeIssuedBatchAttempt(
+    attempt: MintBatchAttempt,
+    error?: string,
+  ): Promise<FinalizedMintOperation[]> {
+    const currentAttempt = await this.mintBatchAttemptRepository.getById(attempt.id);
+    if (!currentAttempt) {
+      throw new Error(`Batch attempt ${attempt.id} not found`);
+    }
+
+    const finalizedAt = Date.now();
+    const finalizedAttempt: MintBatchAttempt = {
+      ...currentAttempt,
+      state: 'finalized',
+      finalizedAt,
+      updatedAt: finalizedAt,
+      error,
+    };
+    await this.mintBatchAttemptRepository.update(finalizedAttempt);
+
+    const finalizedOperations: FinalizedMintOperation[] = [];
+    for (const operationId of finalizedAttempt.operationIds) {
+      const current = await this.mintOperationRepository.getById(operationId);
+      if (!current) {
+        throw new Error(`Operation ${operationId} not found`);
+      }
+      if (current.state === 'finalized') {
+        finalizedOperations.push(current as FinalizedMintOperation);
+        continue;
+      }
+      if (current.state !== 'pending' || current.redeemedByBatchId !== finalizedAttempt.id) {
+        throw new Error(`Cannot finalize batch operation ${operationId} in state ${current.state}`);
+      }
+
+      await this.eventBus.emit('mint-op:quote-state-changed', {
+        mintUrl: current.mintUrl,
+        operationId: current.id,
+        operation: current,
+        quoteId: current.quoteId,
+        state: 'ISSUED',
+      });
+
+      const finalized: FinalizedMintOperation = {
+        ...(current as PendingMintOperation),
+        state: 'finalized',
+        lastObservedRemoteState: 'ISSUED',
+        lastObservedRemoteStateAt: finalizedAt,
+        updatedAt: Date.now(),
+        error,
+      };
+      await this.mintOperationRepository.update(finalized);
+      await this.eventBus.emit('mint-op:finalized', {
+        mintUrl: finalized.mintUrl,
+        operationId: finalized.id,
+        operation: finalized,
+      });
+      finalizedOperations.push(finalized);
+    }
+
+    return finalizedOperations;
+  }
+
+  private async recoverRequestingBatchAttempt(
+    attempt: MintBatchAttempt,
+  ): Promise<FinalizedMintOperation[]> {
+    if (await this.hasSavedBatchOutputs(attempt)) {
+      return this.finalizeIssuedBatchAttempt(attempt);
+    }
+
+    const recovered = await this.proofService.recoverProofsFromOutputData(
+      attempt.mintUrl,
+      attempt.outputData,
+      {
+        createdByBatchId: attempt.id,
+      },
+    );
+    if (recovered.length > 0 && (await this.hasSavedBatchOutputs(attempt))) {
+      return this.finalizeIssuedBatchAttempt(attempt);
+    }
+
+    const failed: MintBatchAttempt = {
+      ...attempt,
+      state: 'failed',
+      error: `Batch attempt ${attempt.id} could not recover issued proofs`,
+      updatedAt: Date.now(),
+    };
+    await this.mintBatchAttemptRepository.update(failed);
+    throw new Error(failed.error);
+  }
+
   private async transitionToPending(
     op: ExecutingMintOperation,
     error?: string,
@@ -955,6 +1262,23 @@ export class MintOperationService {
 
     for (const secret of outputSecrets) {
       const proof = await this.proofRepository.getProofBySecret(op.mintUrl, secret);
+      if (!proof) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async hasSavedBatchOutputs(attempt: MintBatchAttempt): Promise<boolean> {
+    const { keepSecrets, sendSecrets } = getSecretsFromSerializedOutputData(attempt.outputData);
+    const outputSecrets = [...keepSecrets, ...sendSecrets];
+    if (outputSecrets.length === 0) {
+      return false;
+    }
+
+    for (const secret of outputSecrets) {
+      const proof = await this.proofRepository.getProofBySecret(attempt.mintUrl, secret);
       if (!proof) {
         return false;
       }

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -5,6 +5,10 @@ import type { MintQuote } from '@core/models/MintQuote';
 import type { MeltOperation, MeltOperationState } from '@core/operations/melt/MeltOperation';
 import type { MintOperation, MintOperationState } from '@core/operations/mint/MintOperation';
 import type {
+  MintBatchAttempt,
+  MintBatchAttemptState,
+} from '@core/operations/mint/MintBatchAttempt';
+import type {
   ReceiveOperation,
   ReceiveOperationState,
 } from '../operations/receive/ReceiveOperation';
@@ -218,6 +222,16 @@ export interface MintOperationRepository {
   delete(id: string): Promise<void>;
 }
 
+export interface MintBatchAttemptRepository {
+  create(attempt: MintBatchAttempt): Promise<void>;
+  update(attempt: MintBatchAttempt): Promise<void>;
+  getById(id: string): Promise<MintBatchAttempt | null>;
+  getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]>;
+  getByOperationId(operationId: string): Promise<MintBatchAttempt | null>;
+  getPending(): Promise<MintBatchAttempt[]>;
+  delete(id: string): Promise<void>;
+}
+
 export interface ReceiveOperationRepository {
   /** Create a new receive operation */
   create(operation: ReceiveOperation): Promise<void>;
@@ -284,6 +298,7 @@ interface RepositoriesBase {
   meltOperationRepository: MeltOperationRepository;
   authSessionRepository: AuthSessionRepository;
   mintOperationRepository: MintOperationRepository;
+  mintBatchAttemptRepository: MintBatchAttemptRepository;
   receiveOperationRepository: ReceiveOperationRepository;
   paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -14,6 +14,10 @@ import type { MintQuote } from '@core/models/MintQuote';
 import type { MeltOperation, MeltOperationState } from '@core/operations/melt/MeltOperation';
 import type { MintOperation, MintOperationState } from '@core/operations/mint/MintOperation';
 import type {
+  MintBatchAttempt,
+  MintBatchAttemptState,
+} from '@core/operations/mint/MintBatchAttempt';
+import type {
   ReceiveOperation,
   ReceiveOperationState,
 } from '../operations/receive/ReceiveOperation';
@@ -234,6 +238,16 @@ export interface MintOperationRepository {
   delete(id: string): Promise<void>;
 }
 
+export interface MintBatchAttemptRepository {
+  create(attempt: MintBatchAttempt): Promise<void>;
+  update(attempt: MintBatchAttempt): Promise<void>;
+  getById(id: string): Promise<MintBatchAttempt | null>;
+  getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]>;
+  getByOperationId(operationId: string): Promise<MintBatchAttempt | null>;
+  getPending(): Promise<MintBatchAttempt[]>;
+  delete(id: string): Promise<void>;
+}
+
 export interface ReceiveOperationRepository {
   /** Create a new receive operation */
   create(operation: ReceiveOperation): Promise<void>;
@@ -270,6 +284,7 @@ interface RepositoriesBase {
   meltOperationRepository: MeltOperationRepository;
   authSessionRepository: AuthSessionRepository;
   mintOperationRepository: MintOperationRepository;
+  mintBatchAttemptRepository: MintBatchAttemptRepository;
   receiveOperationRepository: ReceiveOperationRepository;
 }
 

--- a/packages/core/repositories/memory/MemoryMintBatchAttemptRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintBatchAttemptRepository.ts
@@ -1,0 +1,62 @@
+import type { MintBatchAttemptRepository } from '..';
+import type {
+  MintBatchAttempt,
+  MintBatchAttemptState,
+} from '../../operations/mint/MintBatchAttempt';
+
+export class MemoryMintBatchAttemptRepository implements MintBatchAttemptRepository {
+  private readonly attempts = new Map<string, MintBatchAttempt>();
+
+  async create(attempt: MintBatchAttempt): Promise<void> {
+    if (this.attempts.has(attempt.id)) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} already exists`);
+    }
+    this.attempts.set(attempt.id, { ...attempt });
+  }
+
+  async update(attempt: MintBatchAttempt): Promise<void> {
+    if (!this.attempts.has(attempt.id)) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} not found`);
+    }
+    this.attempts.set(attempt.id, { ...attempt, updatedAt: Date.now() });
+  }
+
+  async getById(id: string): Promise<MintBatchAttempt | null> {
+    const attempt = this.attempts.get(id);
+    return attempt ? { ...attempt } : null;
+  }
+
+  async getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]> {
+    const results: MintBatchAttempt[] = [];
+    for (const attempt of this.attempts.values()) {
+      if (attempt.state === state) {
+        results.push({ ...attempt });
+      }
+    }
+    return results;
+  }
+
+  async getByOperationId(operationId: string): Promise<MintBatchAttempt | null> {
+    for (const attempt of this.attempts.values()) {
+      if (attempt.operationIds.includes(operationId)) {
+        return { ...attempt };
+      }
+    }
+    return null;
+  }
+
+  async getPending(): Promise<MintBatchAttempt[]> {
+    const pendingStates = new Set<MintBatchAttemptState>(['prepared', 'requesting', 'recovering']);
+    const results: MintBatchAttempt[] = [];
+    for (const attempt of this.attempts.values()) {
+      if (pendingStates.has(attempt.state)) {
+        results.push({ ...attempt });
+      }
+    }
+    return results;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.attempts.delete(id);
+  }
+}

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -14,6 +14,7 @@ import type {
   MintOperationRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
 } from '..';
 import { MemoryAuthSessionRepository } from './MemoryAuthSessionRepository';
@@ -27,6 +28,7 @@ import { MemoryMintRepository } from './MemoryMintRepository';
 import { MemoryProofRepository } from './MemoryProofRepository';
 import { MemorySendOperationRepository } from './MemorySendOperationRepository';
 import { MemoryMintOperationRepository } from './MemoryMintOperationRepository';
+import { MemoryMintBatchAttemptRepository } from './MemoryMintBatchAttemptRepository';
 import { MemoryReceiveOperationRepository } from './MemoryReceiveOperationRepository';
 import {
   MemoryPaymentRequestReceiveAttemptRepository,
@@ -45,6 +47,7 @@ export class MemoryRepositories implements Repositories {
   meltOperationRepository: MeltOperationRepository;
   authSessionRepository: AuthSessionRepository;
   mintOperationRepository: MintOperationRepository;
+  mintBatchAttemptRepository: MintBatchAttemptRepository;
   receiveOperationRepository: ReceiveOperationRepository;
   paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -76,6 +79,7 @@ export class MemoryRepositories implements Repositories {
       new MemoryPaymentRequestReceiveOperationRepository();
     this.paymentRequestReceiveAttemptRepository =
       new MemoryPaymentRequestReceiveAttemptRepository();
+    this.mintBatchAttemptRepository = new MemoryMintBatchAttemptRepository();
   }
 
   async init(): Promise<void> {

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -13,6 +13,7 @@ import type {
   RepositoryTransactionScope,
   SendOperationRepository,
   MintOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
 } from '..';
 import { MemoryAuthSessionRepository } from './MemoryAuthSessionRepository';
@@ -27,6 +28,7 @@ import { MemoryMintRepository } from './MemoryMintRepository';
 import { MemoryProofRepository } from './MemoryProofRepository';
 import { MemorySendOperationRepository } from './MemorySendOperationRepository';
 import { MemoryMintOperationRepository } from './MemoryMintOperationRepository';
+import { MemoryMintBatchAttemptRepository } from './MemoryMintBatchAttemptRepository';
 import { MemoryReceiveOperationRepository } from './MemoryReceiveOperationRepository';
 
 export class MemoryRepositories implements Repositories {
@@ -42,6 +44,7 @@ export class MemoryRepositories implements Repositories {
   meltOperationRepository: MeltOperationRepository;
   authSessionRepository: AuthSessionRepository;
   mintOperationRepository: MintOperationRepository;
+  mintBatchAttemptRepository: MintBatchAttemptRepository;
   receiveOperationRepository: ReceiveOperationRepository;
 
   constructor() {
@@ -57,6 +60,7 @@ export class MemoryRepositories implements Repositories {
     this.meltOperationRepository = new MemoryMeltOperationRepository();
     this.authSessionRepository = new MemoryAuthSessionRepository();
     this.mintOperationRepository = new MemoryMintOperationRepository();
+    this.mintBatchAttemptRepository = new MemoryMintBatchAttemptRepository();
     this.receiveOperationRepository = new MemoryReceiveOperationRepository();
   }
 

--- a/packages/core/repositories/memory/index.ts
+++ b/packages/core/repositories/memory/index.ts
@@ -11,5 +11,6 @@ export * from './MemoryRepositories';
 export * from './MemorySendOperationRepository';
 export * from './MemoryMeltOperationRepository';
 export * from './MemoryMintOperationRepository';
+export * from './MemoryMintBatchAttemptRepository';
 export * from './MemoryReceiveOperationRepository';
 export * from './MemoryPaymentRequestReceiveRepository';

--- a/packages/core/repositories/memory/index.ts
+++ b/packages/core/repositories/memory/index.ts
@@ -12,4 +12,5 @@ export * from './MemoryRepositories';
 export * from './MemorySendOperationRepository';
 export * from './MemoryMeltOperationRepository';
 export * from './MemoryMintOperationRepository';
+export * from './MemoryMintBatchAttemptRepository';
 export * from './MemoryReceiveOperationRepository';

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -17,6 +17,12 @@ import { normalizeMintUrl } from '../utils';
 import { DEFAULT_UNIT, normalizeUnit, normalizeUnitAmount, type UnitAmount } from '../amounts.ts';
 
 const MINT_REFRESH_TTL_S = 60 * 5;
+const DEFAULT_BATCH_MINT_CAP = 100;
+
+export interface MintBatchCapability {
+  supported: boolean;
+  maxBatchSize: number;
+}
 
 export interface MethodUnitCapability {
   supported: boolean;
@@ -295,6 +301,27 @@ export class MintService {
         `NUT-${nut} method ${method} unit ${capability.unit} requires amount <= ${capability.maxAmount}`,
       );
     }
+  }
+
+  async getMintBatchCapability(mintUrl: string, method: string): Promise<MintBatchCapability> {
+    const mintInfo = await this.getMintInfo(mintUrl);
+    const nut29 = (mintInfo as any).nuts?.[29] ?? (mintInfo as any).nuts?.['29'];
+    if (!nut29) {
+      return { supported: false, maxBatchSize: 0 };
+    }
+
+    const methods = Array.isArray(nut29.methods) ? nut29.methods : undefined;
+    if (methods && !methods.includes(method)) {
+      return { supported: false, maxBatchSize: 0 };
+    }
+
+    const advertisedMax = Number(nut29.max_batch_size);
+    const maxBatchSize =
+      Number.isFinite(advertisedMax) && advertisedMax > 0
+        ? Math.min(Math.floor(advertisedMax), DEFAULT_BATCH_MINT_CAP)
+        : DEFAULT_BATCH_MINT_CAP;
+
+    return { supported: true, maxBatchSize };
   }
 
   async getAllMints(): Promise<Mint[]> {

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -10,6 +10,12 @@ import type { Logger } from '../logging/Logger.ts';
 import { normalizeMintUrl } from '../utils';
 
 const MINT_REFRESH_TTL_S = 60 * 5;
+const DEFAULT_BATCH_MINT_CAP = 100;
+
+export interface MintBatchCapability {
+  supported: boolean;
+  maxBatchSize: number;
+}
 
 export class MintService {
   private readonly mintRepo: MintRepository;
@@ -150,6 +156,27 @@ export class MintService {
     // ensureUpdatedMint already normalizes, but normalize here for consistency
     const { mint } = await this.ensureUpdatedMint(normalizeMintUrl(mintUrl));
     return mint.mintInfo;
+  }
+
+  async getMintBatchCapability(mintUrl: string, method: string): Promise<MintBatchCapability> {
+    const mintInfo = await this.getMintInfo(mintUrl);
+    const nut29 = (mintInfo as any).nuts?.[29] ?? (mintInfo as any).nuts?.['29'];
+    if (!nut29) {
+      return { supported: false, maxBatchSize: 0 };
+    }
+
+    const methods = Array.isArray(nut29.methods) ? nut29.methods : undefined;
+    if (methods && !methods.includes(method)) {
+      return { supported: false, maxBatchSize: 0 };
+    }
+
+    const advertisedMax = Number(nut29.max_batch_size);
+    const maxBatchSize =
+      Number.isFinite(advertisedMax) && advertisedMax > 0
+        ? Math.min(Math.floor(advertisedMax), DEFAULT_BATCH_MINT_CAP)
+        : DEFAULT_BATCH_MINT_CAP;
+
+    return { supported: true, maxBatchSize };
   }
 
   async getAllMints(): Promise<Mint[]> {

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -1007,7 +1007,12 @@ export class ProofService {
   async recoverProofsFromOutputData(
     mintUrl: string,
     serializedOutputData: SerializedOutputData,
-    options: { unit: string; createdByOperationId?: string; persistRecoveredProofs?: boolean },
+    options: {
+      unit: string;
+      createdByOperationId?: string;
+      createdByBatchId?: string;
+      persistRecoveredProofs?: boolean;
+    },
   ): Promise<Proof[]> {
     if (!mintUrl || mintUrl.trim().length === 0) {
       throw new ProofValidationError('mintUrl is required');
@@ -1088,6 +1093,7 @@ export class ProofService {
         mapProofToCoreProof(mintUrl, 'ready', unspentProofs, {
           unit,
           createdByOperationId: options?.createdByOperationId,
+          createdByBatchId: options?.createdByBatchId,
         }),
       );
     }

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -851,7 +851,11 @@ export class ProofService {
   async recoverProofsFromOutputData(
     mintUrl: string,
     serializedOutputData: SerializedOutputData,
-    options?: { createdByOperationId?: string; persistRecoveredProofs?: boolean },
+    options?: {
+      createdByOperationId?: string;
+      createdByBatchId?: string;
+      persistRecoveredProofs?: boolean;
+    },
   ): Promise<Proof[]> {
     if (!mintUrl || mintUrl.trim().length === 0) {
       throw new ProofValidationError('mintUrl is required');
@@ -918,6 +922,7 @@ export class ProofService {
         mintUrl,
         mapProofToCoreProof(mintUrl, 'ready', unspentProofs, {
           createdByOperationId: options?.createdByOperationId,
+          createdByBatchId: options?.createdByBatchId,
         }),
       );
     }

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -40,6 +40,7 @@ export class MintOperationProcessor {
 
   private running = false;
   private queue: QueueItem[] = [];
+  private readonly activeItems = new Set<string>();
   private processing = false;
   private processingTimer?: ReturnType<typeof setTimeout>;
   private offStateChanged?: () => void;
@@ -200,11 +201,17 @@ export class MintOperationProcessor {
     }
   }
 
-  // TODO: Improve deduplication by tracking an "active" set keyed by `${mintUrl}::${operationId}`
-  // to prevent re-enqueueing while an item is currently being processed. Today we only
-  // deduplicate within the queue, so an item can be enqueued again if a new event arrives
-  // during in-flight processing.
+  private queueKey(mintUrl: string, operationId: string): string {
+    return `${mintUrl}::${operationId}`;
+  }
+
   private enqueue(mintUrl: string, operationId: string, method: string): void {
+    const key = this.queueKey(mintUrl, operationId);
+    if (this.activeItems.has(key)) {
+      this.logger?.debug('Mint operation already being processed', { mintUrl, operationId });
+      return;
+    }
+
     // Check if already in queue
     const existing = this.queue.find(
       (item) => item.mintUrl === mintUrl && item.operationId === operationId,
@@ -283,12 +290,18 @@ export class MintOperationProcessor {
       return;
     }
     this.processing = true;
+    const activeKeys = [this.queueKey(item.mintUrl, item.operationId)];
+    this.activeItems.add(activeKeys[0]!);
 
     try {
-      await this.processItem(item);
+      const extraActiveKeys = await this.processItem(item);
+      activeKeys.push(...extraActiveKeys);
     } catch (err) {
       this.handleProcessingError(item, err);
     } finally {
+      for (const key of activeKeys) {
+        this.activeItems.delete(key);
+      }
       this.processing = false;
       if (this.running) {
         this.scheduleNextProcess();
@@ -296,7 +309,7 @@ export class MintOperationProcessor {
     }
   }
 
-  private async processItem(item: QueueItem): Promise<void> {
+  private async processItem(item: QueueItem): Promise<string[]> {
     const { mintUrl, operationId, method } = item;
 
     const handler = this.handlers.get(method);
@@ -306,7 +319,7 @@ export class MintOperationProcessor {
         mintUrl,
         operationId,
       });
-      return;
+      return [];
     }
 
     this.logger?.info('Processing mint operation', {
@@ -316,8 +329,83 @@ export class MintOperationProcessor {
       attempt: item.retryCount + 1,
     });
 
+    const operation =
+      typeof (this.mintOperations as any).getOperation === 'function'
+        ? await this.mintOperations.getOperation(operationId)
+        : null;
+    if (
+      operation?.state === 'pending' &&
+      operation.batchEligible &&
+      !operation.outputData &&
+      operation.lastObservedRemoteState === 'PAID'
+    ) {
+      const batchItems = await this.collectBatchItems(item, operation.unit);
+      if (batchItems.length > 1) {
+        const batchIds = batchItems.map((batchItem) => batchItem.operationId);
+        const extraActiveKeys = batchItems
+          .slice(1)
+          .map((batchItem) => this.queueKey(batchItem.mintUrl, batchItem.operationId));
+        for (const key of extraActiveKeys) {
+          this.activeItems.add(key);
+        }
+
+        try {
+          await this.mintOperations.finalizeBatch(batchIds);
+          this.logger?.info('Successfully processed mint batch', {
+            mintUrl,
+            method,
+            count: batchIds.length,
+          });
+          return extraActiveKeys;
+        } catch (error) {
+          this.logger?.warn('Mint batch processing failed, falling back to single operation', {
+            mintUrl,
+            operationId,
+            method,
+            count: batchIds.length,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          for (const key of extraActiveKeys) {
+            this.activeItems.delete(key);
+          }
+          for (const batchItem of batchItems.slice(1)) {
+            this.queue.push(batchItem);
+          }
+        }
+      }
+    }
+
     await handler.process(mintUrl, operationId);
     this.logger?.info('Successfully processed mint operation', { mintUrl, operationId, method });
+    return [];
+  }
+
+  private async collectBatchItems(item: QueueItem, unit: string): Promise<QueueItem[]> {
+    const batchItems = [item];
+    const remaining: QueueItem[] = [];
+
+    for (const candidate of this.queue) {
+      if (candidate.mintUrl !== item.mintUrl || candidate.method !== item.method) {
+        remaining.push(candidate);
+        continue;
+      }
+
+      const operation = await this.mintOperations.getOperation(candidate.operationId);
+      if (
+        operation?.state === 'pending' &&
+        operation.unit === unit &&
+        operation.batchEligible &&
+        !operation.outputData &&
+        operation.lastObservedRemoteState === 'PAID'
+      ) {
+        batchItems.push(candidate);
+      } else {
+        remaining.push(candidate);
+      }
+    }
+
+    this.queue = remaining;
+    return batchItems;
   }
 
   private handleProcessingError(item: QueueItem, err: unknown): void {

--- a/packages/core/test/integration/integration.test.ts
+++ b/packages/core/test/integration/integration.test.ts
@@ -32,12 +32,11 @@ async function createRepositories() {
 
 runIntegrationTests(
   {
-    createRepositories,
+    createRepositories: createRepositories as any,
     mintUrl,
     customUnit,
     logger: getTestLogger(),
     suiteName: 'Testnut Integration Tests',
   },
-  //@ts-expect-error stupid type error that no one cares about
-  { describe, it, beforeEach, afterEach, expect },
+  { describe, it, beforeEach, afterEach, expect } as any,
 );

--- a/packages/core/test/integration/integration.test.ts
+++ b/packages/core/test/integration/integration.test.ts
@@ -31,11 +31,10 @@ async function createRepositories() {
 
 runIntegrationTests(
   {
-    createRepositories,
+    createRepositories: createRepositories as any,
     mintUrl,
     logger: getTestLogger(),
     suiteName: 'Testnut Integration Tests',
   },
-  //@ts-expect-error stupid type error that no one cares about
-  { describe, it, beforeEach, afterEach, expect },
+  { describe, it, beforeEach, afterEach, expect } as any,
 );

--- a/packages/core/test/unit/MintBolt11Handler.test.ts
+++ b/packages/core/test/unit/MintBolt11Handler.test.ts
@@ -167,9 +167,7 @@ describe('MintBolt11Handler', () => {
       expect(result.quoteId).toBe(quoteId);
       expect(result.amount).toEqual(quote.amount);
       expect(result.request).toBe(quote.request);
-      expect(result.outputData.keep).toHaveLength(1);
-      expect(result.outputData.send).toEqual([]);
-      expect(result.outputData.keep[0]?.blindedMessage).toEqual(outputData.keep[0]?.blindedMessage);
+      expect(result.outputData).toBeUndefined();
       expect(result.lastObservedRemoteState).toBe('PAID');
     });
 

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../operations/mint/MintMethodHandler';
 import type { MintHandlerProvider } from '../../infra/handlers/mint';
 import { MemoryMintOperationRepository } from '../../repositories/memory/MemoryMintOperationRepository';
+import { MemoryMintBatchAttemptRepository } from '../../repositories/memory/MemoryMintBatchAttemptRepository';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
 import type { MintService } from '../../services/MintService';
 import type { WalletService } from '../../services/WalletService';
@@ -31,6 +32,7 @@ describe('MintOperationService', () => {
   const keysetId = 'keyset-1';
 
   let operationRepo: MemoryMintOperationRepository;
+  let batchAttemptRepo: MemoryMintBatchAttemptRepository;
   let proofRepo: MemoryProofRepository;
   let proofService: ProofService;
   let mintService: MintService;
@@ -103,11 +105,13 @@ describe('MintOperationService', () => {
 
   const makeExecutingOp = (id: string, secret = 'out-1'): ExecutingMintOperation => ({
     ...makePendingOp(id, secret),
+    outputData: makeSerializedOutputData(secret),
     state: 'executing',
   });
 
   beforeEach(async () => {
     operationRepo = new MemoryMintOperationRepository();
+    batchAttemptRepo = new MemoryMintBatchAttemptRepository();
     proofRepo = new MemoryProofRepository();
     eventBus = new EventBus<CoreEvents>();
 
@@ -169,6 +173,7 @@ describe('MintOperationService', () => {
     service = new MintOperationService(
       handlerProvider,
       operationRepo,
+      batchAttemptRepo,
       proofRepo,
       proofService,
       mintService,

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../operations/mint/MintMethodHandler';
 import type { MintHandlerProvider } from '../../infra/handlers/mint';
 import { MemoryMintOperationRepository } from '../../repositories/memory/MemoryMintOperationRepository';
+import { MemoryMintBatchAttemptRepository } from '../../repositories/memory/MemoryMintBatchAttemptRepository';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
 import type { MintService } from '../../services/MintService';
 import type { WalletService } from '../../services/WalletService';
@@ -31,6 +32,7 @@ describe('MintOperationService', () => {
   const keysetId = 'keyset-1';
 
   let operationRepo: MemoryMintOperationRepository;
+  let batchAttemptRepo: MemoryMintBatchAttemptRepository;
   let proofRepo: MemoryProofRepository;
   let proofService: ProofService;
   let mintService: MintService;
@@ -102,11 +104,13 @@ describe('MintOperationService', () => {
 
   const makeExecutingOp = (id: string, secret = 'out-1'): ExecutingMintOperation => ({
     ...makePendingOp(id, secret),
+    outputData: makeSerializedOutputData(secret),
     state: 'executing',
   });
 
   beforeEach(async () => {
     operationRepo = new MemoryMintOperationRepository();
+    batchAttemptRepo = new MemoryMintBatchAttemptRepository();
     proofRepo = new MemoryProofRepository();
     eventBus = new EventBus<CoreEvents>();
 
@@ -167,6 +171,7 @@ describe('MintOperationService', () => {
     service = new MintOperationService(
       handlerProvider,
       operationRepo,
+      batchAttemptRepo,
       proofRepo,
       proofService,
       mintService,

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -68,6 +68,7 @@ describe('MintOpsApi', () => {
     };
     const executingOperation: ExecutingMintOperation = {
       ...pendingOperation,
+      outputData: pendingOperation.outputData!,
       state: 'executing',
     };
     const finalizedOperation: TerminalMintOperation = {
@@ -231,6 +232,7 @@ describe('MintOpsApi', () => {
 
     const executingOperation: ExecutingMintOperation = {
       ...pendingOperation,
+      outputData: pendingOperation.outputData!,
       state: 'executing',
     };
 

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -68,6 +68,7 @@ describe('MintOpsApi', () => {
     };
     const executingOperation: ExecutingMintOperation = {
       ...pendingOperation,
+      outputData: pendingOperation.outputData!,
       state: 'executing',
     };
     const finalizedOperation: TerminalMintOperation = {
@@ -230,6 +231,7 @@ describe('MintOpsApi', () => {
 
     const executingOperation: ExecutingMintOperation = {
       ...pendingOperation,
+      outputData: pendingOperation.outputData!,
       state: 'executing',
     };
 

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -57,4 +57,10 @@ export interface CoreProof extends Proof {
    * Used for auditing and rollback purposes.
    */
   createdByOperationId?: string;
+
+  /**
+   * ID of the batch attempt that created this proof as output.
+   * Batch-created proofs are not attributable to a single mint operation.
+   */
+  createdByBatchId?: string;
 }

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -46,4 +46,10 @@ export interface CoreProof extends Proof {
    * Used for auditing and rollback purposes.
    */
   createdByOperationId?: string;
+
+  /**
+   * ID of the batch attempt that created this proof as output.
+   * Batch-created proofs are not attributable to a single mint operation.
+   */
+  createdByBatchId?: string;
 }

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -147,7 +147,7 @@ export function mapProofToCoreProof(
   mintUrl: string,
   state: ProofState,
   proofs: Proof[],
-  options: { unit: string; createdByOperationId?: string },
+  options: { unit: string; createdByOperationId?: string; createdByBatchId?: string },
 ): CoreProof[] {
   const unit = normalizeUnit(options.unit);
   return proofs.map((p) => ({
@@ -156,6 +156,7 @@ export function mapProofToCoreProof(
     unit,
     state,
     createdByOperationId: options?.createdByOperationId,
+    createdByBatchId: options?.createdByBatchId,
   }));
 }
 

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -146,13 +146,14 @@ export function mapProofToCoreProof(
   mintUrl: string,
   state: ProofState,
   proofs: Proof[],
-  options?: { createdByOperationId?: string },
+  options?: { createdByOperationId?: string; createdByBatchId?: string },
 ): CoreProof[] {
   return proofs.map((p) => ({
     ...p,
     mintUrl,
     state,
     createdByOperationId: options?.createdByOperationId,
+    createdByBatchId: options?.createdByBatchId,
   }));
 }
 

--- a/packages/expo-sqlite/src/index.ts
+++ b/packages/expo-sqlite/src/index.ts
@@ -12,6 +12,7 @@ import type {
   MintOperationRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { ExpoSendOperationRepository } from './repositories/SendOperationReposit
 import { ExpoMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { ExpoAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { ExpoMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { ExpoMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { ExpoReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 import {
   ExpoPaymentRequestReceiveAttemptRepository,
@@ -48,6 +50,7 @@ export class ExpoSqliteRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -66,6 +69,7 @@ export class ExpoSqliteRepositories implements Repositories {
     this.meltOperationRepository = new ExpoMeltOperationRepository(this.db);
     this.authSessionRepository = new ExpoAuthSessionRepository(this.db);
     this.mintOperationRepository = new ExpoMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new ExpoMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new ExpoReceiveOperationRepository(this.db);
     this.paymentRequestReceiveOperationRepository =
       new ExpoPaymentRequestReceiveOperationRepository(this.db);
@@ -92,6 +96,7 @@ export class ExpoSqliteRepositories implements Repositories {
         meltOperationRepository: new ExpoMeltOperationRepository(txDb),
         authSessionRepository: new ExpoAuthSessionRepository(txDb),
         mintOperationRepository: new ExpoMintOperationRepository(txDb),
+        mintBatchAttemptRepository: new ExpoMintBatchAttemptRepository(txDb),
         receiveOperationRepository: new ExpoReceiveOperationRepository(txDb),
         paymentRequestReceiveOperationRepository: new ExpoPaymentRequestReceiveOperationRepository(
           txDb,
@@ -122,6 +127,7 @@ export {
   ExpoMeltOperationRepository,
   ExpoAuthSessionRepository,
   ExpoMintOperationRepository,
+  ExpoMintBatchAttemptRepository,
   ExpoReceiveOperationRepository,
   ExpoPaymentRequestReceiveOperationRepository,
   ExpoPaymentRequestReceiveAttemptRepository,

--- a/packages/expo-sqlite/src/index.ts
+++ b/packages/expo-sqlite/src/index.ts
@@ -11,6 +11,7 @@ import type {
   MeltOperationRepository,
   AuthSessionRepository,
   MintOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { ExpoSendOperationRepository } from './repositories/SendOperationReposit
 import { ExpoMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { ExpoAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { ExpoMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { ExpoMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { ExpoReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 
 export interface ExpoSqliteRepositoriesOptions extends ExpoSqliteDbOptions {}
@@ -45,6 +47,7 @@ export class ExpoSqliteRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly db: ExpoSqliteDb;
 
@@ -62,6 +65,7 @@ export class ExpoSqliteRepositories implements Repositories {
     this.meltOperationRepository = new ExpoMeltOperationRepository(this.db);
     this.authSessionRepository = new ExpoAuthSessionRepository(this.db);
     this.mintOperationRepository = new ExpoMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new ExpoMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new ExpoReceiveOperationRepository(this.db);
   }
 
@@ -84,6 +88,7 @@ export class ExpoSqliteRepositories implements Repositories {
         meltOperationRepository: new ExpoMeltOperationRepository(txDb),
         authSessionRepository: new ExpoAuthSessionRepository(txDb),
         mintOperationRepository: new ExpoMintOperationRepository(txDb),
+        mintBatchAttemptRepository: new ExpoMintBatchAttemptRepository(txDb),
         receiveOperationRepository: new ExpoReceiveOperationRepository(txDb),
       };
 
@@ -109,6 +114,7 @@ export {
   ExpoMeltOperationRepository,
   ExpoAuthSessionRepository,
   ExpoMintOperationRepository,
+  ExpoMintBatchAttemptRepository,
   ExpoReceiveOperationRepository,
 };
 

--- a/packages/expo-sqlite/src/repositories/MintBatchAttemptRepository.ts
+++ b/packages/expo-sqlite/src/repositories/MintBatchAttemptRepository.ts
@@ -1,0 +1,160 @@
+import type {
+  MintBatchAttempt,
+  MintBatchAttemptRepository,
+  MintBatchAttemptState,
+} from '@cashu/coco-core';
+import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core';
+import { ExpoSqliteDb, getUnixTimeSeconds } from '../db.ts';
+
+interface MintBatchAttemptRow {
+  id: string;
+  mintUrl: string;
+  method: MintBatchAttempt['method'];
+  unit: string;
+  operationIdsJson: string;
+  quoteIdsJson: string;
+  quoteAmountsJson: string;
+  totalAmount: string | number;
+  outputDataJson: string;
+  keysetId: string;
+  counterStart: number | null;
+  counterEnd: number | null;
+  state: MintBatchAttemptState;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt: number | null;
+  finalizedAt: number | null;
+}
+
+const rowToAttempt = (row: MintBatchAttemptRow): MintBatchAttempt => ({
+  id: row.id,
+  mintUrl: row.mintUrl,
+  method: row.method,
+  unit: row.unit,
+  operationIds: JSON.parse(row.operationIdsJson) as string[],
+  quoteIds: JSON.parse(row.quoteIdsJson) as string[],
+  quoteAmounts: (JSON.parse(row.quoteAmountsJson) as Array<string | number>).map(deserializeAmount),
+  totalAmount: deserializeAmount(row.totalAmount),
+  outputData: JSON.parse(row.outputDataJson),
+  keysetId: row.keysetId,
+  ...(row.counterStart !== null ? { counterStart: row.counterStart } : {}),
+  ...(row.counterEnd !== null ? { counterEnd: row.counterEnd } : {}),
+  state: row.state,
+  ...(row.error ? { error: row.error } : {}),
+  createdAt: row.createdAt * 1000,
+  updatedAt: row.updatedAt * 1000,
+  ...(row.requestedAt !== null ? { requestedAt: row.requestedAt * 1000 } : {}),
+  ...(row.finalizedAt !== null ? { finalizedAt: row.finalizedAt * 1000 } : {}),
+});
+
+const attemptToParams = (attempt: MintBatchAttempt): unknown[] => [
+  attempt.id,
+  attempt.mintUrl,
+  attempt.method,
+  attempt.unit,
+  stringifyJson(attempt.operationIds),
+  stringifyJson(attempt.quoteIds),
+  stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+  serializeAmount(attempt.totalAmount),
+  stringifyJson(attempt.outputData),
+  attempt.keysetId,
+  attempt.counterStart ?? null,
+  attempt.counterEnd ?? null,
+  attempt.state,
+  attempt.error ?? null,
+  Math.floor(attempt.createdAt / 1000),
+  Math.floor(attempt.updatedAt / 1000),
+  attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+  attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+];
+
+export class ExpoMintBatchAttemptRepository implements MintBatchAttemptRepository {
+  constructor(private readonly db: ExpoSqliteDb) {}
+
+  async create(attempt: MintBatchAttempt): Promise<void> {
+    const exists = await this.db.get<{ id: string }>(
+      'SELECT id FROM coco_cashu_mint_batch_attempts WHERE id = ? LIMIT 1',
+      [attempt.id],
+    );
+    if (exists) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} already exists`);
+    }
+
+    await this.db.run(
+      `INSERT INTO coco_cashu_mint_batch_attempts
+        (id, mintUrl, method, unit, operationIdsJson, quoteIdsJson, quoteAmountsJson, totalAmount, outputDataJson, keysetId, counterStart, counterEnd, state, error, createdAt, updatedAt, requestedAt, finalizedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      attemptToParams(attempt),
+    );
+  }
+
+  async update(attempt: MintBatchAttempt): Promise<void> {
+    const exists = await this.db.get<{ id: string }>(
+      'SELECT id FROM coco_cashu_mint_batch_attempts WHERE id = ? LIMIT 1',
+      [attempt.id],
+    );
+    if (!exists) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} not found`);
+    }
+
+    await this.db.run(
+      `UPDATE coco_cashu_mint_batch_attempts
+       SET mintUrl = ?, method = ?, unit = ?, operationIdsJson = ?, quoteIdsJson = ?, quoteAmountsJson = ?, totalAmount = ?, outputDataJson = ?, keysetId = ?, counterStart = ?, counterEnd = ?, state = ?, error = ?, updatedAt = ?, requestedAt = ?, finalizedAt = ?
+       WHERE id = ?`,
+      [
+        attempt.mintUrl,
+        attempt.method,
+        attempt.unit,
+        stringifyJson(attempt.operationIds),
+        stringifyJson(attempt.quoteIds),
+        stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+        serializeAmount(attempt.totalAmount),
+        stringifyJson(attempt.outputData),
+        attempt.keysetId,
+        attempt.counterStart ?? null,
+        attempt.counterEnd ?? null,
+        attempt.state,
+        attempt.error ?? null,
+        getUnixTimeSeconds(),
+        attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+        attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+        attempt.id,
+      ],
+    );
+  }
+
+  async getById(id: string): Promise<MintBatchAttempt | null> {
+    const row = await this.db.get<MintBatchAttemptRow>(
+      'SELECT * FROM coco_cashu_mint_batch_attempts WHERE id = ?',
+      [id],
+    );
+    return row ? rowToAttempt(row) : null;
+  }
+
+  async getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      'SELECT * FROM coco_cashu_mint_batch_attempts WHERE state = ?',
+      [state],
+    );
+    return rows.map(rowToAttempt);
+  }
+
+  async getByOperationId(operationId: string): Promise<MintBatchAttempt | null> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      "SELECT * FROM coco_cashu_mint_batch_attempts WHERE state IN ('prepared', 'requesting', 'recovering', 'finalized') ORDER BY updatedAt DESC",
+    );
+    return rows.map(rowToAttempt).find((attempt) => attempt.operationIds.includes(operationId)) ?? null;
+  }
+
+  async getPending(): Promise<MintBatchAttempt[]> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      "SELECT * FROM coco_cashu_mint_batch_attempts WHERE state IN ('prepared', 'requesting', 'recovering')",
+    );
+    return rows.map(rowToAttempt);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.run('DELETE FROM coco_cashu_mint_batch_attempts WHERE id = ?', [id]);
+  }
+}

--- a/packages/expo-sqlite/src/repositories/MintOperationRepository.ts
+++ b/packages/expo-sqlite/src/repositories/MintOperationRepository.ts
@@ -27,6 +27,8 @@ interface MintOperationRow {
   lastObservedRemoteStateAt: number | null;
   terminalFailureJson: string | null;
   outputDataJson: string | null;
+  batchEligible: number | null;
+  redeemedByBatchId: string | null;
 }
 
 const persistedStates = ['pending', 'executing', 'finalized', 'failed'] as const;
@@ -79,7 +81,9 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     pubkey: row.pubkey ?? undefined,
     lastObservedRemoteState: row.lastObservedRemoteState ?? undefined,
     lastObservedRemoteStateAt: row.lastObservedRemoteStateAt ?? undefined,
-    outputData: row.outputDataJson ? JSON.parse(row.outputDataJson) : { keep: [], send: [] },
+    ...(row.outputDataJson ? { outputData: JSON.parse(row.outputDataJson) } : {}),
+    ...(row.batchEligible !== null ? { batchEligible: row.batchEligible === 1 } : {}),
+    ...(row.redeemedByBatchId ? { redeemedByBatchId: row.redeemedByBatchId } : {}),
   } as MintOperation;
 };
 
@@ -108,6 +112,8 @@ const operationToParams = (operation: MintOperation): unknown[] => {
       null,
       operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
       null,
+      null,
+      null,
     ];
   }
 
@@ -129,7 +135,9 @@ const operationToParams = (operation: MintOperation): unknown[] => {
     operation.lastObservedRemoteState ?? null,
     operation.lastObservedRemoteStateAt ?? null,
     operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
-    JSON.stringify(operation.outputData),
+    operation.outputData ? JSON.stringify(operation.outputData) : null,
+    operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+    operation.redeemedByBatchId ?? null,
   ];
 };
 
@@ -152,8 +160,8 @@ export class ExpoMintOperationRepository implements MintOperationRepository {
     const params = operationToParams(operation);
     await this.db.run(
       `INSERT INTO coco_cashu_mint_operations
-        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson, batchEligible, redeemedByBatchId)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       params,
     );
   }
@@ -172,7 +180,7 @@ export class ExpoMintOperationRepository implements MintOperationRepository {
     if (operation.state === 'init') {
       await this.db.run(
         `UPDATE coco_cashu_mint_operations
-         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?
+         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?, batchEligible = ?, redeemedByBatchId = ?
          WHERE id = ?`,
         [
           operation.quoteId ?? null,
@@ -184,6 +192,8 @@ export class ExpoMintOperationRepository implements MintOperationRepository {
           serializeAmount(operation.amount),
           operation.unit,
           operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
+          null,
+          null,
           operation.id,
         ],
       );
@@ -192,7 +202,7 @@ export class ExpoMintOperationRepository implements MintOperationRepository {
 
     await this.db.run(
       `UPDATE coco_cashu_mint_operations
-       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?
+       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?, batchEligible = ?, redeemedByBatchId = ?
        WHERE id = ?`,
       [
         operation.quoteId,
@@ -209,7 +219,9 @@ export class ExpoMintOperationRepository implements MintOperationRepository {
         operation.lastObservedRemoteState ?? null,
         operation.lastObservedRemoteStateAt ?? null,
         operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
-        JSON.stringify(operation.outputData),
+        operation.outputData ? JSON.stringify(operation.outputData) : null,
+        operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+        operation.redeemedByBatchId ?? null,
         operation.id,
       ],
     );

--- a/packages/expo-sqlite/src/repositories/ProofRepository.ts
+++ b/packages/expo-sqlite/src/repositories/ProofRepository.ts
@@ -22,12 +22,13 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByBatchId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
 
 const PROOF_COLUMNS =
-  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId';
+  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId';
 
 function normalizeProofUnit(proof: CoreProof): string {
   return normalizeUnit((proof as { unit?: string }).unit);
@@ -66,6 +67,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -93,7 +95,7 @@ export class ExpoProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByBatchId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of normalizedProofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -110,6 +112,7 @@ export class ExpoProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByBatchId ?? null,
         ]);
       }
     });

--- a/packages/expo-sqlite/src/repositories/ProofRepository.ts
+++ b/packages/expo-sqlite/src/repositories/ProofRepository.ts
@@ -18,6 +18,7 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByBatchId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
@@ -37,6 +38,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -60,7 +62,7 @@ export class ExpoProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByBatchId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -76,6 +78,7 @@ export class ExpoProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByBatchId ?? null,
         ]);
       }
     });
@@ -83,7 +86,7 @@ export class ExpoProofRepository implements ProofRepository {
 
   async getReadyProofs(mintUrl: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = "ready"',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = "ready"',
       [mintUrl],
     );
     return rows.map(rowToProof);
@@ -92,7 +95,7 @@ export class ExpoProofRepository implements ProofRepository {
   async getInflightProofs(mintUrls?: string[]): Promise<CoreProof[]> {
     if (!mintUrls || mintUrls.length === 0) {
       const rows = await this.db.all<ProofRow>(
-        'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = "inflight"',
+        'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = "inflight"',
       );
       return rows.map(rowToProof);
     }
@@ -101,7 +104,7 @@ export class ExpoProofRepository implements ProofRepository {
     const uniqueMintUrls = Array.from(new Set(mintUrlList));
     const placeholders = uniqueMintUrls.map(() => '?').join(', ');
     const rows = await this.db.all<ProofRow>(
-      `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = "inflight" AND mintUrl IN (${placeholders})`,
+      `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = "inflight" AND mintUrl IN (${placeholders})`,
       uniqueMintUrls,
     );
     return rows.map(rowToProof);
@@ -109,14 +112,14 @@ export class ExpoProofRepository implements ProofRepository {
 
   async getAllReadyProofs(): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = "ready"',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = "ready"',
     );
     return rows.map(rowToProof);
   }
 
   async getProofsByKeysetId(mintUrl: string, keysetId: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = "ready"',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = "ready"',
       [mintUrl, keysetId],
     );
     return rows.map(rowToProof);
@@ -210,7 +213,7 @@ export class ExpoProofRepository implements ProofRepository {
 
   async getProofBySecret(mintUrl: string, secret: string): Promise<CoreProof | null> {
     const row = await this.db.get<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?',
       [mintUrl, secret],
     );
     return row ? rowToProof(row) : null;
@@ -228,7 +231,7 @@ export class ExpoProofRepository implements ProofRepository {
       const secretBatch = uniqueSecrets.slice(i, i + MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE);
       const placeholders = secretBatch.map(() => '?').join(', ');
       const rows = await this.db.all<ProofRow>(
-        `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret IN (${placeholders})`,
+        `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret IN (${placeholders})`,
         [mintUrl, ...secretBatch],
       );
 
@@ -245,7 +248,7 @@ export class ExpoProofRepository implements ProofRepository {
 
   async getProofsByOperationId(mintUrl: string, operationId: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND (usedByOperationId = ? OR createdByOperationId = ?)',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND (usedByOperationId = ? OR createdByOperationId = ?)',
       [mintUrl, operationId, operationId],
     );
     return rows.map(rowToProof);
@@ -253,7 +256,7 @@ export class ExpoProofRepository implements ProofRepository {
 
   async getAvailableProofs(mintUrl: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = "ready" AND usedByOperationId IS NULL',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = "ready" AND usedByOperationId IS NULL',
       [mintUrl],
     );
     return rows.map(rowToProof);
@@ -261,7 +264,7 @@ export class ExpoProofRepository implements ProofRepository {
 
   async getReservedProofs(): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = "ready" AND usedByOperationId IS NOT NULL',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = "ready" AND usedByOperationId IS NOT NULL',
     );
     return rows.map(rowToProof);
   }

--- a/packages/expo-sqlite/src/schema.ts
+++ b/packages/expo-sqlite/src/schema.ts
@@ -1140,6 +1140,59 @@ const MIGRATIONS: readonly Migration[] = [
     id: '029_backfill_send_operation_tokens',
     run: backfillSendOperationTokensFromHistory,
   },
+  {
+    id: '030_mint_batch_attempts',
+    run: async (db) => {
+      const proofColumns = await getTableColumns(db, 'coco_cashu_proofs');
+      if (!proofColumns.has('createdByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_proofs ADD COLUMN createdByBatchId TEXT');
+      }
+
+      const mintOperationColumns = await getTableColumns(db, 'coco_cashu_mint_operations');
+      if (!mintOperationColumns.has('batchEligible')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN batchEligible INTEGER');
+      }
+      if (!mintOperationColumns.has('redeemedByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN redeemedByBatchId TEXT');
+      }
+
+      await db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_proofs_createdByBatch
+          ON coco_cashu_proofs(createdByBatchId)
+          WHERE createdByBatchId IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_operations_redeemedByBatch
+          ON coco_cashu_mint_operations(redeemedByBatchId)
+          WHERE redeemedByBatchId IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS coco_cashu_mint_batch_attempts (
+          id TEXT PRIMARY KEY,
+          mintUrl TEXT NOT NULL,
+          method TEXT NOT NULL,
+          unit TEXT NOT NULL,
+          operationIdsJson TEXT NOT NULL,
+          quoteIdsJson TEXT NOT NULL,
+          quoteAmountsJson TEXT NOT NULL,
+          totalAmount TEXT NOT NULL,
+          outputDataJson TEXT NOT NULL,
+          keysetId TEXT NOT NULL,
+          counterStart INTEGER,
+          counterEnd INTEGER,
+          state TEXT NOT NULL CHECK (state IN ('prepared', 'requesting', 'finalized', 'recovering', 'failed')),
+          error TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          requestedAt INTEGER,
+          finalizedAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_state
+          ON coco_cashu_mint_batch_attempts(state);
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_mint
+          ON coco_cashu_mint_batch_attempts(mintUrl);
+      `);
+    },
+  },
 ];
 
 // Export for testing

--- a/packages/expo-sqlite/src/schema.ts
+++ b/packages/expo-sqlite/src/schema.ts
@@ -948,6 +948,59 @@ const MIGRATIONS: readonly Migration[] = [
     id: '024_amount_columns_text',
     run: migrateAmountColumnsToText,
   },
+  {
+    id: '025_mint_batch_attempts',
+    run: async (db) => {
+      const proofColumns = await getTableColumns(db, 'coco_cashu_proofs');
+      if (!proofColumns.has('createdByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_proofs ADD COLUMN createdByBatchId TEXT');
+      }
+
+      const mintOperationColumns = await getTableColumns(db, 'coco_cashu_mint_operations');
+      if (!mintOperationColumns.has('batchEligible')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN batchEligible INTEGER');
+      }
+      if (!mintOperationColumns.has('redeemedByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN redeemedByBatchId TEXT');
+      }
+
+      await db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_proofs_createdByBatch
+          ON coco_cashu_proofs(createdByBatchId)
+          WHERE createdByBatchId IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_operations_redeemedByBatch
+          ON coco_cashu_mint_operations(redeemedByBatchId)
+          WHERE redeemedByBatchId IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS coco_cashu_mint_batch_attempts (
+          id TEXT PRIMARY KEY,
+          mintUrl TEXT NOT NULL,
+          method TEXT NOT NULL,
+          unit TEXT NOT NULL,
+          operationIdsJson TEXT NOT NULL,
+          quoteIdsJson TEXT NOT NULL,
+          quoteAmountsJson TEXT NOT NULL,
+          totalAmount TEXT NOT NULL,
+          outputDataJson TEXT NOT NULL,
+          keysetId TEXT NOT NULL,
+          counterStart INTEGER,
+          counterEnd INTEGER,
+          state TEXT NOT NULL CHECK (state IN ('prepared', 'requesting', 'finalized', 'recovering', 'failed')),
+          error TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          requestedAt INTEGER,
+          finalizedAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_state
+          ON coco_cashu_mint_batch_attempts(state);
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_mint
+          ON coco_cashu_mint_batch_attempts(mintUrl);
+      `);
+    },
+  },
 ];
 
 // Export for testing

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -12,6 +12,7 @@ import type {
   MintOperationRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { IdbSendOperationRepository } from './repositories/SendOperationReposito
 import { IdbMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { IdbAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { IdbMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { IdbMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { IdbReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 import {
   IdbPaymentRequestReceiveAttemptRepository,
@@ -48,6 +50,7 @@ export class IndexedDbRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -67,6 +70,7 @@ export class IndexedDbRepositories implements Repositories {
     this.meltOperationRepository = new IdbMeltOperationRepository(this.db);
     this.authSessionRepository = new IdbAuthSessionRepository(this.db);
     this.mintOperationRepository = new IdbMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new IdbMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new IdbReceiveOperationRepository(this.db);
     this.paymentRequestReceiveOperationRepository = new IdbPaymentRequestReceiveOperationRepository(
       this.db,
@@ -102,6 +106,7 @@ export class IndexedDbRepositories implements Repositories {
         meltOperationRepository: new IdbMeltOperationRepository(scopedDb),
         authSessionRepository: new IdbAuthSessionRepository(scopedDb),
         mintOperationRepository: new IdbMintOperationRepository(scopedDb),
+        mintBatchAttemptRepository: new IdbMintBatchAttemptRepository(scopedDb),
         receiveOperationRepository: new IdbReceiveOperationRepository(scopedDb),
         paymentRequestReceiveOperationRepository: new IdbPaymentRequestReceiveOperationRepository(
           scopedDb,
@@ -129,6 +134,7 @@ export {
   IdbMeltOperationRepository,
   IdbAuthSessionRepository,
   IdbMintOperationRepository,
+  IdbMintBatchAttemptRepository,
   IdbReceiveOperationRepository,
   IdbPaymentRequestReceiveOperationRepository,
   IdbPaymentRequestReceiveAttemptRepository,

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -11,6 +11,7 @@ import type {
   MeltOperationRepository,
   AuthSessionRepository,
   MintOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { IdbSendOperationRepository } from './repositories/SendOperationReposito
 import { IdbMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { IdbAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { IdbMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { IdbMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { IdbReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 
 export interface IndexedDbRepositoriesOptions extends IdbDbOptions {}
@@ -45,6 +47,7 @@ export class IndexedDbRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly db: IdbDb;
   private initialized = false;
@@ -63,6 +66,7 @@ export class IndexedDbRepositories implements Repositories {
     this.meltOperationRepository = new IdbMeltOperationRepository(this.db);
     this.authSessionRepository = new IdbAuthSessionRepository(this.db);
     this.mintOperationRepository = new IdbMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new IdbMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new IdbReceiveOperationRepository(this.db);
   }
 
@@ -93,6 +97,7 @@ export class IndexedDbRepositories implements Repositories {
         meltOperationRepository: new IdbMeltOperationRepository(scopedDb),
         authSessionRepository: new IdbAuthSessionRepository(scopedDb),
         mintOperationRepository: new IdbMintOperationRepository(scopedDb),
+        mintBatchAttemptRepository: new IdbMintBatchAttemptRepository(scopedDb),
         receiveOperationRepository: new IdbReceiveOperationRepository(scopedDb),
       };
       return fn(scopedRepositories);
@@ -115,5 +120,6 @@ export {
   IdbMeltOperationRepository,
   IdbAuthSessionRepository,
   IdbMintOperationRepository,
+  IdbMintBatchAttemptRepository,
   IdbReceiveOperationRepository,
 };

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -144,6 +144,7 @@ export interface ProofRow {
   createdAt: number;
   usedByOperationId?: string | null;
   createdByOperationId?: string | null;
+  createdByBatchId?: string | null;
 }
 
 export interface MintQuoteRow {
@@ -308,4 +309,27 @@ export interface MintOperationRow {
   lastObservedRemoteStateAt?: number | null;
   terminalFailureJson?: string | null;
   outputDataJson?: string | null;
+  batchEligible?: number | null;
+  redeemedByBatchId?: string | null;
+}
+
+export interface MintBatchAttemptRow {
+  id: string;
+  mintUrl: string;
+  method: string;
+  unit: string;
+  operationIdsJson: string;
+  quoteIdsJson: string;
+  quoteAmountsJson: string;
+  totalAmount: string | number;
+  outputDataJson: string;
+  keysetId: string;
+  counterStart?: number | null;
+  counterEnd?: number | null;
+  state: 'prepared' | 'requesting' | 'finalized' | 'recovering' | 'failed';
+  error?: string | null;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt?: number | null;
+  finalizedAt?: number | null;
 }

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -143,6 +143,7 @@ export interface ProofRow {
   createdAt: number;
   usedByOperationId?: string | null;
   createdByOperationId?: string | null;
+  createdByBatchId?: string | null;
 }
 
 export interface MintQuoteRow {
@@ -266,4 +267,27 @@ export interface MintOperationRow {
   lastObservedRemoteStateAt?: number | null;
   terminalFailureJson?: string | null;
   outputDataJson?: string | null;
+  batchEligible?: number | null;
+  redeemedByBatchId?: string | null;
+}
+
+export interface MintBatchAttemptRow {
+  id: string;
+  mintUrl: string;
+  method: string;
+  unit: string;
+  operationIdsJson: string;
+  quoteIdsJson: string;
+  quoteAmountsJson: string;
+  totalAmount: string | number;
+  outputDataJson: string;
+  keysetId: string;
+  counterStart?: number | null;
+  counterEnd?: number | null;
+  state: 'prepared' | 'requesting' | 'finalized' | 'recovering' | 'failed';
+  error?: string | null;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt?: number | null;
+  finalizedAt?: number | null;
 }

--- a/packages/indexeddb/src/lib/schema.ts
+++ b/packages/indexeddb/src/lib/schema.ts
@@ -810,4 +810,27 @@ export async function ensureSchema(db: IdbDb): Promise<void> {
           if (tokenJson) op.tokenJson = tokenJson;
         });
     });
+
+  // Version 27: Add batch mint attempts and batch proof ownership.
+  db.version(27).stores({
+    coco_cashu_mints: '&mintUrl, name, updatedAt, trusted',
+    coco_cashu_keysets: '&[mintUrl+id], mintUrl, id, updatedAt, unit',
+    coco_cashu_counters: '&[mintUrl+keysetId]',
+    coco_cashu_proofs:
+      '&[mintUrl+secret], [mintUrl+state], [mintUrl+unit+state], [mintUrl+id+state], [mintUrl+id+unit+state], [mintUrl+unit+id+state], [unit+state], state, mintUrl, unit, id, usedByOperationId, createdByOperationId, createdByBatchId',
+    coco_cashu_mint_quotes: '&[mintUrl+quote], state, mintUrl',
+    coco_cashu_melt_quotes: '&[mintUrl+quote], state, mintUrl',
+    coco_cashu_history:
+      '++id, mintUrl, type, createdAt, [mintUrl+quoteId+type], [mintUrl+operationId]',
+    coco_cashu_keypairs: '&publicKey, createdAt, derivationIndex',
+    coco_cashu_send_operations: '&id, state, mintUrl, createdAt',
+    coco_cashu_melt_operations: '&id, state, mintUrl, createdAt, [mintUrl+quoteId]',
+    coco_cashu_receive_operations: '&id, state, mintUrl, createdAt',
+    coco_cashu_auth_sessions: '&mintUrl',
+    coco_cashu_mint_operations: '&id, state, mintUrl, createdAt, [mintUrl+quoteId]',
+    coco_cashu_payment_request_receive_operations: '&id, state, requestId',
+    coco_cashu_payment_request_receive_attempts:
+      '&id, requestOperationId, requestId, state, &[requestOperationId+payloadHash], [requestId+payloadHash], &transportMessageId, &receiveOperationId',
+    coco_cashu_mint_batch_attempts: '&id, state, mintUrl',
+  });
 }

--- a/packages/indexeddb/src/lib/schema.ts
+++ b/packages/indexeddb/src/lib/schema.ts
@@ -553,4 +553,24 @@ export async function ensureSchema(db: IdbDb): Promise<void> {
           row.amount = normalizeStoredAmount(row.amount);
         });
     });
+
+  // Version 19: Add batch mint attempts and batch proof ownership.
+  db.version(19).stores({
+    coco_cashu_mints: '&mintUrl, name, updatedAt, trusted',
+    coco_cashu_keysets: '&[mintUrl+id], mintUrl, id, updatedAt, unit',
+    coco_cashu_counters: '&[mintUrl+keysetId]',
+    coco_cashu_proofs:
+      '&[mintUrl+secret], [mintUrl+state], [mintUrl+id+state], state, mintUrl, id, usedByOperationId, createdByOperationId, createdByBatchId',
+    coco_cashu_mint_quotes: '&[mintUrl+quote], state, mintUrl',
+    coco_cashu_melt_quotes: '&[mintUrl+quote], state, mintUrl',
+    coco_cashu_history:
+      '++id, mintUrl, type, createdAt, [mintUrl+quoteId+type], [mintUrl+operationId]',
+    coco_cashu_keypairs: '&publicKey, createdAt, derivationIndex',
+    coco_cashu_send_operations: '&id, state, mintUrl',
+    coco_cashu_melt_operations: '&id, state, mintUrl, [mintUrl+quoteId]',
+    coco_cashu_receive_operations: '&id, state, mintUrl',
+    coco_cashu_auth_sessions: '&mintUrl',
+    coco_cashu_mint_operations: '&id, state, mintUrl, [mintUrl+quoteId]',
+    coco_cashu_mint_batch_attempts: '&id, state, mintUrl',
+  });
 }

--- a/packages/indexeddb/src/repositories/MintBatchAttemptRepository.ts
+++ b/packages/indexeddb/src/repositories/MintBatchAttemptRepository.ts
@@ -1,0 +1,118 @@
+import type {
+  MintBatchAttempt,
+  MintBatchAttemptRepository,
+  MintBatchAttemptState,
+} from '@cashu/coco-core';
+import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core';
+import type { IdbDb, MintBatchAttemptRow } from '../lib/db.ts';
+import { getUnixTimeSeconds } from '../lib/db.ts';
+
+const rowToAttempt = (row: MintBatchAttemptRow): MintBatchAttempt => ({
+  id: row.id,
+  mintUrl: row.mintUrl,
+  method: row.method as MintBatchAttempt['method'],
+  unit: row.unit,
+  operationIds: JSON.parse(row.operationIdsJson) as string[],
+  quoteIds: JSON.parse(row.quoteIdsJson) as string[],
+  quoteAmounts: (JSON.parse(row.quoteAmountsJson) as Array<string | number>).map(deserializeAmount),
+  totalAmount: deserializeAmount(row.totalAmount),
+  outputData: JSON.parse(row.outputDataJson),
+  keysetId: row.keysetId,
+  ...(row.counterStart !== null && row.counterStart !== undefined
+    ? { counterStart: row.counterStart }
+    : {}),
+  ...(row.counterEnd !== null && row.counterEnd !== undefined ? { counterEnd: row.counterEnd } : {}),
+  state: row.state,
+  ...(row.error ? { error: row.error } : {}),
+  createdAt: row.createdAt * 1000,
+  updatedAt: row.updatedAt * 1000,
+  ...(row.requestedAt ? { requestedAt: row.requestedAt * 1000 } : {}),
+  ...(row.finalizedAt ? { finalizedAt: row.finalizedAt * 1000 } : {}),
+});
+
+const attemptToRow = (attempt: MintBatchAttempt): MintBatchAttemptRow => ({
+  id: attempt.id,
+  mintUrl: attempt.mintUrl,
+  method: attempt.method,
+  unit: attempt.unit,
+  operationIdsJson: stringifyJson(attempt.operationIds),
+  quoteIdsJson: stringifyJson(attempt.quoteIds),
+  quoteAmountsJson: stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+  totalAmount: serializeAmount(attempt.totalAmount),
+  outputDataJson: stringifyJson(attempt.outputData),
+  keysetId: attempt.keysetId,
+  counterStart: attempt.counterStart ?? null,
+  counterEnd: attempt.counterEnd ?? null,
+  state: attempt.state,
+  error: attempt.error ?? null,
+  createdAt: Math.floor(attempt.createdAt / 1000),
+  updatedAt: Math.floor(attempt.updatedAt / 1000),
+  requestedAt: attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+  finalizedAt: attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+});
+
+export class IdbMintBatchAttemptRepository implements MintBatchAttemptRepository {
+  constructor(private readonly db: IdbDb) {}
+
+  async create(attempt: MintBatchAttempt): Promise<void> {
+    await this.db.runTransaction('rw', ['coco_cashu_mint_batch_attempts'], async (tx) => {
+      const table = tx.table('coco_cashu_mint_batch_attempts');
+      const existing = await table.get(attempt.id);
+      if (existing) {
+        throw new Error(`MintBatchAttempt with id ${attempt.id} already exists`);
+      }
+      await table.add(attemptToRow(attempt));
+    });
+  }
+
+  async update(attempt: MintBatchAttempt): Promise<void> {
+    await this.db.runTransaction('rw', ['coco_cashu_mint_batch_attempts'], async (tx) => {
+      const table = tx.table('coco_cashu_mint_batch_attempts');
+      const existing = await table.get(attempt.id);
+      if (!existing) {
+        throw new Error(`MintBatchAttempt with id ${attempt.id} not found`);
+      }
+      const row = attemptToRow(attempt);
+      row.updatedAt = getUnixTimeSeconds();
+      await table.put(row);
+    });
+  }
+
+  async getById(id: string): Promise<MintBatchAttempt | null> {
+    const row = (await (this.db as any).table('coco_cashu_mint_batch_attempts').get(id)) as
+      | MintBatchAttemptRow
+      | undefined;
+    return row ? rowToAttempt(row) : null;
+  }
+
+  async getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]> {
+    const rows = (await (this.db as any)
+      .table('coco_cashu_mint_batch_attempts')
+      .where('state')
+      .equals(state)
+      .toArray()) as MintBatchAttemptRow[];
+    return rows.map(rowToAttempt);
+  }
+
+  async getByOperationId(operationId: string): Promise<MintBatchAttempt | null> {
+    const rows = (await (this.db as any)
+      .table('coco_cashu_mint_batch_attempts')
+      .toArray()) as MintBatchAttemptRow[];
+    return rows.map(rowToAttempt).find((attempt) => attempt.operationIds.includes(operationId)) ?? null;
+  }
+
+  async getPending(): Promise<MintBatchAttempt[]> {
+    const rows = (await (this.db as any)
+      .table('coco_cashu_mint_batch_attempts')
+      .where('state')
+      .anyOf(['prepared', 'requesting', 'recovering'])
+      .toArray()) as MintBatchAttemptRow[];
+    return rows.map(rowToAttempt);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.runTransaction('rw', ['coco_cashu_mint_batch_attempts'], async (tx) => {
+      await tx.table('coco_cashu_mint_batch_attempts').delete(id);
+    });
+  }
+}

--- a/packages/indexeddb/src/repositories/MintOperationRepository.ts
+++ b/packages/indexeddb/src/repositories/MintOperationRepository.ts
@@ -58,7 +58,11 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     pubkey: row.pubkey ?? undefined,
     lastObservedRemoteState: row.lastObservedRemoteState ?? undefined,
     lastObservedRemoteStateAt: row.lastObservedRemoteStateAt ?? undefined,
-    outputData: row.outputDataJson ? JSON.parse(row.outputDataJson) : { keep: [], send: [] },
+    ...(row.outputDataJson ? { outputData: JSON.parse(row.outputDataJson) } : {}),
+    ...(row.batchEligible !== null && row.batchEligible !== undefined
+      ? { batchEligible: row.batchEligible === 1 }
+      : {}),
+    ...(row.redeemedByBatchId ? { redeemedByBatchId: row.redeemedByBatchId } : {}),
   } as MintOperation;
 };
 
@@ -84,6 +88,8 @@ const operationToRow = (operation: MintOperation): MintOperationRow => {
         ? JSON.stringify(operation.terminalFailure)
         : null,
       outputDataJson: null,
+      batchEligible: null,
+      redeemedByBatchId: null,
     };
   }
 
@@ -107,7 +113,9 @@ const operationToRow = (operation: MintOperation): MintOperationRow => {
     terminalFailureJson: operation.terminalFailure
       ? JSON.stringify(operation.terminalFailure)
       : null,
-    outputDataJson: JSON.stringify(operation.outputData),
+    outputDataJson: operation.outputData ? JSON.stringify(operation.outputData) : null,
+    batchEligible: operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+    redeemedByBatchId: operation.redeemedByBatchId ?? null,
   };
 };
 

--- a/packages/indexeddb/src/repositories/ProofRepository.ts
+++ b/packages/indexeddb/src/repositories/ProofRepository.ts
@@ -35,6 +35,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -74,6 +75,7 @@ export class IdbProofRepository implements ProofRepository {
           createdAt: now,
           usedByOperationId: p.usedByOperationId ?? null,
           createdByOperationId: p.createdByOperationId ?? null,
+          createdByBatchId: p.createdByBatchId ?? null,
         };
         await table.put(row);
       }

--- a/packages/indexeddb/src/repositories/ProofRepository.ts
+++ b/packages/indexeddb/src/repositories/ProofRepository.ts
@@ -17,6 +17,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -51,6 +52,7 @@ export class IdbProofRepository implements ProofRepository {
           createdAt: now,
           usedByOperationId: p.usedByOperationId ?? null,
           createdByOperationId: p.createdByOperationId ?? null,
+          createdByBatchId: p.createdByBatchId ?? null,
         };
         await table.put(row);
       }

--- a/packages/sqlite-bun/src/index.ts
+++ b/packages/sqlite-bun/src/index.ts
@@ -12,6 +12,7 @@ import type {
   MintOperationRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { SqliteSendOperationRepository } from './repositories/SendOperationRepos
 import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { SqliteMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 import {
   SqlitePaymentRequestReceiveAttemptRepository,
@@ -48,6 +50,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -66,6 +69,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = new SqliteMeltOperationRepository(this.db);
     this.authSessionRepository = new SqliteAuthSessionRepository(this.db);
     this.mintOperationRepository = new SqliteMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new SqliteMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new SqliteReceiveOperationRepository(this.db);
     this.paymentRequestReceiveOperationRepository =
       new SqlitePaymentRequestReceiveOperationRepository(this.db);
@@ -92,6 +96,7 @@ export class SqliteRepositories implements Repositories {
         meltOperationRepository: new SqliteMeltOperationRepository(txDb),
         authSessionRepository: new SqliteAuthSessionRepository(txDb),
         mintOperationRepository: new SqliteMintOperationRepository(txDb),
+        mintBatchAttemptRepository: new SqliteMintBatchAttemptRepository(txDb),
         receiveOperationRepository: new SqliteReceiveOperationRepository(txDb),
         paymentRequestReceiveOperationRepository:
           new SqlitePaymentRequestReceiveOperationRepository(txDb),
@@ -121,6 +126,7 @@ export {
   SqliteMeltOperationRepository,
   SqliteAuthSessionRepository,
   SqliteMintOperationRepository,
+  SqliteMintBatchAttemptRepository,
   SqliteReceiveOperationRepository,
   SqlitePaymentRequestReceiveOperationRepository,
   SqlitePaymentRequestReceiveAttemptRepository,

--- a/packages/sqlite-bun/src/index.ts
+++ b/packages/sqlite-bun/src/index.ts
@@ -11,6 +11,7 @@ import type {
   MeltOperationRepository,
   AuthSessionRepository,
   MintOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { SqliteSendOperationRepository } from './repositories/SendOperationRepos
 import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { SqliteMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 
 export interface SqliteRepositoriesOptions extends SqliteDbOptions {}
@@ -45,6 +47,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly db: SqliteDb;
 
@@ -62,6 +65,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = new SqliteMeltOperationRepository(this.db);
     this.authSessionRepository = new SqliteAuthSessionRepository(this.db);
     this.mintOperationRepository = new SqliteMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new SqliteMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new SqliteReceiveOperationRepository(this.db);
   }
 
@@ -84,6 +88,7 @@ export class SqliteRepositories implements Repositories {
         meltOperationRepository: new SqliteMeltOperationRepository(txDb),
         authSessionRepository: new SqliteAuthSessionRepository(txDb),
         mintOperationRepository: new SqliteMintOperationRepository(txDb),
+        mintBatchAttemptRepository: new SqliteMintBatchAttemptRepository(txDb),
         receiveOperationRepository: new SqliteReceiveOperationRepository(txDb),
       };
 
@@ -109,6 +114,7 @@ export {
   SqliteMeltOperationRepository,
   SqliteAuthSessionRepository,
   SqliteMintOperationRepository,
+  SqliteMintBatchAttemptRepository,
   SqliteReceiveOperationRepository,
 };
 

--- a/packages/sqlite-bun/src/repositories/MintBatchAttemptRepository.ts
+++ b/packages/sqlite-bun/src/repositories/MintBatchAttemptRepository.ts
@@ -1,0 +1,160 @@
+import type {
+  MintBatchAttempt,
+  MintBatchAttemptRepository,
+  MintBatchAttemptState,
+} from '@cashu/coco-core';
+import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core';
+import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+
+interface MintBatchAttemptRow {
+  id: string;
+  mintUrl: string;
+  method: MintBatchAttempt['method'];
+  unit: string;
+  operationIdsJson: string;
+  quoteIdsJson: string;
+  quoteAmountsJson: string;
+  totalAmount: string | number;
+  outputDataJson: string;
+  keysetId: string;
+  counterStart: number | null;
+  counterEnd: number | null;
+  state: MintBatchAttemptState;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt: number | null;
+  finalizedAt: number | null;
+}
+
+const rowToAttempt = (row: MintBatchAttemptRow): MintBatchAttempt => ({
+  id: row.id,
+  mintUrl: row.mintUrl,
+  method: row.method,
+  unit: row.unit,
+  operationIds: JSON.parse(row.operationIdsJson) as string[],
+  quoteIds: JSON.parse(row.quoteIdsJson) as string[],
+  quoteAmounts: (JSON.parse(row.quoteAmountsJson) as Array<string | number>).map(deserializeAmount),
+  totalAmount: deserializeAmount(row.totalAmount),
+  outputData: JSON.parse(row.outputDataJson),
+  keysetId: row.keysetId,
+  ...(row.counterStart !== null ? { counterStart: row.counterStart } : {}),
+  ...(row.counterEnd !== null ? { counterEnd: row.counterEnd } : {}),
+  state: row.state,
+  ...(row.error ? { error: row.error } : {}),
+  createdAt: row.createdAt * 1000,
+  updatedAt: row.updatedAt * 1000,
+  ...(row.requestedAt !== null ? { requestedAt: row.requestedAt * 1000 } : {}),
+  ...(row.finalizedAt !== null ? { finalizedAt: row.finalizedAt * 1000 } : {}),
+});
+
+const attemptToParams = (attempt: MintBatchAttempt): unknown[] => [
+  attempt.id,
+  attempt.mintUrl,
+  attempt.method,
+  attempt.unit,
+  stringifyJson(attempt.operationIds),
+  stringifyJson(attempt.quoteIds),
+  stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+  serializeAmount(attempt.totalAmount),
+  stringifyJson(attempt.outputData),
+  attempt.keysetId,
+  attempt.counterStart ?? null,
+  attempt.counterEnd ?? null,
+  attempt.state,
+  attempt.error ?? null,
+  Math.floor(attempt.createdAt / 1000),
+  Math.floor(attempt.updatedAt / 1000),
+  attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+  attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+];
+
+export class SqliteMintBatchAttemptRepository implements MintBatchAttemptRepository {
+  constructor(private readonly db: SqliteDb) {}
+
+  async create(attempt: MintBatchAttempt): Promise<void> {
+    const exists = await this.db.get<{ id: string }>(
+      'SELECT id FROM coco_cashu_mint_batch_attempts WHERE id = ? LIMIT 1',
+      [attempt.id],
+    );
+    if (exists) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} already exists`);
+    }
+
+    await this.db.run(
+      `INSERT INTO coco_cashu_mint_batch_attempts
+        (id, mintUrl, method, unit, operationIdsJson, quoteIdsJson, quoteAmountsJson, totalAmount, outputDataJson, keysetId, counterStart, counterEnd, state, error, createdAt, updatedAt, requestedAt, finalizedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      attemptToParams(attempt),
+    );
+  }
+
+  async update(attempt: MintBatchAttempt): Promise<void> {
+    const exists = await this.db.get<{ id: string }>(
+      'SELECT id FROM coco_cashu_mint_batch_attempts WHERE id = ? LIMIT 1',
+      [attempt.id],
+    );
+    if (!exists) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} not found`);
+    }
+
+    await this.db.run(
+      `UPDATE coco_cashu_mint_batch_attempts
+       SET mintUrl = ?, method = ?, unit = ?, operationIdsJson = ?, quoteIdsJson = ?, quoteAmountsJson = ?, totalAmount = ?, outputDataJson = ?, keysetId = ?, counterStart = ?, counterEnd = ?, state = ?, error = ?, updatedAt = ?, requestedAt = ?, finalizedAt = ?
+       WHERE id = ?`,
+      [
+        attempt.mintUrl,
+        attempt.method,
+        attempt.unit,
+        stringifyJson(attempt.operationIds),
+        stringifyJson(attempt.quoteIds),
+        stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+        serializeAmount(attempt.totalAmount),
+        stringifyJson(attempt.outputData),
+        attempt.keysetId,
+        attempt.counterStart ?? null,
+        attempt.counterEnd ?? null,
+        attempt.state,
+        attempt.error ?? null,
+        getUnixTimeSeconds(),
+        attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+        attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+        attempt.id,
+      ],
+    );
+  }
+
+  async getById(id: string): Promise<MintBatchAttempt | null> {
+    const row = await this.db.get<MintBatchAttemptRow>(
+      'SELECT * FROM coco_cashu_mint_batch_attempts WHERE id = ?',
+      [id],
+    );
+    return row ? rowToAttempt(row) : null;
+  }
+
+  async getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      'SELECT * FROM coco_cashu_mint_batch_attempts WHERE state = ?',
+      [state],
+    );
+    return rows.map(rowToAttempt);
+  }
+
+  async getByOperationId(operationId: string): Promise<MintBatchAttempt | null> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      "SELECT * FROM coco_cashu_mint_batch_attempts WHERE state IN ('prepared', 'requesting', 'recovering', 'finalized') ORDER BY updatedAt DESC",
+    );
+    return rows.map(rowToAttempt).find((attempt) => attempt.operationIds.includes(operationId)) ?? null;
+  }
+
+  async getPending(): Promise<MintBatchAttempt[]> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      "SELECT * FROM coco_cashu_mint_batch_attempts WHERE state IN ('prepared', 'requesting', 'recovering')",
+    );
+    return rows.map(rowToAttempt);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.run('DELETE FROM coco_cashu_mint_batch_attempts WHERE id = ?', [id]);
+  }
+}

--- a/packages/sqlite-bun/src/repositories/MintOperationRepository.ts
+++ b/packages/sqlite-bun/src/repositories/MintOperationRepository.ts
@@ -27,6 +27,8 @@ interface MintOperationRow {
   lastObservedRemoteStateAt: number | null;
   terminalFailureJson: string | null;
   outputDataJson: string | null;
+  batchEligible: number | null;
+  redeemedByBatchId: string | null;
 }
 
 const persistedStates = ['pending', 'executing', 'finalized', 'failed'] as const;
@@ -79,7 +81,9 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     pubkey: row.pubkey ?? undefined,
     lastObservedRemoteState: row.lastObservedRemoteState ?? undefined,
     lastObservedRemoteStateAt: row.lastObservedRemoteStateAt ?? undefined,
-    outputData: row.outputDataJson ? JSON.parse(row.outputDataJson) : { keep: [], send: [] },
+    ...(row.outputDataJson ? { outputData: JSON.parse(row.outputDataJson) } : {}),
+    ...(row.batchEligible !== null ? { batchEligible: row.batchEligible === 1 } : {}),
+    ...(row.redeemedByBatchId ? { redeemedByBatchId: row.redeemedByBatchId } : {}),
   } as MintOperation;
 };
 
@@ -108,6 +112,8 @@ const operationToParams = (operation: MintOperation): unknown[] => {
       null,
       operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
       null,
+      null,
+      null,
     ];
   }
 
@@ -129,7 +135,9 @@ const operationToParams = (operation: MintOperation): unknown[] => {
     operation.lastObservedRemoteState ?? null,
     operation.lastObservedRemoteStateAt ?? null,
     operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
-    JSON.stringify(operation.outputData),
+    operation.outputData ? JSON.stringify(operation.outputData) : null,
+    operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+    operation.redeemedByBatchId ?? null,
   ];
 };
 
@@ -152,8 +160,8 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
     const params = operationToParams(operation);
     await this.db.run(
       `INSERT INTO coco_cashu_mint_operations
-        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson, batchEligible, redeemedByBatchId)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       params,
     );
   }
@@ -172,7 +180,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
     if (operation.state === 'init') {
       await this.db.run(
         `UPDATE coco_cashu_mint_operations
-         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?
+         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?, batchEligible = ?, redeemedByBatchId = ?
          WHERE id = ?`,
         [
           operation.quoteId ?? null,
@@ -184,6 +192,8 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
           serializeAmount(operation.amount),
           operation.unit,
           operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
+          null,
+          null,
           operation.id,
         ],
       );
@@ -192,7 +202,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
 
     await this.db.run(
       `UPDATE coco_cashu_mint_operations
-       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?
+       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?, batchEligible = ?, redeemedByBatchId = ?
        WHERE id = ?`,
       [
         operation.quoteId,
@@ -209,7 +219,9 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
         operation.lastObservedRemoteState ?? null,
         operation.lastObservedRemoteStateAt ?? null,
         operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
-        JSON.stringify(operation.outputData),
+        operation.outputData ? JSON.stringify(operation.outputData) : null,
+        operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+        operation.redeemedByBatchId ?? null,
         operation.id,
       ],
     );

--- a/packages/sqlite-bun/src/repositories/ProofRepository.ts
+++ b/packages/sqlite-bun/src/repositories/ProofRepository.ts
@@ -22,12 +22,13 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByBatchId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
 
 const PROOF_COLUMNS =
-  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId';
+  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId';
 
 function normalizeProofUnit(proof: CoreProof): string {
   return normalizeUnit((proof as { unit?: string }).unit);
@@ -66,6 +67,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -93,7 +95,7 @@ export class SqliteProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByBatchId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of normalizedProofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -110,6 +112,7 @@ export class SqliteProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByBatchId ?? null,
         ]);
       }
     });

--- a/packages/sqlite-bun/src/repositories/ProofRepository.ts
+++ b/packages/sqlite-bun/src/repositories/ProofRepository.ts
@@ -18,6 +18,7 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByBatchId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
@@ -37,6 +38,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -60,7 +62,7 @@ export class SqliteProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByBatchId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -76,6 +78,7 @@ export class SqliteProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByBatchId ?? null,
         ]);
       }
     });
@@ -83,7 +86,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getReadyProofs(mintUrl: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready'",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready'",
       [mintUrl],
     );
     return rows.map(rowToProof);
@@ -92,7 +95,7 @@ export class SqliteProofRepository implements ProofRepository {
   async getInflightProofs(mintUrls?: string[]): Promise<CoreProof[]> {
     if (!mintUrls || mintUrls.length === 0) {
       const rows = await this.db.all<ProofRow>(
-        "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'inflight'",
+        "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'inflight'",
       );
       return rows.map(rowToProof);
     }
@@ -101,7 +104,7 @@ export class SqliteProofRepository implements ProofRepository {
     const uniqueMintUrls = Array.from(new Set(mintUrlList));
     const placeholders = uniqueMintUrls.map(() => '?').join(', ');
     const rows = await this.db.all<ProofRow>(
-      `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'inflight' AND mintUrl IN (${placeholders})`,
+      `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'inflight' AND mintUrl IN (${placeholders})`,
       uniqueMintUrls,
     );
     return rows.map(rowToProof);
@@ -109,14 +112,14 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getAllReadyProofs(): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'ready'",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'ready'",
     );
     return rows.map(rowToProof);
   }
 
   async getProofsByKeysetId(mintUrl: string, keysetId: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = 'ready'",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = 'ready'",
       [mintUrl, keysetId],
     );
     return rows.map(rowToProof);
@@ -210,7 +213,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getProofBySecret(mintUrl: string, secret: string): Promise<CoreProof | null> {
     const row = await this.db.get<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?',
       [mintUrl, secret],
     );
     return row ? rowToProof(row) : null;
@@ -228,7 +231,7 @@ export class SqliteProofRepository implements ProofRepository {
       const secretBatch = uniqueSecrets.slice(i, i + MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE);
       const placeholders = secretBatch.map(() => '?').join(', ');
       const rows = await this.db.all<ProofRow>(
-        `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret IN (${placeholders})`,
+        `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret IN (${placeholders})`,
         [mintUrl, ...secretBatch],
       );
 
@@ -245,7 +248,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getProofsByOperationId(mintUrl: string, operationId: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND (usedByOperationId = ? OR createdByOperationId = ?)',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND (usedByOperationId = ? OR createdByOperationId = ?)',
       [mintUrl, operationId, operationId],
     );
     return rows.map(rowToProof);
@@ -253,7 +256,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getAvailableProofs(mintUrl: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready' AND usedByOperationId IS NULL",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready' AND usedByOperationId IS NULL",
       [mintUrl],
     );
     return rows.map(rowToProof);
@@ -261,7 +264,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getReservedProofs(): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'ready' AND usedByOperationId IS NOT NULL",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'ready' AND usedByOperationId IS NOT NULL",
     );
     return rows.map(rowToProof);
   }

--- a/packages/sqlite-bun/src/schema.ts
+++ b/packages/sqlite-bun/src/schema.ts
@@ -1140,6 +1140,59 @@ const MIGRATIONS: readonly Migration[] = [
     id: '029_backfill_send_operation_tokens',
     run: backfillSendOperationTokensFromHistory,
   },
+  {
+    id: '030_mint_batch_attempts',
+    run: async (db) => {
+      const proofColumns = await getTableColumns(db, 'coco_cashu_proofs');
+      if (!proofColumns.has('createdByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_proofs ADD COLUMN createdByBatchId TEXT');
+      }
+
+      const mintOperationColumns = await getTableColumns(db, 'coco_cashu_mint_operations');
+      if (!mintOperationColumns.has('batchEligible')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN batchEligible INTEGER');
+      }
+      if (!mintOperationColumns.has('redeemedByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN redeemedByBatchId TEXT');
+      }
+
+      await db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_proofs_createdByBatch
+          ON coco_cashu_proofs(createdByBatchId)
+          WHERE createdByBatchId IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_operations_redeemedByBatch
+          ON coco_cashu_mint_operations(redeemedByBatchId)
+          WHERE redeemedByBatchId IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS coco_cashu_mint_batch_attempts (
+          id TEXT PRIMARY KEY,
+          mintUrl TEXT NOT NULL,
+          method TEXT NOT NULL,
+          unit TEXT NOT NULL,
+          operationIdsJson TEXT NOT NULL,
+          quoteIdsJson TEXT NOT NULL,
+          quoteAmountsJson TEXT NOT NULL,
+          totalAmount TEXT NOT NULL,
+          outputDataJson TEXT NOT NULL,
+          keysetId TEXT NOT NULL,
+          counterStart INTEGER,
+          counterEnd INTEGER,
+          state TEXT NOT NULL CHECK (state IN ('prepared', 'requesting', 'finalized', 'recovering', 'failed')),
+          error TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          requestedAt INTEGER,
+          finalizedAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_state
+          ON coco_cashu_mint_batch_attempts(state);
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_mint
+          ON coco_cashu_mint_batch_attempts(mintUrl);
+      `);
+    },
+  },
 ];
 
 // Export for testing

--- a/packages/sqlite-bun/src/schema.ts
+++ b/packages/sqlite-bun/src/schema.ts
@@ -948,6 +948,59 @@ const MIGRATIONS: readonly Migration[] = [
     id: '024_amount_columns_text',
     run: migrateAmountColumnsToText,
   },
+  {
+    id: '025_mint_batch_attempts',
+    run: async (db) => {
+      const proofColumns = await getTableColumns(db, 'coco_cashu_proofs');
+      if (!proofColumns.has('createdByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_proofs ADD COLUMN createdByBatchId TEXT');
+      }
+
+      const mintOperationColumns = await getTableColumns(db, 'coco_cashu_mint_operations');
+      if (!mintOperationColumns.has('batchEligible')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN batchEligible INTEGER');
+      }
+      if (!mintOperationColumns.has('redeemedByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN redeemedByBatchId TEXT');
+      }
+
+      await db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_proofs_createdByBatch
+          ON coco_cashu_proofs(createdByBatchId)
+          WHERE createdByBatchId IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_operations_redeemedByBatch
+          ON coco_cashu_mint_operations(redeemedByBatchId)
+          WHERE redeemedByBatchId IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS coco_cashu_mint_batch_attempts (
+          id TEXT PRIMARY KEY,
+          mintUrl TEXT NOT NULL,
+          method TEXT NOT NULL,
+          unit TEXT NOT NULL,
+          operationIdsJson TEXT NOT NULL,
+          quoteIdsJson TEXT NOT NULL,
+          quoteAmountsJson TEXT NOT NULL,
+          totalAmount TEXT NOT NULL,
+          outputDataJson TEXT NOT NULL,
+          keysetId TEXT NOT NULL,
+          counterStart INTEGER,
+          counterEnd INTEGER,
+          state TEXT NOT NULL CHECK (state IN ('prepared', 'requesting', 'finalized', 'recovering', 'failed')),
+          error TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          requestedAt INTEGER,
+          finalizedAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_state
+          ON coco_cashu_mint_batch_attempts(state);
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_mint
+          ON coco_cashu_mint_batch_attempts(mintUrl);
+      `);
+    },
+  },
 ];
 
 // Export for testing

--- a/packages/sqlite3/src/index.ts
+++ b/packages/sqlite3/src/index.ts
@@ -12,6 +12,7 @@ import type {
   MintOperationRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { SqliteSendOperationRepository } from './repositories/SendOperationRepos
 import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { SqliteMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 import {
   SqlitePaymentRequestReceiveAttemptRepository,
@@ -48,6 +50,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -66,6 +69,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = new SqliteMeltOperationRepository(this.db);
     this.authSessionRepository = new SqliteAuthSessionRepository(this.db);
     this.mintOperationRepository = new SqliteMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new SqliteMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new SqliteReceiveOperationRepository(this.db);
     this.paymentRequestReceiveOperationRepository =
       new SqlitePaymentRequestReceiveOperationRepository(this.db);
@@ -92,6 +96,7 @@ export class SqliteRepositories implements Repositories {
         meltOperationRepository: new SqliteMeltOperationRepository(txDb),
         authSessionRepository: new SqliteAuthSessionRepository(txDb),
         mintOperationRepository: new SqliteMintOperationRepository(txDb),
+        mintBatchAttemptRepository: new SqliteMintBatchAttemptRepository(txDb),
         receiveOperationRepository: new SqliteReceiveOperationRepository(txDb),
         paymentRequestReceiveOperationRepository:
           new SqlitePaymentRequestReceiveOperationRepository(txDb),
@@ -121,6 +126,7 @@ export {
   SqliteMeltOperationRepository,
   SqliteAuthSessionRepository,
   SqliteMintOperationRepository,
+  SqliteMintBatchAttemptRepository,
   SqliteReceiveOperationRepository,
   SqlitePaymentRequestReceiveOperationRepository,
   SqlitePaymentRequestReceiveAttemptRepository,

--- a/packages/sqlite3/src/index.ts
+++ b/packages/sqlite3/src/index.ts
@@ -11,6 +11,7 @@ import type {
   MeltOperationRepository,
   AuthSessionRepository,
   MintOperationRepository,
+  MintBatchAttemptRepository,
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core';
@@ -28,6 +29,7 @@ import { SqliteSendOperationRepository } from './repositories/SendOperationRepos
 import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { SqliteMintBatchAttemptRepository } from './repositories/MintBatchAttemptRepository.ts';
 import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 
 export interface SqliteRepositoriesOptions extends SqliteDbOptions {}
@@ -45,6 +47,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintBatchAttemptRepository: MintBatchAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly db: SqliteDb;
 
@@ -62,6 +65,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = new SqliteMeltOperationRepository(this.db);
     this.authSessionRepository = new SqliteAuthSessionRepository(this.db);
     this.mintOperationRepository = new SqliteMintOperationRepository(this.db);
+    this.mintBatchAttemptRepository = new SqliteMintBatchAttemptRepository(this.db);
     this.receiveOperationRepository = new SqliteReceiveOperationRepository(this.db);
   }
 
@@ -84,6 +88,7 @@ export class SqliteRepositories implements Repositories {
         meltOperationRepository: new SqliteMeltOperationRepository(txDb),
         authSessionRepository: new SqliteAuthSessionRepository(txDb),
         mintOperationRepository: new SqliteMintOperationRepository(txDb),
+        mintBatchAttemptRepository: new SqliteMintBatchAttemptRepository(txDb),
         receiveOperationRepository: new SqliteReceiveOperationRepository(txDb),
       };
 
@@ -109,6 +114,7 @@ export {
   SqliteMeltOperationRepository,
   SqliteAuthSessionRepository,
   SqliteMintOperationRepository,
+  SqliteMintBatchAttemptRepository,
   SqliteReceiveOperationRepository,
 };
 

--- a/packages/sqlite3/src/repositories/MintBatchAttemptRepository.ts
+++ b/packages/sqlite3/src/repositories/MintBatchAttemptRepository.ts
@@ -1,0 +1,160 @@
+import type {
+  MintBatchAttempt,
+  MintBatchAttemptRepository,
+  MintBatchAttemptState,
+} from '@cashu/coco-core';
+import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core';
+import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+
+interface MintBatchAttemptRow {
+  id: string;
+  mintUrl: string;
+  method: MintBatchAttempt['method'];
+  unit: string;
+  operationIdsJson: string;
+  quoteIdsJson: string;
+  quoteAmountsJson: string;
+  totalAmount: string | number;
+  outputDataJson: string;
+  keysetId: string;
+  counterStart: number | null;
+  counterEnd: number | null;
+  state: MintBatchAttemptState;
+  error: string | null;
+  createdAt: number;
+  updatedAt: number;
+  requestedAt: number | null;
+  finalizedAt: number | null;
+}
+
+const rowToAttempt = (row: MintBatchAttemptRow): MintBatchAttempt => ({
+  id: row.id,
+  mintUrl: row.mintUrl,
+  method: row.method,
+  unit: row.unit,
+  operationIds: JSON.parse(row.operationIdsJson) as string[],
+  quoteIds: JSON.parse(row.quoteIdsJson) as string[],
+  quoteAmounts: (JSON.parse(row.quoteAmountsJson) as Array<string | number>).map(deserializeAmount),
+  totalAmount: deserializeAmount(row.totalAmount),
+  outputData: JSON.parse(row.outputDataJson),
+  keysetId: row.keysetId,
+  ...(row.counterStart !== null ? { counterStart: row.counterStart } : {}),
+  ...(row.counterEnd !== null ? { counterEnd: row.counterEnd } : {}),
+  state: row.state,
+  ...(row.error ? { error: row.error } : {}),
+  createdAt: row.createdAt * 1000,
+  updatedAt: row.updatedAt * 1000,
+  ...(row.requestedAt !== null ? { requestedAt: row.requestedAt * 1000 } : {}),
+  ...(row.finalizedAt !== null ? { finalizedAt: row.finalizedAt * 1000 } : {}),
+});
+
+const attemptToParams = (attempt: MintBatchAttempt): unknown[] => [
+  attempt.id,
+  attempt.mintUrl,
+  attempt.method,
+  attempt.unit,
+  stringifyJson(attempt.operationIds),
+  stringifyJson(attempt.quoteIds),
+  stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+  serializeAmount(attempt.totalAmount),
+  stringifyJson(attempt.outputData),
+  attempt.keysetId,
+  attempt.counterStart ?? null,
+  attempt.counterEnd ?? null,
+  attempt.state,
+  attempt.error ?? null,
+  Math.floor(attempt.createdAt / 1000),
+  Math.floor(attempt.updatedAt / 1000),
+  attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+  attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+];
+
+export class SqliteMintBatchAttemptRepository implements MintBatchAttemptRepository {
+  constructor(private readonly db: SqliteDb) {}
+
+  async create(attempt: MintBatchAttempt): Promise<void> {
+    const exists = await this.db.get<{ id: string }>(
+      'SELECT id FROM coco_cashu_mint_batch_attempts WHERE id = ? LIMIT 1',
+      [attempt.id],
+    );
+    if (exists) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} already exists`);
+    }
+
+    await this.db.run(
+      `INSERT INTO coco_cashu_mint_batch_attempts
+        (id, mintUrl, method, unit, operationIdsJson, quoteIdsJson, quoteAmountsJson, totalAmount, outputDataJson, keysetId, counterStart, counterEnd, state, error, createdAt, updatedAt, requestedAt, finalizedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      attemptToParams(attempt),
+    );
+  }
+
+  async update(attempt: MintBatchAttempt): Promise<void> {
+    const exists = await this.db.get<{ id: string }>(
+      'SELECT id FROM coco_cashu_mint_batch_attempts WHERE id = ? LIMIT 1',
+      [attempt.id],
+    );
+    if (!exists) {
+      throw new Error(`MintBatchAttempt with id ${attempt.id} not found`);
+    }
+
+    await this.db.run(
+      `UPDATE coco_cashu_mint_batch_attempts
+       SET mintUrl = ?, method = ?, unit = ?, operationIdsJson = ?, quoteIdsJson = ?, quoteAmountsJson = ?, totalAmount = ?, outputDataJson = ?, keysetId = ?, counterStart = ?, counterEnd = ?, state = ?, error = ?, updatedAt = ?, requestedAt = ?, finalizedAt = ?
+       WHERE id = ?`,
+      [
+        attempt.mintUrl,
+        attempt.method,
+        attempt.unit,
+        stringifyJson(attempt.operationIds),
+        stringifyJson(attempt.quoteIds),
+        stringifyJson(attempt.quoteAmounts.map(serializeAmount)),
+        serializeAmount(attempt.totalAmount),
+        stringifyJson(attempt.outputData),
+        attempt.keysetId,
+        attempt.counterStart ?? null,
+        attempt.counterEnd ?? null,
+        attempt.state,
+        attempt.error ?? null,
+        getUnixTimeSeconds(),
+        attempt.requestedAt ? Math.floor(attempt.requestedAt / 1000) : null,
+        attempt.finalizedAt ? Math.floor(attempt.finalizedAt / 1000) : null,
+        attempt.id,
+      ],
+    );
+  }
+
+  async getById(id: string): Promise<MintBatchAttempt | null> {
+    const row = await this.db.get<MintBatchAttemptRow>(
+      'SELECT * FROM coco_cashu_mint_batch_attempts WHERE id = ?',
+      [id],
+    );
+    return row ? rowToAttempt(row) : null;
+  }
+
+  async getByState(state: MintBatchAttemptState): Promise<MintBatchAttempt[]> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      'SELECT * FROM coco_cashu_mint_batch_attempts WHERE state = ?',
+      [state],
+    );
+    return rows.map(rowToAttempt);
+  }
+
+  async getByOperationId(operationId: string): Promise<MintBatchAttempt | null> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      "SELECT * FROM coco_cashu_mint_batch_attempts WHERE state IN ('prepared', 'requesting', 'recovering', 'finalized') ORDER BY updatedAt DESC",
+    );
+    return rows.map(rowToAttempt).find((attempt) => attempt.operationIds.includes(operationId)) ?? null;
+  }
+
+  async getPending(): Promise<MintBatchAttempt[]> {
+    const rows = await this.db.all<MintBatchAttemptRow>(
+      "SELECT * FROM coco_cashu_mint_batch_attempts WHERE state IN ('prepared', 'requesting', 'recovering')",
+    );
+    return rows.map(rowToAttempt);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.run('DELETE FROM coco_cashu_mint_batch_attempts WHERE id = ?', [id]);
+  }
+}

--- a/packages/sqlite3/src/repositories/MintOperationRepository.ts
+++ b/packages/sqlite3/src/repositories/MintOperationRepository.ts
@@ -27,6 +27,8 @@ interface MintOperationRow {
   lastObservedRemoteStateAt: number | null;
   terminalFailureJson: string | null;
   outputDataJson: string | null;
+  batchEligible: number | null;
+  redeemedByBatchId: string | null;
 }
 
 const persistedStates = ['pending', 'executing', 'finalized', 'failed'] as const;
@@ -79,7 +81,9 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     pubkey: row.pubkey ?? undefined,
     lastObservedRemoteState: row.lastObservedRemoteState ?? undefined,
     lastObservedRemoteStateAt: row.lastObservedRemoteStateAt ?? undefined,
-    outputData: row.outputDataJson ? JSON.parse(row.outputDataJson) : { keep: [], send: [] },
+    ...(row.outputDataJson ? { outputData: JSON.parse(row.outputDataJson) } : {}),
+    ...(row.batchEligible !== null ? { batchEligible: row.batchEligible === 1 } : {}),
+    ...(row.redeemedByBatchId ? { redeemedByBatchId: row.redeemedByBatchId } : {}),
   } as MintOperation;
 };
 
@@ -108,6 +112,8 @@ const operationToParams = (operation: MintOperation): unknown[] => {
       null,
       operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
       null,
+      null,
+      null,
     ];
   }
 
@@ -129,7 +135,9 @@ const operationToParams = (operation: MintOperation): unknown[] => {
     operation.lastObservedRemoteState ?? null,
     operation.lastObservedRemoteStateAt ?? null,
     operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
-    JSON.stringify(operation.outputData),
+    operation.outputData ? JSON.stringify(operation.outputData) : null,
+    operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+    operation.redeemedByBatchId ?? null,
   ];
 };
 
@@ -152,8 +160,8 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
     const params = operationToParams(operation);
     await this.db.run(
       `INSERT INTO coco_cashu_mint_operations
-        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson, batchEligible, redeemedByBatchId)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       params,
     );
   }
@@ -172,7 +180,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
     if (operation.state === 'init') {
       await this.db.run(
         `UPDATE coco_cashu_mint_operations
-         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?
+         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?, batchEligible = ?, redeemedByBatchId = ?
          WHERE id = ?`,
         [
           operation.quoteId ?? null,
@@ -184,6 +192,8 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
           serializeAmount(operation.amount),
           operation.unit,
           operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
+          null,
+          null,
           operation.id,
         ],
       );
@@ -192,7 +202,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
 
     await this.db.run(
       `UPDATE coco_cashu_mint_operations
-       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?
+       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?, batchEligible = ?, redeemedByBatchId = ?
        WHERE id = ?`,
       [
         operation.quoteId,
@@ -209,7 +219,9 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
         operation.lastObservedRemoteState ?? null,
         operation.lastObservedRemoteStateAt ?? null,
         operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
-        JSON.stringify(operation.outputData),
+        operation.outputData ? JSON.stringify(operation.outputData) : null,
+        operation.batchEligible === undefined ? null : operation.batchEligible ? 1 : 0,
+        operation.redeemedByBatchId ?? null,
         operation.id,
       ],
     );

--- a/packages/sqlite3/src/repositories/ProofRepository.ts
+++ b/packages/sqlite3/src/repositories/ProofRepository.ts
@@ -22,12 +22,13 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByBatchId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
 
 const PROOF_COLUMNS =
-  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId';
+  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId';
 
 function normalizeProofUnit(proof: CoreProof): string {
   return normalizeUnit((proof as { unit?: string }).unit);
@@ -66,6 +67,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -93,7 +95,7 @@ export class SqliteProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByBatchId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of normalizedProofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -110,6 +112,7 @@ export class SqliteProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByBatchId ?? null,
         ]);
       }
     });

--- a/packages/sqlite3/src/repositories/ProofRepository.ts
+++ b/packages/sqlite3/src/repositories/ProofRepository.ts
@@ -18,6 +18,7 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByBatchId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
@@ -37,6 +38,7 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByBatchId ? { createdByBatchId: r.createdByBatchId } : {}),
   };
 }
 
@@ -60,7 +62,7 @@ export class SqliteProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByBatchId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -76,6 +78,7 @@ export class SqliteProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByBatchId ?? null,
         ]);
       }
     });
@@ -83,7 +86,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getReadyProofs(mintUrl: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready'",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready'",
       [mintUrl],
     );
     return rows.map(rowToProof);
@@ -92,7 +95,7 @@ export class SqliteProofRepository implements ProofRepository {
   async getInflightProofs(mintUrls?: string[]): Promise<CoreProof[]> {
     if (!mintUrls || mintUrls.length === 0) {
       const rows = await this.db.all<ProofRow>(
-        "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'inflight'",
+        "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'inflight'",
       );
       return rows.map(rowToProof);
     }
@@ -101,7 +104,7 @@ export class SqliteProofRepository implements ProofRepository {
     const uniqueMintUrls = Array.from(new Set(mintUrlList));
     const placeholders = uniqueMintUrls.map(() => '?').join(', ');
     const rows = await this.db.all<ProofRow>(
-      `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'inflight' AND mintUrl IN (${placeholders})`,
+      `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'inflight' AND mintUrl IN (${placeholders})`,
       uniqueMintUrls,
     );
     return rows.map(rowToProof);
@@ -109,14 +112,14 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getAllReadyProofs(): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'ready'",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'ready'",
     );
     return rows.map(rowToProof);
   }
 
   async getProofsByKeysetId(mintUrl: string, keysetId: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = 'ready'",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = 'ready'",
       [mintUrl, keysetId],
     );
     return rows.map(rowToProof);
@@ -210,7 +213,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getProofBySecret(mintUrl: string, secret: string): Promise<CoreProof | null> {
     const row = await this.db.get<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?',
       [mintUrl, secret],
     );
     return row ? rowToProof(row) : null;
@@ -228,7 +231,7 @@ export class SqliteProofRepository implements ProofRepository {
       const secretBatch = uniqueSecrets.slice(i, i + MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE);
       const placeholders = secretBatch.map(() => '?').join(', ');
       const rows = await this.db.all<ProofRow>(
-        `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret IN (${placeholders})`,
+        `SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND secret IN (${placeholders})`,
         [mintUrl, ...secretBatch],
       );
 
@@ -245,7 +248,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getProofsByOperationId(mintUrl: string, operationId: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND (usedByOperationId = ? OR createdByOperationId = ?)',
+      'SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND (usedByOperationId = ? OR createdByOperationId = ?)',
       [mintUrl, operationId, operationId],
     );
     return rows.map(rowToProof);
@@ -253,7 +256,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getAvailableProofs(mintUrl: string): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready' AND usedByOperationId IS NULL",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready' AND usedByOperationId IS NULL",
       [mintUrl],
     );
     return rows.map(rowToProof);
@@ -261,7 +264,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getReservedProofs(): Promise<CoreProof[]> {
     const rows = await this.db.all<ProofRow>(
-      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId FROM coco_cashu_proofs WHERE state = 'ready' AND usedByOperationId IS NOT NULL",
+      "SELECT mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByBatchId FROM coco_cashu_proofs WHERE state = 'ready' AND usedByOperationId IS NOT NULL",
     );
     return rows.map(rowToProof);
   }

--- a/packages/sqlite3/src/schema.ts
+++ b/packages/sqlite3/src/schema.ts
@@ -1140,6 +1140,59 @@ const MIGRATIONS: readonly Migration[] = [
     id: '029_backfill_send_operation_tokens',
     run: backfillSendOperationTokensFromHistory,
   },
+  {
+    id: '030_mint_batch_attempts',
+    run: async (db) => {
+      const proofColumns = await getTableColumns(db, 'coco_cashu_proofs');
+      if (!proofColumns.has('createdByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_proofs ADD COLUMN createdByBatchId TEXT');
+      }
+
+      const mintOperationColumns = await getTableColumns(db, 'coco_cashu_mint_operations');
+      if (!mintOperationColumns.has('batchEligible')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN batchEligible INTEGER');
+      }
+      if (!mintOperationColumns.has('redeemedByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN redeemedByBatchId TEXT');
+      }
+
+      await db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_proofs_createdByBatch
+          ON coco_cashu_proofs(createdByBatchId)
+          WHERE createdByBatchId IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_operations_redeemedByBatch
+          ON coco_cashu_mint_operations(redeemedByBatchId)
+          WHERE redeemedByBatchId IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS coco_cashu_mint_batch_attempts (
+          id TEXT PRIMARY KEY,
+          mintUrl TEXT NOT NULL,
+          method TEXT NOT NULL,
+          unit TEXT NOT NULL,
+          operationIdsJson TEXT NOT NULL,
+          quoteIdsJson TEXT NOT NULL,
+          quoteAmountsJson TEXT NOT NULL,
+          totalAmount TEXT NOT NULL,
+          outputDataJson TEXT NOT NULL,
+          keysetId TEXT NOT NULL,
+          counterStart INTEGER,
+          counterEnd INTEGER,
+          state TEXT NOT NULL CHECK (state IN ('prepared', 'requesting', 'finalized', 'recovering', 'failed')),
+          error TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          requestedAt INTEGER,
+          finalizedAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_state
+          ON coco_cashu_mint_batch_attempts(state);
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_mint
+          ON coco_cashu_mint_batch_attempts(mintUrl);
+      `);
+    },
+  },
 ];
 
 // Export for testing

--- a/packages/sqlite3/src/schema.ts
+++ b/packages/sqlite3/src/schema.ts
@@ -948,6 +948,59 @@ const MIGRATIONS: readonly Migration[] = [
     id: '024_amount_columns_text',
     run: migrateAmountColumnsToText,
   },
+  {
+    id: '025_mint_batch_attempts',
+    run: async (db) => {
+      const proofColumns = await getTableColumns(db, 'coco_cashu_proofs');
+      if (!proofColumns.has('createdByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_proofs ADD COLUMN createdByBatchId TEXT');
+      }
+
+      const mintOperationColumns = await getTableColumns(db, 'coco_cashu_mint_operations');
+      if (!mintOperationColumns.has('batchEligible')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN batchEligible INTEGER');
+      }
+      if (!mintOperationColumns.has('redeemedByBatchId')) {
+        await db.run('ALTER TABLE coco_cashu_mint_operations ADD COLUMN redeemedByBatchId TEXT');
+      }
+
+      await db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_proofs_createdByBatch
+          ON coco_cashu_proofs(createdByBatchId)
+          WHERE createdByBatchId IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_operations_redeemedByBatch
+          ON coco_cashu_mint_operations(redeemedByBatchId)
+          WHERE redeemedByBatchId IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS coco_cashu_mint_batch_attempts (
+          id TEXT PRIMARY KEY,
+          mintUrl TEXT NOT NULL,
+          method TEXT NOT NULL,
+          unit TEXT NOT NULL,
+          operationIdsJson TEXT NOT NULL,
+          quoteIdsJson TEXT NOT NULL,
+          quoteAmountsJson TEXT NOT NULL,
+          totalAmount TEXT NOT NULL,
+          outputDataJson TEXT NOT NULL,
+          keysetId TEXT NOT NULL,
+          counterStart INTEGER,
+          counterEnd INTEGER,
+          state TEXT NOT NULL CHECK (state IN ('prepared', 'requesting', 'finalized', 'recovering', 'failed')),
+          error TEXT,
+          createdAt INTEGER NOT NULL,
+          updatedAt INTEGER NOT NULL,
+          requestedAt INTEGER,
+          finalizedAt INTEGER
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_state
+          ON coco_cashu_mint_batch_attempts(state);
+        CREATE INDEX IF NOT EXISTS idx_coco_cashu_mint_batch_attempts_mint
+          ON coco_cashu_mint_batch_attempts(mintUrl);
+      `);
+    },
+  },
 ];
 
 // Export for testing

--- a/scripts/auth_mint/docker-compose.yml
+++ b/scripts/auth_mint/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   mint:
     container_name: coco-auth-mint
-    image: cashubtc/mintd:0.15.2-test-static-4
+    image: cashubtc/mintd:v0.16.0
     command: >
       sh -c "
         echo 'Waiting for Keycloak...' &&

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -162,7 +162,7 @@ start_mint_container() {
             -p "${port}:3338" \
             --name "$container_name" \
             -v "${config_file}:/config/config.toml:ro" \
-            cashubtc/mintd:0.15.1 \
+            cashubtc/mintd:v0.16.0 \
             sh -c "cdk-mintd -c /config/config.toml"
     else
         # Start new container
@@ -177,7 +177,7 @@ start_mint_container() {
             -e CDK_MINTD_FAKE_WALLET_MIN_DELAY=0 \
             -e CDK_MINTD_FAKE_WALLET_MAX_DELAY=0 \
             -e CDK_MINTD_MNEMONIC='abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about' \
-            cashubtc/mintd:0.15.1
+            cashubtc/mintd:v0.16.0
     fi
 
     # Wait for mint to be ready

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -115,7 +115,7 @@ start_mint_container() {
         -e CDK_MINTD_FAKE_WALLET_MIN_DELAY=0 \
         -e CDK_MINTD_FAKE_WALLET_MAX_DELAY=0 \
         -e CDK_MINTD_MNEMONIC='abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about' \
-        cashubtc/mintd:0.15.1
+        cashubtc/mintd:v0.16.0
 
     # Wait for mint to be ready
     log_info "Waiting for mint to be ready..."


### PR DESCRIPTION
This pull request adds output-deferred single minting and optimized BOLT11 batch mint finalization for NUT-29-capable mints.

## Problem

Preparing output data at quote creation prevents multiple paid quotes from being combined into better denomination splits. That keeps single 23-sat quotes at `16,4,2,1` each, instead of allowing three quotes to mint as `64,4,1`.

## Summary

- Moves single mint output-data creation to execution, persisted before calling the mint.
- Adds batch attempt persistence and recovery metadata across core and storage adapters.
- Adds a shared SQLite-backed integration test proving three 23-sat quotes mint into 3 consolidated proofs.
- Updates the integration mint image to `cashubtc/mintd:v0.16.0`.
- Adds `.changeset/batch-minting.md`.

## Verification

- `bun --cwd packages/adapter-tests typecheck`
- `bun --cwd packages/core typecheck`
- `bun --cwd packages/core test:unit`
- `bun --cwd packages/sqlite3 typecheck`
- `bun --cwd packages/sqlite-bun typecheck`
- `bun --cwd packages/expo-sqlite typecheck`
- `bun --cwd packages/indexeddb typecheck`
- `./scripts/test-integration.sh sqlite3`
- targeted batch integration for `sqlite3`, `sqlite-bun`, and `expo-sqlite`

IndexedDB browser integration was skipped because Playwright does not work on this system.

## Changeset

- Added `.changeset/batch-minting.md`.