### PR TITLE
fix: normalize P2PK witness encoding

### DIFF
--- a/.changeset/fix-p2pk-witness-encoding.md
+++ b/.changeset/fix-p2pk-witness-encoding.md
@@ -1,0 +1,9 @@
+---
+'@cashu/coco-core': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-indexeddb': patch
+---
+
+Fix P2PK proof witness encoding so signed proofs do not produce nested JSON strings.

--- a/bun.lock
+++ b/bun.lock
@@ -17,22 +17,22 @@
     },
     "packages/adapter-tests": {
       "name": "@cashu/coco-adapter-tests",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "fake-bolt11": "^0.1.0",
       },
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.5",
+        "@cashu/coco-core": "1.0.0",
       },
       "peerDependencies": {
         "@cashu/cashu-ts": "^3.3.0",
-        "@cashu/coco-core": "^1.0.0-rc.5",
+        "@cashu/coco-core": "^1.0.0",
         "typescript": "^5",
       },
     },
     "packages/core": {
       "name": "@cashu/coco-core",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "@cashu/cashu-ts": "^3.5.0",
         "@noble/curves": "^2.0.1",
@@ -40,7 +40,7 @@
         "@scure/bip32": "^2.0.1",
       },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
+        "@cashu/coco-adapter-tests": "1.0.0",
         "typescript-eslint": "^8.40.0",
       },
       "peerDependencies": {
@@ -55,7 +55,7 @@
     },
     "packages/expo-sqlite": {
       "name": "@cashu/coco-expo-sqlite",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0-rc.2",
       },
@@ -67,7 +67,7 @@
     },
     "packages/indexeddb": {
       "name": "@cashu/coco-indexeddb",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "dexie": "^4.0.8",
       },
@@ -84,9 +84,9 @@
     },
     "packages/react": {
       "name": "@cashu/coco-react",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.5",
+        "@cashu/coco-core": "1.0.0",
         "@eslint/js": "^9.33.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.10",
@@ -105,13 +105,13 @@
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.5",
+        "@cashu/coco-core": "1.0.0",
         "react": "^19",
       },
     },
     "packages/sqlite-bun": {
       "name": "@cashu/coco-sqlite-bun",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0-rc.2",
       },
@@ -122,7 +122,7 @@
     },
     "packages/sqlite3": {
       "name": "@cashu/coco-sqlite",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
       },

--- a/packages/core/repositories/ProofWitnessSerialization.ts
+++ b/packages/core/repositories/ProofWitnessSerialization.ts
@@ -1,0 +1,39 @@
+import type { Proof } from '@cashu/cashu-ts';
+
+type ProofWitness = NonNullable<Proof['witness']>;
+
+function normalizeWitnessValue(value: unknown): Proof['witness'] {
+  if (!value) {
+    return undefined;
+  }
+
+  let normalized = value;
+  let lastString = typeof value === 'string' ? value : undefined;
+  while (typeof normalized === 'string') {
+    lastString = normalized;
+    try {
+      normalized = JSON.parse(normalized);
+    } catch {
+      return normalized;
+    }
+  }
+
+  if (normalized && typeof normalized === 'object') {
+    return normalized as ProofWitness;
+  }
+
+  return lastString;
+}
+
+export function normalizeProofWitness(witness: Proof['witness']): Proof['witness'] {
+  return normalizeWitnessValue(witness);
+}
+
+export function stringifyProofWitness(witness: Proof['witness']): string | null {
+  const normalized = normalizeProofWitness(witness);
+  return normalized ? JSON.stringify(normalized) : null;
+}
+
+export function parsePersistedProofWitness(witnessJson: string | null): Proof['witness'] {
+  return normalizeWitnessValue(witnessJson);
+}

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -23,6 +23,12 @@ import type { Mint } from '../models/Mint';
 import type { SendOperation, SendOperationState } from '../operations/send/SendOperation';
 import type { CoreProof, ProofState } from '../types';
 
