### PR TITLE
fix(core): dedupe proof watcher finalization checks

### DIFF
--- a/.changeset/single-proof-finalization.md
+++ b/.changeset/single-proof-finalization.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Avoid duplicate send finalization checks for proof state subscription notifications.

--- a/.changeset/single-proof-finalization.md
+++ b/.changeset/single-proof-finalization.md
@@ -2,4 +2,5 @@
 '@cashu/coco-core': patch
 ---
 
-Avoid duplicate send finalization checks for proof state subscription notifications.
+Avoid duplicate send finalization checks for proof state subscription notifications and batched
+spent-proof events from the same operation.

--- a/packages/core/services/watchers/ProofStateWatcherService.ts
+++ b/packages/core/services/watchers/ProofStateWatcherService.ts
@@ -248,9 +248,6 @@ export class ProofStateWatcherService {
             subId,
           });
           await this.stopWatching(key);
-
-          // Check if this proof is part of a send operation and finalize it
-          await this.tryFinalizeSendOperation(mintUrl, secret);
         } catch (err) {
           this.logger?.error('Failed to mark inflight proof as spent', { mintUrl, subId, err });
         } finally {

--- a/packages/core/services/watchers/ProofStateWatcherService.ts
+++ b/packages/core/services/watchers/ProofStateWatcherService.ts
@@ -96,6 +96,8 @@ export class ProofStateWatcherService {
               });
             }
           } else if (state === 'spent') {
+            const operationIds = new Set<string>();
+
             // Stop watching if we already are
             for (const secret of secrets) {
               const key = toKey(mintUrl, secret);
@@ -109,15 +111,24 @@ export class ProofStateWatcherService {
                 });
               }
 
