### PR TITLE
feat(core): enforce canonical quote identity

### DIFF
--- a/.changeset/canonical-quote-identity.md
+++ b/.changeset/canonical-quote-identity.md
@@ -1,0 +1,10 @@
+---
+'@cashu/coco-core': minor
+'@cashu/coco-adapter-tests': patch
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+---
+
+Add canonical quote identity contracts and enforce `(mintUrl, quoteId)` uniqueness for stored mint and melt quotes.

--- a/.changeset/canonical-quote-identity.md
+++ b/.changeset/canonical-quote-identity.md
@@ -1,5 +1,5 @@
 ---
-'@cashu/coco-core': minor
+'@cashu/coco-core': major
 '@cashu/coco-adapter-tests': patch
 '@cashu/coco-indexeddb': patch
 '@cashu/coco-sqlite': patch

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -7,12 +7,16 @@ import {
   type MeltOperation,
   type MintQuote,
   type MeltQuote,
+  type QuoteIdentity,
+  type MintQuoteRef,
+  type MeltQuoteRef,
   type MintOperation,
   type PaymentRequestReceiveAttempt,
   type PaymentRequestReceiveOperation,
   type ReceiveOperation,
   type SendOperation,
   type AuthSession,
+  QuoteIdentityConflictError,
 } from '@cashu/coco-core';
 
 type TransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
@@ -149,6 +153,20 @@ async function expectThrows(fn: () => Promise<void>, expect: Expectation) {
     didThrow = true;
   }
   expect(didThrow).toBe(true);
+}
+
+async function expectThrowsError(
+  fn: () => Promise<void>,
+  errorClass: Function,
+  expect: Expectation,
+) {
+  let thrown: unknown;
+  try {
+    await fn();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown instanceof errorClass).toBe(true);
 }
 
 function createDeferred<T = void>() {
@@ -548,6 +566,118 @@ export async function runMintOperationRepositoryContract(
       }
     });
 
