### PR TITLE
feat(core): persist optional memo on executed send token

### DIFF
--- a/.changeset/persist-send-memo.md
+++ b/.changeset/persist-send-memo.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': minor
+---
+
+Allow attaching an optional memo when executing a send. `SendOpsApi.execute`
+now accepts `ExecuteSendOptions` with a `memo`, which is persisted on the
+executed send token.

--- a/packages/core/api/SendOpsApi.ts
+++ b/packages/core/api/SendOpsApi.ts
@@ -6,7 +6,10 @@ import type {
   SendOperation,
 } from '../operations/send/SendOperation';
 import type { SendMethod, SendMethodData } from '../operations/send/SendMethodHandler';
-import type { SendOperationService } from '../operations/send/SendOperationService';
+import type {
+  ExecuteSendOptions,
+  SendOperationService,
+} from '../operations/send/SendOperationService';
 import { parseUnitAmount, type UnitAmountLike } from '../amounts.ts';
 
 type NonDefaultSendMethod = Exclude<SendMethod, 'default'>;
@@ -85,6 +88,7 @@ export class SendOpsApi {
    */
   async execute(
     operationOrId: SendOperation | string,
+    options?: ExecuteSendOptions,
   ): Promise<{ operation: PendingSendOperation; token: Token }> {
     const operation = await this.resolveOperation(operationOrId);
     if (operation.state !== 'prepared') {
@@ -93,7 +97,7 @@ export class SendOpsApi {
       );
     }
 
-    return this.sendOperationService.execute(operation);
+    return this.sendOperationService.execute(operation, options);
   }
 
   /** Returns a send operation by ID, or `null` when it does not exist. */

--- a/packages/core/api/SendOpsApi.ts
+++ b/packages/core/api/SendOpsApi.ts
@@ -84,7 +84,8 @@ export class SendOpsApi {
    * Executes a prepared send operation and returns the shareable token.
    *
    * Accepts either a prepared operation object or its ID. The latest operation
-   * state is always reloaded before execution.
+   * state is always reloaded before execution. When provided, `options.memo`
+   * is trimmed and persisted on the returned token; whitespace-only memos are omitted.
    */
   async execute(
     operationOrId: SendOperation | string,

--- a/packages/core/infra/handlers/send/DefaultSendHandler.ts
+++ b/packages/core/infra/handlers/send/DefaultSendHandler.ts
@@ -7,6 +7,7 @@ import type {
   RollbackContext,
   RecoverExecutingContext,
   ExecutionResult,
+  RecoveryResult,
 } from '../../../operations/send/SendMethodHandler';
 import type {
   PreparedSendOperation,
@@ -323,7 +324,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
   /**
    * Recover an executing operation that failed mid-execution.
    */
-  async recoverExecuting(ctx: RecoverExecutingContext): Promise<ExecutionResult> {
+  async recoverExecuting(ctx: RecoverExecutingContext): Promise<RecoveryResult> {
     const { operation, wallet, proofRepository, proofService, logger } = ctx;
 
     // Case: Exact match - no mint interaction, always safe to rollback

--- a/packages/core/infra/handlers/send/P2pkSendHandler.ts
+++ b/packages/core/infra/handlers/send/P2pkSendHandler.ts
@@ -7,6 +7,7 @@ import type {
   RollbackContext,
   RecoverExecutingContext,
   ExecutionResult,
+  RecoveryResult,
 } from '../../../operations/send/SendMethodHandler';
 import type {
   PreparedSendOperation,
@@ -245,7 +246,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
   /**
    * Recover an executing operation that failed mid-execution.
    */
-  async recoverExecuting(ctx: RecoverExecutingContext): Promise<ExecutionResult> {
+  async recoverExecuting(ctx: RecoverExecutingContext): Promise<RecoveryResult> {
     const { operation, wallet, proofRepository, proofService, logger } = ctx;
 
     // P2PK always requires swap - check with mint

--- a/packages/core/operations/send/SendMethodHandler.ts
+++ b/packages/core/operations/send/SendMethodHandler.ts
@@ -79,7 +79,26 @@ export interface RecoverExecutingContext extends BaseHandlerDeps {
   wallet: Wallet;
 }
 
+/**
+ * Result of a normal execution. A pending result must carry the token so the
+ * caller can hand it to the recipient.
+ */
 export type ExecutionResult =
+  | {
+      status: 'PENDING';
+      pending: PendingSendOperation;
+      token: Token;
+    }
+  | {
+      status: 'FAILED';
+      failed: RolledBackSendOperation;
+    };
+
+/**
+ * Result of recovering an executing operation. Recovery may legitimately reach a
+ * pending state without being able to reconstruct the token, so it is optional.
+ */
+export type RecoveryResult =
   | {
       status: 'PENDING';
       pending: PendingSendOperation;
@@ -102,7 +121,7 @@ export interface SendMethodHandler<M extends SendMethod = SendMethod> {
    * Recover an executing operation that failed mid-execution.
    * Handlers must implement this method to handle recovery logic.
    */
-  recoverExecuting(ctx: RecoverExecutingContext): Promise<ExecutionResult>;
+  recoverExecuting(ctx: RecoverExecutingContext): Promise<RecoveryResult>;
 }
 
 export type SendMethodHandlerRegistry = Record<SendMethod, SendMethodHandler<any>>;

--- a/packages/core/operations/send/SendOperationService.ts
+++ b/packages/core/operations/send/SendOperationService.ts
@@ -246,9 +246,9 @@ export class SendOperationService {
       };
       await this.sendOperationRepository.update(executing);
 
-      let pending: PendingSendOperation | null = null;
-      let token: Token | null = null;
-      let failed: RolledBackSendOperation | null = null;
+      let pending: PendingSendOperation | undefined;
+      let token: Token | undefined;
+      let failed: RolledBackSendOperation | undefined;
       try {
         const handler = this.handlerProvider.get(operation.method);
         if (!handler) {
@@ -279,17 +279,14 @@ export class SendOperationService {
         const result = await handler.execute(ctx);
 
         if (result.status === 'PENDING') {
-          const tokenWithMemo = this.applyTokenMemo(
-            result.token ?? result.pending.token,
-            options?.memo,
-          );
-          const pendingWithMemo: PendingSendOperation = tokenWithMemo
-            ? { ...result.pending, token: tokenWithMemo }
-            : result.pending;
+          const resolvedToken = options?.memo
+            ? this.applyTokenMemo(result.token!, options.memo)
+            : result.token!;
+          const pendingWithMemo: PendingSendOperation = { ...result.pending, token: resolvedToken };
           // Save the pending operation to the repository
           await this.sendOperationRepository.update(pendingWithMemo);
           pending = pendingWithMemo;
-          token = tokenWithMemo ?? null;
+          token = resolvedToken;
         } else {
           // Handler returned FAILED - persist the terminal result without re-running recovery
           await this.sendOperationRepository.update(result.failed);
@@ -832,14 +829,14 @@ export class SendOperationService {
     return orphanedProofs.length;
   }
 
-  private normalizeMemo(memo: string | undefined): string | undefined {
-    const trimmed = memo?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  private normalizeMemo(memo: string): string | undefined {
+    const trimmed = memo.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
   }
 
-  private applyTokenMemo(token: Token | undefined, memo: string | undefined): Token | undefined {
+  private applyTokenMemo(token: Token, memo: string): Token {
     const normalized = this.normalizeMemo(memo);
-    return token && normalized ? { ...token, memo: normalized } : token;
+    return normalized ? { ...token, memo: normalized } : token;
   }
 
   /**

--- a/packages/core/operations/send/SendOperationService.ts
+++ b/packages/core/operations/send/SendOperationService.ts
@@ -280,8 +280,8 @@ export class SendOperationService {
 
         if (result.status === 'PENDING') {
           const resolvedToken = options?.memo
-            ? this.applyTokenMemo(result.token!, options.memo)
-            : result.token!;
+            ? this.applyTokenMemo(result.token, options.memo)
+            : result.token;
           const pendingWithMemo: PendingSendOperation = { ...result.pending, token: resolvedToken };
           // Save the pending operation to the repository
           await this.sendOperationRepository.update(pendingWithMemo);

--- a/packages/core/operations/send/SendOperationService.ts
+++ b/packages/core/operations/send/SendOperationService.ts
@@ -36,7 +36,11 @@ import { MintScopedLock } from '../MintScopedLock';
 import { OperationIdLock } from '../OperationIdLock';
 import { normalizeUnitAmount, type UnitAmount } from '../../amounts.ts';
 
+/**
+ * Options applied when a prepared send operation is executed.
+ */
 export interface ExecuteSendOptions {
+  /** Optional memo to persist on the shareable token. Whitespace-only memos are ignored. */
   memo?: string;
 }
 
@@ -221,6 +225,8 @@ export class SendOperationService {
   /**
    * Execute the prepared operation.
    * Performs the swap (if needed) and creates the token.
+   * If a memo is provided, trims it and persists it on the token before saving the
+   * pending operation. Whitespace-only memos are omitted.
    *
    * If execution fails after transitioning to 'executing' state,
    * automatically attempts to recover the operation.

--- a/packages/core/operations/send/SendOperationService.ts
+++ b/packages/core/operations/send/SendOperationService.ts
@@ -36,6 +36,10 @@ import { MintScopedLock } from '../MintScopedLock';
 import { OperationIdLock } from '../OperationIdLock';
 import { normalizeUnitAmount, type UnitAmount } from '../../amounts.ts';
 
+export interface ExecuteSendOptions {
+  memo?: string;
+}
+
 /**
  * Service that manages send operations as sagas.
  *
@@ -226,6 +230,7 @@ export class SendOperationService {
    */
   async execute(
     operation: PreparedSendOperation,
+    options?: ExecuteSendOptions,
   ): Promise<{ operation: PendingSendOperation; token: Token }> {
     if (!this.handlerProvider) {
       throw new Error('SendHandlerProvider is required');
@@ -274,10 +279,17 @@ export class SendOperationService {
         const result = await handler.execute(ctx);
 
         if (result.status === 'PENDING') {
+          const tokenWithMemo = this.applyTokenMemo(
+            result.token ?? result.pending.token,
+            options?.memo,
+          );
+          const pendingWithMemo: PendingSendOperation = tokenWithMemo
+            ? { ...result.pending, token: tokenWithMemo }
+            : result.pending;
           // Save the pending operation to the repository
-          await this.sendOperationRepository.update(result.pending);
-          pending = result.pending;
-          token = result.token ?? null;
+          await this.sendOperationRepository.update(pendingWithMemo);
+          pending = pendingWithMemo;
+          token = tokenWithMemo ?? null;
         } else {
           // Handler returned FAILED - persist the terminal result without re-running recovery
           await this.sendOperationRepository.update(result.failed);
@@ -818,6 +830,16 @@ export class SendOperationService {
     }
 
     return orphanedProofs.length;
+  }
+
+  private normalizeMemo(memo: string | undefined): string | undefined {
+    const trimmed = memo?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private applyTokenMemo(token: Token | undefined, memo: string | undefined): Token | undefined {
+    const normalized = this.normalizeMemo(memo);
+    return token && normalized ? { ...token, memo: normalized } : token;
   }
 
   /**

--- a/packages/core/test/unit/HistoryService.test.ts
+++ b/packages/core/test/unit/HistoryService.test.ts
@@ -32,6 +32,7 @@ describe('HistoryService', () => {
     eventBus = new EventBus<CoreEvents>();
     eventBus.on('history:updated', (payload) => {
       historyUpdateEvents.push(payload);
+      repositoryEntries.set(payload.entry.id, payload.entry);
     });
 
     const historyRepository: HistoryRepository = {
@@ -84,6 +85,27 @@ describe('HistoryService', () => {
       unit: 'usd',
       token: pending.token,
     });
+  });
+
+  it('returns memo-bearing send token projections from paginated history', async () => {
+    const prepared = makePreparedSendOperation('send-op-memo');
+    const pending = {
+      ...prepared,
+      state: 'pending',
+      token: { mint: mintUrl, proofs: receiveProofs, unit: 'usd', memo: 'hello' },
+    } as PendingSendOperation;
+
+    await eventBus.emit('send:pending', {
+      mintUrl,
+      operationId: pending.id,
+      operation: pending,
+      token: pending.token!,
+    });
+
+    const history = await service.getPaginatedHistory(0, 10);
+    const sendEntry = history.find((entry) => entry.type === 'send');
+
+    expect(sendEntry?.token?.memo).toBe('hello');
   });
 
   it('projects melt operation states without mapping them to quote states', async () => {

--- a/packages/core/test/unit/SendOperationService.test.ts
+++ b/packages/core/test/unit/SendOperationService.test.ts
@@ -447,4 +447,44 @@ describe('SendOperationService', () => {
     expect(persistedStateDuringFinalize).toBe('pending');
     expect((await sendOpRepo.getById(pendingOp.id))?.state).toBe('finalized');
   });
+
+  it('persists memo on the token when execute is called with a memo option', async () => {
+    await proofRepo.saveProofs(mintUrl, [makeProof('proof-1', 100)]);
+
+    const initOp = await service.init(mintUrl, unitAmount(100));
+    const preparedOp = await service.prepare(initOp);
+    const result = await service.execute(preparedOp, { memo: 'hello' });
+
+    expect(result.token.memo).toBe('hello');
+    const persisted = await sendOpRepo.getById(preparedOp.id);
+    expect((persisted as PendingSendOperation).token?.memo).toBe('hello');
+  });
+
+  it('omits memo from token when memo is whitespace-only', async () => {
+    await proofRepo.saveProofs(mintUrl, [makeProof('proof-1', 100)]);
+
+    const initOp = await service.init(mintUrl, unitAmount(100));
+    const preparedOp = await service.prepare(initOp);
+    const result = await service.execute(preparedOp, { memo: '   ' });
+
+    expect(result.token.memo).toBeUndefined();
+    const persisted = await sendOpRepo.getById(preparedOp.id);
+    expect((persisted as PendingSendOperation).token?.memo).toBeUndefined();
+  });
+
+  it('emits send:pending event with memo-bearing token', async () => {
+    await proofRepo.saveProofs(mintUrl, [makeProof('proof-1', 100)]);
+
+    const initOp = await service.init(mintUrl, unitAmount(100));
+    const preparedOp = await service.prepare(initOp);
+
+    let eventToken: import('@cashu/cashu-ts').Token | undefined;
+    eventBus.on('send:pending', ({ token }) => {
+      eventToken = token;
+    });
+
+    await service.execute(preparedOp, { memo: 'event-memo' });
+
+    expect(eventToken?.memo).toBe('event-memo');
+  });
 });

--- a/packages/core/test/unit/SendOperationService.test.ts
+++ b/packages/core/test/unit/SendOperationService.test.ts
@@ -1,4 +1,4 @@
-import { Amount } from '@cashu/cashu-ts';
+import { Amount, type Token } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
 import { SendOperationService } from '../../operations/send/SendOperationService';
 import { DefaultSendHandler } from '../../infra/handlers/send/DefaultSendHandler';
@@ -478,7 +478,7 @@ describe('SendOperationService', () => {
     const initOp = await service.init(mintUrl, unitAmount(100));
     const preparedOp = await service.prepare(initOp);
 
-    let eventToken: import('@cashu/cashu-ts').Token | undefined;
+    let eventToken: Token | undefined;
     eventBus.on('send:pending', ({ token }) => {
       eventToken = token;
     });

--- a/packages/core/test/unit/SendOpsApi.test.ts
+++ b/packages/core/test/unit/SendOpsApi.test.ts
@@ -106,7 +106,7 @@ describe('SendOpsApi', () => {
     const result = await api.execute(staleOperation);
 
     expect(sendOperationService.getOperation).toHaveBeenCalledWith(preparedOperation.id);
-    expect(sendOperationService.execute).toHaveBeenCalledWith(preparedOperation);
+    expect(sendOperationService.execute).toHaveBeenCalledWith(preparedOperation, undefined);
     expect(result.operation).toBe(pendingOperation);
   });
 
@@ -175,5 +175,11 @@ describe('SendOpsApi', () => {
 
     await expect(api.finalize(finalizedOperation.id)).resolves.toBeUndefined();
     expect(sendOperationService.finalize).toHaveBeenCalledWith(finalizedOperation.id);
+  });
+
+  it('execute passes memo option through to the service', async () => {
+    await api.execute(preparedOperation.id, { memo: 'hello' });
+
+    expect(sendOperationService.execute).toHaveBeenCalledWith(preparedOperation, { memo: 'hello' });
   });
 });

--- a/packages/docs/pages/send-operations.md
+++ b/packages/docs/pages/send-operations.md
@@ -37,7 +37,7 @@ init ──► prepared ──► executing ──► pending ──► finalize
 | Action                                  | Valid input state              | Resulting state                        | Use when                                                          |
 | --------------------------------------- | ------------------------------ | -------------------------------------- | ----------------------------------------------------------------- |
 | `prepare({ mintUrl, amount, target? })` | none                           | `prepared`                             | You want to reserve proofs and show fees before creating a token. |
-| `execute(operationOrId)`                | `prepared`                     | `pending`                              | The user confirmed the send and you need the shareable token.     |
+| `execute(operationOrId, options?)`      | `prepared`                     | `pending`                              | The user confirmed the send and you need the shareable token.     |
 | `refresh(operationId)`                  | any, actively checks `pending` | latest stored state                    | You are resuming stale persisted state or building recovery UI.   |
 | `cancel(operationId)`                   | `prepared`                     | `rolled_back`                          | The user abandons the send before a token is created.             |
 | `reclaim(operationId)`                  | `pending`                      | `rolled_back` when reclaim is possible | The token was created but should be reclaimed before receipt.     |
@@ -71,6 +71,18 @@ const { operation, token } = await coco.ops.send.execute(prepared.id);
 // Step 3: Share token with recipient
 shareToken(token);
 ```
+
+To persist a memo with the token and send history entry, pass it when executing
+the prepared send:
+
+```ts
+const { token } = await coco.ops.send.execute(prepared.id, { memo: 'Dinner' });
+
+console.log(token.memo); // "Dinner"
+```
+
+Memos are trimmed before persistence. Whitespace-only memos are treated as
+omitted.
 
 ### Cancelling a Prepared Send
 


### PR DESCRIPTION
## Fixes #186 

## Sumary

Adds an optional `memo` option to the send execution path so callers can attach
a memo to the token before it is persisted.

```ts
const { token } = await manager.ops.send.execute(preparedId, { memo: 'hello' });
``` 
The memo is normalized (trimmed, whitespace-only treated as absent) and applied to the token before `sendOperationRepository.update()` so the memo is stored in tokenJson.

- 3 new tests (memo persisted, whitespace omitted, event carries memo-bearing token) and 1 new API-level test (options forwarded).