### PR TITLE
feat(react): initialize Coco from provider config

### DIFF
--- a/.changeset/react-provider-initializes.md
+++ b/.changeset/react-provider-initializes.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-react': minor
+---
+
+Allow `CocoCashuProvider` to initialize Coco from a `CocoConfig` on initial
+mount, with loading and error fallbacks, while preserving the existing
+initialized-manager provider path.

--- a/.changeset/react-provider-initializes.md
+++ b/.changeset/react-provider-initializes.md
@@ -4,4 +4,5 @@
 
 Allow `CocoCashuProvider` to initialize Coco from a `CocoConfig` on initial
 mount, with loading and error fallbacks, while preserving the existing
-initialized-manager provider path.
+initialized-manager provider path. Add `localStorageSeedGetter()` as a browser
+localStorage-backed seed getter helper for React applications.

--- a/bun.lock
+++ b/bun.lock
@@ -17,22 +17,22 @@
     },
     "packages/adapter-tests": {
       "name": "@cashu/coco-adapter-tests",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "fake-bolt11": "^0.1.0",
       },
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.5",
+        "@cashu/coco-core": "1.0.0",
       },
       "peerDependencies": {
         "@cashu/cashu-ts": "^4.1.0",
-        "@cashu/coco-core": "^1.0.0-rc.5",
+        "@cashu/coco-core": "^1.0.0",
         "typescript": "^5",
       },
     },
     "packages/core": {
       "name": "@cashu/coco-core",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "@cashu/cashu-ts": "^4.1.0",
         "@noble/curves": "^2.0.1",
@@ -40,7 +40,7 @@
         "@scure/bip32": "^2.0.1",
       },
       "devDependencies": {
-        "@cashu/coco-adapter-tests": "1.0.0-rc.5",
+        "@cashu/coco-adapter-tests": "1.0.0",
         "typescript-eslint": "^8.40.0",
       },
       "peerDependencies": {
@@ -55,7 +55,7 @@
     },
     "packages/expo-sqlite": {
       "name": "@cashu/coco-expo-sqlite",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0-rc.2",
       },
@@ -67,7 +67,7 @@
     },
     "packages/indexeddb": {
       "name": "@cashu/coco-indexeddb",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "dexie": "^4.0.8",
       },
@@ -84,9 +84,9 @@
     },
     "packages/react": {
       "name": "@cashu/coco-react",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "devDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.5",
+        "@cashu/coco-core": "1.0.0",
         "@eslint/js": "^9.33.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.10",
@@ -105,13 +105,13 @@
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@cashu/coco-core": "1.0.0-rc.5",
+        "@cashu/coco-core": "1.0.0",
         "react": "^19",
       },
     },
     "packages/sqlite-bun": {
       "name": "@cashu/coco-sqlite-bun",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0-rc.2",
       },
@@ -122,7 +122,7 @@
     },
     "packages/sqlite3": {
       "name": "@cashu/coco-sqlite",
-      "version": "1.0.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
       },

--- a/packages/docs/pages/react-overview.md
+++ b/packages/docs/pages/react-overview.md
@@ -38,39 +38,20 @@ npm i @cashu/coco-react @cashu/coco-core
 
 ## Setup
 