+              if (!this.sendOperationService) continue;
+
               try {
-                await this.tryFinalizeSendOperation(mintUrl, secret);
+                const operationId = await this.getSendOperationIdForSpentProof(mintUrl, secret);
+                if (operationId) {
+                  operationIds.add(operationId);
+                }
               } catch (err) {
-                this.logger?.warn('Failed to finalize send operation from spent proof event', {
+                this.logger?.warn('Failed to resolve send operation from spent proof event', {
                   mintUrl,
                   secret,
                   err,
                 });
               }
+            }
+
+            for (const operationId of operationIds) {
+              await this.tryFinalizeSendOperation(mintUrl, operationId);
             }
           }
         } catch (err) {
@@ -358,17 +369,24 @@ export class ProofStateWatcherService {
   }
 
   /**
-   * Check if a spent proof is part of a send operation and finalize it if all send proofs are spent.
+   * Resolve the send operation associated with a spent proof, if any.
    */
-  private async tryFinalizeSendOperation(mintUrl: string, secret: string): Promise<void> {
+  private async getSendOperationIdForSpentProof(
+    mintUrl: string,
+    secret: string,
+  ): Promise<string | undefined> {
+    const spentProof = await this.proofRepository.getProofBySecret(mintUrl, secret);
+    // Check both usedByOperationId (for exact match sends) and createdByOperationId (for swap sends)
+    return spentProof?.usedByOperationId || spentProof?.createdByOperationId;
+  }
+
+  /**
+   * Check if all send proofs for an operation are spent and finalize it if so.
+   */
+  private async tryFinalizeSendOperation(mintUrl: string, operationId: string): Promise<void> {
     if (!this.sendOperationService) return;
 
     try {
-      // Look up the specific proof that was just spent
-      const spentProof = await this.proofRepository.getProofBySecret(mintUrl, secret);
-      // Check both usedByOperationId (for exact match sends) and createdByOperationId (for swap sends)
-      const operationId = spentProof?.usedByOperationId || spentProof?.createdByOperationId;
-      if (!operationId) return;
       const operation = await this.sendOperationService.getOperation(operationId);
 
       if (!operation || operation.state !== 'pending') return;
@@ -391,7 +409,7 @@ export class ProofStateWatcherService {
         await this.sendOperationService.finalize(operationId);
       }
     } catch (err) {
-      this.logger?.error('Failed to check/finalize send operation', { mintUrl, secret, err });
+      this.logger?.error('Failed to check/finalize send operation', { mintUrl, operationId, err });
     }
   }
 }

--- a/packages/core/test/unit/ProofStateWatcherService.test.ts
+++ b/packages/core/test/unit/ProofStateWatcherService.test.ts
@@ -10,6 +10,7 @@ import type { ProofRepository } from '../../repositories/index.ts';
 import type { CoreProof } from '../../types.ts';
 import type { SendOperationService } from '../../operations/send/SendOperationService.ts';
 import { NullLogger } from '../../logging/NullLogger.ts';
+import { buildYHexMapsForSecrets } from '../../utils.ts';
 
 describe('ProofStateWatcherService', () => {
   const mintUrlA = 'https://mint-a.test';
@@ -218,6 +219,79 @@ describe('ProofStateWatcherService', () => {
 
     expect(getProofsBySecrets).toHaveBeenCalledTimes(1);
     expect(finalize).not.toHaveBeenCalled();
+
+    await watcher.stop();
+  });
+
+  it('finalizes once for a spent subscription notification emitted through proof state events', async () => {
+    const secret = 'spent-1';
+    const { yHexBySecret } = buildYHexMapsForSecrets([secret]);
+    let subscriptionCallback:
+      | ((payload: { Y: string; state: 'SPENT'; witness?: unknown }) => Promise<void> | void)
+      | undefined;
+    const unsubscribe = mock(async () => {});
+    const subscribe = mock(async (_mintUrl, _kind, _filters, callback) => {
+      subscriptionCallback = callback;
+      return { subId: 'sub-1', unsubscribe };
+    });
+    const setProofState = mock(
+      async (mintUrl: string, secrets: string[], state: 'inflight' | 'ready' | 'spent') => {
+        await bus.emit('proofs:state-changed', { mintUrl, secrets, state });
+      },
+    );
+    const getProofBySecret = mock(async () =>
+      makeProof({ secret, state: 'spent', usedByOperationId: 'send-op-1' }),
+    );
+    const getProofsBySecrets = mock(async () => [makeProof({ secret, state: 'spent' })]);
+    const finalize = mock(async () => {});
+    const getOperation = mock(async () => ({
+      id: 'send-op-1',
+      state: 'pending',
+      mintUrl: mintUrlA,
+      amount: Amount.from(1),
+      unit: 'sat',
+      method: 'default',
+      methodData: {},
+      needsSwap: false,
+      fee: Amount.from(0),
+      inputAmount: Amount.from(1),
+      inputProofSecrets: [secret],
+      createdAt: 0,
+      updatedAt: 0,
+    }));
+
+    const watcher = new ProofStateWatcherService(
+      { subscribe } as unknown as SubscriptionManager,
+      {
+        isTrustedMint: mock(async () => true),
+      } as unknown as MintService,
+      {
+        setProofState,
+      } as unknown as ProofService,
+      {
+        getProofBySecret,
+        getProofsBySecrets,
+      } as unknown as ProofRepository,
+      bus,
+      new NullLogger(),
+      { watchExistingInflightOnStart: false },
+    );
+    watcher.setSendOperationService({ getOperation, finalize } as unknown as SendOperationService);
+
+    await watcher.start();
+    await watcher.watchProof(mintUrlA, [secret]);
+    expect(subscriptionCallback).toBeDefined();
+
+    await subscriptionCallback!({ Y: yHexBySecret.get(secret)!, state: 'SPENT' });
+
+    expect(setProofState).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(getProofBySecret).toHaveBeenCalledTimes(1);
+    expect(getProofBySecret).toHaveBeenCalledWith(mintUrlA, secret);
+    expect(getProofsBySecrets).toHaveBeenCalledTimes(1);
+    expect(getProofsBySecrets).toHaveBeenCalledWith(mintUrlA, [secret]);
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(finalize).toHaveBeenCalledWith('send-op-1');
 
     await watcher.stop();
   });

--- a/packages/core/test/unit/ProofStateWatcherService.test.ts
+++ b/packages/core/test/unit/ProofStateWatcherService.test.ts
@@ -175,6 +175,128 @@ describe('ProofStateWatcherService', () => {
     await watcher.stop();
   });
 
+  it('checks finalization once for a batched spent event from the same send operation', async () => {
+    const getProofBySecret = mock(async (_mintUrl: string, secret: string) =>
+      makeProof({ secret, state: 'spent', usedByOperationId: 'send-op-1' }),
+    );
+    const getProofsBySecrets = mock(async () => [
+      makeProof({ secret: 'spent-1', state: 'spent' }),
+      makeProof({ secret: 'spent-2', state: 'spent' }),
+    ]);
+    const finalize = mock(async () => {});
+    const getOperation = mock(async () => ({
+      id: 'send-op-1',
+      state: 'pending',
+      mintUrl: mintUrlA,
+      amount: Amount.from(2),
+      method: 'default',
+      methodData: {},
+      needsSwap: false,
+      fee: Amount.from(0),
+      inputAmount: Amount.from(2),
+      inputProofSecrets: ['spent-1', 'spent-2'],
+      createdAt: 0,
+      updatedAt: 0,
+    }));
+
+    const watcher = new ProofStateWatcherService(
+      {} as SubscriptionManager,
+      {} as MintService,
+      {} as ProofService,
+      {
+        getProofBySecret,
+        getProofsBySecrets,
+      } as unknown as ProofRepository,
+      bus,
+      new NullLogger(),
+      { watchExistingInflightOnStart: false },
+    );
+    watcher.setSendOperationService({ getOperation, finalize } as unknown as SendOperationService);
+
+    await watcher.start();
+    await bus.emit('proofs:state-changed', {
+      mintUrl: mintUrlA,
+      secrets: ['spent-1', 'spent-2'],
+      state: 'spent',
+    });
+
+    expect(getProofBySecret).toHaveBeenCalledTimes(2);
+    expect(getProofBySecret).toHaveBeenCalledWith(mintUrlA, 'spent-1');
+    expect(getProofBySecret).toHaveBeenCalledWith(mintUrlA, 'spent-2');
+    expect(getOperation).toHaveBeenCalledTimes(1);
+    expect(getOperation).toHaveBeenCalledWith('send-op-1');
+    expect(getProofsBySecrets).toHaveBeenCalledTimes(1);
+    expect(getProofsBySecrets).toHaveBeenCalledWith(mintUrlA, ['spent-1', 'spent-2']);
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(finalize).toHaveBeenCalledWith('send-op-1');
+
+    await watcher.stop();
+  });
+
+  it('checks each operation once for a batched spent event from different send operations', async () => {
+    const operationBySecret = new Map([
+      ['spent-1', 'send-op-1'],
+      ['spent-2', 'send-op-2'],
+    ]);
+    const getProofBySecret = mock(async (_mintUrl: string, secret: string) =>
+      makeProof({
+        secret,
+        state: 'spent',
+        usedByOperationId: operationBySecret.get(secret),
+      }),
+    );
+    const getProofsBySecrets = mock(async (_mintUrl: string, secrets: string[]) =>
+      secrets.map((secret) => makeProof({ secret, state: 'spent' })),
+    );
+    const finalize = mock(async () => {});
+    const getOperation = mock(async (operationId: string) => ({
+      id: operationId,
+      state: 'pending',
+      mintUrl: mintUrlA,
+      amount: Amount.from(1),
+      method: 'default',
+      methodData: {},
+      needsSwap: false,
+      fee: Amount.from(0),
+      inputAmount: Amount.from(1),
+      inputProofSecrets: operationId === 'send-op-1' ? ['spent-1'] : ['spent-2'],
+      createdAt: 0,
+      updatedAt: 0,
+    }));
+
+    const watcher = new ProofStateWatcherService(
+      {} as SubscriptionManager,
+      {} as MintService,
+      {} as ProofService,
+      {
+        getProofBySecret,
+        getProofsBySecrets,
+      } as unknown as ProofRepository,
+      bus,
+      new NullLogger(),
+      { watchExistingInflightOnStart: false },
+    );
+    watcher.setSendOperationService({ getOperation, finalize } as unknown as SendOperationService);
+
+    await watcher.start();
+    await bus.emit('proofs:state-changed', {
+      mintUrl: mintUrlA,
+      secrets: ['spent-1', 'spent-2'],
+      state: 'spent',
+    });
+
+    expect(getProofBySecret).toHaveBeenCalledTimes(2);
+    expect(getOperation).toHaveBeenCalledTimes(2);
+    expect(getOperation).toHaveBeenCalledWith('send-op-1');
+    expect(getOperation).toHaveBeenCalledWith('send-op-2');
+    expect(getProofsBySecrets).toHaveBeenCalledTimes(2);
+    expect(finalize).toHaveBeenCalledTimes(2);
+    expect(finalize).toHaveBeenCalledWith('send-op-1');
+    expect(finalize).toHaveBeenCalledWith('send-op-2');
+
+    await watcher.stop();
+  });
+
   it('does not finalize a pending send operation when the batched lookup is missing a proof', async () => {
     const getProofBySecret = mock(async () =>
       makeProof({ secret: 'spent-1', state: 'spent', usedByOperationId: 'send-op-1' }),


### PR DESCRIPTION
## Description

This pull request fixes redundant proof watcher send finalization checks.

## Problem

Spent proof handling could trigger repeated send finalization work for the same operation. A subscription-driven spent notification already emitted a proof state event that finalized the send, and batched spent events could also repeat the operation-level check once per proof from the same send operation.

## Summary

- Remove the direct subscription callback finalization path and let proof state events own send finalization.
- Deduplicate candidate send operation IDs within a single spent-proof event before running the all-spent finalization check.
- Add focused watcher tests for subscription notifications, same-operation batched events, and multi-operation batched events.
- Add/update the core patch changeset.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/ProofStateWatcherService.test.ts`
- `bun run --filter='@cashu/coco-core' test -- test/unit/SendOperationService.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `git diff --check`

## Changeset

- `.changeset/single-proof-finalization.md`