+    it('looks up canonical mint quotes by identity without method', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const quote = createDummyMintQuote({
+          mintUrl: 'https://mint.test/',
+          quoteId: 'identity-mint-quote',
+          quote: 'identity-mint-quote',
+        });
+        const ref: MintQuoteRef = quote;
+        const identity: QuoteIdentity = ref;
+        await repositories.mintQuoteRepository.upsertMintQuote(quote);
+
+        const stored = await repositories.mintQuoteRepository.getMintQuoteById(identity);
+        const absent = await repositories.mintQuoteRepository.getMintQuoteById({
+          mintUrl: 'https://mint.test',
+          quoteId: 'missing-mint-quote',
+        });
+
+        expect(stored).toBeDefined();
+        expect(stored!.method).toBe('bolt11');
+        expect(stored!.quoteId).toBe('identity-mint-quote');
+        expect(absent).toBe(null);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('rejects same-mint mint quote identity collisions across methods', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const quote = createDummyMintQuote({
+          mintUrl: 'https://mint.test/',
+          quoteId: 'colliding-mint-quote',
+          quote: 'colliding-mint-quote',
+        });
+        const collidingQuote: MintQuote<'bolt12'> = {
+          mintUrl: 'https://mint.test',
+          method: 'bolt12',
+          quoteId: 'colliding-mint-quote',
+          quote: 'colliding-mint-quote',
+          request: 'lno1collision',
+          unit: 'sat',
+          expiry: 1_730_000_000,
+          pubkey: '02'.padEnd(66, '4'),
+          reusable: true,
+          quoteData: {
+            pubkey: '02'.padEnd(66, '4'),
+            amountPaid: Amount.from(0),
+            amountIssued: Amount.from(0),
+          },
+          lastObservedRemoteStateAt: 20,
+          createdAt: 0,
+          updatedAt: 0,
+        };
+
+        await repositories.mintQuoteRepository.upsertMintQuote(quote);
+        await expectThrowsError(
+          () => repositories.mintQuoteRepository.upsertMintQuote(collidingQuote),
+          QuoteIdentityConflictError,
+          expect,
+        );
+
+        const exact = await repositories.mintQuoteRepository.getMintQuote(
+          'https://mint.test',
+          'bolt11',
+          'colliding-mint-quote',
+        );
+        const missingSibling = await repositories.mintQuoteRepository.getMintQuote(
+          'https://mint.test',
+          'bolt12',
+          'colliding-mint-quote',
+        );
+        expect(exact).toBeDefined();
+        expect(missingSibling).toBe(null);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('keeps mint and melt quote identity namespaces separate', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.mintQuoteRepository.upsertMintQuote(
+          createDummyMintQuote({
+            quoteId: 'shared-cross-kind-quote',
+            quote: 'shared-cross-kind-quote',
+          }),
+        );
+        await repositories.meltQuoteRepository.upsertMeltQuote(
+          createDummyMeltQuote({
+            quoteId: 'shared-cross-kind-quote',
+            quote: 'shared-cross-kind-quote',
+          }),
+        );
+
+        const mintQuote = await repositories.mintQuoteRepository.getMintQuoteById({
+          mintUrl: 'https://mint.test',
+          quoteId: 'shared-cross-kind-quote',
+        });
+        const meltQuote = await repositories.meltQuoteRepository.getMeltQuoteById({
+          mintUrl: 'https://mint.test',
+          quoteId: 'shared-cross-kind-quote',
+        });
+
+        expect(mintQuote).toBeDefined();
+        expect(meltQuote).toBeDefined();
+        expect(mintQuote!.quoteId).toBe(meltQuote!.quoteId);
+      } finally {
+        await dispose();
+      }
+    });
+
     it('persists reusable onchain mint quote data', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {
@@ -719,6 +849,75 @@ export async function runMeltQuoteRepositoryContract(
         expect(stored!.state).toBe('PENDING');
         expect(stored!.lastObservedRemoteState).toBe('PENDING');
         expect(stored!.lastObservedRemoteStateAt).toBe(20);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('looks up canonical melt quotes by identity without method', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const quote = createDummyMeltQuote({
+          mintUrl: 'https://mint.test/',
+          quoteId: 'identity-melt-quote',
+          quote: 'identity-melt-quote',
+        });
+        const ref: MeltQuoteRef = quote;
+        const identity: QuoteIdentity = ref;
+        await repositories.meltQuoteRepository.upsertMeltQuote(quote);
+
+        const stored = await repositories.meltQuoteRepository.getMeltQuoteById(identity);
+        const absent = await repositories.meltQuoteRepository.getMeltQuoteById({
+          mintUrl: 'https://mint.test',
+          quoteId: 'missing-melt-quote',
+        });
+
+        expect(stored).toBeDefined();
+        expect(stored!.method).toBe('bolt11');
+        expect(stored!.quoteId).toBe('identity-melt-quote');
+        expect(absent).toBe(null);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('rejects same-mint melt quote identity collisions across methods', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const quote = createDummyMeltQuote({
+          mintUrl: 'https://mint.test/',
+          quoteId: 'colliding-melt-quote',
+          quote: 'colliding-melt-quote',
+        });
+        const collidingQuote = {
+          ...createDummyMeltQuote({
+            mintUrl: 'https://mint.test',
+            quoteId: 'colliding-melt-quote',
+            quote: 'colliding-melt-quote',
+            request: 'lno1collision',
+          }),
+          method: 'bolt12' as const,
+        } satisfies MeltQuote<'bolt12'>;
+
+        await repositories.meltQuoteRepository.upsertMeltQuote(quote);
+        await expectThrowsError(
+          () => repositories.meltQuoteRepository.upsertMeltQuote(collidingQuote),
+          QuoteIdentityConflictError,
+          expect,
+        );
+
+        const exact = await repositories.meltQuoteRepository.getMeltQuote(
+          'https://mint.test',
+          'bolt11',
+          'colliding-melt-quote',
+        );
+        const missingSibling = await repositories.meltQuoteRepository.getMeltQuote(
+          'https://mint.test',
+          'bolt12',
+          'colliding-melt-quote',
+        );
+        expect(exact).toBeDefined();
+        expect(missingSibling).toBe(null);
       } finally {
         await dispose();
       }

--- a/packages/core/models/Error.ts
+++ b/packages/core/models/Error.ts
@@ -148,3 +148,28 @@ export class AuthSessionExpiredError extends AuthSessionError {
     this.name = `AuthSessionExpiredError`;
   }
 }
+
+export class QuoteIdentityConflictError extends Error {
+  readonly kind: 'mint' | 'melt';
+  readonly mintUrl: string;
+  readonly quoteId: string;
+  readonly methods: readonly string[];
+
+  constructor(
+    kind: 'mint' | 'melt',
+    mintUrl: string,
+    quoteId: string,
+    methods: readonly string[],
+    message?: string,
+  ) {
+    super(
+      message ??
+        `${kind} quote identity conflict for quote ${quoteId} at ${mintUrl}: methods ${methods.join(', ')}`,
+    );
+    this.name = 'QuoteIdentityConflictError';
+    this.kind = kind;
+    this.mintUrl = mintUrl;
+    this.quoteId = quoteId;
+    this.methods = [...methods];
+  }
+}

--- a/packages/core/models/QuoteIdentity.ts
+++ b/packages/core/models/QuoteIdentity.ts
@@ -1,0 +1,15 @@
+import type { MeltMethod } from '../operations/melt/MeltMethodHandler';
+import type { MeltQuote } from './MeltQuote';
+import type { MintMethod } from '../operations/mint/MintMethodHandler';
+import type { MintQuote } from './MintQuote';
+
+export type QuoteIdentity = {
+  mintUrl: string;
+  quoteId: string;
+};
+
+export type MintQuoteRef<M extends MintMethod = MintMethod> = QuoteIdentity &
+  Pick<MintQuote<M>, 'method'>;
+
+export type MeltQuoteRef<M extends MeltMethod = MeltMethod> = QuoteIdentity &
+  Pick<MeltQuote<M>, 'method'>;

--- a/packages/core/models/index.ts
+++ b/packages/core/models/index.ts
@@ -8,3 +8,4 @@ export * from './Mint';
 export * from './MeltQuote';
 export * from './MintQuote';
 export * from './MintQuoteState';
+export * from './QuoteIdentity';

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -3,6 +3,7 @@ import type { HistoryEntry } from '@core/models/History';
 import type { Keypair, KeypairPurpose } from '@core/models/Keypair';
 import type { MeltQuote } from '@core/models/MeltQuote';
 import type { MintQuote } from '@core/models/MintQuote';
+import type { QuoteIdentity } from '@core/models/QuoteIdentity';
 import type { MeltOperation, MeltOperationState } from '@core/operations/melt/MeltOperation';
 import type { MintOperation, MintOperationState } from '@core/operations/mint/MintOperation';
 import type {
@@ -114,6 +115,7 @@ export interface ProofRepository {
 }
 
 export interface MintQuoteRepository {
+  getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null>;
   getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null>;
   upsertMintQuote(quote: MintQuote): Promise<void>;
   setMintQuoteState(
@@ -131,6 +133,7 @@ export interface LegacyMintQuoteRepository {
 }
 
 export interface MeltQuoteRepository {
+  getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null>;
   getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null>;
   upsertMeltQuote(quote: MeltQuote): Promise<void>;
   getPendingMeltQuotes(method?: string): Promise<MeltQuote[]>;

--- a/packages/core/repositories/memory/MemoryMeltQuoteRepository.ts
+++ b/packages/core/repositories/memory/MemoryMeltQuoteRepository.ts
@@ -1,4 +1,6 @@
+import { QuoteIdentityConflictError } from '@core/models/Error';
 import type { MeltQuote } from '@core/models/MeltQuote';
+import type { QuoteIdentity } from '@core/models/QuoteIdentity';
 import type { MeltQuoteRepository } from '..';
 import { normalizeMintUrl } from '../../utils';
 
@@ -9,6 +11,22 @@ export class MemoryMeltQuoteRepository implements MeltQuoteRepository {
     return `${normalizeMintUrl(mintUrl)}::${method}::${quoteId}`;
   }
 
+  async getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const matches = Array.from(this.quotes.values()).filter(
+      (quote) => quote.mintUrl === normalizedMintUrl && quote.quoteId === identity.quoteId,
+    );
+    if (matches.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        identity.quoteId,
+        matches.map((quote) => quote.method),
+      );
+    }
+    return matches[0] ? { ...matches[0] } : null;
+  }
+
   async getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null> {
     const quote = this.quotes.get(this.makeKey(mintUrl, method, quoteId));
     return quote ? { ...quote } : null;
@@ -17,6 +35,19 @@ export class MemoryMeltQuoteRepository implements MeltQuoteRepository {
   async upsertMeltQuote(quote: MeltQuote): Promise<void> {
     const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
     const now = Date.now();
+    const identityOwner = await this.getMeltQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Melt quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const existing = await this.getMeltQuote(normalizedMintUrl, quote.method, quote.quoteId);
     this.quotes.set(this.makeKey(normalizedMintUrl, quote.method, quote.quoteId), {
       ...quote,

--- a/packages/core/repositories/memory/MemoryMintQuoteRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintQuoteRepository.ts
@@ -1,4 +1,6 @@
+import { QuoteIdentityConflictError } from '@core/models/Error';
 import { isMintQuotePending, isStatefulMintQuote, type MintQuote } from '@core/models/MintQuote';
+import type { QuoteIdentity } from '@core/models/QuoteIdentity';
 import type { MintMethodRemoteState } from '@core/operations/mint/MintMethodHandler';
 import type { MintQuoteRepository } from '..';
 import { normalizeMintUrl } from '../../utils';
@@ -10,6 +12,22 @@ export class MemoryMintQuoteRepository implements MintQuoteRepository {
     return `${normalizeMintUrl(mintUrl)}::${method}::${quoteId}`;
   }
 
+  async getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const matches = Array.from(this.quotes.values()).filter(
+      (quote) => quote.mintUrl === normalizedMintUrl && quote.quoteId === identity.quoteId,
+    );
+    if (matches.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        identity.quoteId,
+        matches.map((quote) => quote.method),
+      );
+    }
+    return matches[0] ? { ...matches[0] } : null;
+  }
+
   async getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null> {
     const key = this.makeKey(mintUrl, method, quoteId);
     const quote = this.quotes.get(key);
@@ -19,6 +37,19 @@ export class MemoryMintQuoteRepository implements MintQuoteRepository {
   async upsertMintQuote(quote: MintQuote): Promise<void> {
     const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
     const now = Date.now();
+    const identityOwner = await this.getMintQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Mint quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const existing = await this.getMintQuote(normalizedMintUrl, quote.method, quote.quoteId);
     const key = this.makeKey(normalizedMintUrl, quote.method, quote.quoteId);
     this.quotes.set(key, {

--- a/packages/core/test/unit/MemoryQuoteRepository.test.ts
+++ b/packages/core/test/unit/MemoryQuoteRepository.test.ts
@@ -1,0 +1,137 @@
+import { Amount } from '@cashu/cashu-ts';
+import { describe, expect, it } from 'bun:test';
+import { QuoteIdentityConflictError } from '../../models/Error';
+import type { MeltQuote } from '../../models/MeltQuote';
+import type { MintQuote } from '../../models/MintQuote';
+import { MemoryMeltQuoteRepository } from '../../repositories/memory/MemoryMeltQuoteRepository';
+import { MemoryMintQuoteRepository } from '../../repositories/memory/MemoryMintQuoteRepository';
+
+function makeMintQuote(overrides: Partial<MintQuote<'bolt11'>> = {}): MintQuote<'bolt11'> {
+  const quoteId = overrides.quoteId ?? 'mint-quote';
+  return {
+    mintUrl: 'https://mint.test',
+    method: 'bolt11',
+    quoteId,
+    quote: quoteId,
+    request: 'lnbc1mint',
+    amount: Amount.from(1),
+    unit: 'sat',
+    expiry: 1_730_000_000,
+    state: 'UNPAID',
+    lastObservedRemoteState: 'UNPAID',
+    lastObservedRemoteStateAt: 0,
+    reusable: false,
+    quoteData: { amount: Amount.from(1) },
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeMeltQuote(overrides: Partial<MeltQuote<'bolt11'>> = {}): MeltQuote<'bolt11'> {
+  const quoteId = overrides.quoteId ?? 'melt-quote';
+  return {
+    mintUrl: 'https://mint.test',
+    method: 'bolt11',
+    quoteId,
+    quote: quoteId,
+    request: 'lnbc1melt',
+    amount: Amount.from(1),
+    unit: 'sat',
+    fee_reserve: Amount.from(1),
+    expiry: 1_730_000_000,
+    state: 'UNPAID',
+    lastObservedRemoteState: 'UNPAID',
+    lastObservedRemoteStateAt: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('memory quote repositories', () => {
+  it('looks up mint quotes by canonical identity and returns null when absent', async () => {
+    const repository = new MemoryMintQuoteRepository();
+    await repository.upsertMintQuote(
+      makeMintQuote({ mintUrl: 'https://mint.test/', quoteId: 'identity-quote' }),
+    );
+
+    const stored = await repository.getMintQuoteById({
+      mintUrl: 'https://mint.test',
+      quoteId: 'identity-quote',
+    });
+    const absent = await repository.getMintQuoteById({
+      mintUrl: 'https://mint.test',
+      quoteId: 'missing',
+    });
+
+    expect(stored?.method).toBe('bolt11');
+    expect(stored?.quoteId).toBe('identity-quote');
+    expect(absent).toBe(null);
+  });
+
+  it('rejects same-mint mint quote identity collisions across methods', async () => {
+    const repository = new MemoryMintQuoteRepository();
+    await repository.upsertMintQuote(makeMintQuote({ quoteId: 'collision' }));
+
+    const collidingQuote: MintQuote<'bolt12'> = {
+      mintUrl: 'https://mint.test',
+      method: 'bolt12',
+      quoteId: 'collision',
+      quote: 'collision',
+      request: 'lno1collision',
+      unit: 'sat',
+      expiry: 1_730_000_000,
+      reusable: true,
+      quoteData: {
+        amountPaid: Amount.from(0),
+        amountIssued: Amount.from(0),
+      },
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    await expect(repository.upsertMintQuote(collidingQuote)).rejects.toThrow(
+      QuoteIdentityConflictError,
+    );
+    await expect(repository.getMintQuote('https://mint.test', 'bolt12', 'collision')).resolves.toBe(
+      null,
+    );
+  });
+
+  it('looks up melt quotes by canonical identity and rejects method collisions', async () => {
+    const repository = new MemoryMeltQuoteRepository();
+    await repository.upsertMeltQuote(makeMeltQuote({ quoteId: 'identity-melt' }));
+
+    const stored = await repository.getMeltQuoteById({
+      mintUrl: 'https://mint.test',
+      quoteId: 'identity-melt',
+    });
+    const collidingQuote = {
+      ...makeMeltQuote({ quoteId: 'identity-melt', request: 'lno1collision' }),
+      method: 'bolt12' as const,
+    } satisfies MeltQuote<'bolt12'>;
+
+    expect(stored?.method).toBe('bolt11');
+    await expect(repository.upsertMeltQuote(collidingQuote)).rejects.toThrow(
+      QuoteIdentityConflictError,
+    );
+  });
+
+  it('keeps mint and melt quote identity namespaces separate', async () => {
+    const mintRepository = new MemoryMintQuoteRepository();
+    const meltRepository = new MemoryMeltQuoteRepository();
+
+    await mintRepository.upsertMintQuote(makeMintQuote({ quoteId: 'shared' }));
+    await meltRepository.upsertMeltQuote(makeMeltQuote({ quoteId: 'shared' }));
+
+    expect(
+      (await mintRepository.getMintQuoteById({ mintUrl: 'https://mint.test', quoteId: 'shared' }))
+        ?.quoteId,
+    ).toBe('shared');
+    expect(
+      (await meltRepository.getMeltQuoteById({ mintUrl: 'https://mint.test', quoteId: 'shared' }))
+        ?.quoteId,
+    ).toBe('shared');
+  });
+});

--- a/packages/core/test/unit/MemoryQuoteRepository.test.ts
+++ b/packages/core/test/unit/MemoryQuoteRepository.test.ts
@@ -84,6 +84,7 @@ describe('memory quote repositories', () => {
       expiry: 1_730_000_000,
       reusable: true,
       quoteData: {
+        pubkey: '02'.padEnd(66, '4'),
         amountPaid: Amount.from(0),
         amountIssued: Amount.from(0),
       },

--- a/packages/expo-sqlite/src/repositories/MeltQuoteRepository.ts
+++ b/packages/expo-sqlite/src/repositories/MeltQuoteRepository.ts
@@ -1,10 +1,12 @@
 import {
   deserializeAmount,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MeltQuote,
   type MeltQuoteRepository,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import { ExpoSqliteDb } from '../db.ts';
 
@@ -79,6 +81,27 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
 export class ExpoMeltQuoteRepository implements MeltQuoteRepository {
   constructor(private readonly db: ExpoSqliteDb) {}
 
+  async getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = await this.db.all<MeltQuoteRow>(
+      `SELECT mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
+              payment_preimage, fee_options_json, outpoint, changeJson, lastObservedRemoteState, lastObservedRemoteStateAt,
+              createdAt, updatedAt
+       FROM coco_cashu_melt_quotes
+       WHERE mintUrl = ? AND quoteId = ?`,
+      [normalizedMintUrl, identity.quoteId],
+    );
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToQuote(rows[0]) : null;
+  }
+
   async getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null> {
     const row = await this.db.get<MeltQuoteRow>(
       `SELECT mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -93,6 +116,20 @@ export class ExpoMeltQuoteRepository implements MeltQuoteRepository {
 
   async upsertMeltQuote(quote: MeltQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMeltQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Melt quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     await this.db.run(
       `INSERT INTO coco_cashu_melt_quotes
          (mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -114,7 +151,7 @@ export class ExpoMeltQuoteRepository implements MeltQuoteRepository {
          lastObservedRemoteStateAt=excluded.lastObservedRemoteStateAt,
          updatedAt=excluded.updatedAt`,
       [
-        normalizeMintUrl(quote.mintUrl),
+        normalizedMintUrl,
         quote.method,
         quote.quoteId,
         quote.state,

--- a/packages/expo-sqlite/src/repositories/MintQuoteRepository.ts
+++ b/packages/expo-sqlite/src/repositories/MintQuoteRepository.ts
@@ -5,11 +5,13 @@ import {
   isMintQuotePending,
   isStatefulMintQuote,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MintMethodRemoteState,
   type MintQuote,
   type MintQuoteRepository,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import { ExpoSqliteDb } from '../db.ts';
 
@@ -127,6 +129,27 @@ export class ExpoMintQuoteRepository implements MintQuoteRepository {
     this.db = db;
   }
 
+  async getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = await this.db.all<MintQuoteRow>(
+      `SELECT mintUrl, method, quoteId, state, request, amount, unit, expiry, pubkey,
+              quoteDataJson, lastObservedRemoteState, lastObservedRemoteStateAt, reusable,
+              createdAt, updatedAt
+       FROM coco_cashu_canonical_mint_quotes
+       WHERE mintUrl = ? AND quoteId = ?`,
+      [normalizedMintUrl, identity.quoteId],
+    );
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToMintQuote(rows[0]) : null;
+  }
+
   async getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null> {
     const row = await this.db.get<MintQuoteRow>(
       `SELECT mintUrl, method, quoteId, state, request, amount, unit, expiry, pubkey,
@@ -141,6 +164,20 @@ export class ExpoMintQuoteRepository implements MintQuoteRepository {
 
   async upsertMintQuote(quote: MintQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMintQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Mint quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const state = getMintQuoteRemoteState(quote) ?? null;
     const amount = getMintQuoteAmount(quote);
     await this.db.run(
@@ -161,7 +198,7 @@ export class ExpoMintQuoteRepository implements MintQuoteRepository {
          reusable=excluded.reusable,
          updatedAt=excluded.updatedAt`,
       [
-        normalizeMintUrl(quote.mintUrl),
+        normalizedMintUrl,
         quote.method,
         quote.quoteId,
         state,

--- a/packages/expo-sqlite/src/schema.ts
+++ b/packages/expo-sqlite/src/schema.ts
@@ -1433,6 +1433,15 @@ const MIGRATIONS: readonly Migration[] = [
       DROP INDEX IF EXISTS ux_coco_cashu_history_mint_quote_melt;
     `,
   },
+  {
+    id: '036_quote_identity_unique_indexes',
+    sql: `
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_coco_cashu_canonical_mint_quotes_identity
+        ON coco_cashu_canonical_mint_quotes(mintUrl, quoteId);
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_coco_cashu_melt_quotes_identity
+        ON coco_cashu_melt_quotes(mintUrl, quoteId);
+    `,
+  },
 ];
 
 // Export for testing

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -112,6 +112,56 @@ async function createRepositories() {
   } as const;
 }
 
+async function expectRejects(fn: () => Promise<void>) {
+  let didThrow = false;
+  try {
+    await fn();
+  } catch {
+    didThrow = true;
+  }
+  expect(didThrow).toBe(true);
+}
+
+async function insertMintQuoteRow(
+  repositories: Repositories,
+  method: string,
+  quoteId: string,
+): Promise<void> {
+  await repositories.db.run(
+    `INSERT INTO coco_cashu_canonical_mint_quotes
+       (mintUrl, method, quoteId, state, request, amount, unit, quoteDataJson, reusable, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      'https://mint.test',
+      method,
+      quoteId,
+      method === 'bolt11' ? 'UNPAID' : null,
+      `${method}-request`,
+      method === 'bolt11' ? '1' : null,
+      'sat',
+      method === 'bolt11'
+        ? '{"amount":"1"}'
+        : '{"pubkey":"02","amountPaid":"0","amountIssued":"0"}',
+      method === 'bolt11' ? 0 : 1,
+      0,
+      0,
+    ],
+  );
+}
+
+async function insertMeltQuoteRow(
+  repositories: Repositories,
+  method: string,
+  quoteId: string,
+): Promise<void> {
+  await repositories.db.run(
+    `INSERT INTO coco_cashu_melt_quotes
+       (mintUrl, method, quoteId, state, request, amount, unit, expiry, fee_reserve, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ['https://mint.test', method, quoteId, 'UNPAID', `${method}-request`, '1', 'sat', 0, '1', 0, 0],
+  );
+}
+
 runRepositoryTransactionContract(
   {
     createRepositories,
@@ -135,6 +185,28 @@ runMeltOperationRepositoryContract({ createRepositories }, { describe, it, expec
 runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
+
+describe('expo-sqlite quote storage constraints', () => {
+  it('rejects persisted mint quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await insertMintQuoteRow(repositories, 'bolt11', 'duplicate-mint-quote');
+      await expectRejects(() => insertMintQuoteRow(repositories, 'bolt12', 'duplicate-mint-quote'));
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('rejects persisted melt quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await insertMeltQuoteRow(repositories, 'bolt11', 'duplicate-melt-quote');
+      await expectRejects(() => insertMeltQuoteRow(repositories, 'bolt12', 'duplicate-melt-quote'));
+    } finally {
+      await dispose();
+    }
+  });
+});
 
 describe('expo-sqlite adapter transactions', () => {
   it('commits across repositories', async () => {

--- a/packages/indexeddb/src/lib/schema.ts
+++ b/packages/indexeddb/src/lib/schema.ts
@@ -1051,4 +1051,29 @@ export async function ensureSchema(db: IdbDb): Promise<void> {
     coco_cashu_payment_request_receive_attempts:
       '&id, requestOperationId, requestId, state, &[requestOperationId+payloadHash], [requestId+payloadHash], &transportMessageId, &receiveOperationId',
   });
+
+  // Version 31: Enforce canonical quote identity uniqueness per quote kind.
+  db.version(31).stores({
+    coco_cashu_mints: '&mintUrl, name, updatedAt, trusted',
+    coco_cashu_keysets: '&[mintUrl+id], mintUrl, id, updatedAt, unit',
+    coco_cashu_counters: '&[mintUrl+keysetId]',
+    coco_cashu_proofs:
+      '&[mintUrl+secret], [mintUrl+state], [mintUrl+unit+state], [mintUrl+id+state], [mintUrl+id+unit+state], [mintUrl+unit+id+state], [unit+state], state, mintUrl, unit, id, usedByOperationId, createdByOperationId',
+    coco_cashu_mint_quotes: '&[mintUrl+quote], state, mintUrl',
+    coco_cashu_canonical_mint_quotes:
+      '&[mintUrl+method+quoteId], &[mintUrl+quoteId], state, mintUrl, method',
+    coco_cashu_melt_quotes: '&[mintUrl+method+quoteId], &[mintUrl+quoteId], state, mintUrl, method',
+    coco_cashu_history:
+      '++id, mintUrl, type, createdAt, [mintUrl+quoteId+type], [mintUrl+operationId]',
+    coco_cashu_keypairs: '&publicKey, createdAt, derivationIndex',
+    coco_cashu_send_operations: '&id, state, mintUrl, createdAt',
+    coco_cashu_melt_operations: '&id, state, mintUrl, createdAt, [mintUrl+quoteId]',
+    coco_cashu_receive_operations: '&id, state, mintUrl, createdAt',
+    coco_cashu_auth_sessions: '&mintUrl',
+    coco_cashu_mint_operations:
+      '&id, state, mintUrl, createdAt, [mintUrl+quoteId], [mintUrl+method+quoteId]',
+    coco_cashu_payment_request_receive_operations: '&id, state, requestId',
+    coco_cashu_payment_request_receive_attempts:
+      '&id, requestOperationId, requestId, state, &[requestOperationId+payloadHash], [requestId+payloadHash], &transportMessageId, &receiveOperationId',
+  });
 }

--- a/packages/indexeddb/src/repositories/MeltQuoteRepository.ts
+++ b/packages/indexeddb/src/repositories/MeltQuoteRepository.ts
@@ -1,6 +1,12 @@
 import type { MeltQuoteRepository } from '@cashu/coco-core';
-import { deserializeAmount, normalizeMintUrl, serializeAmount } from '@cashu/coco-core';
+import {
+  deserializeAmount,
+  normalizeMintUrl,
+  QuoteIdentityConflictError,
+  serializeAmount,
+} from '@cashu/coco-core';
 import type { MeltQuote } from '@cashu/coco-core';
+import type { QuoteIdentity } from '@cashu/coco-core';
 import type { IdbDb, MeltQuoteRow } from '../lib/db.ts';
 
 function rowToQuote(row: MeltQuoteRow): MeltQuote {
@@ -52,6 +58,24 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
 export class IdbMeltQuoteRepository implements MeltQuoteRepository {
   constructor(private readonly db: IdbDb) {}
 
+  async getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = (await (this.db as any)
+      .table('coco_cashu_melt_quotes')
+      .where('[mintUrl+quoteId]')
+      .equals([normalizedMintUrl, identity.quoteId])
+      .toArray()) as MeltQuoteRow[];
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToQuote(rows[0]) : null;
+  }
+
   async getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null> {
     const row = (await (this.db as any)
       .table('coco_cashu_melt_quotes')
@@ -61,9 +85,23 @@ export class IdbMeltQuoteRepository implements MeltQuoteRepository {
 
   async upsertMeltQuote(quote: MeltQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMeltQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Melt quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const existing = await this.getMeltQuote(quote.mintUrl, quote.method, quote.quoteId);
     const row: MeltQuoteRow = {
-      mintUrl: normalizeMintUrl(quote.mintUrl),
+      mintUrl: normalizedMintUrl,
       method: quote.method,
       quoteId: quote.quoteId,
       quote: quote.quoteId,

--- a/packages/indexeddb/src/repositories/MintQuoteRepository.ts
+++ b/packages/indexeddb/src/repositories/MintQuoteRepository.ts
@@ -6,10 +6,12 @@ import {
   isMintQuotePending,
   isStatefulMintQuote,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MintMethodRemoteState,
   type MintQuote,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import type { IdbDb, MintQuoteRow } from '../lib/db.ts';
 
@@ -109,6 +111,24 @@ export class IdbMintQuoteRepository implements MintQuoteRepository {
     this.db = db;
   }
 
+  async getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = (await (this.db as any)
+      .table('coco_cashu_canonical_mint_quotes')
+      .where('[mintUrl+quoteId]')
+      .equals([normalizedMintUrl, identity.quoteId])
+      .toArray()) as MintQuoteRow[];
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToMintQuote(rows[0]) : null;
+  }
+
   async getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null> {
     const row = (await (this.db as any)
       .table('coco_cashu_canonical_mint_quotes')
@@ -118,10 +138,24 @@ export class IdbMintQuoteRepository implements MintQuoteRepository {
 
   async upsertMintQuote(quote: MintQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMintQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Mint quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const state = getMintQuoteRemoteState(quote) ?? null;
     const amount = getMintQuoteAmount(quote);
     const row: MintQuoteRow = {
-      mintUrl: normalizeMintUrl(quote.mintUrl),
+      mintUrl: normalizedMintUrl,
       method: quote.method,
       quoteId: quote.quoteId,
       state,

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -24,6 +24,16 @@ async function createRepositories() {
   };
 }
 
+async function expectRejects(fn: () => Promise<void>) {
+  let didThrow = false;
+  try {
+    await fn();
+  } catch {
+    didThrow = true;
+  }
+  expect(didThrow).toBe(true);
+}
+
 runRepositoryTransactionContract(
   {
     createRepositories,
@@ -46,3 +56,95 @@ runMeltOperationRepositoryContract({ createRepositories }, { describe, it, expec
 runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
+
+describe('indexeddb quote storage constraints', () => {
+  it('rejects persisted mint quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await repositories.db.table('coco_cashu_canonical_mint_quotes').add({
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+        quoteId: 'duplicate-mint-quote',
+        state: 'UNPAID',
+        request: 'bolt11-request',
+        amount: '1',
+        unit: 'sat',
+        expiry: null,
+        pubkey: null,
+        quoteDataJson: '{"amount":"1"}',
+        lastObservedRemoteState: 'UNPAID',
+        lastObservedRemoteStateAt: 0,
+        reusable: 0,
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      await expectRejects(async () => {
+        await repositories.db.table('coco_cashu_canonical_mint_quotes').add({
+          mintUrl: 'https://mint.test',
+          method: 'bolt12',
+          quoteId: 'duplicate-mint-quote',
+          state: null,
+          request: 'bolt12-request',
+          amount: null,
+          unit: 'sat',
+          expiry: null,
+          pubkey: '02',
+          quoteDataJson: '{"pubkey":"02","amountPaid":"0","amountIssued":"0"}',
+          lastObservedRemoteState: null,
+          lastObservedRemoteStateAt: 0,
+          reusable: 1,
+          createdAt: 0,
+          updatedAt: 0,
+        });
+      });
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('rejects persisted melt quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await repositories.db.table('coco_cashu_melt_quotes').add({
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+        quoteId: 'duplicate-melt-quote',
+        quote: 'duplicate-melt-quote',
+        state: 'UNPAID',
+        request: 'bolt11-request',
+        amount: '1',
+        unit: 'sat',
+        fee_reserve: '1',
+        expiry: 0,
+        payment_preimage: null,
+        change: undefined,
+        lastObservedRemoteState: 'UNPAID',
+        lastObservedRemoteStateAt: 0,
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      await expectRejects(async () => {
+        await repositories.db.table('coco_cashu_melt_quotes').add({
+          mintUrl: 'https://mint.test',
+          method: 'bolt12',
+          quoteId: 'duplicate-melt-quote',
+          quote: 'duplicate-melt-quote',
+          state: 'UNPAID',
+          request: 'bolt12-request',
+          amount: '1',
+          unit: 'sat',
+          fee_reserve: '1',
+          expiry: 0,
+          payment_preimage: null,
+          change: undefined,
+          lastObservedRemoteState: 'UNPAID',
+          lastObservedRemoteStateAt: 0,
+          createdAt: 0,
+          updatedAt: 0,
+        });
+      });
+    } finally {
+      await dispose();
+    }
+  });
+});

--- a/packages/sqlite-bun/src/repositories/MeltQuoteRepository.ts
+++ b/packages/sqlite-bun/src/repositories/MeltQuoteRepository.ts
@@ -1,10 +1,12 @@
 import {
   deserializeAmount,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MeltQuote,
   type MeltQuoteRepository,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import { SqliteDb } from '../db.ts';
 
@@ -79,6 +81,27 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
 export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
   constructor(private readonly db: SqliteDb) {}
 
+  async getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = await this.db.all<MeltQuoteRow>(
+      `SELECT mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
+              payment_preimage, fee_options_json, outpoint, changeJson, lastObservedRemoteState, lastObservedRemoteStateAt,
+              createdAt, updatedAt
+       FROM coco_cashu_melt_quotes
+       WHERE mintUrl = ? AND quoteId = ?`,
+      [normalizedMintUrl, identity.quoteId],
+    );
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToQuote(rows[0]) : null;
+  }
+
   async getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null> {
     const row = await this.db.get<MeltQuoteRow>(
       `SELECT mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -93,6 +116,20 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
 
   async upsertMeltQuote(quote: MeltQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMeltQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Melt quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     await this.db.run(
       `INSERT INTO coco_cashu_melt_quotes
          (mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -114,7 +151,7 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
          lastObservedRemoteStateAt=excluded.lastObservedRemoteStateAt,
          updatedAt=excluded.updatedAt`,
       [
-        normalizeMintUrl(quote.mintUrl),
+        normalizedMintUrl,
         quote.method,
         quote.quoteId,
         quote.state,

--- a/packages/sqlite-bun/src/repositories/MintQuoteRepository.ts
+++ b/packages/sqlite-bun/src/repositories/MintQuoteRepository.ts
@@ -5,11 +5,13 @@ import {
   isMintQuotePending,
   isStatefulMintQuote,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MintMethodRemoteState,
   type MintQuote,
   type MintQuoteRepository,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import { SqliteDb } from '../db.ts';
 
@@ -127,6 +129,27 @@ export class SqliteMintQuoteRepository implements MintQuoteRepository {
     this.db = db;
   }
 
+  async getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = await this.db.all<MintQuoteRow>(
+      `SELECT mintUrl, method, quoteId, state, request, amount, unit, expiry, pubkey,
+              quoteDataJson, lastObservedRemoteState, lastObservedRemoteStateAt, reusable,
+              createdAt, updatedAt
+       FROM coco_cashu_canonical_mint_quotes
+       WHERE mintUrl = ? AND quoteId = ?`,
+      [normalizedMintUrl, identity.quoteId],
+    );
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToMintQuote(rows[0]) : null;
+  }
+
   async getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null> {
     const row = await this.db.get<MintQuoteRow>(
       `SELECT mintUrl, method, quoteId, state, request, amount, unit, expiry, pubkey,
@@ -141,6 +164,20 @@ export class SqliteMintQuoteRepository implements MintQuoteRepository {
 
   async upsertMintQuote(quote: MintQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMintQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Mint quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const state = getMintQuoteRemoteState(quote) ?? null;
     const amount = getMintQuoteAmount(quote);
     await this.db.run(
@@ -161,7 +198,7 @@ export class SqliteMintQuoteRepository implements MintQuoteRepository {
          reusable=excluded.reusable,
          updatedAt=excluded.updatedAt`,
       [
-        normalizeMintUrl(quote.mintUrl),
+        normalizedMintUrl,
         quote.method,
         quote.quoteId,
         state,

--- a/packages/sqlite-bun/src/schema.ts
+++ b/packages/sqlite-bun/src/schema.ts
@@ -1434,6 +1434,15 @@ const MIGRATIONS: readonly Migration[] = [
       DROP INDEX IF EXISTS ux_coco_cashu_history_mint_quote_melt;
     `,
   },
+  {
+    id: '036_quote_identity_unique_indexes',
+    sql: `
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_coco_cashu_canonical_mint_quotes_identity
+        ON coco_cashu_canonical_mint_quotes(mintUrl, quoteId);
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_coco_cashu_melt_quotes_identity
+        ON coco_cashu_melt_quotes(mintUrl, quoteId);
+    `,
+  },
 ];
 
 // Export for testing

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -38,6 +38,56 @@ async function createRepositories() {
   };
 }
 
+async function expectRejects(fn: () => Promise<void>) {
+  let didThrow = false;
+  try {
+    await fn();
+  } catch {
+    didThrow = true;
+  }
+  expect(didThrow).toBe(true);
+}
+
+async function insertMintQuoteRow(
+  repositories: Repositories,
+  method: string,
+  quoteId: string,
+): Promise<void> {
+  await repositories.db.run(
+    `INSERT INTO coco_cashu_canonical_mint_quotes
+       (mintUrl, method, quoteId, state, request, amount, unit, quoteDataJson, reusable, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      'https://mint.test',
+      method,
+      quoteId,
+      method === 'bolt11' ? 'UNPAID' : null,
+      `${method}-request`,
+      method === 'bolt11' ? '1' : null,
+      'sat',
+      method === 'bolt11'
+        ? '{"amount":"1"}'
+        : '{"pubkey":"02","amountPaid":"0","amountIssued":"0"}',
+      method === 'bolt11' ? 0 : 1,
+      0,
+      0,
+    ],
+  );
+}
+
+async function insertMeltQuoteRow(
+  repositories: Repositories,
+  method: string,
+  quoteId: string,
+): Promise<void> {
+  await repositories.db.run(
+    `INSERT INTO coco_cashu_melt_quotes
+       (mintUrl, method, quoteId, state, request, amount, unit, expiry, fee_reserve, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ['https://mint.test', method, quoteId, 'UNPAID', `${method}-request`, '1', 'sat', 0, '1', 0, 0],
+  );
+}
+
 runRepositoryTransactionContract(
   {
     createRepositories,
@@ -61,6 +111,28 @@ runMeltOperationRepositoryContract({ createRepositories }, { describe, it, expec
 runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
+
+describe('sqlite-bun quote storage constraints', () => {
+  it('rejects persisted mint quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await insertMintQuoteRow(repositories, 'bolt11', 'duplicate-mint-quote');
+      await expectRejects(() => insertMintQuoteRow(repositories, 'bolt12', 'duplicate-mint-quote'));
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('rejects persisted melt quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await insertMeltQuoteRow(repositories, 'bolt11', 'duplicate-melt-quote');
+      await expectRejects(() => insertMeltQuoteRow(repositories, 'bolt12', 'duplicate-melt-quote'));
+    } finally {
+      await dispose();
+    }
+  });
+});
 
 describe('sqlite-bun adapter transactions', () => {
   it('commits across repositories', async () => {

--- a/packages/sqlite3/src/repositories/MeltQuoteRepository.ts
+++ b/packages/sqlite3/src/repositories/MeltQuoteRepository.ts
@@ -1,10 +1,12 @@
 import {
   deserializeAmount,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MeltQuote,
   type MeltQuoteRepository,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import { SqliteDb } from '../db.ts';
 
@@ -79,6 +81,27 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
 export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
   constructor(private readonly db: SqliteDb) {}
 
+  async getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = await this.db.all<MeltQuoteRow>(
+      `SELECT mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
+              payment_preimage, fee_options_json, outpoint, changeJson, lastObservedRemoteState, lastObservedRemoteStateAt,
+              createdAt, updatedAt
+       FROM coco_cashu_melt_quotes
+       WHERE mintUrl = ? AND quoteId = ?`,
+      [normalizedMintUrl, identity.quoteId],
+    );
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToQuote(rows[0]) : null;
+  }
+
   async getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null> {
     const row = await this.db.get<MeltQuoteRow>(
       `SELECT mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -93,6 +116,20 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
 
   async upsertMeltQuote(quote: MeltQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMeltQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Melt quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     await this.db.run(
       `INSERT INTO coco_cashu_melt_quotes
          (mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -114,7 +151,7 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
          lastObservedRemoteStateAt=excluded.lastObservedRemoteStateAt,
          updatedAt=excluded.updatedAt`,
       [
-        normalizeMintUrl(quote.mintUrl),
+        normalizedMintUrl,
         quote.method,
         quote.quoteId,
         quote.state,

--- a/packages/sqlite3/src/repositories/MintQuoteRepository.ts
+++ b/packages/sqlite3/src/repositories/MintQuoteRepository.ts
@@ -5,11 +5,13 @@ import {
   isMintQuotePending,
   isStatefulMintQuote,
   normalizeMintUrl,
+  QuoteIdentityConflictError,
   serializeAmount,
   stringifyJson,
   type MintMethodRemoteState,
   type MintQuote,
   type MintQuoteRepository,
+  type QuoteIdentity,
 } from '@cashu/coco-core';
 import { SqliteDb } from '../db.ts';
 
@@ -127,6 +129,27 @@ export class SqliteMintQuoteRepository implements MintQuoteRepository {
     this.db = db;
   }
 
+  async getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null> {
+    const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);
+    const rows = await this.db.all<MintQuoteRow>(
+      `SELECT mintUrl, method, quoteId, state, request, amount, unit, expiry, pubkey,
+              quoteDataJson, lastObservedRemoteState, lastObservedRemoteStateAt, reusable,
+              createdAt, updatedAt
+       FROM coco_cashu_canonical_mint_quotes
+       WHERE mintUrl = ? AND quoteId = ?`,
+      [normalizedMintUrl, identity.quoteId],
+    );
+    if (rows.length > 1) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        identity.quoteId,
+        rows.map((row) => row.method),
+      );
+    }
+    return rows[0] ? rowToMintQuote(rows[0]) : null;
+  }
+
   async getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null> {
     const row = await this.db.get<MintQuoteRow>(
       `SELECT mintUrl, method, quoteId, state, request, amount, unit, expiry, pubkey,
@@ -141,6 +164,20 @@ export class SqliteMintQuoteRepository implements MintQuoteRepository {
 
   async upsertMintQuote(quote: MintQuote): Promise<void> {
     const now = Date.now();
+    const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
+    const identityOwner = await this.getMintQuoteById({
+      mintUrl: normalizedMintUrl,
+      quoteId: quote.quoteId,
+    });
+    if (identityOwner && identityOwner.method !== quote.method) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        normalizedMintUrl,
+        quote.quoteId,
+        [identityOwner.method, quote.method],
+        `Mint quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
+      );
+    }
     const state = getMintQuoteRemoteState(quote) ?? null;
     const amount = getMintQuoteAmount(quote);
     await this.db.run(
@@ -161,7 +198,7 @@ export class SqliteMintQuoteRepository implements MintQuoteRepository {
          reusable=excluded.reusable,
          updatedAt=excluded.updatedAt`,
       [
-        normalizeMintUrl(quote.mintUrl),
+        normalizedMintUrl,
         quote.method,
         quote.quoteId,
         state,

--- a/packages/sqlite3/src/schema.ts
+++ b/packages/sqlite3/src/schema.ts
@@ -1433,6 +1433,15 @@ const MIGRATIONS: readonly Migration[] = [
       DROP INDEX IF EXISTS ux_coco_cashu_history_mint_quote_melt;
     `,
   },
+  {
+    id: '036_quote_identity_unique_indexes',
+    sql: `
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_coco_cashu_canonical_mint_quotes_identity
+        ON coco_cashu_canonical_mint_quotes(mintUrl, quoteId);
+      CREATE UNIQUE INDEX IF NOT EXISTS ux_coco_cashu_melt_quotes_identity
+        ON coco_cashu_melt_quotes(mintUrl, quoteId);
+    `,
+  },
 ];
 
 // Export for testing

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -38,6 +38,56 @@ async function createRepositories() {
   };
 }
 
+async function expectRejects(fn: () => Promise<void>) {
+  let didThrow = false;
+  try {
+    await fn();
+  } catch {
+    didThrow = true;
+  }
+  expect(didThrow).toBe(true);
+}
+
+async function insertMintQuoteRow(
+  repositories: Repositories,
+  method: string,
+  quoteId: string,
+): Promise<void> {
+  await repositories.db.run(
+    `INSERT INTO coco_cashu_canonical_mint_quotes
+       (mintUrl, method, quoteId, state, request, amount, unit, quoteDataJson, reusable, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      'https://mint.test',
+      method,
+      quoteId,
+      method === 'bolt11' ? 'UNPAID' : null,
+      `${method}-request`,
+      method === 'bolt11' ? '1' : null,
+      'sat',
+      method === 'bolt11'
+        ? '{"amount":"1"}'
+        : '{"pubkey":"02","amountPaid":"0","amountIssued":"0"}',
+      method === 'bolt11' ? 0 : 1,
+      0,
+      0,
+    ],
+  );
+}
+
+async function insertMeltQuoteRow(
+  repositories: Repositories,
+  method: string,
+  quoteId: string,
+): Promise<void> {
+  await repositories.db.run(
+    `INSERT INTO coco_cashu_melt_quotes
+       (mintUrl, method, quoteId, state, request, amount, unit, expiry, fee_reserve, createdAt, updatedAt)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ['https://mint.test', method, quoteId, 'UNPAID', `${method}-request`, '1', 'sat', 0, '1', 0, 0],
+  );
+}
+
 runRepositoryTransactionContract(
   {
     createRepositories,
@@ -61,6 +111,28 @@ runMeltOperationRepositoryContract({ createRepositories }, { describe, it, expec
 runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
+
+describe('sqlite3 quote storage constraints', () => {
+  it('rejects persisted mint quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await insertMintQuoteRow(repositories, 'bolt11', 'duplicate-mint-quote');
+      await expectRejects(() => insertMintQuoteRow(repositories, 'bolt12', 'duplicate-mint-quote'));
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('rejects persisted melt quote method siblings for one identity', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await insertMeltQuoteRow(repositories, 'bolt11', 'duplicate-melt-quote');
+      await expectRejects(() => insertMeltQuoteRow(repositories, 'bolt12', 'duplicate-melt-quote'));
+    } finally {
+      await dispose();
+    }
+  });
+});
 
 describe('sqlite3 adapter transactions', () => {
   it('commits across repositories', async () => {


### PR DESCRIPTION
## Description

This pull request adds canonical quote identity contracts and enforces `(mintUrl, quoteId)` uniqueness for mint and melt quote storage.

This pull request resolves #198.

## Problem

Quote repositories could store method-sibling canonical quotes for the same mint and quote ID, leaving identity-based lookup ambiguous for the v2 quote API refactor.

## Summary

- Adds `QuoteIdentity`, `MintQuoteRef`, `MeltQuoteRef`, and `QuoteIdentityConflictError` to the public core API.
- Adds identity lookup helpers while preserving existing method-aware exact getters.
- Adds repository preflight collision checks and storage uniqueness in memory, SQLite-style adapters, and IndexedDB.
- Adds shared adapter contract coverage plus direct storage duplicate checks.
- Adds `.changeset/canonical-quote-identity.md` for the public core API and adapter storage-contract updates.

## Verification

- `bun run build` in `core`, `adapter-tests`, `sqlite3`, `sqlite-bun`, `expo-sqlite`, `indexeddb`
- `bun run typecheck` in `adapter-tests`, `sqlite3`, `sqlite-bun`, `expo-sqlite`, `indexeddb`
- `bun test test/unit/MemoryQuoteRepository.test.ts`
- `bun test src/test/contract.test.ts src/test/schema.test.ts` in `sqlite-bun`, `expo-sqlite`
- `bun run test:browser -- src/test/contract.test.ts` in `indexeddb`
- `git diff --check`

## Notes

- Full `core` typecheck still fails on pre-existing `cashu-ts` onchain API type mismatches.
- Local `sqlite3` runtime tests are blocked by the existing `better-sqlite3` native module mismatch, but `sqlite3` typecheck/build passed and the same SQLite-style behavior passed in `sqlite-bun` and `expo-sqlite`.

## Changeset

- Added `.changeset/canonical-quote-identity.md` with `@cashu/coco-core` major and adapter package patch entries.