-Create a `Manager` with `@cashu/coco-core`, then pass it to the provider. If
-your manager is created asynchronously, render a loading state until you have a
-`Manager` instance, then render the provider.
+Pass the same config accepted by `initializeCoco()` to `CocoCashuProvider`. The
+provider initializes the manager on initial mount and renders `fallback` until
+the manager is ready.
 
 ```tsx
-import { useEffect, useState } from 'react';
-import type { Manager } from '@cashu/coco-core';
-import { initializeCoco } from '@cashu/coco-core';
 import { CocoCashuProvider } from '@cashu/coco-react';
 
 export function App() {
-  const [manager, setManager] = useState<Manager | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    void initializeCoco({ repo, seedGetter })
-      .then((instance) => {
-        if (!cancelled) setManager(instance);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err : new Error(String(err)));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (error) return <div>Failed</div>;
-  if (!manager) return <div>Loading wallet...</div>;
-
   return (
-    <CocoCashuProvider manager={manager}>
+    <CocoCashuProvider
+      config={{ repo, seedGetter }}
+      fallback={<div>Loading wallet...</div>}
+      errorFallback={<div>Failed</div>}
+    >
       <Wallet />
     </CocoCashuProvider>
   );
@@ -79,6 +60,17 @@ export function App() {
 
 `CocoCashuProvider` is a convenience wrapper that composes `ManagerProvider`,
 `MintProvider`, and `BalanceProvider`.
+
+The `config` prop is initial-only. If you need to rebuild Coco with a different
+configuration, remount `CocoCashuProvider` with a new React `key`.
+
+If your application already owns initialization, pass an existing manager:
+
+```tsx
+<CocoCashuProvider manager={manager}>
+  <Wallet />
+</CocoCashuProvider>
+```
 
 For operation hooks, `ManagerProvider` is the only required context. The mint
 and balance providers are only needed for derived-data hooks such as

--- a/packages/docs/pages/react-providers.md
+++ b/packages/docs/pages/react-providers.md
@@ -5,21 +5,40 @@ the `CocoCashuProvider` convenience wrapper or compose providers individually.
 
 ## CocoCashuProvider
 
-Wraps `ManagerProvider`, `MintProvider`, and `BalanceProvider` in the correct
-order.
+Initializes Coco from config on initial mount, then wraps `ManagerProvider`,
+`MintProvider`, and `BalanceProvider` in the correct order. Pass `fallback` for
+the loading state and `errorFallback` for initialization failures.
 
 ```tsx
 import { CocoCashuProvider } from '@cashu/coco-react';
 
+<CocoCashuProvider
+  config={{ repo, seedGetter }}
+  fallback={<Spinner />}
+  errorFallback={(error) => <InitError error={error} />}
+>
+  {children}
+</CocoCashuProvider>;
+```
+
+The `config` prop is initial-only. To initialize with a different config,
+remount the provider with a new React `key`.
+
+For backwards compatibility or advanced lifecycle control, pass an initialized
+manager instead:
+
+```tsx
 <CocoCashuProvider manager={manager}>{children}</CocoCashuProvider>;
 ```
 
 ## ManagerProvider and ManagerGate
 
-`ManagerProvider` exposes the `Manager` instance. `ManagerGate` is a helper that
-only renders children when the manager is ready. The four operation hooks only
-require `ManagerProvider`. `MintProvider` and `BalanceProvider` are for
-derived-data hooks and require `ManagerProvider` to be above them in the tree.
+`ManagerProvider` exposes an already initialized `Manager` instance. It is the
+low-level provider for custom provider composition and tests. `ManagerGate` is a
+helper that only renders children when the manager is ready. The four operation
+hooks only require `ManagerProvider`. `MintProvider` and `BalanceProvider` are
+for derived-data hooks and require `ManagerProvider` to be above them in the
+tree.
 
 ```tsx
 import { ManagerProvider, ManagerGate, useManagerContext } from '@cashu/coco-react';

--- a/packages/docs/pages/react-providers.md
+++ b/packages/docs/pages/react-providers.md
@@ -28,7 +28,7 @@ For backwards compatibility or advanced lifecycle control, pass an initialized
 manager instead:
 
 ```tsx
-<CocoCashuProvider manager={manager}>{children}</CocoCashuProvider>;
+<CocoCashuProvider manager={manager}>{children}</CocoCashuProvider>
 ```
 
 ## ManagerProvider and ManagerGate

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,7 +24,13 @@ npm install @cashu/coco-react @cashu/coco-core react
 ## Usage
 
 ```tsx
-import { CocoCashuProvider, useSendOperation } from '@cashu/coco-react';
+import {
+  CocoCashuProvider,
+  localStorageSeedGetter,
+  useSendOperation,
+} from '@cashu/coco-react';
+
+const seedGetter = localStorageSeedGetter();
 
 function SendButton() {
   const { prepare, execute, currentOperation, executeResult, isLoading } = useSendOperation();
@@ -58,6 +64,10 @@ export function App() {
   );
 }
 ```
