### PR TITLE
chore: enforce dependency release age checks

### DIFF
--- a/.github/workflows/auth-integration-tests.yml
+++ b/.github/workflows/auth-integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -7,12 +7,18 @@ on:
     paths:
       - 'packages/**'
       - 'scripts/build.ts'
+      - 'scripts/check-release-age.ts'
+      - 'bun.lock'
+      - 'bunfig.toml'
       - 'package.json'
       - '.github/workflows/build-packages.yml'
   pull_request:
     paths:
       - 'packages/**'
       - 'scripts/build.ts'
+      - 'scripts/check-release-age.ts'
+      - 'bun.lock'
+      - 'bunfig.toml'
       - 'package.json'
       - '.github/workflows/build-packages.yml'
 
@@ -26,7 +32,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
+
+      - name: Check dependency release age
+        run: bun run security:release-age
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/core-integration-tests.yml
+++ b/.github/workflows/core-integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload core integration coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           working-directory: packages/core
           files: coverage/integration/lcov.info

--- a/.github/workflows/core-integration-tests.yml
+++ b/.github/workflows/core-integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload core coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: coverage/core/lcov.info
           disable_search: true

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/dependency-release-age.yml
+++ b/.github/workflows/dependency-release-age.yml
@@ -1,0 +1,36 @@
+name: dependency-release-age
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'bun.lock'
+      - 'bunfig.toml'
+      - 'package.json'
+      - 'packages/*/package.json'
+      - 'scripts/check-release-age.ts'
+      - '.github/workflows/dependency-release-age.yml'
+  pull_request:
+    paths:
+      - 'bun.lock'
+      - 'bunfig.toml'
+      - 'package.json'
+      - 'packages/*/package.json'
+      - 'scripts/check-release-age.ts'
+      - '.github/workflows/dependency-release-age.yml'
+
+jobs:
+  dependency-release-age:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Check dependency release age
+        run: bun run security:release-age

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/expo-sqlite-integration-tests.yml
+++ b/.github/workflows/expo-sqlite-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/indexeddb-integration-tests.yml
+++ b/.github/workflows/indexeddb-integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox webkit
+        run: bun --cwd packages/indexeddb playwright install --with-deps chromium firefox webkit
 
       - name: Run indexeddb integration tests
         run: ./scripts/test-integration.sh indexeddb

--- a/.github/workflows/indexeddb-integration-tests.yml
+++ b/.github/workflows/indexeddb-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
+
+      - name: Check dependency release age
+        run: bun run security:release-age
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
+
+      - name: Check dependency release age
+        run: bun run security:release-age
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
+
+      - name: Check dependency release age
+        run: bun run security:release-age
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/sqlite-bun-integration-tests.yml
+++ b/.github/workflows/sqlite-bun-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/sqlite3-integration-tests.yml
+++ b/.github/workflows/sqlite3-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.18
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Only resolve npm package versions that have been available for at least 7 days.
+minimumReleaseAge = 604800

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "docs:dev": "vitepress dev packages/docs",
     "docs:build": "vitepress build packages/docs",
     "docs:preview": "vitepress preview packages/docs",
+    "security:release-age": "bun scripts/check-release-age.ts",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   }