+export {
+  normalizeProofWitness,
+  parsePersistedProofWitness,
+  stringifyProofWitness,
+} from './ProofWitnessSerialization.ts';
+
 export interface MintRepository {
   isTrustedMint(mintUrl: string): Promise<boolean>;
   getMintByUrl(mintUrl: string): Promise<Mint>;

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -94,7 +94,7 @@ export class KeyRingService {
     const signature = schnorr.sign(sha256(message), keyPair.secretKey);
     const signedProof = {
       ...proof,
-      witness: JSON.stringify({ signatures: [bytesToHex(signature)] }),
+      witness: { signatures: [bytesToHex(signature)] },
     };
     this.logger?.debug('Proof signed successfully', { publicKey });
     return signedProof;

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -4,7 +4,7 @@ import { SeedService } from '../../services/SeedService.ts';
 import { MemoryKeyRingRepository } from '../../repositories/memory/MemoryKeyRingRepository.ts';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { schnorr } from '@noble/curves/secp256k1.js';
-import type { Proof } from '@cashu/cashu-ts';
+import { getDecodedToken, getEncodedToken, type Proof } from '@cashu/cashu-ts';
 
 // Mock seed for deterministic testing
 const MOCK_SEED = new Uint8Array(64);
@@ -342,14 +342,18 @@ describe('KeyRingService', () => {
       const signed = await service.signProof(proof, kp.publicKeyHex);
 
       expect(signed.witness).toBeDefined();
-      expect(typeof signed.witness).toBe('string');
+      expect(typeof signed.witness).toBe('object');
 
-      const witness = JSON.parse(signed.witness as string);
-      expect(witness.signatures).toBeDefined();
-      expect(Array.isArray(witness.signatures)).toBe(true);
-      expect(witness.signatures.length).toBe(1);
-      expect(typeof witness.signatures[0]).toBe('string');
-      expect(witness.signatures[0].length).toBe(128); // 64 bytes * 2 for hex
+      const witness = signed.witness as { signatures?: string[] };
+      const signatures = witness.signatures;
+      expect(signatures).toBeDefined();
+      expect(Array.isArray(signatures)).toBe(true);
+      if (!signatures) {
+        throw new Error('Expected witness signatures');
+      }
+      expect(signatures.length).toBe(1);
+      expect(typeof signatures[0]).toBe('string');
+      expect(signatures[0]?.length).toBe(128); // 64 bytes * 2 for hex
     });
 
     it('does not mutate the original proof', async () => {
@@ -381,8 +385,11 @@ describe('KeyRingService', () => {
       const signed = await service.signProof(proof, kp.publicKeyHex);
 
       // Verify the signature is valid
-      const witness = JSON.parse(signed.witness as string);
+      const witness = signed.witness as { signatures: string[] };
       const signatureHex = witness.signatures[0];
+      if (!signatureHex) {
+        throw new Error('Expected witness signature');
+      }
       const signatureBytes = new Uint8Array(
         signatureHex.match(/.{2}/g)!.map((byte: string) => parseInt(byte, 16)),
       );
@@ -399,6 +406,34 @@ describe('KeyRingService', () => {
       // We can't easily verify without the public key in the right format,
       // but we can verify the signature structure is correct
       expect(signatureBytes.length).toBe(64);
+    });
+
+    it('encodes signed proof witnesses without nested JSON strings', async () => {
+      const kp = await service.generateNewKeyPair();
+
+      const proof: Proof = {
+        id: '009a1f2b3c4d5e6f',
+        amount: 64,
+        secret: 'my-secret-string',
+        C: '02abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      };
+
+      const signed = await service.signProof(proof, kp.publicKeyHex);
+      const encodedToken = getEncodedToken({
+        mint: 'https://mint.test',
+        proofs: [signed],
+        unit: 'sat',
+      });
+      const decoded = getDecodedToken(encodedToken);
+
+      const decodedWitness = decoded.proofs[0]?.witness;
+      expect(typeof decodedWitness).toBe('string');
+
+      const parsedWitness = JSON.parse(decodedWitness as string);
+      expect(typeof parsedWitness).toBe('object');
+      expect(parsedWitness.signatures).toEqual(
+        (signed.witness as { signatures: string[] }).signatures,
+      );
     });
 
     it('throws when keypair not found', async () => {

--- a/packages/core/test/unit/ProofWitnessSerialization.test.ts
+++ b/packages/core/test/unit/ProofWitnessSerialization.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  normalizeProofWitness,
+  parsePersistedProofWitness,
+  stringifyProofWitness,
+} from '../../repositories/ProofWitnessSerialization.ts';
+
+describe('ProofWitnessSerialization', () => {
+  const witness = {
+    signatures: ['abc123'],
+  };
+  const witnessJson = JSON.stringify(witness);
+  const doubleEncodedWitnessJson = JSON.stringify(witnessJson);
+
+  it('stores object witnesses as one JSON object layer', () => {
+    expect(stringifyProofWitness(witness)).toBe(witnessJson);
+  });
+
+  it('normalizes JSON string witnesses before storing', () => {
+    expect(stringifyProofWitness(witnessJson)).toBe(witnessJson);
+  });
+
+  it('normalizes legacy double-encoded persisted witnesses', () => {
+    expect(parsePersistedProofWitness(doubleEncodedWitnessJson)).toEqual(witness);
+  });
+
+  it('leaves non-JSON string witnesses round-trippable', () => {
+    expect(stringifyProofWitness('mock-signature')).toBe('"mock-signature"');
+    expect(parsePersistedProofWitness('"mock-signature"')).toBe('mock-signature');
+  });
+
+  it('normalizes nested JSON string witnesses', () => {
+    expect(normalizeProofWitness(doubleEncodedWitnessJson)).toEqual(witness);
+  });
+});

--- a/packages/expo-sqlite/src/repositories/ProofRepository.ts
+++ b/packages/expo-sqlite/src/repositories/ProofRepository.ts
@@ -1,4 +1,10 @@
-import type { ProofRepository, CoreProof, ProofState } from '@cashu/coco-core';
+import {
+  parsePersistedProofWitness,
+  stringifyProofWitness,
+  type ProofRepository,
+  type CoreProof,
+  type ProofState,
+} from '@cashu/coco-core';
 import { ExpoSqliteDb, getUnixTimeSeconds } from '../db.ts';
 
 interface ProofRow {
@@ -23,7 +29,7 @@ function rowToProof(r: ProofRow): CoreProof {
     secret: r.secret,
     C: r.C,
     ...(r.dleqJson ? { dleq: JSON.parse(r.dleqJson) } : {}),
-    ...(r.witnessJson ? { witness: JSON.parse(r.witnessJson) } : {}),
+    ...(r.witnessJson ? { witness: parsePersistedProofWitness(r.witnessJson) } : {}),
   };
   return {
     ...base,
@@ -57,7 +63,7 @@ export class ExpoProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
+        const witnessJson = stringifyProofWitness(p.witness);
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/indexeddb/src/repositories/ProofRepository.ts
+++ b/packages/indexeddb/src/repositories/ProofRepository.ts
@@ -1,4 +1,10 @@
-import type { ProofRepository, CoreProof, ProofState } from '@cashu/coco-core';
+import {
+  parsePersistedProofWitness,
+  stringifyProofWitness,
+  type ProofRepository,
+  type CoreProof,
+  type ProofState,
+} from '@cashu/coco-core';
 import type { IdbDb, ProofRow } from '../lib/db.ts';
 
 function rowToProof(r: ProofRow): CoreProof {
@@ -8,7 +14,7 @@ function rowToProof(r: ProofRow): CoreProof {
     secret: r.secret,
     C: r.C,
     ...(r.dleqJson ? { dleq: JSON.parse(r.dleqJson) } : {}),
-    ...(r.witness ? { witness: JSON.parse(r.witness) } : {}),
+    ...(r.witness ? { witness: parsePersistedProofWitness(r.witness) } : {}),
   };
   return {
     ...base,
@@ -45,7 +51,7 @@ export class IdbProofRepository implements ProofRepository {
           secret: p.secret,
           C: p.C,
           dleqJson: p.dleq ? JSON.stringify(p.dleq) : null,
-          witness: p.witness ? JSON.stringify(p.witness) : null,
+          witness: stringifyProofWitness(p.witness),
           state: p.state,
           createdAt: now,
           usedByOperationId: p.usedByOperationId ?? null,

--- a/packages/sqlite-bun/src/repositories/ProofRepository.ts
+++ b/packages/sqlite-bun/src/repositories/ProofRepository.ts
@@ -1,4 +1,10 @@
-import type { ProofRepository, CoreProof, ProofState } from '@cashu/coco-core';
+import {
+  parsePersistedProofWitness,
+  stringifyProofWitness,
+  type ProofRepository,
+  type CoreProof,
+  type ProofState,
+} from '@cashu/coco-core';
 import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
 
 interface ProofRow {
@@ -23,7 +29,7 @@ function rowToProof(r: ProofRow): CoreProof {
     secret: r.secret,
     C: r.C,
     ...(r.dleqJson ? { dleq: JSON.parse(r.dleqJson) } : {}),
-    ...(r.witnessJson ? { witness: JSON.parse(r.witnessJson) } : {}),
+    ...(r.witnessJson ? { witness: parsePersistedProofWitness(r.witnessJson) } : {}),
   };
   return {
     ...base,
@@ -57,7 +63,7 @@ export class SqliteProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
+        const witnessJson = stringifyProofWitness(p.witness);
         await tx.run(insertSql, [
           mintUrl,
           p.id,

--- a/packages/sqlite3/src/repositories/ProofRepository.ts
+++ b/packages/sqlite3/src/repositories/ProofRepository.ts
@@ -1,4 +1,10 @@
-import type { ProofRepository, CoreProof, ProofState } from '@cashu/coco-core';
+import {
+  parsePersistedProofWitness,
+  stringifyProofWitness,
+  type ProofRepository,
+  type CoreProof,
+  type ProofState,
+} from '@cashu/coco-core';
 import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
 
 interface ProofRow {
@@ -23,7 +29,7 @@ function rowToProof(r: ProofRow): CoreProof {
     secret: r.secret,
     C: r.C,
     ...(r.dleqJson ? { dleq: JSON.parse(r.dleqJson) } : {}),
-    ...(r.witnessJson ? { witness: JSON.parse(r.witnessJson) } : {}),
+    ...(r.witnessJson ? { witness: parsePersistedProofWitness(r.witnessJson) } : {}),
   };
   return {
     ...base,
@@ -57,7 +63,7 @@ export class SqliteProofRepository implements ProofRepository {
         'INSERT INTO coco_cashu_proofs (mintUrl, id, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of proofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
-        const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
+        const witnessJson = stringifyProofWitness(p.witness);
         await tx.run(insertSql, [
           mintUrl,
           p.id,


### PR DESCRIPTION
## Description

This pull request fixes P2PK proof witness encoding so signed proofs no longer produce nested JSON strings when persisted or exported as Cashu tokens.

This pull request resolves #168.

## Problem

`KeyRingService.signProof()` pre-stringified P2PK witnesses, adapters stringified them again for storage, and `cashu-ts` stringified them again during token encoding. Decoded tokens could then expose `witness` as a JSON string literal, causing `witness.signatures` lookups to fail.

## Summary

- Return structured P2PK witness objects from `KeyRingService.signProof()`.
- Add shared witness serialization helpers that normalize object, string, and legacy double-encoded persisted witnesses.
- Use the shared helpers in SQLite3, sqlite-bun, Expo SQLite, and IndexedDB proof repositories.
- Add regression tests for token encoding and persisted witness normalization.
- Include `.changeset/fix-p2pk-witness-encoding.md` for core and all affected proof adapter packages.
- Note: this branch includes the existing `chore: update lockfile` commit and is currently behind `master`.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/KeyRingService.test.ts test/unit/ProofWitnessSerialization.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-sqlite' build`
- `bun run --filter='@cashu/coco-sqlite-bun' build`
- `bun run --filter='@cashu/coco-indexeddb' build`
- `bun run --filter='@cashu/coco-expo-sqlite' build`
- `./node_modules/.bin/prettier --check ...`
- `git diff --check`