### PR TITLE
fix(core): defer watcher send finalization while locked

### DIFF
--- a/.changeset/silent-send-finalization.md
+++ b/.changeset/silent-send-finalization.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Defer proof-watcher send finalization until an in-progress send operation releases its lock.

--- a/packages/core/operations/send/SendOperationService.ts
+++ b/packages/core/operations/send/SendOperationService.ts
@@ -58,6 +58,8 @@ export class SendOperationService {
   private recoveryLock: Promise<void> | null = null;
   /** In-memory lock to serialize proof selection/reservation per mint */
   private readonly mintScopedLock: MintScopedLock;
+  /** Operations that observed spent send proofs while another saga step held the lock. */
+  private readonly deferredSpentProofFinalizations = new Set<string>();
 
   constructor(
     sendOperationRepository: SendOperationRepository,
@@ -211,6 +213,7 @@ export class SendOperationService {
       return prepared;
     } finally {
       releaseLock();
+      this.drainDeferredSpentProofFinalization(operation.id);
     }
   }
 
@@ -316,6 +319,7 @@ export class SendOperationService {
       return { operation: pending, token };
     } finally {
       releaseLock();
+      this.drainDeferredSpentProofFinalization(operation.id);
     }
   }
 
@@ -433,7 +437,53 @@ export class SendOperationService {
       this.logger?.info('Send operation finalized', { operationId });
     } finally {
       releaseLock?.();
+      this.drainDeferredSpentProofFinalization(operationId);
     }
