### PR TITLE
fix(core): unblind restored signatures via toProof() in recoverProofsFromOutputData

### DIFF
--- a/.changeset/restored-proofs-unblind.md
+++ b/.changeset/restored-proofs-unblind.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Unblind restored signatures during proof recovery and reject restored proofs from mismatched keyset units.

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -1030,23 +1030,28 @@ export class ProofService {
     // Build blinded messages for restore request
     const blindedMessages = allOutputs.map((o) => o.blindedMessage);
 
+    // Fetch keysets needed to unblind restored signatures
+    const { keysets } = await this.mintService.ensureUpdatedMint(mintUrl);
+    const keysetMap: { [id: string]: Keyset } = {};
+    keysets.forEach((ks) => {
+      keysetMap[ks.id] = ks;
+    });
+
     // Call mint restore endpoint
     const restoreResult = await wallet.mint.restore({ outputs: blindedMessages });
 
-    // Match signatures back to outputs and construct proofs
+    // Match signatures back to outputs and unblind to construct proofs
     const restoredProofs: Proof[] = [];
     for (let i = 0; i < restoreResult.outputs.length; i++) {
       const output = allOutputs.find((o) => o.blindedMessage.B_ === restoreResult.outputs[i]?.B_);
       const signature = restoreResult.signatures[i];
       if (output && signature) {
-        // Construct proof from output data and signature
-        const proof: Proof = {
-          id: signature.id,
-          amount: signature.amount,
-          secret: new TextDecoder().decode(output.secret),
-          C: signature.C_,
-        };
-        restoredProofs.push(proof);
+        const keyset = keysetMap[signature.id];
+        if (!keyset) {
+          this.logger?.warn('Missing keyset for restored signature', { id: signature.id });
+          continue;
+        }
+        restoredProofs.push(output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }));
       }
     }
 

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -1051,7 +1051,9 @@ export class ProofService {
           this.logger?.warn('Missing keyset for restored signature', { id: signature.id });
           continue;
         }
-        restoredProofs.push(output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }));
+        restoredProofs.push(
+          output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }),
+        );
       }
     }
 

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -1051,6 +1051,11 @@ export class ProofService {
           this.logger?.warn('Missing keyset for restored signature', { id: signature.id });
           continue;
         }
+        assertSameUnit(
+          normalizeUnit(keyset.unit, { defaultUnit: DEFAULT_UNIT }),
+          unit,
+          'Restored proof keyset',
+        );
         restoredProofs.push(
           output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }),
         );

--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -10,6 +10,7 @@ import { SeedService } from '../../services/SeedService.ts';
 import {
   ProofOperationError,
   ProofValidationError,
+  UnitMismatchError,
   UnitValidationError,
 } from '../../models/Error.ts';
 import type { CoreProof } from '../../types.ts';
@@ -1310,7 +1311,7 @@ describe('ProofService', () => {
       OutputData.prototype.toProof = originalToProof;
     });
 
