### PR TITLE
fix(core): wait for paid quote subscription states

### DIFF
--- a/.changeset/quiet-quotes-wait.md
+++ b/.changeset/quiet-quotes-wait.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Wait for paid quote subscription states before resolving mint and melt quote payment helpers.

--- a/packages/core/api/SubscriptionApi.ts
+++ b/packages/core/api/SubscriptionApi.ts
@@ -1,6 +1,19 @@
 import type { Logger } from '../logging/Logger.ts';
 import { SubscriptionManager } from '../infra/SubscriptionManager.ts';
-import type { SubscriptionKind } from '../infra/SubscriptionProtocol.ts';
+import type { SubscriptionKind, UnsubscribeHandler } from '../infra/SubscriptionProtocol.ts';
+
+type QuoteStatePayload = {
+  state?: unknown;
+};
+
+function getQuoteState(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') {
+    return undefined;
+  }
+
+  const state = (payload as QuoteStatePayload).state;
+  return typeof state === 'string' ? state : undefined;
+}
 
 export class SubscriptionApi {
   private readonly subs: SubscriptionManager;
@@ -12,31 +25,58 @@ export class SubscriptionApi {
   }
 
   async awaitMintQuotePaid(mintUrl: string, quoteId: string): Promise<unknown> {
-    return this.awaitFirstNotification(mintUrl, 'bolt11_mint_quote', [quoteId]);
+    return this.awaitMatchingNotification(
+      mintUrl,
+      'bolt11_mint_quote',
+      [quoteId],
+      (payload) => {
+        const state = getQuoteState(payload);
+        return state === 'PAID' || state === 'ISSUED';
+      },
+    );
   }
 
   async awaitMeltQuotePaid(mintUrl: string, quoteId: string): Promise<unknown> {
-    return this.awaitFirstNotification(mintUrl, 'bolt11_melt_quote', [quoteId]);
+    return this.awaitMatchingNotification(
+      mintUrl,
+      'bolt11_melt_quote',
+      [quoteId],
+      (payload) => getQuoteState(payload) === 'PAID',
+    );
   }
 
-  private async awaitFirstNotification(
+  private async awaitMatchingNotification(
     mintUrl: string,
     kind: SubscriptionKind,
     filters: string[],
+    matches: (payload: unknown) => boolean,
   ): Promise<unknown> {
-    return new Promise<unknown>(async (resolve, reject) => {
-      try {
-        const { unsubscribe } = await this.subs.subscribe(mintUrl, kind, filters, (payload) => {
-          try {
-            resolve(payload);
-          } finally {
+    return new Promise<unknown>((resolve, reject) => {
+      let settled = false;
+      let unsubscribe: UnsubscribeHandler | undefined;
+
+      const complete = (payload: unknown) => {
+        if (settled || !matches(payload)) {
+          return;
+        }
+
+        settled = true;
+        resolve(payload);
+        void unsubscribe?.().catch(() => undefined);
+      };
+
+      this.subs
+        .subscribe(mintUrl, kind, filters, complete)
+        .then((subscription) => {
+          unsubscribe = subscription.unsubscribe;
+          if (settled) {
             void unsubscribe().catch(() => undefined);
           }
+        })
+        .catch((err) => {
+          this.logger?.error('Failed to await subscription notification', { mintUrl, kind, err });
+          reject(err);
         });
-      } catch (err) {
-        this.logger?.error('Failed to await subscription notification', { mintUrl, kind, err });
-        reject(err);
-      }
     });
   }
 }

--- a/packages/core/api/SubscriptionApi.ts
+++ b/packages/core/api/SubscriptionApi.ts
@@ -25,15 +25,10 @@ export class SubscriptionApi {
   }
 
   async awaitMintQuotePaid(mintUrl: string, quoteId: string): Promise<unknown> {
-    return this.awaitMatchingNotification(
-      mintUrl,
-      'bolt11_mint_quote',
-      [quoteId],
-      (payload) => {
-        const state = getQuoteState(payload);
-        return state === 'PAID' || state === 'ISSUED';
-      },
-    );
+    return this.awaitMatchingNotification(mintUrl, 'bolt11_mint_quote', [quoteId], (payload) => {
+      const state = getQuoteState(payload);
+      return state === 'PAID' || state === 'ISSUED';
+    });
   }
 
   async awaitMeltQuotePaid(mintUrl: string, quoteId: string): Promise<unknown> {

--- a/packages/core/test/unit/SubscriptionApi.test.ts
+++ b/packages/core/test/unit/SubscriptionApi.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { SubscriptionApi } from '../../api/SubscriptionApi.ts';
+import type { SubscriptionCallback, SubscriptionManager } from '../../infra/SubscriptionManager.ts';
+import type { SubscriptionKind, UnsubscribeHandler } from '../../infra/SubscriptionProtocol.ts';
+
+const mintUrl = 'https://mint.test';
+
+function createSubscriptionApiHarness() {
+  let callback: SubscriptionCallback | undefined;
+  const unsubscribe = mock(async () => {});
+  const subscribe = mock(
+    async (
+      _mintUrl: string,
+      _kind: SubscriptionKind,
+      _filters: string[],
+      onNotification?: SubscriptionCallback,
+    ): Promise<{ subId: string; unsubscribe: UnsubscribeHandler }> => {
+      callback = onNotification;
+      return { subId: 'sub-1', unsubscribe };
+    },
+  );
+
+  const subscriptions = { subscribe } as unknown as SubscriptionManager;
+  const api = new SubscriptionApi(subscriptions);
+
+  return {
+    api,
+    subscribe,
+    unsubscribe,
+    emit: async (payload: unknown) => {
+      await callback?.(payload);
+    },
+  };
+}
+
+describe('SubscriptionApi', () => {
+  it('awaitMintQuotePaid ignores initial UNPAID notifications', async () => {
+    const harness = createSubscriptionApiHarness();
+    let resolved: unknown;
+
+    const wait = harness.api.awaitMintQuotePaid(mintUrl, 'quote-1').then((payload) => {
+      resolved = payload;
+      return payload;
+    });
+
+    await harness.emit({ quote: 'quote-1', state: 'UNPAID' });
+    await Promise.resolve();
+
+    expect(resolved).toBeUndefined();
+    expect(harness.unsubscribe).not.toHaveBeenCalled();
+
+    const paidPayload = { quote: 'quote-1', state: 'PAID' };
+    await harness.emit(paidPayload);
+
+    await expect(wait).resolves.toBe(paidPayload);
+    expect(harness.subscribe).toHaveBeenCalledWith(
+      mintUrl,
+      'bolt11_mint_quote',
+      ['quote-1'],
+      expect.any(Function),
+    );
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaitMintQuotePaid also resolves when the quote is already ISSUED', async () => {
+    const harness = createSubscriptionApiHarness();
+    const wait = harness.api.awaitMintQuotePaid(mintUrl, 'quote-issued');
+
+    const issuedPayload = { quote: 'quote-issued', state: 'ISSUED' };
+    await harness.emit(issuedPayload);
+
+    await expect(wait).resolves.toBe(issuedPayload);
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('awaitMeltQuotePaid waits for PAID instead of the first notification', async () => {
+    const harness = createSubscriptionApiHarness();
+    let resolved: unknown;
+
+    const wait = harness.api.awaitMeltQuotePaid(mintUrl, 'melt-quote-1').then((payload) => {
+      resolved = payload;
+      return payload;
+    });
+
+    await harness.emit({ quote: 'melt-quote-1', state: 'PENDING' });
+    await Promise.resolve();
+
+    expect(resolved).toBeUndefined();
+    expect(harness.unsubscribe).not.toHaveBeenCalled();
+
+    const paidPayload = { quote: 'melt-quote-1', state: 'PAID' };
+    await harness.emit(paidPayload);
+
+    await expect(wait).resolves.toBe(paidPayload);
+    expect(harness.subscribe).toHaveBeenCalledWith(
+      mintUrl,
+      'bolt11_melt_quote',
+      ['melt-quote-1'],
+      expect.any(Function),
+    );
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Make quote subscription wait helpers ignore non-terminal/current-state notifications.
- Resolve mint quote waits only on `PAID` or `ISSUED`, and melt quote waits only on `PAID`.
- Add focused `SubscriptionApi` unit coverage for initial unpaid/pending notifications.
- Add a patch changeset for `@cashu/coco-core`.

## Problem

Fakewallet quote subscriptions may first emit the current quote state, which can still be `UNPAID`. `awaitMintQuotePaid` previously resolved on the first notification, so minting could continue too early and fail with `Quote not paid`.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/SubscriptionApi.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-adapter-tests' typecheck`
- `MINT_URL=https://bls.thesimplekid.dev ./scripts/test-integration.sh core` passed locally in the existing dirty BLS worktree while diagnosing this failure.
- `env BUN_TMPDIR=/tmp/codex-bun-tmp bunx @changesets/cli status --verbose`