### PR TITLE
fix(core): prevent double JSON encoding of  p2pk witness

### DIFF
--- a/.changeset/few-parks-return.md
+++ b/.changeset/few-parks-return.md
@@ -1,0 +1,9 @@
+---
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-core': patch
+---
+
+fix: prevent double JSON encoding of P2PK witness. KeyRingService now returns witness as object instead of string. ProofRepository checks type before JSON.stringify to prevent double-encoding. Fixes P2PK signature verification failure.

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -1,11 +1,11 @@
 import type { Proof } from '@cashu/cashu-ts';
 import type { Logger } from '@core/logging';
-import type { KeyRingRepository } from '@core/repositories';
 import type { Keypair } from '@core/models/Keypair';
+import type { KeyRingRepository } from '@core/repositories';
+import type { SeedService } from '@core/services/SeedService.ts';
 import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
-import type { SeedService } from '@core/services/SeedService.ts';
 import { HDKey } from '@scure/bip32';
 
 export class KeyRingService {
@@ -94,7 +94,7 @@ export class KeyRingService {
     const signature = schnorr.sign(sha256(message), keyPair.secretKey);
     const signedProof = {
       ...proof,
-      witness: JSON.stringify({ signatures: [bytesToHex(signature)] }),
+      witness: { signatures: [bytesToHex(signature)] },
     };
     this.logger?.debug('Proof signed successfully', { publicKey });
     return signedProof;

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -1,11 +1,11 @@
+import type { Proof } from '@cashu/cashu-ts';
 import { Amount } from '@cashu/cashu-ts';
-import { describe, it, beforeEach, expect } from 'bun:test';
+import { schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/curves/utils.js';
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { MemoryKeyRingRepository } from '../../repositories/memory/MemoryKeyRingRepository.ts';
 import { KeyRingService } from '../../services/KeyRingService.ts';
 import { SeedService } from '../../services/SeedService.ts';
-import { MemoryKeyRingRepository } from '../../repositories/memory/MemoryKeyRingRepository.ts';
-import { bytesToHex } from '@noble/curves/utils.js';
-import { schnorr } from '@noble/curves/secp256k1.js';
-import type { Proof } from '@cashu/cashu-ts';
 
 // Mock seed for deterministic testing
 const MOCK_SEED = new Uint8Array(64);
@@ -343,9 +343,9 @@ describe('KeyRingService', () => {
       const signed = await service.signProof(proof, kp.publicKeyHex);
 
       expect(signed.witness).toBeDefined();
-      expect(typeof signed.witness).toBe('string');
+      expect(typeof signed.witness).toBe('object');
 
-      const witness = JSON.parse(signed.witness as string);
+      const witness = signed.witness as any;
       expect(witness.signatures).toBeDefined();
       expect(Array.isArray(witness.signatures)).toBe(true);
       expect(witness.signatures.length).toBe(1);
@@ -382,7 +382,7 @@ describe('KeyRingService', () => {
       const signed = await service.signProof(proof, kp.publicKeyHex);
 
       // Verify the signature is valid
-      const witness = JSON.parse(signed.witness as string);
+      const witness = signed.witness as any;
       const signatureHex = witness.signatures[0];
       const signatureBytes = new Uint8Array(
         signatureHex.match(/.{2}/g)!.map((byte: string) => parseInt(byte, 16)),

--- a/packages/expo-sqlite/src/repositories/ProofRepository.ts
+++ b/packages/expo-sqlite/src/repositories/ProofRepository.ts
@@ -63,7 +63,11 @@ export class ExpoProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-         const witnessJson = p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null;
+        const witnessJson = p.witness
+          ? typeof p.witness === 'string'
+            ? p.witness
+            : JSON.stringify(p.witness)
+          : null;
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/expo-sqlite/src/repositories/ProofRepository.ts
+++ b/packages/expo-sqlite/src/repositories/ProofRepository.ts
@@ -1,8 +1,8 @@
 import {
   deserializeAmount,
   serializeAmount,
-  type ProofRepository,
   type CoreProof,
+  type ProofRepository,
   type ProofState,
 } from '@cashu/coco-core';
 import { ExpoSqliteDb, getUnixTimeSeconds } from '../db.ts';
@@ -63,7 +63,7 @@ export class ExpoProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
+         const witnessJson = p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null;
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/indexeddb/src/repositories/ProofRepository.ts
+++ b/packages/indexeddb/src/repositories/ProofRepository.ts
@@ -46,7 +46,11 @@ export class IdbProofRepository implements ProofRepository {
           secret: p.secret,
           C: p.C,
           dleqJson: p.dleq ? JSON.stringify(p.dleq) : null,
-         witness: p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null,
+          witness: p.witness
+            ? typeof p.witness === 'string'
+              ? p.witness
+              : JSON.stringify(p.witness)
+            : null,
           state: p.state,
           createdAt: now,
           usedByOperationId: p.usedByOperationId ?? null,

--- a/packages/indexeddb/src/repositories/ProofRepository.ts
+++ b/packages/indexeddb/src/repositories/ProofRepository.ts
@@ -1,4 +1,4 @@
-import type { ProofRepository, CoreProof, ProofState } from '@cashu/coco-core';
+import type { CoreProof, ProofRepository, ProofState } from '@cashu/coco-core';
 import { deserializeAmount, serializeAmount } from '@cashu/coco-core';
 import type { IdbDb, ProofRow } from '../lib/db.ts';
 
@@ -46,7 +46,7 @@ export class IdbProofRepository implements ProofRepository {
           secret: p.secret,
           C: p.C,
           dleqJson: p.dleq ? JSON.stringify(p.dleq) : null,
-          witness: p.witness ? JSON.stringify(p.witness) : null,
+         witness: p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null,
           state: p.state,
           createdAt: now,
           usedByOperationId: p.usedByOperationId ?? null,

--- a/packages/sqlite-bun/src/repositories/ProofRepository.ts
+++ b/packages/sqlite-bun/src/repositories/ProofRepository.ts
@@ -1,8 +1,8 @@
 import {
   deserializeAmount,
   serializeAmount,
-  type ProofRepository,
   type CoreProof,
+  type ProofRepository,
   type ProofState,
 } from '@cashu/coco-core';
 import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
@@ -63,7 +63,7 @@ export class SqliteProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
+         const witnessJson = p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null;
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/sqlite-bun/src/repositories/ProofRepository.ts
+++ b/packages/sqlite-bun/src/repositories/ProofRepository.ts
@@ -63,7 +63,11 @@ export class SqliteProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-         const witnessJson = p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null;
+        const witnessJson = p.witness
+          ? typeof p.witness === 'string'
+            ? p.witness
+            : JSON.stringify(p.witness)
+          : null;
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/sqlite3/src/repositories/ProofRepository.ts
+++ b/packages/sqlite3/src/repositories/ProofRepository.ts
@@ -63,7 +63,11 @@ export class SqliteProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null;
+        const witnessJson = p.witness
+          ? typeof p.witness === 'string'
+            ? p.witness
+            : JSON.stringify(p.witness)
+          : null;
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/sqlite3/src/repositories/ProofRepository.ts
+++ b/packages/sqlite3/src/repositories/ProofRepository.ts
@@ -1,8 +1,8 @@
 import {
   deserializeAmount,
   serializeAmount,
-  type ProofRepository,
   type CoreProof,
+  type ProofRepository,
   type ProofState,
 } from '@cashu/coco-core';
 import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
@@ -63,7 +63,7 @@ export class SqliteProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
+        const witnessJson = p.witness ? (typeof p.witness === 'string' ? p.witness : JSON.stringify(p.witness)) : null;
         await tx.run(insertSql, [
           mintUrl,
           p.id,


### PR DESCRIPTION
- KeyRingService returns witness as object (not string)
- ProofRepository checks type before JSON.stringify
- Fix triple-encoded witness breaking P2PK token verification Affected packages: core, sqlite3, sqlite-bun, expo-sqlite, indexeddb

This PR resoves #168 