--- a/scripts/check-release-age.ts
+++ b/scripts/check-release-age.ts
@@ -1,0 +1,337 @@
+#!/usr/bin/env bun
+
+const DEFAULT_BUNFIG_PATH = 'bunfig.toml';
+const DEFAULT_LOCKFILE_PATH = 'bun.lock';
+const DEFAULT_REGISTRY_URL = 'https://registry.npmjs.org';
+const DEFAULT_CONCURRENCY = 24;
+const MAX_DISPLAYED_FAILURES = 25;
+
+type ReleaseAgeConfig = {
+  minimumReleaseAgeSeconds: number;
+  excludes: Set<string>;
+};
+
+type LockedPackage = {
+  name: string;
+  version: string;
+  line: number;
+};
+
+type RegistryMetadata = {
+  time?: Record<string, unknown>;
+};
+
+type CheckedPackage = LockedPackage & {
+  publishedAt?: Date;
+  ageSeconds?: number;
+  warning?: string;
+};
+
+type FailedPackage = CheckedPackage & {
+  publishedAt: Date;
+  ageSeconds: number;
+};
+
+function readArg(name: string): string | undefined {
+  const prefix = `${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+}
+
+function usage(): string {
+  return [
+    'Usage: bun scripts/check-release-age.ts [--config=path] [--lockfile=path]',
+    '',
+    'Checks bun.lock against the minimumReleaseAge configured in bunfig.toml.',
+    'Set NPM_REGISTRY_URL to use a registry other than https://registry.npmjs.org.',
+  ].join('\n');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function readReleaseAgeConfig(configPath: string): Promise<ReleaseAgeConfig> {
+  const text = await Bun.file(configPath).text();
+  const parsed = Bun.TOML.parse(text);
+  if (!isRecord(parsed)) {
+    throw new Error(`${configPath} does not contain a TOML object`);
+  }
+
+  const install = parsed.install;
+  if (!isRecord(install)) {
+    throw new Error(`${configPath} must define [install].minimumReleaseAge`);
+  }
+
+  const minimumReleaseAge = install.minimumReleaseAge;
+  if (
+    typeof minimumReleaseAge !== 'number' ||
+    !Number.isFinite(minimumReleaseAge) ||
+    minimumReleaseAge <= 0
+  ) {
+    throw new Error(`${configPath} must define a positive numeric [install].minimumReleaseAge`);
+  }
+
+  const excludes = install.minimumReleaseAgeExcludes;
+  if (
+    excludes !== undefined &&
+    (!Array.isArray(excludes) || excludes.some((name) => typeof name !== 'string'))
+  ) {
+    throw new Error(
+      `${configPath} [install].minimumReleaseAgeExcludes must be an array of strings`,
+    );
+  }
+
+  return {
+    minimumReleaseAgeSeconds: minimumReleaseAge,
+    excludes: new Set(excludes as string[] | undefined),
+  };
+}
+
+function parseLockString(raw: string): string {
+  return JSON.parse(`"${raw}"`) as string;
+}
+
+function parsePackageSpec(spec: string): { name: string; version: string } | null {
+  const aliasMarker = '@npm:';
+  const aliasIndex = spec.lastIndexOf(aliasMarker);
+  const packageSpec = aliasIndex === -1 ? spec : spec.slice(aliasIndex + aliasMarker.length);
+  const versionSeparator = packageSpec.lastIndexOf('@');
+
+  if (versionSeparator <= 0 || versionSeparator === packageSpec.length - 1) {
+    return null;
+  }
+
+  const name = packageSpec.slice(0, versionSeparator);
+  const version = packageSpec.slice(versionSeparator + 1);
+  if (name.includes(':') || version.includes(':')) {
+    return null;
+  }
+
+  return { name, version };
+}
+
+async function readLockedPackages(lockfilePath: string): Promise<LockedPackage[]> {
+  const text = await Bun.file(lockfilePath).text();
+  const packages = new Map<string, LockedPackage>();
+  const entryPattern = /^\s{4}"(?:\\.|[^"\\])*": \["((?:\\.|[^"\\])*)"/;
+
+  text.split('\n').forEach((line, index) => {
+    const match = line.match(entryPattern);
+    if (!match?.[1]) return;
+
+    const spec = parseLockString(match[1]);
+    const parsed = parsePackageSpec(spec);
+    if (!parsed) return;
+
+    const key = `${parsed.name}@${parsed.version}`;
+    if (!packages.has(key)) {
+      packages.set(key, {
+        ...parsed,
+        line: index + 1,
+      });
+    }
+  });
+
+  if (packages.size === 0) {
+    throw new Error(`No npm package entries were found in ${lockfilePath}`);
+  }
+
+  return [...packages.values()].sort((a, b) => {
+    const byName = a.name.localeCompare(b.name);
+    return byName === 0 ? a.version.localeCompare(b.version) : byName;
+  });
+}
+
+function packageMetadataUrl(registryUrl: string, name: string): string {
+  const registry = registryUrl.replace(/\/+$/, '');
+  return `${registry}/${encodeURIComponent(name)}`;
+}
+
+async function fetchRegistryMetadata(name: string, registryUrl: string): Promise<RegistryMetadata> {
+  const url = packageMetadataUrl(registryUrl, name);
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+        },
+      });
+
+      if (response.ok) {
+        const metadata = await response.json();
+        if (!isRecord(metadata)) {
+          throw new Error(`Registry response for ${name} was not an object`);
+        }
+        return metadata as RegistryMetadata;
+      }
+
+      const retryable = response.status === 429 || response.status >= 500;
+      if (!retryable || attempt === 3) {
+        throw new Error(`Registry returned ${response.status} for ${name}`);
+      }
+
+      lastError = new Error(`Registry returned ${response.status} for ${name}`);
+    } catch (error) {
+      lastError = error;
+      if (attempt === 3) break;
+    }
+
+    await Bun.sleep(attempt * 1_000);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function mapConcurrent<T, U>(
+  values: T[],
+  concurrency: number,
+  mapper: (value: T) => Promise<U>,
+): Promise<U[]> {
+  const results = new Array<U>(values.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(values[index]!);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, values.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+function formatDuration(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const days = Math.floor(seconds / 86_400);
+  const hours = Math.floor((seconds % 86_400) / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (days === 0 && minutes > 0) parts.push(`${minutes}m`);
+  return parts.length === 0 ? `${seconds}s` : parts.join(' ');
+}
+
+function getPublishedAt(pkg: LockedPackage, metadata: RegistryMetadata): Date | undefined {
+  const publishedAt = metadata.time?.[pkg.version];
+  if (typeof publishedAt !== 'string') return undefined;
+
+  const date = new Date(publishedAt);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function groupByPackageName(packages: LockedPackage[]): Map<string, LockedPackage[]> {
+  const packagesByName = new Map<string, LockedPackage[]>();
+  for (const pkg of packages) {
+    const versions = packagesByName.get(pkg.name);
+    if (versions) {
+      versions.push(pkg);
+    } else {
+      packagesByName.set(pkg.name, [pkg]);
+    }
+  }
+  return packagesByName;
+}
+
+async function checkPackages(
+  packages: LockedPackage[],
+  registryUrl: string,
+  now: Date,
+): Promise<CheckedPackage[]> {
+  const packagesByName = groupByPackageName(packages);
+  const checkedGroups = await mapConcurrent(
+    [...packagesByName.entries()],
+    DEFAULT_CONCURRENCY,
+    async ([name, versions]) => {
+      const metadata = await fetchRegistryMetadata(name, registryUrl);
+
+      return versions.map((pkg): CheckedPackage => {
+        const publishedAt = getPublishedAt(pkg, metadata);
+        if (!publishedAt) {
+          return {
+            ...pkg,
+            warning: `No publish time found for ${pkg.name}@${pkg.version}; treating as allowed`,
+          };
+        }
+
+        return {
+          ...pkg,
+          publishedAt,
+          ageSeconds: (now.getTime() - publishedAt.getTime()) / 1_000,
+        };
+      });
+    },
+  );
+
+  return checkedGroups.flat();
+}
+
+async function main() {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    console.log(usage());
+    return;
+  }
+
+  const configPath = readArg('--config') ?? DEFAULT_BUNFIG_PATH;
+  const lockfilePath = readArg('--lockfile') ?? DEFAULT_LOCKFILE_PATH;
+  const registryUrl = process.env.NPM_REGISTRY_URL ?? DEFAULT_REGISTRY_URL;
+  const config = await readReleaseAgeConfig(configPath);
+  const lockedPackages = await readLockedPackages(lockfilePath);
+  const packagesToCheck = lockedPackages.filter((pkg) => !config.excludes.has(pkg.name));
+  const checkedPackages = await checkPackages(packagesToCheck, registryUrl, new Date());
+  const failures = checkedPackages
+    .filter(
+      (pkg): pkg is FailedPackage =>
+        pkg.publishedAt !== undefined &&
+        pkg.ageSeconds !== undefined &&
+        pkg.ageSeconds < config.minimumReleaseAgeSeconds,
+    )
+    .sort((a, b) => a.ageSeconds - b.ageSeconds);
+  const warnings = checkedPackages.filter((pkg) => pkg.warning);
+
+  for (const warning of warnings) {
+    console.warn(`warning: ${warning.warning}`);
+  }
+
+  if (failures.length > 0) {
+    const threshold = formatDuration(config.minimumReleaseAgeSeconds);
+    console.error(
+      `Dependency release age check failed: ${failures.length} locked package version(s) ` +
+        `are newer than ${threshold}.`,
+    );
+
+    for (const pkg of failures.slice(0, MAX_DISPLAYED_FAILURES)) {
+      const age = formatDuration(pkg.ageSeconds);
+      console.error(
+        `  - ${pkg.name}@${pkg.version} published ${pkg.publishedAt.toISOString()} ` +
+          `(${age} old, ${lockfilePath}:${pkg.line})`,
+      );
+    }
+
+    if (failures.length > MAX_DISPLAYED_FAILURES) {
+      console.error(`  ...and ${failures.length - MAX_DISPLAYED_FAILURES} more`);
+    }
+
+    process.exit(1);
+  }
+
+  const excludedCount = lockedPackages.length - packagesToCheck.length;
+  const threshold = formatDuration(config.minimumReleaseAgeSeconds);
+  const suffix = excludedCount === 0 ? '' : ` (${excludedCount} excluded by bunfig.toml)`;
+  console.log(
+    `Checked ${packagesToCheck.length} locked npm package version(s) against ` +
+      `${threshold} minimum release age${suffix}.`,
+  );
+}
+
+main().catch((error: unknown) => {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+  console.error(normalized.message);
+  process.exit(1);
+});

--- a/scripts/check-release-age.ts
+++ b/scripts/check-release-age.ts
@@ -87,10 +87,6 @@ async function readReleaseAgeConfig(configPath: string): Promise<ReleaseAgeConfi
   };
 }
 
-function parseLockString(raw: string): string {
-  return JSON.parse(`"${raw}"`) as string;
-}
-
 function parsePackageSpec(spec: string): { name: string; version: string } | null {
   const aliasMarker = '@npm:';
   const aliasIndex = spec.lastIndexOf(aliasMarker);
@@ -110,27 +106,191 @@ function parsePackageSpec(spec: string): { name: string; version: string } | nul
   return { name, version };
 }
 
+type JsonPosition = {
+  index: number;
+  line: number;
+};
+
+type JsonStringToken = JsonPosition & {
+  value: string;
+};
+
+function readJsonStringToken(text: string, startIndex: number, line: number): JsonStringToken {
+  let index = startIndex + 1;
+  let escaped = false;
+
+  while (index < text.length) {
+    const char = text[index];
+    if (char === '"' && !escaped) {
+      return {
+        value: JSON.parse(text.slice(startIndex, index + 1)) as string,
+        index: index + 1,
+        line,
+      };
+    }
+
+    escaped = char === '\\' && !escaped;
+    if (char !== '\\') {
+      escaped = false;
+    }
+    index += 1;
+  }
+
+  throw new Error('Unterminated string in bun.lock');
+}
+
+function skipJsonWhitespaceAndComments(text: string, position: JsonPosition): JsonPosition {
+  let { index, line } = position;
+
+  while (index < text.length) {
+    const char = text[index];
+    if (char === '\n') {
+      index += 1;
+      line += 1;
+      continue;
+    }
+    if (char === ' ' || char === '\r' || char === '\t') {
+      index += 1;
+      continue;
+    }
+    if (char === '/' && text[index + 1] === '/') {
+      index += 2;
+      while (index < text.length && text[index] !== '\n') {
+        index += 1;
+      }
+      continue;
+    }
+    if (char === '/' && text[index + 1] === '*') {
+      index += 2;
+      while (index < text.length && !(text[index] === '*' && text[index + 1] === '/')) {
+        if (text[index] === '\n') {
+          line += 1;
+        }
+        index += 1;
+      }
+      index += 2;
+      continue;
+    }
+
+    break;
+  }
+
+  return { index, line };
+}
+
+function findPackagesObject(text: string): JsonPosition {
+  let position: JsonPosition = { index: 0, line: 1 };
+  let objectDepth = 0;
+
+  while (position.index < text.length) {
+    position = skipJsonWhitespaceAndComments(text, position);
+    const char = text[position.index];
+
+    if (char === '"') {
+      const key = readJsonStringToken(text, position.index, position.line);
+      if (objectDepth === 1 && key.value === 'packages') {
+        let afterKey = skipJsonWhitespaceAndComments(text, key);
+        if (text[afterKey.index] === ':') {
+          afterKey = skipJsonWhitespaceAndComments(text, {
+            index: afterKey.index + 1,
+            line: afterKey.line,
+          });
+          if (text[afterKey.index] === '{') {
+            return afterKey;
+          }
+        }
+      }
+
+      position = key;
+      continue;
+    }
+
+    if (char === '{') {
+      objectDepth += 1;
+    } else if (char === '}') {
+      objectDepth -= 1;
+    } else if (char === '\n') {
+      position.line += 1;
+    }
+    position.index += 1;
+  }
+
+  return { index: -1, line: 1 };
+}
+
+function readLockPackageLines(lockfileText: string): Map<string, number> {
+  const packageLines = new Map<string, number>();
+  let position = findPackagesObject(lockfileText);
+  if (position.index === -1) {
+    return packageLines;
+  }
+
+  let objectDepth = 1;
+  position = { index: position.index + 1, line: position.line };
+
+  while (position.index < lockfileText.length && objectDepth > 0) {
+    position = skipJsonWhitespaceAndComments(lockfileText, position);
+    const char = lockfileText[position.index];
+
+    if (char === '"') {
+      const key = readJsonStringToken(lockfileText, position.index, position.line);
+      if (objectDepth === 1) {
+        const afterKey = skipJsonWhitespaceAndComments(lockfileText, key);
+        if (lockfileText[afterKey.index] === ':') {
+          packageLines.set(key.value, position.line);
+        }
+      }
+      position = key;
+      continue;
+    }
+
+    if (char === '{') {
+      objectDepth += 1;
+    } else if (char === '}') {
+      objectDepth -= 1;
+    } else if (char === '\n') {
+      position.line += 1;
+    }
+    position.index += 1;
+  }
+
+  return packageLines;
+}
+
 async function readLockedPackages(lockfilePath: string): Promise<LockedPackage[]> {
   const text = await Bun.file(lockfilePath).text();
+  const parsedLockfile = Bun.JSONC.parse(text);
+  if (!isRecord(parsedLockfile)) {
+    throw new Error(`${lockfilePath} does not contain a JSONC object`);
+  }
+
+  const lockfilePackages = parsedLockfile.packages;
+  if (!isRecord(lockfilePackages)) {
+    throw new Error(`${lockfilePath} must define a packages object`);
+  }
+
   const packages = new Map<string, LockedPackage>();
-  const entryPattern = /^\s{4}"(?:\\.|[^"\\])*": \["((?:\\.|[^"\\])*)"/;
+  const packageLines = readLockPackageLines(text);
 
-  text.split('\n').forEach((line, index) => {
-    const match = line.match(entryPattern);
-    if (!match?.[1]) return;
+  for (const [packageKey, packageEntry] of Object.entries(lockfilePackages)) {
+    if (!Array.isArray(packageEntry) || typeof packageEntry[0] !== 'string') {
+      throw new Error(
+        `${lockfilePath}:${packageLines.get(packageKey) ?? 1} has an invalid package entry`,
+      );
+    }
 
-    const spec = parseLockString(match[1]);
+    const spec = packageEntry[0];
     const parsed = parsePackageSpec(spec);
-    if (!parsed) return;
+    if (!parsed) continue;
 
     const key = `${parsed.name}@${parsed.version}`;
     if (!packages.has(key)) {
       packages.set(key, {
         ...parsed,
-        line: index + 1,
+        line: packageLines.get(packageKey) ?? 1,
       });
     }
-  });
+  }
 
   if (packages.size === 0) {
     throw new Error(`No npm package entries were found in ${lockfilePath}`);

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -109,9 +109,10 @@ is_browser_test_package() {
 ensure_playwright_browsers() {
     log_info "Ensuring Playwright browsers are installed..."
     cd "$PROJECT_ROOT"
-    npx playwright install --with-deps chromium firefox webkit 2>/dev/null || {
+    bun --cwd packages/indexeddb playwright install --with-deps \
+        chromium firefox webkit 2>/dev/null || {
         log_warn "Failed to install all browsers, trying without deps..."
-        npx playwright install chromium firefox webkit || {
+        bun --cwd packages/indexeddb playwright install chromium firefox webkit || {
             log_error "Failed to install Playwright browsers"
             return 1
         }


### PR DESCRIPTION
## Description

Adds a 7-day npm package release-age gate for Bun installs and CI validation.

## Problem

Bun's resolver gate only affects new dependency resolution. Committed `bun.lock` entries still need explicit validation so too-new package versions cannot slip through by lockfile update.

## Summary

- Add `minimumReleaseAge = 604800` in `bunfig.toml`.
- Add a Bun lockfile audit script backed by npm registry publish timestamps.
- Run the audit in package build CI, publish CI, and a dedicated dependency-age workflow.
- Update workflow Bun pins to `1.3.11` so CI uses a Bun version with release-age support.

## Verification

- `bun run security:release-age`
- `env BUN_TMPDIR=/tmp/codex-bun-tmp BUN_INSTALL=/tmp/codex-bun-install bun install --frozen-lockfile`
- `bun run format:check`
- `git diff --check`

## Changeset

- Not added; this is repo security/CI tooling and does not change published package runtime APIs.