+
+`localStorageSeedGetter()` stores a generated browser seed under
+`COCO_REACT_SEED` by default. Pass `localStorageSeedGetter({ storageKey })` to
+use a different localStorage key.
 
 If your application already owns the manager lifecycle, pass an initialized
 manager instead:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,11 +24,7 @@ npm install @cashu/coco-react @cashu/coco-core react
 ## Usage
 
 ```tsx
-import {
-  CocoCashuProvider,
-  localStorageSeedGetter,
-  useSendOperation,
-} from '@cashu/coco-react';
+import { CocoCashuProvider, localStorageSeedGetter, useSendOperation } from '@cashu/coco-react';
 
 const seedGetter = localStorageSeedGetter();
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -6,7 +6,8 @@
 React hooks and providers for integrating a Coco `Manager` into React
 applications.
 
-The package exports the `CocoCashuProvider` convenience wrapper, the underlying
+The package exports the `CocoCashuProvider` convenience wrapper, which can
+initialize Coco from config or accept an existing manager, the underlying
 providers, operation-oriented hooks such as `useSendOperation`,
 `useReceiveOperation`, `useMintOperation`, and `useMeltOperation`, plus
 derived-data hooks such as `usePaginatedHistory`, `useBalances`, and
@@ -23,7 +24,6 @@ npm install @cashu/coco-react @cashu/coco-core react
 ## Usage
 
 ```tsx
-import type { Manager } from '@cashu/coco-core';
 import { CocoCashuProvider, useSendOperation } from '@cashu/coco-react';
 
 function SendButton() {
@@ -46,14 +46,30 @@ function SendButton() {
   );
 }
 