+  }
+
+  /**
+   * Finalize a send operation only when all token proofs are already locally marked spent.
+   *
+   * This is used by proof-state watchers. If the watcher observes a spent proof while the
+   * send saga still holds the operation lock, finalization is deferred until that lock
+   * releases instead of blocking the event listener.
+   */
+  async finalizeIfAllSendProofsSpent(operationId: string): Promise<void> {
+    const operation = await this.sendOperationRepository.getById(operationId);
+    if (!operation || isTerminalOperation(operation) || operation.state === 'rolling_back') {
+      return;
+    }
+
+    if (this.operationIdLock.isLocked(operationId)) {
+      this.deferredSpentProofFinalizations.add(operationId);
+      this.logger?.debug('Deferred send finalization while operation is locked', { operationId });
+      return;
+    }
+
+    if (operation.state !== 'pending' || !hasPreparedData(operation)) {
+      return;
+    }
+
+    const sendProofSecrets = getSendProofSecrets(operation);
+    if (sendProofSecrets.length === 0) {
+      return;
+    }
+
+    const sendProofs = await this.proofRepository.getProofsBySecrets(
+      operation.mintUrl,
+      sendProofSecrets,
+    );
+    const expectedProofCount = new Set(sendProofSecrets).size;
+    const allSpent =
+      sendProofs.length === expectedProofCount &&
+      sendProofs.every((proof) => proof.state === 'spent');
+
+    if (!allSpent) {
+      return;
+    }
+
+    this.logger?.info('All send proofs spent, finalizing operation', { operationId });
+    await this.finalize(operationId);
   }
 
   /**
@@ -498,6 +548,7 @@ export class SendOperationService {
       await this.markAsRolledBack(opForRollback, reason);
     } finally {
       releaseLock();
+      this.drainDeferredSpentProofFinalization(operationId);
     }
   }
 
@@ -738,6 +789,19 @@ export class SendOperationService {
     }
 
     return sendStates.every((s) => s.state === 'SPENT') ? 'finalize' : 'stay_pending';
+  }
+
+  private drainDeferredSpentProofFinalization(operationId: string): void {
+    if (!this.deferredSpentProofFinalizations.delete(operationId)) {
+      return;
+    }
+
+    void this.finalizeIfAllSendProofsSpent(operationId).catch((error) => {
+      this.logger?.warn('Deferred send finalization failed', {
+        operationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   }
 
   /**

--- a/packages/core/services/watchers/ProofStateWatcherService.ts
+++ b/packages/core/services/watchers/ProofStateWatcherService.ts
@@ -4,7 +4,6 @@ import type { SubscriptionManager, UnsubscribeHandler } from '@core/infra/Subscr
 import type { MintService } from '../MintService';
 import type { ProofService } from '../ProofService';
 import type { SendOperationService } from '../../operations/send/SendOperationService';
-import { getSendProofSecrets, hasPreparedData } from '../../operations/send/SendOperation';
 import type { ProofRepository } from '../../repositories';
 import { buildYHexMapsForSecrets } from '../../utils.ts';
 
@@ -372,27 +371,8 @@ export class ProofStateWatcherService {
       // Check both usedByOperationId (for exact match sends) and createdByOperationId (for swap sends)
       const operationId = spentProof?.usedByOperationId || spentProof?.createdByOperationId;
       if (!operationId) return;
-      const operation = await this.sendOperationService.getOperation(operationId);
 
-      if (!operation || operation.state !== 'pending') return;
-
-      // Operation must have prepared data to derive send secrets
-      if (!hasPreparedData(operation)) return;
-
-      // Derive send proof secrets from operation data
-      const sendProofSecrets = getSendProofSecrets(operation);
-      if (sendProofSecrets.length === 0) return;
-
-      const sendProofs = await this.proofRepository.getProofsBySecrets(mintUrl, sendProofSecrets);
-      const expectedProofCount = new Set(sendProofSecrets).size;
-      const allSpent =
-        sendProofs.length === expectedProofCount &&
-        sendProofs.every((proof) => proof.state === 'spent');
-
-      if (allSpent) {
-        this.logger?.info('All send proofs spent, finalizing operation', { operationId });
-        await this.sendOperationService.finalize(operationId);
-      }
+      await this.sendOperationService.finalizeIfAllSendProofsSpent(operationId);
     } catch (err) {
       this.logger?.error('Failed to check/finalize send operation', { mintUrl, secret, err });
     }

--- a/packages/core/test/unit/ProofStateWatcherService.test.ts
+++ b/packages/core/test/unit/ProofStateWatcherService.test.ts
@@ -119,29 +119,11 @@ describe('ProofStateWatcherService', () => {
     await watcher.stop();
   });
 
-  it('finalizes a pending send operation when the batched send proofs are all spent', async () => {
+  it('delegates spent send proof finalization to the send operation service', async () => {
     const getProofBySecret = mock(async () =>
       makeProof({ secret: 'spent-1', state: 'spent', usedByOperationId: 'send-op-1' }),
     );
-    const getProofsBySecrets = mock(async () => [
-      makeProof({ secret: 'spent-1', state: 'spent' }),
-      makeProof({ secret: 'spent-2', state: 'spent' }),
-    ]);
-    const finalize = mock(async () => {});
-    const getOperation = mock(async () => ({
-      id: 'send-op-1',
-      state: 'pending',
-      mintUrl: mintUrlA,
-      amount: Amount.from(2),
-      method: 'default',
-      methodData: {},
-      needsSwap: false,
-      fee: Amount.from(0),
-      inputAmount: Amount.from(2),
-      inputProofSecrets: ['spent-1', 'spent-2'],
-      createdAt: 0,
-      updatedAt: 0,
-    }));
+    const finalizeIfAllSendProofsSpent = mock(async () => {});
 
     const watcher = new ProofStateWatcherService(
       {} as SubscriptionManager,
@@ -149,13 +131,14 @@ describe('ProofStateWatcherService', () => {
       {} as ProofService,
       {
         getProofBySecret,
-        getProofsBySecrets,
       } as unknown as ProofRepository,
       bus,
       new NullLogger(),
       { watchExistingInflightOnStart: false },
     );
-    watcher.setSendOperationService({ getOperation, finalize } as unknown as SendOperationService);
+    watcher.setSendOperationService({
+      finalizeIfAllSendProofsSpent,
+    } as unknown as SendOperationService);
 
     await watcher.start();
     await bus.emit('proofs:state-changed', {
@@ -166,34 +149,15 @@ describe('ProofStateWatcherService', () => {
 
     expect(getProofBySecret).toHaveBeenCalledTimes(1);
     expect(getProofBySecret).toHaveBeenCalledWith(mintUrlA, 'spent-1');
-    expect(getProofsBySecrets).toHaveBeenCalledTimes(1);
-    expect(getProofsBySecrets).toHaveBeenCalledWith(mintUrlA, ['spent-1', 'spent-2']);
-    expect(finalize).toHaveBeenCalledTimes(1);
-    expect(finalize).toHaveBeenCalledWith('send-op-1');
+    expect(finalizeIfAllSendProofsSpent).toHaveBeenCalledTimes(1);
+    expect(finalizeIfAllSendProofsSpent).toHaveBeenCalledWith('send-op-1');
 
     await watcher.stop();
   });
 
-  it('does not finalize a pending send operation when the batched lookup is missing a proof', async () => {
-    const getProofBySecret = mock(async () =>
-      makeProof({ secret: 'spent-1', state: 'spent', usedByOperationId: 'send-op-1' }),
-    );
-    const getProofsBySecrets = mock(async () => [makeProof({ secret: 'spent-1', state: 'spent' })]);
-    const finalize = mock(async () => {});
-    const getOperation = mock(async () => ({
-      id: 'send-op-1',
-      state: 'pending',
-      mintUrl: mintUrlA,
-      amount: Amount.from(2),
-      method: 'default',
-      methodData: {},
-      needsSwap: false,
-      fee: Amount.from(0),
-      inputAmount: Amount.from(2),
-      inputProofSecrets: ['spent-1', 'spent-2'],
-      createdAt: 0,
-      updatedAt: 0,
-    }));
+  it('does not delegate spent proof finalization when the proof is not tied to a send operation', async () => {
+    const getProofBySecret = mock(async () => makeProof({ secret: 'spent-1', state: 'spent' }));
+    const finalizeIfAllSendProofsSpent = mock(async () => {});
 
     const watcher = new ProofStateWatcherService(
       {} as SubscriptionManager,
@@ -201,13 +165,14 @@ describe('ProofStateWatcherService', () => {
       {} as ProofService,
       {
         getProofBySecret,
-        getProofsBySecrets,
       } as unknown as ProofRepository,
       bus,
       new NullLogger(),
       { watchExistingInflightOnStart: false },
     );
-    watcher.setSendOperationService({ getOperation, finalize } as unknown as SendOperationService);
+    watcher.setSendOperationService({
+      finalizeIfAllSendProofsSpent,
+    } as unknown as SendOperationService);
 
     await watcher.start();
     await bus.emit('proofs:state-changed', {
@@ -216,8 +181,8 @@ describe('ProofStateWatcherService', () => {
       state: 'spent',
     });
 
-    expect(getProofsBySecrets).toHaveBeenCalledTimes(1);
-    expect(finalize).not.toHaveBeenCalled();
+    expect(getProofBySecret).toHaveBeenCalledTimes(1);
+    expect(finalizeIfAllSendProofsSpent).not.toHaveBeenCalled();
 
     await watcher.stop();
   });

--- a/packages/core/test/unit/SendOperationService.test.ts
+++ b/packages/core/test/unit/SendOperationService.test.ts
@@ -1,4 +1,4 @@
-import { Amount } from '@cashu/cashu-ts';
+import { Amount, type Token } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
 import { SendOperationService } from '../../operations/send/SendOperationService';
 import { DefaultSendHandler } from '../../infra/handlers/send/DefaultSendHandler';
@@ -446,5 +446,247 @@ describe('SendOperationService', () => {
     expect(customHandler.finalize).toHaveBeenCalledTimes(1);
     expect(persistedStateDuringFinalize).toBe('pending');
     expect((await sendOpRepo.getById(pendingOp.id))?.state).toBe('finalized');
+  });
+
+  it('drains spent-proof finalization deferred while finalize holds the operation lock', async () => {
+    const pendingOp: PendingSendOperation = {
+      id: 'send-op-deferred-finalize-during-finalize',
+      state: 'pending',
+      mintUrl,
+      amount: Amount.from(100),
+      unit: 'sat',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      needsSwap: false,
+      fee: Amount.from(0),
+      inputAmount: Amount.from(100),
+      inputProofSecrets: ['send-secret-1'],
+      method: 'default',
+      methodData: {},
+    };
+    await sendOpRepo.create(pendingOp);
+    await proofRepo.saveProofs(mintUrl, [
+      {
+        ...makeProof('send-secret-1', 100),
+        state: 'spent',
+        usedByOperationId: pendingOp.id,
+      },
+    ]);
+
+    const finalized = new Promise<void>((resolve) => {
+      eventBus.on('send:finalized', ({ operationId }) => {
+        if (operationId === pendingOp.id) {
+          resolve();
+        }
+      });
+    });
+
+    let finalizeAttempts = 0;
+    const customHandler: SendMethodHandler<'default'> = {
+      prepare: mock(async () => {
+        throw new Error('not used');
+      }),
+      execute: mock(async () => {
+        throw new Error('not used');
+      }),
+      finalize: mock(async ({ operation }) => {
+        finalizeAttempts += 1;
+        if (finalizeAttempts === 1) {
+          await service.finalizeIfAllSendProofsSpent(operation.id);
+          throw new Error('transient finalization failure');
+        }
+      }),
+      recoverExecuting: mock(async () => {
+        throw new Error('not used');
+      }),
+    };
+
+    handlerProvider = new SendHandlerProvider({
+      default: customHandler,
+      p2pk: new P2pkSendHandler(),
+    });
+    service = new SendOperationService(
+      sendOpRepo,
+      proofRepo,
+      proofService,
+      mintService,
+      walletService,
+      eventBus,
+      handlerProvider,
+      logger,
+    );
+
+    await expect(service.finalize(pendingOp.id)).rejects.toThrow('transient finalization failure');
+    await finalized;
+
+    expect(customHandler.finalize).toHaveBeenCalledTimes(2);
+    expect((await sendOpRepo.getById(pendingOp.id))?.state).toBe('finalized');
+  });
+
+  it('logs deferred spent-proof finalization failures without rethrowing', async () => {
+    const pendingOp: PendingSendOperation = {
+      id: 'send-op-deferred-finalize-failure',
+      state: 'pending',
+      mintUrl,
+      amount: Amount.from(100),
+      unit: 'sat',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      needsSwap: false,
+      fee: Amount.from(0),
+      inputAmount: Amount.from(100),
+      inputProofSecrets: ['send-secret-1'],
+      method: 'default',
+      methodData: {},
+    };
+    await sendOpRepo.create(pendingOp);
+    await proofRepo.saveProofs(mintUrl, [
+      {
+        ...makeProof('send-secret-1', 100),
+        state: 'spent',
+        usedByOperationId: pendingOp.id,
+      },
+    ]);
+
+    let resolveDeferredWarning: () => void;
+    const deferredWarningLogged = new Promise<void>((resolve) => {
+      resolveDeferredWarning = resolve;
+    });
+    let deferredWarningArgs: unknown[] = [];
+    (logger.warn as Mock<any>).mockImplementation((message: string, ...meta: unknown[]) => {
+      if (message === 'Deferred send finalization failed') {
+        deferredWarningArgs = [message, ...meta];
+        resolveDeferredWarning();
+      }
+    });
+
+    let finalizeAttempts = 0;
+    const customHandler: SendMethodHandler<'default'> = {
+      prepare: mock(async () => {
+        throw new Error('not used');
+      }),
+      execute: mock(async () => {
+        throw new Error('not used');
+      }),
+      finalize: mock(async ({ operation }) => {
+        finalizeAttempts += 1;
+        if (finalizeAttempts === 1) {
+          await service.finalizeIfAllSendProofsSpent(operation.id);
+          throw new Error('initial finalization failure');
+        }
+
+        throw new Error('deferred finalization failure');
+      }),
+      recoverExecuting: mock(async () => {
+        throw new Error('not used');
+      }),
+    };
+
+    handlerProvider = new SendHandlerProvider({
+      default: customHandler,
+      p2pk: new P2pkSendHandler(),
+    });
+    service = new SendOperationService(
+      sendOpRepo,
+      proofRepo,
+      proofService,
+      mintService,
+      walletService,
+      eventBus,
+      handlerProvider,
+      logger,
+    );
+
+    await expect(service.finalize(pendingOp.id)).rejects.toThrow('initial finalization failure');
+    await deferredWarningLogged;
+
+    expect(customHandler.finalize).toHaveBeenCalledTimes(2);
+    expect(deferredWarningArgs).toEqual([
+      'Deferred send finalization failed',
+      {
+        operationId: pendingOp.id,
+        error: 'deferred finalization failure',
+      },
+    ]);
+    expect((await sendOpRepo.getById(pendingOp.id))?.state).toBe('pending');
+  });
+
+  it('defers spent-proof finalization while execute holds the operation lock', async () => {
+    const preparedOp: PreparedSendOperation = {
+      id: 'send-op-deferred-finalize',
+      state: 'prepared',
+      mintUrl,
+      amount: Amount.from(100),
+      unit: 'sat',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      needsSwap: false,
+      fee: Amount.from(0),
+      inputAmount: Amount.from(100),
+      inputProofSecrets: ['send-secret-1'],
+      method: 'default',
+      methodData: {},
+    };
+    await sendOpRepo.create(preparedOp);
+    await proofRepo.saveProofs(mintUrl, [
+      {
+        ...makeProof('send-secret-1', 100),
+        state: 'spent',
+        usedByOperationId: preparedOp.id,
+      },
+    ]);
+
+    const token: Token = {
+      mint: mintUrl,
+      unit: 'sat',
+      proofs: [{ id: keysetId, amount: Amount.from(100), secret: 'send-secret-1', C: 'C_1' }],
+    } as Token;
+    const pendingOp: PendingSendOperation = {
+      ...preparedOp,
+      state: 'pending',
+      token,
+    };
+    const finalized = new Promise<void>((resolve) => {
+      eventBus.on('send:finalized', ({ operationId }) => {
+        if (operationId === preparedOp.id) {
+          resolve();
+        }
+      });
+    });
+
+    const customHandler: SendMethodHandler<'default'> = {
+      prepare: mock(async () => preparedOp),
+      execute: mock(async () => {
+        await service.finalizeIfAllSendProofsSpent(preparedOp.id);
+        return { status: 'PENDING' as const, pending: pendingOp, token };
+      }),
+      finalize: mock(async () => {}),
+      recoverExecuting: mock(async () => {
+        throw new Error('not used');
+      }),
+    };
+
+    handlerProvider = new SendHandlerProvider({
+      default: customHandler,
+      p2pk: new P2pkSendHandler(),
+    });
+    service = new SendOperationService(
+      sendOpRepo,
+      proofRepo,
+      proofService,
+      mintService,
+      walletService,
+      eventBus,
+      handlerProvider,
+      logger,
+    );
+
+    await expect(service.execute(preparedOp)).resolves.toMatchObject({
+      operation: { state: 'pending' },
+    });
+    await finalized;
+
+    expect(customHandler.finalize).toHaveBeenCalledTimes(1);
+    expect((await sendOpRepo.getById(preparedOp.id))?.state).toBe('finalized');
   });
 });


### PR DESCRIPTION
## Description

This pull request fixes send finalization triggered by proof-state watchers when the send operation is still holding its operation lock.

## Problem

A proof-state watcher can observe spent send proofs while `SendOperationService.execute()` is still inside the operation lock and emitting sequential event-bus listeners. Waiting on that lock from the watcher path can deadlock the send flow, while returning early can leave the operation pending until later recovery.

## Summary

- Move the all-send-proofs-spent finalization check behind `SendOperationService.finalizeIfAllSendProofsSpent()` so send operation state owns the invariant.
- Defer watcher-triggered finalization while the operation is locked and drain it after `prepare`, `execute`, `finalize`, or `rollback` releases the lock.
- Update focused watcher/send-operation tests for delegation, lock deferral, and deferred retry behavior.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/ProofStateWatcherService.test.ts test/unit/SendOperationService.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `git diff --check`

## Changeset

- Added `.changeset/silent-send-finalization.md` for `@cashu/coco-core` patch release.