-    it('undblinds signatures via toProof() rather than copying C_ directly', async () => {
+    it('unblinds signatures via toProof() rather than copying C_ directly', async () => {
       const B_ = 'mock_blinded_point_B_';
       const serializedOutputData: SerializedOutputData = {
         keep: [],
@@ -1388,6 +1389,82 @@ describe('ProofService', () => {
       // C must be the unblinded value produced by toProof(), not the raw blinded signature C_
       expect(recovered[0]?.C).toBe(unblindedC);
       expect(recovered[0]?.C).not.toBe(blindedC_);
+    });
+
+    it('rejects restored signatures from a different-unit keyset', async () => {
+      const B_ = 'mock_blinded_point_B_';
+      const serializedOutputData: SerializedOutputData = {
+        keep: [],
+        send: [
+          {
+            blindedMessage: { amount: '1', id: keysetId, B_ },
+            blindingFactor: 'deadbeef',
+            secret: Buffer.from('test-secret').toString('hex'),
+          },
+        ],
+      };
+
+      const toProof = mock(() => ({
+        id: keysetId,
+        amount: Amount.from(1),
+        secret: 'test-secret',
+        C: 'UNBLINDED_C',
+      }));
+      (OutputData.prototype as any).toProof = toProof;
+
+      const localMintService = {
+        async getAllTrustedMints() {
+          return [{ mintUrl }];
+        },
+        async ensureUpdatedMint(_url: string) {
+          return {
+            mint: {},
+            keysets: [{ id: keysetId, unit: 'usd', active: true, keypairs: { '1': 'pubkey-1' } }],
+          };
+        },
+      };
+
+      const localWalletService = {
+        async getWalletWithActiveKeysetId() {
+          return {
+            wallet: {
+              mint: {
+                async restore(_req: any) {
+                  return {
+                    outputs: [{ B_, amount: 1, id: keysetId }],
+                    signatures: [{ B_, id: keysetId, amount: Amount.from(1), C_: 'BLINDED_C_' }],
+                  };
+                },
+              },
+              async checkProofsStates(_proofs: any[]) {
+                return [{ state: 'UNSPENT' }];
+              },
+            },
+          };
+        },
+        async getWallet() {
+          return { selectProofsToSend: (p: any[]) => ({ send: p }) };
+        },
+      };
+
+      const service = new ProofService(
+        counterService,
+        proofRepo,
+        localWalletService as any,
+        localMintService as any,
+        keyRingService as any,
+        seedService,
+        undefined,
+        bus,
+      );
+
+      await expect(
+        service.recoverProofsFromOutputData(mintUrl, serializedOutputData, {
+          unit: 'sat',
+          persistRecoveredProofs: false,
+        }),
+      ).rejects.toThrow(UnitMismatchError);
+      expect(toProof).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../models/Error.ts';
 import type { CoreProof } from '../../types.ts';
 import { OutputData } from '@cashu/cashu-ts';
+import type { SerializedOutputData } from '../../utils.ts';
 
 describe('ProofService', () => {
   const mintUrl = 'https://mint.test';
@@ -37,6 +38,7 @@ describe('ProofService', () => {
   // Minimal mint service stub
   let mintService: {
     getAllTrustedMints: () => Promise<{ mintUrl: string }[]>;
+    ensureUpdatedMint: (mintUrl: string) => Promise<{ mint: any; keysets: any[] }>;
   };
 
   // Minimal keyRingService stub
@@ -90,6 +92,9 @@ describe('ProofService', () => {
     mintService = {
       async getAllTrustedMints() {
         return [{ mintUrl }];
+      },
+      async ensureUpdatedMint(_mintUrl: string) {
+        return { mint: {}, keysets: [] };
       },
     };
 
@@ -1291,6 +1296,99 @@ describe('ProofService', () => {
       await expect(service.getTrustedBalancesBreakdown()).resolves.toEqual({
         [mintUrl]: { ready: Amount.from(50), reserved: Amount.from(100), total: Amount.from(150) },
       });
+    });
+  });
+
+  describe('recoverProofsFromOutputData', () => {
+    let originalToProof: typeof OutputData.prototype.toProof;
+
+    beforeEach(() => {
+      originalToProof = OutputData.prototype.toProof;
+    });
+
+    afterEach(() => {
+      OutputData.prototype.toProof = originalToProof;
+    });
+
+    it('undblinds signatures via toProof() rather than copying C_ directly', async () => {
+      const B_ = 'mock_blinded_point_B_';
+      const serializedOutputData: SerializedOutputData = {
+        keep: [],
+        send: [
+          {
+            blindedMessage: { amount: '1', id: keysetId, B_ },
+            blindingFactor: 'deadbeef',
+            secret: Buffer.from('test-secret').toString('hex'),
+          },
+        ],
+      };
+
+      const unblindedC = 'UNBLINDED_C';
+      const blindedC_ = 'BLINDED_C_';
+
+      (OutputData.prototype as any).toProof = mock(() => ({
+        id: keysetId,
+        amount: Amount.from(1),
+        secret: 'test-secret',
+        C: unblindedC,
+      }));
+
+      const localMintService = {
+        async getAllTrustedMints() {
+          return [{ mintUrl }];
+        },
+        async ensureUpdatedMint(_url: string) {
+          return {
+            mint: {},
+            keysets: [{ id: keysetId, unit: 'sat', active: true, keypairs: { '1': 'pubkey-1' } }],
+          };
+        },
+      };
+
+      const localWalletService = {
+        async getWalletWithActiveKeysetId() {
+          return {
+            wallet: {
+              mint: {
+                async restore(_req: any) {
+                  return {
+                    outputs: [{ B_, amount: 1, id: keysetId }],
+                    signatures: [{ B_, id: keysetId, amount: Amount.from(1), C_: blindedC_ }],
+                  };
+                },
+              },
+              async checkProofsStates(_proofs: any[]) {
+                return [{ state: 'UNSPENT' }];
+              },
+            },
+          };
+        },
+        async getWallet() {
+          return { selectProofsToSend: (p: any[]) => ({ send: p }) };
+        },
+      };
+
+      const service = new ProofService(
+        counterService,
+        proofRepo,
+        localWalletService as any,
+        localMintService as any,
+        keyRingService as any,
+        seedService,
+        undefined,
+        bus,
+      );
+
+      const recovered = await service.recoverProofsFromOutputData(
+        mintUrl,
+        serializedOutputData,
+        { unit: 'sat', persistRecoveredProofs: false },
+      );
+
+      expect(recovered).toHaveLength(1);
+      // C must be the unblinded value produced by toProof(), not the raw blinded signature C_
+      expect(recovered[0]?.C).toBe(unblindedC);
+      expect(recovered[0]?.C).not.toBe(blindedC_);
     });
   });
 });

--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -1379,11 +1379,10 @@ describe('ProofService', () => {
         bus,
       );
 
-      const recovered = await service.recoverProofsFromOutputData(
-        mintUrl,
-        serializedOutputData,
-        { unit: 'sat', persistRecoveredProofs: false },
-      );
+      const recovered = await service.recoverProofsFromOutputData(mintUrl, serializedOutputData, {
+        unit: 'sat',
+        persistRecoveredProofs: false,
+      });
 
       expect(recovered).toHaveLength(1);
       // C must be the unblinded value produced by toProof(), not the raw blinded signature C_


### PR DESCRIPTION
## Fixes #157 

## Summary

`ProofService.recoverProofsFromOutputData()` was copying the blinded signature point (`C_`) directly into `Proof.C` instead of unblinding it first. This produced structurally plausible but cryptographically invalid proofs that pass secret/Y-based state checks locally but fail when spent at the mint.

## Changes

**`ProofService.ts`**
- Replaced manual `{ id, amount, secret, C: signature.C_ }` construction with `output.toProof(sig, keyset)`
- Keysets are now fetched via `this.mintService.ensureUpdatedMint(mintUrl)` and mapped by `id`, mirroring `unblindAndSaveChangeProofs()`
- If a keyset is missing for a given signature, it is skipped with a warning rather than producing a broken proof

**`ProofService.test.ts`**
- Added a `describe('recoverProofsFromOutputData')` regression test block
- Mocks `OutputData.prototype.toProof` to return `C: 'UNBLINDED_C'` and the restore mock to return `C_: 'BLINDED_C_'`
- Asserts `recovered[0].C === 'UNBLINDED_C'` and `!== 'BLINDED_C_'`
- Extended `mintService` stub with `ensureUpdatedMint` to support the new code path
- This test fails against the old code and passes with the fix