### PR TITLE
fix: use valid runner temp path in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,6 @@ jobs:
   build:
     if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
-    env:
-      SITE_DIR: ${{ runner.temp }}/site
     steps:
       - name: Resolve stable docs ref
         id: stable-ref
@@ -84,8 +82,8 @@ jobs:
 
       - name: Stage stable docs
         run: |
-          mkdir -p "$SITE_DIR"
-          cp -R stable/packages/docs/.vitepress/dist/. "$SITE_DIR/"
+          mkdir -p "$RUNNER_TEMP/site"
+          cp -R stable/packages/docs/.vitepress/dist/. "$RUNNER_TEMP/site/"
 
       - name: Install nightly dependencies
         working-directory: nightly
@@ -100,13 +98,13 @@ jobs:
 
       - name: Stage nightly docs
         run: |
-          mkdir -p "$SITE_DIR/nightly"
-          cp -R nightly/packages/docs/.vitepress/dist/. "$SITE_DIR/nightly/"
+          mkdir -p "$RUNNER_TEMP/site/nightly"
+          cp -R nightly/packages/docs/.vitepress/dist/. "$RUNNER_TEMP/site/nightly/"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: ${{ env.SITE_DIR }}
+          path: ${{ runner.temp }}/site
 
   deploy:
     if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}


### PR DESCRIPTION
## Summary

- Remove the job-level `SITE_DIR` env expression that referenced `runner.temp`.
- Use `$RUNNER_TEMP/site` inside shell steps for staging docs output.
- Keep `${{ runner.temp }}/site` only on the upload action input, where the runner context is valid.

## Problem

The docs deploy workflow failed during GitHub Actions expression validation with `Unrecognized named-value: 'runner'` because `runner.temp` is not available in `jobs.<job_id>.env`.

## Verification

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docs.yml'); puts 'YAML OK'"`
- `git diff --check`

## Changeset

- Not added; this is GitHub Actions workflow configuration only.