-export function App({ manager }: { manager: Manager }) {
+export function App() {
   return (
-    <CocoCashuProvider manager={manager}>
+    <CocoCashuProvider
+      config={{ repo, seedGetter }}
+      fallback={<div>Loading wallet...</div>}
+      errorFallback={<div>Wallet failed to load.</div>}
+    >
       <SendButton />
     </CocoCashuProvider>
   );
 }
 ```
+
+If your application already owns the manager lifecycle, pass an initialized
+manager instead:
+
+```tsx
+<CocoCashuProvider manager={manager}>
+  <SendButton />
+</CocoCashuProvider>
+```
+
+The `config` prop is initial-only. Remount the provider with a new React `key`
+when you intentionally need to initialize with a different config.
 
 Each operation hook stays bound to one local operation flow for the lifetime of
 that hook instance. It starts unbound until you call the hook's creation action

--- a/packages/react/src/lib/index.ts
+++ b/packages/react/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './providers';
 export * from './contexts';
 export * from './hooks';
+export * from './utils';

--- a/packages/react/src/lib/providers/root.test.tsx
+++ b/packages/react/src/lib/providers/root.test.tsx
@@ -1,0 +1,123 @@
+import { initializeCoco, type CocoConfig, type Manager } from '@cashu/coco-core';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CocoCashuProvider } from './root';
+
+vi.mock('@cashu/coco-core', async () => {
+  const actual = await vi.importActual<typeof import('@cashu/coco-core')>('@cashu/coco-core');
+  return {
+    ...actual,
+    initializeCoco: vi.fn(),
+  };
+});
+
+const initializeCocoMock = vi.mocked(initializeCoco);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+async function waitForAssertion(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+
+  throw lastError;
+}
+
+function createManagerMock(): Manager {
+  return {
+    mint: {
+      getAllMints: vi.fn().mockResolvedValue([]),
+      addMint: vi.fn(),
+      trustMint: vi.fn(),
+      untrustMint: vi.fn(),
+      isTrustedMint: vi.fn(),
+    },
+    wallet: {
+      balances: {
+        byMint: vi.fn().mockResolvedValue({}),
+      },
+    },
+    on: vi.fn(),
+    off: vi.fn(),
+  } as unknown as Manager;
+}
+
+function createConfigMock(): CocoConfig {
+  return {
+    repo: {
+      init: vi.fn(),
+    },
+    seedGetter: vi.fn(),
+  } as unknown as CocoConfig;
+}
+
+describe('CocoCashuProvider', () => {
+  it('initializes a manager from config and renders the fallback until ready', async () => {
+    const manager = createManagerMock();
+    const config = createConfigMock();
+    initializeCocoMock.mockResolvedValue(manager);
+
+    const { getByText, queryByText } = render(
+      <CocoCashuProvider config={config} fallback={<div>Loading wallet</div>}>
+        <div>Wallet ready</div>
+      </CocoCashuProvider>,
+    );
+
+    expect(getByText('Loading wallet')).not.toBeNull();
+    expect(queryByText('Wallet ready')).toBeNull();
+
+    await waitForAssertion(() => {
+      expect(getByText('Wallet ready')).not.toBeNull();
+    });
+
+    expect(initializeCocoMock).toHaveBeenCalledTimes(1);
+    expect(initializeCocoMock).toHaveBeenCalledWith(config);
+  });
+
+  it('renders an initialization error fallback', async () => {
+    const config = createConfigMock();
+    initializeCocoMock.mockRejectedValue(new Error('seed unavailable'));
+
+    const { getByText, queryByText } = render(
+      <CocoCashuProvider
+        config={config}
+        errorFallback={(error) => <div>Failed: {error.message}</div>}
+      >
+        <div>Wallet ready</div>
+      </CocoCashuProvider>,
+    );
+
+    await waitForAssertion(() => {
+      expect(getByText('Failed: seed unavailable')).not.toBeNull();
+    });
+
+    expect(queryByText('Wallet ready')).toBeNull();
+  });
+
+  it('continues to accept an already initialized manager', () => {
+    const manager = createManagerMock();
+
+    const { getByText } = render(
+      <CocoCashuProvider manager={manager}>
+        <div>Wallet ready</div>
+      </CocoCashuProvider>,
+    );
+
+    expect(getByText('Wallet ready')).not.toBeNull();
+    expect(initializeCocoMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/lib/providers/root.test.tsx
+++ b/packages/react/src/lib/providers/root.test.tsx
@@ -53,6 +53,8 @@ function createManagerMock(): Manager {
     },
     on: vi.fn(),
     off: vi.fn(),
+    pauseSubscriptions: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn().mockResolvedValue(undefined),
   } as unknown as Manager;
 }
 
@@ -111,7 +113,7 @@ describe('CocoCashuProvider', () => {
   it('continues to accept an already initialized manager', () => {
     const manager = createManagerMock();
 
-    const { getByText } = render(
+    const { getByText, unmount } = render(
       <CocoCashuProvider manager={manager}>
         <div>Wallet ready</div>
       </CocoCashuProvider>,
@@ -119,5 +121,61 @@ describe('CocoCashuProvider', () => {
 
     expect(getByText('Wallet ready')).not.toBeNull();
     expect(initializeCocoMock).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(manager.pauseSubscriptions).not.toHaveBeenCalled();
+    expect(manager.dispose).not.toHaveBeenCalled();
+  });
+
+  it('tears down an owned manager on unmount after initialization', async () => {
+    const manager = createManagerMock();
+    const config = createConfigMock();
+    initializeCocoMock.mockResolvedValue(manager);
+
+    const { getByText, unmount } = render(
+      <CocoCashuProvider config={config}>
+        <div>Wallet ready</div>
+      </CocoCashuProvider>,
+    );
+
+    await waitForAssertion(() => {
+      expect(getByText('Wallet ready')).not.toBeNull();
+    });
+
+    unmount();
+
+    await waitForAssertion(() => {
+      expect(manager.pauseSubscriptions).toHaveBeenCalledTimes(1);
+      expect(manager.dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('tears down an owned manager that resolves after unmount', async () => {
+    const manager = createManagerMock();
+    const config = createConfigMock();
+    let resolveInitialization: (manager: Manager) => void = () => {};
+    const initialization = new Promise<Manager>((resolve) => {
+      resolveInitialization = resolve;
+    });
+    initializeCocoMock.mockReturnValue(initialization);
+
+    const { unmount } = render(
+      <CocoCashuProvider config={config}>
+        <div>Wallet ready</div>
+      </CocoCashuProvider>,
+    );
+
+    unmount();
+
+    await act(async () => {
+      resolveInitialization(manager);
+      await initialization;
+    });
+
+    await waitForAssertion(() => {
+      expect(manager.pauseSubscriptions).toHaveBeenCalledTimes(1);
+      expect(manager.dispose).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react/src/lib/providers/root.tsx
+++ b/packages/react/src/lib/providers/root.tsx
@@ -72,8 +72,7 @@ const InitializingCocoCashuProvider = ({
     effectGenerationRef.current = effectGeneration;
     let cancelled = false;
 
-    const initialization =
-      initializationRef.current ?? initializeCoco(initialConfigRef.current);
+    const initialization = initializationRef.current ?? initializeCoco(initialConfigRef.current);
     initializationRef.current = initialization;
 
     initialization
@@ -129,9 +128,7 @@ const InitializingCocoCashuProvider = ({
 
 export const CocoCashuProvider = (props: CocoCashuProviderProps) => {
   if (props.manager !== undefined) {
-    return (
-      <CocoCashuProviderTree manager={props.manager}>{props.children}</CocoCashuProviderTree>
-    );
+    return <CocoCashuProviderTree manager={props.manager}>{props.children}</CocoCashuProviderTree>;
   }
 
   return (

--- a/packages/react/src/lib/providers/root.tsx
+++ b/packages/react/src/lib/providers/root.tsx
@@ -1,9 +1,28 @@
-import type { Manager } from '@cashu/coco-core';
+import { initializeCoco, type CocoConfig, type Manager } from '@cashu/coco-core';
+import { useEffect, useRef, useState } from 'react';
 import { ManagerProvider } from './Manager';
 import { BalanceProvider } from './Balance';
 import { MintProvider } from './MintProvider';
 
-export const CocoCashuProvider = ({
+type CocoCashuProviderBaseProps = {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  errorFallback?: React.ReactNode | ((error: Error) => React.ReactNode);
+};
+
+export type CocoCashuProviderProps = CocoCashuProviderBaseProps &
+  (
+    | {
+        config: CocoConfig;
+        manager?: never;
+      }
+    | {
+        manager: Manager;
+        config?: never;
+      }
+  );
+
+const CocoCashuProviderTree = ({
   manager,
   children,
 }: {
@@ -16,3 +35,77 @@ export const CocoCashuProvider = ({
     </MintProvider>
   </ManagerProvider>
 );
+
+const renderErrorFallback = (
+  error: Error,
+  errorFallback: CocoCashuProviderBaseProps['errorFallback'],
+) => (typeof errorFallback === 'function' ? errorFallback(error) : errorFallback);
+
+const normalizeError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const InitializingCocoCashuProvider = ({
+  config,
+  children,
+  fallback = null,
+  errorFallback = null,
+}: CocoCashuProviderBaseProps & { config: CocoConfig }) => {
+  const initialConfigRef = useRef(config);
+  const initializationRef = useRef<Promise<Manager> | null>(null);
+  const [manager, setManager] = useState<Manager | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const initialization =
+      initializationRef.current ?? initializeCoco(initialConfigRef.current);
+    initializationRef.current = initialization;
+
+    initialization
+      .then((initializedManager) => {
+        if (!cancelled) {
+          setManager(initializedManager);
+          setError(null);
+        }
+      })
+      .catch((initError: unknown) => {
+        if (!cancelled) {
+          setManager(null);
+          setError(normalizeError(initError));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return <>{renderErrorFallback(error, errorFallback)}</>;
+  }
+
+  if (!manager) {
+    return <>{fallback}</>;
+  }
+
+  return <CocoCashuProviderTree manager={manager}>{children}</CocoCashuProviderTree>;
+};
+
+export const CocoCashuProvider = (props: CocoCashuProviderProps) => {
+  if (props.manager !== undefined) {
+    return (
+      <CocoCashuProviderTree manager={props.manager}>{props.children}</CocoCashuProviderTree>
+    );
+  }
+
+  return (
+    <InitializingCocoCashuProvider
+      config={props.config}
+      fallback={props.fallback}
+      errorFallback={props.errorFallback}
+    >
+      {props.children}
+    </InitializingCocoCashuProvider>
+  );
+};

--- a/packages/react/src/lib/providers/root.tsx
+++ b/packages/react/src/lib/providers/root.tsx
@@ -44,6 +44,16 @@ const renderErrorFallback = (
 const normalizeError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
+const teardownOwnedManager = async (manager: Manager): Promise<void> => {
+  // TODO: Replace this bandaid with manager.dispose() once core disposal tears down
+  // watchers, processors, and subscriptions.
+  try {
+    await manager.pauseSubscriptions();
+  } finally {
+    await manager.dispose();
+  }
+};
+
 const InitializingCocoCashuProvider = ({
   config,
   children,
@@ -52,10 +62,14 @@ const InitializingCocoCashuProvider = ({
 }: CocoCashuProviderBaseProps & { config: CocoConfig }) => {
   const initialConfigRef = useRef(config);
   const initializationRef = useRef<Promise<Manager> | null>(null);
+  const managerRef = useRef<Manager | null>(null);
+  const effectGenerationRef = useRef(0);
   const [manager, setManager] = useState<Manager | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
+    const effectGeneration = effectGenerationRef.current + 1;
+    effectGenerationRef.current = effectGeneration;
     let cancelled = false;
 
     const initialization =
@@ -64,13 +78,14 @@ const InitializingCocoCashuProvider = ({
 
     initialization
       .then((initializedManager) => {
-        if (!cancelled) {
+        if (!cancelled && effectGenerationRef.current === effectGeneration) {
+          managerRef.current = initializedManager;
           setManager(initializedManager);
           setError(null);
         }
       })
       .catch((initError: unknown) => {
-        if (!cancelled) {
+        if (!cancelled && effectGenerationRef.current === effectGeneration) {
           setManager(null);
           setError(normalizeError(initError));
         }
@@ -78,6 +93,26 @@ const InitializingCocoCashuProvider = ({
 
     return () => {
       cancelled = true;
+
+      void Promise.resolve().then(() => {
+        if (effectGenerationRef.current !== effectGeneration) return;
+
+        const initializedManager = managerRef.current;
+        managerRef.current = null;
+
+        if (initializedManager) {
+          void teardownOwnedManager(initializedManager).catch(() => undefined);
+          return;
+        }
+
+        void initialization
+          .then((lateInitializedManager) => {
+            if (effectGenerationRef.current === effectGeneration) {
+              void teardownOwnedManager(lateInitializedManager).catch(() => undefined);
+            }
+          })
+          .catch(() => undefined);
+      });
     };
   }, []);
 

--- a/packages/react/src/lib/utils/index.ts
+++ b/packages/react/src/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './localStorageSeedGetter';

--- a/packages/react/src/lib/utils/localStorageSeedGetter.test.ts
+++ b/packages/react/src/lib/utils/localStorageSeedGetter.test.ts
@@ -14,16 +14,16 @@ const encodeSeed = (seed: Uint8Array): string => {
 };
 
 const mockRandomValues = (seed: Uint8Array) =>
-  vi.spyOn(window.crypto, 'getRandomValues').mockImplementation(<T extends ArrayBufferView | null>(
-    array: T,
-  ): T => {
-    if (!(array instanceof Uint8Array)) {
-      throw new Error('expected Uint8Array');
-    }
+  vi
+    .spyOn(window.crypto, 'getRandomValues')
+    .mockImplementation(<T extends ArrayBufferView | null>(array: T): T => {
+      if (!(array instanceof Uint8Array)) {
+        throw new Error('expected Uint8Array');
+      }
 
-    array.set(seed);
-    return array;
-  });
+      array.set(seed);
+      return array;
+    });
 
 const installLocalStorageMock = () => {
   const storage = new Map<string, string>();

--- a/packages/react/src/lib/utils/localStorageSeedGetter.test.ts
+++ b/packages/react/src/lib/utils/localStorageSeedGetter.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { localStorageSeedGetter } from './localStorageSeedGetter';
+
+const makeSeed = (offset = 0): Uint8Array =>
+  Uint8Array.from({ length: 64 }, (_, index) => (index + offset) % 256);
+
+const encodeSeed = (seed: Uint8Array): string => {
+  let binary = '';
+  for (const byte of seed) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return window.btoa(binary);
+};
+
+const mockRandomValues = (seed: Uint8Array) =>
+  vi.spyOn(window.crypto, 'getRandomValues').mockImplementation(<T extends ArrayBufferView | null>(
+    array: T,
+  ): T => {
+    if (!(array instanceof Uint8Array)) {
+      throw new Error('expected Uint8Array');
+    }
+
+    array.set(seed);
+    return array;
+  });
+
+const installLocalStorageMock = () => {
+  const storage = new Map<string, string>();
+  const localStorageMock: Storage = {
+    get length() {
+      return storage.size;
+    },
+    clear: vi.fn(() => {
+      storage.clear();
+    }),
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      storage.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      storage.set(key, value);
+    }),
+  };
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: localStorageMock,
+  });
+};
+
+beforeEach(() => {
+  installLocalStorageMock();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('localStorageSeedGetter', () => {
+  it('creates and stores a seed under the default key', async () => {
+    const seed = makeSeed();
+    const getRandomValues = mockRandomValues(seed);
+    const seedGetter = localStorageSeedGetter();
+
+    await expect(seedGetter()).resolves.toEqual(seed);
+    expect(window.localStorage.getItem('COCO_REACT_SEED')).toBe(encodeSeed(seed));
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a custom storage key', async () => {
+    const seed = makeSeed(3);
+    mockRandomValues(seed);
+    const seedGetter = localStorageSeedGetter({ storageKey: 'MY_COCO_SEED' });
+
+    await expect(seedGetter()).resolves.toEqual(seed);
+    expect(window.localStorage.getItem('MY_COCO_SEED')).toBe(encodeSeed(seed));
+    expect(window.localStorage.getItem('COCO_REACT_SEED')).toBeNull();
+  });
+
+  it('reads an existing seed from localStorage', async () => {
+    const seed = makeSeed(7);
+    const getRandomValues = mockRandomValues(makeSeed(11));
+    window.localStorage.setItem('COCO_REACT_SEED', encodeSeed(seed));
+
+    const seedGetter = localStorageSeedGetter();
+
+    await expect(seedGetter()).resolves.toEqual(seed);
+    expect(getRandomValues).not.toHaveBeenCalled();
+  });
+
+  it('caches the seed in the returned getter closure', async () => {
+    const seed = makeSeed(13);
+    mockRandomValues(seed);
+    const seedGetter = localStorageSeedGetter();
+
+    const firstSeed = await seedGetter();
+    firstSeed[0] = 255;
+    window.localStorage.setItem('COCO_REACT_SEED', encodeSeed(makeSeed(17)));
+
+    await expect(seedGetter()).resolves.toEqual(seed);
+  });
+
+  it('does not cache a generated seed when localStorage persistence fails', async () => {
+    const seed = makeSeed(19);
+    const getRandomValues = mockRandomValues(seed);
+    vi.mocked(window.localStorage.setItem).mockImplementationOnce(() => {
+      throw new Error('quota exceeded');
+    });
+    const seedGetter = localStorageSeedGetter();
+
+    await expect(seedGetter()).rejects.toThrow('quota exceeded');
+    expect(window.localStorage.getItem('COCO_REACT_SEED')).toBeNull();
+
+    await expect(seedGetter()).resolves.toEqual(seed);
+    expect(window.localStorage.getItem('COCO_REACT_SEED')).toBe(encodeSeed(seed));
+    expect(getRandomValues).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react/src/lib/utils/localStorageSeedGetter.ts
+++ b/packages/react/src/lib/utils/localStorageSeedGetter.ts
@@ -1,0 +1,85 @@
+const DEFAULT_STORAGE_KEY = 'COCO_REACT_SEED';
+const SEED_LENGTH_BYTES = 64;
+
+export type LocalStorageSeedGetterConfig = {
+  storageKey?: string;
+};
+
+const getBrowserWindow = (): Window & typeof globalThis => {
+  if (typeof window === 'undefined') {
+    throw new Error('localStorageSeedGetter requires a browser window.');
+  }
+
+  if (!window.localStorage) {
+    throw new Error('localStorageSeedGetter requires window.localStorage.');
+  }
+
+  if (!window.crypto?.getRandomValues) {
+    throw new Error('localStorageSeedGetter requires window.crypto.getRandomValues.');
+  }
+
+  return window;
+};
+
+const encodeSeed = (seed: Uint8Array, browserWindow: Window & typeof globalThis): string => {
+  let binary = '';
+  for (const byte of seed) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return browserWindow.btoa(binary);
+};
+
+const decodeSeed = (encodedSeed: string, browserWindow: Window & typeof globalThis): Uint8Array => {
+  const binary = browserWindow.atob(encodedSeed);
+  const seed = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    seed[index] = binary.charCodeAt(index);
+  }
+
+  if (seed.length !== SEED_LENGTH_BYTES) {
+    throw new Error(
+      `localStorageSeedGetter expected a ${SEED_LENGTH_BYTES}-byte seed in localStorage.`,
+    );
+  }
+
+  return seed;
+};
+
+const createSeed = (browserWindow: Window & typeof globalThis): Uint8Array => {
+  const seed = new Uint8Array(SEED_LENGTH_BYTES);
+  browserWindow.crypto.getRandomValues(seed);
+  return seed;
+};
+
+/**
+ * Creates a Coco seed getter backed by browser localStorage.
+ *
+ * The returned getter reads or creates the seed once, then serves it from its
+ * closure on later calls.
+ */
+export const localStorageSeedGetter = (config: LocalStorageSeedGetterConfig = {}) => {
+  const storageKey = config.storageKey ?? DEFAULT_STORAGE_KEY;
+  let cachedSeed: Uint8Array | null = null;
+
+  return async (): Promise<Uint8Array> => {
+    if (cachedSeed) {
+      return new Uint8Array(cachedSeed);
+    }
+
+    const browserWindow = getBrowserWindow();
+    const storedSeed = browserWindow.localStorage.getItem(storageKey);
+
+    if (storedSeed) {
+      cachedSeed = decodeSeed(storedSeed, browserWindow);
+      return new Uint8Array(cachedSeed);
+    }
+
+    const generatedSeed = createSeed(browserWindow);
+    browserWindow.localStorage.setItem(storageKey, encodeSeed(generatedSeed, browserWindow));
+    cachedSeed = generatedSeed;
+
+    return new Uint8Array(generatedSeed);
+  };
+};


### PR DESCRIPTION
## Summary

- allow `CocoCashuProvider` to initialize Coco from a `CocoConfig` on initial mount
- preserve the existing `manager={manager}` path for apps that own manager lifecycle
- add loading/error fallback handling, focused provider tests, docs, and a changeset

## Problem

React consumers previously had to run async `initializeCoco()` outside the provider before rendering the app tree. This duplicated loading and error handling in applications and made the top-level React setup less ergonomic.

## Verification

- `bun run --filter='@cashu/coco-core' build`
- `bun run test -- src/lib/providers/root.test.tsx`
- `bun run typecheck`
- `bun run lint` (passes with existing warnings in `operationHooks.test.tsx`)
- `bun run build`

## Changeset

- `.changeset/react-provider-initializes.md`