### PR TITLE
feat(core): resolve quotes by identity

### DIFF
--- a/.changeset/methodless-quote-refresh.md
+++ b/.changeset/methodless-quote-refresh.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-adapter-tests': patch
+---
+
+Make canonical quote get and refresh APIs resolve mint and melt quotes by `{ mintUrl, quoteId }`.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -242,7 +242,6 @@ async function waitForOnchainQuoteAvailable(
   for (let attempt = 0; attempt < 30; attempt++) {
     latest = await manager.quotes.mint.refresh({
       mintUrl,
-      method: 'onchain',
       quoteId,
     });
 
@@ -390,7 +389,6 @@ async function getMintQuoteForOperation(
 ): Promise<MintQuote | null> {
   return manager.quotes.mint.get({
     mintUrl: operation.mintUrl,
-    method: operation.method,
     quoteId: operation.quoteId,
   });
 }

--- a/packages/core/api/QuoteApi.ts
+++ b/packages/core/api/QuoteApi.ts
@@ -3,6 +3,7 @@ import type { MintMethodQuoteSnapshot } from '@core/operations/mint';
 import { DEFAULT_UNIT, normalizeUnit, parseUnitAmount, type UnitAmountLike } from '../amounts.ts';
 import type { MeltQuote } from '../models/MeltQuote';
 import type { MintQuote } from '../models/MintQuote';
+import type { QuoteIdentity } from '../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../quotes/QuoteLifecycle';
 import type { DefaultSupportedMeltMethod } from './MeltOpsApi.ts';
 
@@ -28,12 +29,6 @@ export type CreateMintQuoteInput =
       description?: string;
     };
 
-export type GetMintQuoteInput = {
-  mintUrl: string;
-  method: DefaultSupportedMintQuoteMethod;
-  quoteId: string;
-};
-
 export type ImportMintQuoteInput = {
   /** Mint that issued the existing quote. */
   mintUrl: string;
@@ -42,8 +37,6 @@ export type ImportMintQuoteInput = {
   /** Mint method for the quote snapshot. */
   method: 'bolt11';
 };
-
-export type RefreshMintQuoteInput = GetMintQuoteInput;
 
 export type ListPendingMintQuotesInput = {
   method?: DefaultSupportedMintQuoteMethod;
@@ -57,14 +50,6 @@ export type CreateMeltQuoteInput = {
     unit?: string;
   };
 }[DefaultSupportedMeltMethod];
-
-export type GetMeltQuoteInput = {
-  mintUrl: string;
-  method: DefaultSupportedMeltMethod;
-  quoteId: string;
-};
-
-export type RefreshMeltQuoteInput = GetMeltQuoteInput;
 
 export type ListPendingMeltQuotesInput = {
   method?: DefaultSupportedMeltMethod;
@@ -99,8 +84,8 @@ export class MintQuoteApi {
     });
   }
 
-  get(input: GetMintQuoteInput): Promise<MintQuote | null> {
-    return this.quoteLifecycle.getMintQuote(input.mintUrl, input.method, input.quoteId);
+  get(input: QuoteIdentity): Promise<MintQuote | null> {
+    return this.quoteLifecycle.getMintQuoteById(input);
   }
 
   import(input: ImportMintQuoteInput): Promise<MintQuote> {
@@ -111,8 +96,8 @@ export class MintQuoteApi {
     return this.quoteLifecycle.getPendingMintQuotes(input.method);
   }
 
-  refresh(input: RefreshMintQuoteInput): Promise<MintQuote> {
-    return this.quoteLifecycle.refreshMintQuote(input.mintUrl, input.method, input.quoteId);
+  refresh(input: QuoteIdentity): Promise<MintQuote> {
+    return this.quoteLifecycle.refreshMintQuoteById(input);
   }
 }
 
@@ -128,16 +113,16 @@ export class MeltQuoteApi {
     );
   }
 
-  get(input: GetMeltQuoteInput): Promise<MeltQuote | null> {
-    return this.quoteLifecycle.getMeltQuote(input.mintUrl, input.method, input.quoteId);
+  get(input: QuoteIdentity): Promise<MeltQuote | null> {
+    return this.quoteLifecycle.getMeltQuoteById(input);
   }
 
   listPending(input: ListPendingMeltQuotesInput = {}): Promise<MeltQuote[]> {
     return this.quoteLifecycle.getPendingMeltQuotes(input.method);
   }
 
-  refresh(input: RefreshMeltQuoteInput): Promise<MeltQuote> {
-    return this.quoteLifecycle.refreshMeltQuote(input.mintUrl, input.method, input.quoteId);
+  refresh(input: QuoteIdentity): Promise<MeltQuote> {
+    return this.quoteLifecycle.refreshMeltQuoteById(input);
   }
 }
 

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -43,6 +43,7 @@ import type {
   MintMethodQuoteSnapshot,
   MintMethodRemoteState,
 } from '../operations/mint/MintMethodHandler';
+import type { QuoteIdentity } from '../models/QuoteIdentity';
 
 const MINT_QUOTE_STATE_RANK: Record<string, number> = {
   UNPAID: 0,
@@ -157,6 +158,40 @@ export class QuoteLifecycle {
     };
   }
 
+  private async refreshResolvedMintQuote(existingQuote: MintQuote): Promise<MintQuote> {
+    const handler = this.mintHandlerProvider.get(existingQuote.method);
+    const refreshed = await handler.fetchRemoteQuote({
+      ...this.buildDeps(),
+      quote: existingQuote,
+    });
+
+    const remoteStateChanged = getRemoteStateChange(existingQuote, refreshed);
+    const quote = await this.persistCanonicalMintQuote(refreshed);
+    await this.emitMintQuoteUpdatedIfNeeded(quote, remoteStateChanged);
+    return quote;
+  }
+
+  private async refreshResolvedMeltQuote(existingQuote: MeltQuote): Promise<MeltQuote> {
+    const handler = this.meltHandlerProvider.get(existingQuote.method);
+    const refreshed = await handler.fetchRemoteQuote({
+      ...this.buildDeps(),
+      quote: existingQuote,
+    });
+
+    await this.meltQuoteRepository.upsertMeltQuote(refreshed);
+    const quote = await this.meltQuoteRepository.getMeltQuote(
+      existingQuote.mintUrl,
+      existingQuote.method,
+      existingQuote.quoteId,
+    );
+    if (!quote) {
+      throw new Error(
+        `Cannot refresh quote: melt quote ${existingQuote.quoteId} was not found after persistence`,
+      );
+    }
+    return quote;
+  }
+
   async createMintQuote(mintUrl: string, intent: UnitAmount, method?: 'bolt11'): Promise<MintQuote>;
   async createMintQuote<M extends MintMethod>(
     mintUrl: string,
@@ -230,6 +265,10 @@ export class QuoteLifecycle {
     return this.mintQuoteRepository.getMintQuote(mintUrl, method, quoteId);
   }
 
+  getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null> {
+    return this.mintQuoteRepository.getMintQuoteById(identity);
+  }
+
   getPendingMintQuotes(method?: MintMethod): Promise<MintQuote[]> {
     return this.mintQuoteRepository.getPendingMintQuotes(method);
   }
@@ -240,16 +279,16 @@ export class QuoteLifecycle {
       throw new Error(`Mint quote ${quoteId} for ${method} at ${mintUrl} was not found`);
     }
 
-    const handler = this.mintHandlerProvider.get(method);
-    const refreshed = await handler.fetchRemoteQuote({
-      ...this.buildDeps(),
-      quote: existingQuote,
-    });
+    return this.refreshResolvedMintQuote(existingQuote);
+  }
 
-    const remoteStateChanged = getRemoteStateChange(existingQuote, refreshed);
-    const quote = await this.persistCanonicalMintQuote(refreshed);
-    await this.emitMintQuoteUpdatedIfNeeded(quote, remoteStateChanged);
-    return quote;
+  async refreshMintQuoteById(identity: QuoteIdentity): Promise<MintQuote> {
+    const existingQuote = await this.mintQuoteRepository.getMintQuoteById(identity);
+    if (!existingQuote) {
+      throw new Error(`Mint quote ${identity.quoteId} at ${identity.mintUrl} was not found`);
+    }
+
+    return this.refreshResolvedMintQuote(existingQuote);
   }
 
   async requireMintQuoteForPrepare(
@@ -503,6 +542,10 @@ export class QuoteLifecycle {
     return this.meltQuoteRepository.getMeltQuote(mintUrl, method, quoteId);
   }
 
+  getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
+    return this.meltQuoteRepository.getMeltQuoteById(identity);
+  }
+
   getPendingMeltQuotes(method?: MeltMethod): Promise<MeltQuote[]> {
     return this.meltQuoteRepository.getPendingMeltQuotes(method);
   }
@@ -513,24 +556,16 @@ export class QuoteLifecycle {
       throw new Error(`Melt quote ${quoteId} for ${method} at ${mintUrl} was not found`);
     }
 
-    const handler = this.meltHandlerProvider.get(method);
-    const refreshed = await handler.fetchRemoteQuote({
-      ...this.buildDeps(),
-      quote: existingQuote,
-    });
+    return this.refreshResolvedMeltQuote(existingQuote);
+  }
 
-    await this.meltQuoteRepository.upsertMeltQuote(refreshed);
-    const quote = await this.meltQuoteRepository.getMeltQuote(
-      existingQuote.mintUrl,
-      method,
-      quoteId,
-    );
-    if (!quote) {
-      throw new Error(
-        `Cannot refresh quote: melt quote ${quoteId} for ${method} at ${mintUrl} was not found after persistence`,
-      );
+  async refreshMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote> {
+    const existingQuote = await this.meltQuoteRepository.getMeltQuoteById(identity);
+    if (!existingQuote) {
+      throw new Error(`Melt quote ${identity.quoteId} at ${identity.mintUrl} was not found`);
     }
-    return quote;
+
+    return this.refreshResolvedMeltQuote(existingQuote);
   }
 
   async requireMeltQuoteForPrepare(

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -393,9 +393,27 @@ describe('MeltOperationService', () => {
       expect(quotes.map((quote) => quote.quoteId).sort()).toEqual(['quote-1', 'quote-pending']);
     });
 
-    it('refreshMeltQuote persists a canonical melt quote after fetching remote state', async () => {
+    it('gets canonical melt quotes by quote identity', async () => {
+      const quote = await quoteLifecycle.getMeltQuoteById({ mintUrl, quoteId: 'quote-1' });
+      const missing = await quoteLifecycle.getMeltQuoteById({ mintUrl, quoteId: 'missing' });
+
+      expect(quote?.quoteId).toBe('quote-1');
+      expect(missing).toBeNull();
+    });
+
+    it('refreshMeltQuoteById resolves the stored method before fetching remote state', async () => {
+      const quote = await quoteLifecycle.refreshMeltQuoteById({ mintUrl, quoteId: 'quote-1' });
+
+      expect(handlerProvider.get).toHaveBeenCalledWith('bolt11');
+      expect(handler.fetchRemoteQuote).toHaveBeenCalled();
+      expect(quote.state).toBe('PENDING');
+      expect(await quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-1')).toEqual(quote);
+    });
+
+    it('refreshMeltQuote keeps the method-aware exact refresh path for internal callers', async () => {
       const quote = await quoteLifecycle.refreshMeltQuote(mintUrl, 'bolt11', 'quote-1');
 
+      expect(handlerProvider.get).toHaveBeenCalledWith('bolt11');
       expect(handler.fetchRemoteQuote).toHaveBeenCalled();
       expect(quote.state).toBe('PENDING');
       expect(await quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-1')).toEqual(quote);

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -597,16 +597,15 @@ describe('MintOperationService', () => {
     });
   });
 
-  it('getQuote returns a persisted quote by full identity', async () => {
+  it('getQuoteById returns a persisted quote by canonical identity', async () => {
     await persistQuote('quote-exact');
 
-    const found = await quoteLifecycle.getMintQuote(mintUrl, 'bolt11', 'quote-exact');
-    const wrongQuoteId = await quoteLifecycle.getMintQuote(mintUrl, 'bolt11', 'quote-other');
-    const wrongMint = await quoteLifecycle.getMintQuote(
-      'https://other-mint.test',
-      'bolt11',
-      'quote-exact',
-    );
+    const found = await quoteLifecycle.getMintQuoteById({ mintUrl, quoteId: 'quote-exact' });
+    const wrongQuoteId = await quoteLifecycle.getMintQuoteById({ mintUrl, quoteId: 'quote-other' });
+    const wrongMint = await quoteLifecycle.getMintQuoteById({
+      mintUrl: 'https://other-mint.test',
+      quoteId: 'quote-exact',
+    });
 
     expect(found?.quoteId).toBe('quote-exact');
     expect(wrongQuoteId).toBeNull();
@@ -644,10 +643,24 @@ describe('MintOperationService', () => {
 
   it('refreshMintQuote fails when the canonical quote is missing', async () => {
     await expect(
-      quoteLifecycle.refreshMintQuote(mintUrl, 'bolt11', 'missing-quote'),
+      quoteLifecycle.refreshMintQuoteById({ mintUrl, quoteId: 'missing-quote' }),
     ).rejects.toThrow('was not found');
 
     expect(handler.fetchRemoteQuote).not.toHaveBeenCalled();
+  });
+
+  it('refreshMintQuote keeps the method-aware exact refresh path for internal callers', async () => {
+    await persistQuote('quote-exact-refresh');
+
+    const refreshed = await quoteLifecycle.refreshMintQuote(
+      mintUrl,
+      'bolt11',
+      'quote-exact-refresh',
+    );
+
+    expect(handlerProvider.get).toHaveBeenCalledWith('bolt11');
+    expect(handler.fetchRemoteQuote).toHaveBeenCalled();
+    expect(refreshed.quoteId).toBe('quote-exact-refresh');
   });
 
   it('refreshMintQuote persists the canonical quote before emitting mint-quote:updated', async () => {
@@ -679,7 +692,7 @@ describe('MintOperationService', () => {
       persistedDuringEvent.push(storedQuote?.state);
     });
 
-    const refreshed = await quoteLifecycle.refreshMintQuote(mintUrl, 'bolt11', quoteId);
+    const refreshed = await quoteLifecycle.refreshMintQuoteById({ mintUrl, quoteId });
 
     expect(handler.fetchRemoteQuote).toHaveBeenCalled();
     expect(refreshed.state).toBe('PAID');
@@ -726,8 +739,12 @@ describe('MintOperationService', () => {
       }
     });
 
-    const refreshed = await quoteLifecycle.refreshMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const refreshed = await quoteLifecycle.refreshMintQuoteById({
+      mintUrl,
+      quoteId: onchainQuoteId,
+    });
 
+    expect(handlerProvider.get).toHaveBeenCalledWith('onchain');
     expect(onchainHandler.fetchRemoteQuote).toHaveBeenCalled();
     expect(refreshed.method).toBe('onchain');
     if (refreshed.method !== 'onchain') throw new Error('Expected onchain quote');

--- a/packages/core/test/unit/QuoteApi.test.ts
+++ b/packages/core/test/unit/QuoteApi.test.ts
@@ -8,6 +8,33 @@ import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 const mintUrl = 'https://mint.test';
 const quoteId = 'quote-1';
 
+type MintCreateInput = Parameters<QuoteApi['mint']['create']>[0];
+type MintImportInput = Parameters<QuoteApi['mint']['import']>[0];
+type MeltCreateInput = Parameters<QuoteApi['melt']['create']>[0];
+
+function assertMethodRequirementsRemain(): void {
+  // @ts-expect-error Mint quote creation still requires method.
+  const mintCreateWithoutMethod: MintCreateInput = { mintUrl, amount: Amount.from(10) };
+  // @ts-expect-error Mint quote import still requires method.
+  const mintImportWithoutMethod: MintImportInput = {
+    mintUrl,
+    quote: {
+      quote: quoteId,
+      request: 'lnbc1mint',
+      amount: Amount.from(10),
+      unit: 'sat',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      state: 'UNPAID',
+    },
+  };
+  // @ts-expect-error Melt quote creation still requires method.
+  const meltCreateWithoutMethod: MeltCreateInput = {
+    mintUrl,
+    methodData: { invoice: 'lnbc1melt' },
+  };
+  void [mintCreateWithoutMethod, mintImportWithoutMethod, meltCreateWithoutMethod];
+}
+
 const makeMintQuote = (): MintQuote<'bolt11'> => ({
   mintUrl,
   method: 'bolt11',
@@ -58,13 +85,13 @@ describe('QuoteApi', () => {
     quoteLifecycle = {
       createMintQuote: mock(async () => mintQuote),
       importMintQuote: mock(async () => mintQuote),
-      getMintQuote: mock(async () => mintQuote),
+      getMintQuoteById: mock(async () => mintQuote),
       getPendingMintQuotes: mock(async () => [mintQuote]),
-      refreshMintQuote: mock(async () => ({ ...mintQuote, state: 'PAID' })),
+      refreshMintQuoteById: mock(async () => ({ ...mintQuote, state: 'PAID' })),
       createMeltQuote: mock(async () => meltQuote),
-      getMeltQuote: mock(async () => meltQuote),
+      getMeltQuoteById: mock(async () => meltQuote),
       getPendingMeltQuotes: mock(async () => [meltQuote]),
-      refreshMeltQuote: mock(async () => ({ ...meltQuote, state: 'PENDING' })),
+      refreshMeltQuoteById: mock(async () => ({ ...meltQuote, state: 'PENDING' })),
     } as unknown as QuoteLifecycle;
 
     api = new QuoteApi(quoteLifecycle);
@@ -74,7 +101,7 @@ describe('QuoteApi', () => {
     await expect(
       api.mint.create({ mintUrl, amount: Amount.from(10), method: 'bolt11' }),
     ).resolves.toBe(mintQuote);
-    await expect(api.mint.get({ mintUrl, method: 'bolt11', quoteId })).resolves.toBe(mintQuote);
+    await expect(api.mint.get({ mintUrl, quoteId })).resolves.toBe(mintQuote);
     await expect(
       api.mint.import({
         mintUrl,
@@ -90,7 +117,7 @@ describe('QuoteApi', () => {
       }),
     ).resolves.toBe(mintQuote);
     await expect(api.mint.listPending({ method: 'bolt11' })).resolves.toEqual([mintQuote]);
-    await expect(api.mint.refresh({ mintUrl, method: 'bolt11', quoteId })).resolves.toMatchObject({
+    await expect(api.mint.refresh({ mintUrl, quoteId })).resolves.toMatchObject({
       state: 'PAID',
     });
 
@@ -105,9 +132,9 @@ describe('QuoteApi', () => {
       expiry: mintQuote.expiry,
       state: 'UNPAID',
     });
-    expect(quoteLifecycle.getMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt11', quoteId);
+    expect(quoteLifecycle.getMintQuoteById).toHaveBeenCalledWith({ mintUrl, quoteId });
     expect(quoteLifecycle.getPendingMintQuotes).toHaveBeenCalledWith('bolt11');
-    expect(quoteLifecycle.refreshMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt11', quoteId);
+    expect(quoteLifecycle.refreshMintQuoteById).toHaveBeenCalledWith({ mintUrl, quoteId });
   });
 
   it('delegates onchain mint quote creation without an amount', async () => {
@@ -154,6 +181,14 @@ describe('QuoteApi', () => {
     });
   });
 
+  it('returns null for absent methodless quote lookups', async () => {
+    (quoteLifecycle.getMintQuoteById as any).mockImplementationOnce(async () => null);
+    (quoteLifecycle.getMeltQuoteById as any).mockImplementationOnce(async () => null);
+
+    await expect(api.mint.get({ mintUrl, quoteId: 'missing-mint' })).resolves.toBeNull();
+    await expect(api.melt.get({ mintUrl, quoteId: 'missing-melt' })).resolves.toBeNull();
+  });
+
   it('delegates melt quote methods', async () => {
     await expect(
       api.melt.create({
@@ -162,9 +197,9 @@ describe('QuoteApi', () => {
         methodData: { invoice: 'lnbc1melt' },
       }),
     ).resolves.toBe(meltQuote);
-    await expect(api.melt.get({ mintUrl, method: 'bolt11', quoteId })).resolves.toBe(meltQuote);
+    await expect(api.melt.get({ mintUrl, quoteId })).resolves.toBe(meltQuote);
     await expect(api.melt.listPending({ method: 'bolt11' })).resolves.toEqual([meltQuote]);
-    await expect(api.melt.refresh({ mintUrl, method: 'bolt11', quoteId })).resolves.toMatchObject({
+    await expect(api.melt.refresh({ mintUrl, quoteId })).resolves.toMatchObject({
       state: 'PENDING',
     });
 
@@ -174,8 +209,12 @@ describe('QuoteApi', () => {
       { invoice: 'lnbc1melt' },
       undefined,
     );
-    expect(quoteLifecycle.getMeltQuote).toHaveBeenCalledWith(mintUrl, 'bolt11', quoteId);
+    expect(quoteLifecycle.getMeltQuoteById).toHaveBeenCalledWith({ mintUrl, quoteId });
     expect(quoteLifecycle.getPendingMeltQuotes).toHaveBeenCalledWith('bolt11');
-    expect(quoteLifecycle.refreshMeltQuote).toHaveBeenCalledWith(mintUrl, 'bolt11', quoteId);
+    expect(quoteLifecycle.refreshMeltQuoteById).toHaveBeenCalledWith({ mintUrl, quoteId });
+  });
+
+  it('keeps method required for quote creation and import inputs', () => {
+    assertMethodRequirementsRemain();
   });
 });

--- a/packages/docs/pages/melt-operations.md
+++ b/packages/docs/pages/melt-operations.md
@@ -30,9 +30,10 @@ preparing a melt operation:
 - `create({ mintUrl, method: 'bolt11', methodData: { invoice }, unit? })` creates and persists a canonical quote row only
 - `create({ mintUrl, method: 'bolt12', methodData: { offer, amountSats }, unit? })` creates and persists a canonical quote row only
 - `create({ mintUrl, method: 'onchain', methodData: { address, amountSats }, unit? })` creates and persists a canonical quote row with `fee_options`
-- `get({ mintUrl, method, quoteId })` loads a canonical quote by full identity
+- `get({ mintUrl, quoteId })` loads a canonical quote by quote identity
 - `listPending({ method? })` lists canonical quote rows that have not reached `PAID`
-- `refresh({ mintUrl, method, quoteId })` checks the remote quote state and persists the canonical quote update
+- `refresh({ mintUrl, quoteId })` checks the remote quote state and persists
+  the canonical quote update
 
 ## Operation States
 

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -39,10 +39,10 @@ after reload without creating or loading a mint operation:
   quote row only
 - `import({ mintUrl, method, quote })` imports an existing remote quote snapshot
   into canonical quote storage only
-- `get({ mintUrl, method, quoteId })` loads a canonical quote by full identity
+- `get({ mintUrl, quoteId })` loads a canonical quote by quote identity
 - `listPending({ method? })` lists canonical quote rows that have not reached
   `ISSUED`
-- `refresh({ mintUrl, method, quoteId })` checks the remote quote state and
+- `refresh({ mintUrl, quoteId })` checks the remote quote state and
   persists the canonical quote update before emitting `mint-quote:updated`
 
 `mint-quote:updated` is emitted when a quote is created/imported or remote
@@ -119,7 +119,7 @@ if (check.category === 'ready' || check.category === 'completed') {
 
 Onchain and BOLT12 mint quotes are canonical quote records first. Create and
 refresh them through `coco.quotes.mint`, then prepare one or more mint
-operations against the same `(mintUrl, method, quoteId)` identity.
+operations against the same `{ mintUrl, quoteId }` identity.
 
 ```ts
 const quote = await coco.quotes.mint.create({
@@ -132,7 +132,6 @@ showAddress(quote.request);
 
 const refreshed = await coco.quotes.mint.refresh({
   mintUrl,
-  method: 'onchain',
   quoteId: quote.quoteId,
 });
 

--- a/packages/docs/starting/migrating-from-v1.md
+++ b/packages/docs/starting/migrating-from-v1.md
@@ -20,17 +20,17 @@ Use `manager.quotes` when you need to create, reload, list, or refresh quote
 payment requests without treating that quote as a wallet activity yet:
 
 - `manager.quotes.mint.create({ mintUrl, amount, unit?, method })`
-- `manager.quotes.mint.get({ mintUrl, method, quoteId })`
+- `manager.quotes.mint.get({ mintUrl, quoteId })`
 - `manager.quotes.mint.listPending({ method? })`
-- `manager.quotes.mint.refresh({ mintUrl, method, quoteId })`
+- `manager.quotes.mint.refresh({ mintUrl, quoteId })`
 - `manager.quotes.melt.create({ mintUrl, method, methodData, unit? })`
-- `manager.quotes.melt.get({ mintUrl, method, quoteId })`
+- `manager.quotes.melt.get({ mintUrl, quoteId })`
 - `manager.quotes.melt.listPending({ method? })`
-- `manager.quotes.melt.refresh({ mintUrl, method, quoteId })`
+- `manager.quotes.melt.refresh({ mintUrl, quoteId })`
 
 For BOLT11 quotes, the invoice is exposed as `quote.request`.
 
-Store quote identity as `mintUrl + method + quoteId`. `quoteId` is no longer a
+Store quote identity as `{ mintUrl, quoteId }`. `quoteId` is no longer a
 sufficient lookup key on its own, and it should not be treated as an operation
 id.
 
@@ -153,8 +153,10 @@ The bundled adapters migrate existing data automatically:
 
 Custom repository implementations must provide the current repository contract:
 
-- `MintQuoteRepository` keyed by `mintUrl + method + quoteId`
-- `MeltQuoteRepository` keyed by `mintUrl + method + quoteId`
+- `MintQuoteRepository` with `{ mintUrl, quoteId }` identity helpers and
+  method-aware exact lookup
+- `MeltQuoteRepository` with `{ mintUrl, quoteId }` identity helpers and
+  method-aware exact lookup
 - `LegacyMintQuoteRepository` for startup reconciliation of old mint quote rows
 - method-aware `MintOperationRepository.getByQuoteId(...)`
 

--- a/packages/docs/starting/minting.md
+++ b/packages/docs/starting/minting.md
@@ -89,7 +89,6 @@ console.log('fund this: ', quote.request);
 
 const refreshed = await coco.quotes.mint.refresh({
   mintUrl: 'https://minturl.com',
-  method: 'onchain',
   quoteId: quote.quoteId,
 });
 


### PR DESCRIPTION
## Description

This pull request updates canonical quote get and refresh APIs so callers use `{ mintUrl, quoteId }` for mint and melt quote lookup.

This pull request resolves #199.

## Problem

Quote callers still had to pass `method` back into public get/refresh APIs even though canonical quote storage now owns method resolution by quote identity.

## Summary

- Updates `QuoteApi` get/refresh inputs to use `QuoteIdentity`.
- Adds identity-based lifecycle get/refresh paths that resolve the stored method before selecting refresh handlers.
- Updates adapter-test call sites, focused tests, docs snippets, and adds a changeset.
- Compatibility: public core quote get/refresh input shape is breaking.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/QuoteApi.test.ts test/unit/MintOperationService.test.ts test/unit/MeltOperationService.test.ts test/unit/MemoryQuoteRepository.test.ts`
- `bun run --filter='@cashu/coco-core' test -- test/unit/MintOperationService.test.ts test/unit/MeltOperationService.test.ts`
- `bun run test:coverage:core`
- `bun run typecheck` in `packages/adapter-tests`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run docs:build`
- `git diff --check`

## Notes

- Full `@cashu/coco-core` typecheck still fails on pre-existing `cashu-ts` onchain API type mismatches unrelated to this slice.
- Coverage investigation found the drop came from moving tests to the new identity refresh API while leaving the internal method-aware exact refresh wrappers unexercised in the core-unit flag. Added exact-wrapper tests and confirmed `QuoteLifecycle.ts` no longer has missed lines in local `coverage/core/lcov.info`.

## Changeset

- Added `.changeset/methodless-quote-refresh.md`.