### PR TITLE
fix(core): avoid duplicate proof state polling batches

### DIFF
--- a/.changeset/unique-proof-state-batches.md
+++ b/.changeset/unique-proof-state-batches.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Avoid duplicate proof state entries in polling fallback `/checkstate` requests.

--- a/packages/core/infra/PollingTransport.ts
+++ b/packages/core/infra/PollingTransport.ts
@@ -317,13 +317,20 @@ export class PollingTransport implements RealTimeTransport {
       if (queue.length === 0 || yToSubs.size === 0) return;
 
       const selected: string[] = [];
-      // Pull up to 100 Ys in round robin
-      while (selected.length < 100 && queue.length > 0) {
+      const selectedSet = new Set<string>();
+      let remaining = queue.length;
+      // Pull up to 100 unique Ys in round robin.
+      while (selected.length < 100 && remaining > 0 && queue.length > 0) {
+        remaining--;
         const y = queue.shift()!;
         const subs = yToSubs.get(y);
-        if (subs && subs.size > 0) {
+        if (subs && subs.size > 0 && !selectedSet.has(y)) {
           selected.push(y);
+          selectedSet.add(y);
           queue.push(y); // rotate for fairness
+        } else if (subs && subs.size > 0) {
+          // Drop duplicate queue entries while keeping the rotated selected entry.
+          continue;
         } else {
           // drop stale y (no subscribers)
           const set = this.proofSetByMint.get(mintUrl);

--- a/packages/core/test/unit/PollingTransport.test.ts
+++ b/packages/core/test/unit/PollingTransport.test.ts
@@ -89,6 +89,66 @@ describe('PollingTransport per-mint intervals', () => {
   });
 });
 
+describe('PollingTransport proof state batching', () => {
+  const mintUrl = 'https://mint.example.com';
+
+  it('does not duplicate a single watched proof in the checkstate request', async () => {
+    const checkProofStates = mock((_: string, ys: string[]) =>
+      Promise.resolve(ys.map((Y) => ({ Y, state: 'UNSPENT' }))),
+    );
+    const adapter = {
+      checkMintQuoteState: mock(() => Promise.resolve({})),
+      checkMeltQuoteState: mock(() => Promise.resolve({})),
+      checkProofStates,
+    } as unknown as MintAdapter;
+    const transport = new PollingTransport(adapter, { intervalMs: 5000 }, new NullLogger());
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.send(mintUrl, {
+      jsonrpc: '2.0',
+      method: 'subscribe',
+      params: { kind: 'proof_state', subId: 'proof-sub-1', filters: ['y-single'] },
+      id: 1,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(checkProofStates).toHaveBeenCalledTimes(1);
+    expect(checkProofStates.mock.calls[0]?.[1]).toEqual(['y-single']);
+
+    transport.closeAll();
+  });
+
+  it('caps proof state batches at 100 unique Ys', async () => {
+    const checkProofStates = mock((_: string, ys: string[]) =>
+      Promise.resolve(ys.map((Y) => ({ Y, state: 'UNSPENT' }))),
+    );
+    const adapter = {
+      checkMintQuoteState: mock(() => Promise.resolve({})),
+      checkMeltQuoteState: mock(() => Promise.resolve({})),
+      checkProofStates,
+    } as unknown as MintAdapter;
+    const transport = new PollingTransport(adapter, { intervalMs: 5000 }, new NullLogger());
+    const filters = Array.from({ length: 150 }, (_, index) => `y-${index}`);
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.send(mintUrl, {
+      jsonrpc: '2.0',
+      method: 'subscribe',
+      params: { kind: 'proof_state', subId: 'proof-sub-2', filters },
+      id: 1,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const ys = checkProofStates.mock.calls[0]?.[1] ?? [];
+    expect(ys).toHaveLength(100);
+    expect(new Set(ys).size).toBe(100);
+
+    transport.closeAll();
+  });
+});
+
 describe('PollingTransport unsubscribe during processing', () => {
   const mintUrl = 'https://mint.example.com';
 


### PR DESCRIPTION
## Summary
- Keep polling fallback proof-state `/checkstate` requests unique per batch while preserving round-robin queue rotation.
- Add unit coverage for the single watched-proof case that previously repeated the same `Y` up to 100 times.
- Add a patch changeset for `@cashu/coco-core`.

## Verification
- `bun run --filter='@cashu/coco-core' test -- test/unit/PollingTransport.test.ts`
- `bun run --filter='@cashu/coco-core' build`
- `git diff --check`

Note: `bun run --filter='@cashu/coco-core' typecheck` still fails on pre-existing integration-test typing errors unrelated to this patch.