### PR TITLE
feat(core): prepare mint operations from quote refs

### DIFF
--- a/.changeset/mint-prepare-quote-refs.md
+++ b/.changeset/mint-prepare-quote-refs.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-react': major
+'@cashu/coco-adapter-tests': patch
+---
+
+Refactor mint operation prepare to accept `{ quote, amount }`, deriving method and unit data from the stored canonical mint quote.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -770,7 +770,7 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
           const pending = await mgr.ops.mint.prepare({
             quote,
-            amount: testAmount(12),
+            amount: 12,
           });
 
           expect(pending.method).toBe('onchain');
@@ -835,11 +835,11 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
           const first = await mgr.ops.mint.prepare({
             quote,
-            amount: testAmount(7),
+            amount: 7,
           });
           const second = await mgr.ops.mint.prepare({
             quote,
-            amount: testAmount(5),
+            amount: 5,
           });
 
           expect(first.quoteId).toBe(quote.quoteId);

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -363,11 +363,8 @@ async function prepareMintOperation(
   });
 
   return manager.ops.mint.prepare({
-    mintUrl,
-    quoteId: quote.quoteId,
-    unit,
-    method: 'bolt11',
-    methodData: {},
+    quote,
+    amount,
   });
 }
 
@@ -772,11 +769,8 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           );
 
           const pending = await mgr.ops.mint.prepare({
-            mintUrl,
-            method: 'onchain',
-            quoteId: quote.quoteId,
+            quote,
             amount: testAmount(12),
-            methodData: {},
           });
 
           expect(pending.method).toBe('onchain');
@@ -840,18 +834,12 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
           await waitForOnchainQuoteAvailable(mgr, mintUrl, quote.quoteId, testAmount(12));
 
           const first = await mgr.ops.mint.prepare({
-            mintUrl,
-            method: 'onchain',
-            quoteId: quote.quoteId,
+            quote,
             amount: testAmount(7),
-            methodData: {},
           });
           const second = await mgr.ops.mint.prepare({
-            mintUrl,
-            method: 'onchain',
-            quoteId: quote.quoteId,
+            quote,
             amount: testAmount(5),
-            methodData: {},
           });
 
           expect(first.quoteId).toBe(quote.quoteId);

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -71,7 +71,11 @@ import { PluginHost } from './plugins/PluginHost.ts';
 import type { MintMethodQuoteSnapshot } from './operations/mint';
 import type { Plugin, ServiceMap, PluginExtensions } from './plugins/types.ts';
 import { QuoteLifecycle } from './quotes/QuoteLifecycle.ts';
-import { isStatefulMintQuote, mintQuoteToMethodSnapshot } from './models/MintQuote.ts';
+import {
+  getMintQuoteAmount,
+  isStatefulMintQuote,
+  mintQuoteToMethodSnapshot,
+} from './models/MintQuote.ts';
 
 /**
  * Configuration options for initializing the Coco Cashu manager
@@ -532,12 +536,12 @@ export class Manager {
           'bolt11',
           mintQuoteToMethodSnapshot(quote) as MintMethodQuoteSnapshot<'bolt11'>,
         );
-        const operation = await this.mintOperationService.prepare(
-          imported.mintUrl,
-          imported.method,
-          imported.quoteId,
-          {},
-        );
+        const amount = getMintQuoteAmount(imported);
+        if (!amount) {
+          throw new Error(`Legacy mint quote ${imported.quoteId} does not have a fixed amount`);
+        }
+
+        const operation = await this.mintOperationService.prepare(imported, amount);
         reconciled.push(operation.quoteId);
       } catch (err) {
         this.logger.warn('Failed to reconcile legacy mint quote', {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -84,10 +84,8 @@ const quote = await manager.quotes.mint.create({
 });
 
 const pendingMint = await manager.ops.mint.prepare({
-  mintUrl: 'https://nofees.testnut.cashu.space',
-  quoteId: quote.quoteId,
-  method: 'bolt11',
-  methodData: {},
+  quote,
+  amount: 100,
 });
 
 // Optionally, wait via subscription API instead of polling

--- a/packages/core/api/MintOpsApi.ts
+++ b/packages/core/api/MintOpsApi.ts
@@ -1,53 +1,22 @@
+import { Amount, type AmountLike } from '@cashu/cashu-ts';
 import type {
   MintMethod,
-  MintMethodData,
   MintOperation,
   MintOperationService,
   PendingMintCheckResult,
   PendingMintOperation,
 } from '@core/operations/mint';
-import { parseUnitAmount, type UnitAmountLike } from '../amounts.ts';
+import type { MintQuoteRef } from '../models/QuoteIdentity.ts';
 
 /** Mint methods supported by the default `Manager` wiring. */
 export type DefaultSupportedMintMethod = 'bolt11' | 'onchain' | 'bolt12';
 
-type PrepareExistingQuoteInputCommon = {
-  /** Mint that issued the canonical quote. */
-  mintUrl: string;
-  /** Existing canonical mint quote ID to prepare against. */
-  quoteId: string;
-  /** Optional expected unit for the quote. */
-  unit?: string;
-};
-
-type MethodDataInput<M extends MintMethod> =
-  MintMethodData<M> extends Record<string, never>
-    ? {
-        /** Method-specific payload required for the selected mint method. */
-        methodData?: MintMethodData<M>;
-      }
-    : {
-        /** Method-specific payload required for the selected mint method. */
-        methodData: MintMethodData<M>;
-      };
-
 export type PrepareMintInput<TSupported extends MintMethod = DefaultSupportedMintMethod> = {
-  [M in TSupported]: PrepareExistingQuoteInputCommon & {
-    /** Mint method to prepare, for example `bolt11`. */
-    method: M;
-  } & (M extends 'onchain'
-      ? {
-          /** Amount to withdraw from the reusable onchain quote. */
-          amount: UnitAmountLike;
-        }
-      : M extends 'bolt12'
-        ? {
-            /** Amount to mint from the reusable BOLT12 quote. */
-            amount: UnitAmountLike;
-          }
-        : {}) &
-    MethodDataInput<M>;
-}[TSupported];
+  /** Existing canonical mint quote or structural quote reference. */
+  quote: MintQuoteRef<TSupported>;
+  /** Amount to mint using the canonical quote's stored unit. */
+  amount: AmountLike;
+};
 
 export type GetMintByQuoteInput<TSupported extends MintMethod = DefaultSupportedMintMethod> = {
   [M in TSupported]: {
@@ -96,20 +65,7 @@ export class MintOpsApi<TSupported extends MintMethod = DefaultSupportedMintMeth
    * Prepares a mint operation against an existing canonical quote without executing it.
    */
   async prepare(input: PrepareMintInput<TSupported>): Promise<PendingMintOperation> {
-    const methodData = ('methodData' in input ? input.methodData : undefined) ?? {};
-    const explicitAmount =
-      'amount' in input && input.amount !== undefined
-        ? parseUnitAmount(input.amount, { explicitUnit: input.unit })
-        : undefined;
-
-    return this.mintOperationService.prepare(
-      input.mintUrl,
-      input.method,
-      input.quoteId,
-      methodData,
-      input.unit,
-      explicitAmount,
-    );
+    return this.mintOperationService.prepare(input.quote, Amount.from(input.amount));
   }
 
   /**

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -45,6 +45,7 @@ import {
   getMintQuoteAmount,
   type MintQuote,
 } from '../../models/MintQuote';
+import type { MintQuoteRef } from '../../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 
 export interface ClaimMintQuoteOptions {
@@ -231,46 +232,36 @@ export class MintOperationService {
     return quote;
   }
 
-  async prepare(
-    mintUrl: string,
-    method: MintMethod,
-    quoteId: string,
-    methodData: MintMethodData = {},
-    expectedUnit?: string,
-    explicitAmount?: UnitAmount,
-  ): Promise<PendingMintOperation> {
-    const quote = await this.quoteLifecycle.requireMintQuoteForPrepare(
-      mintUrl,
-      method,
-      quoteId,
-      expectedUnit,
-    );
+  async prepare(quoteRef: MintQuoteRef, requestedAmount: Amount): Promise<PendingMintOperation> {
+    const quote = await this.quoteLifecycle.requireMintQuoteRefForPrepare(quoteRef);
+    const amount = Amount.from(requestedAmount);
 
     const fixedAmount = getMintQuoteAmount(quote);
-    const amount = fixedAmount ?? explicitAmount?.amount;
-    if (!amount) {
+    if (fixedAmount && !fixedAmount.equals(amount)) {
       throw new Error(
-        `Mint quote ${quoteId} for ${method} at ${mintUrl} does not have a fixed amount; pass an explicit amount for reusable quote preparation`,
-      );
-    }
-    if (explicitAmount && explicitAmount.unit !== quote.unit) {
-      throw new ProofValidationError(
-        `Mint quote ${quoteId} unit ${quote.unit} does not match requested unit ${explicitAmount.unit}`,
+        `Mint quote ${quote.quoteId} amount ${fixedAmount} does not match requested amount ${amount}`,
       );
     }
 
-    const handler = this.handlerProvider.get(method);
+    const handler = this.handlerProvider.get(quote.method);
     await handler.validateQuoteForPrepare?.(quote as any);
 
     const initOperation = await this.createInitOperation(
       quote.mintUrl,
       { amount, unit: quote.unit },
-      method,
-      methodData,
+      quote.method,
+      this.deriveMintOperationMethodData(quote) as MintMethodData,
       { quoteId: quote.quoteId },
     );
 
     return this.prepareInitOperation(initOperation.id);
+  }
+
+  private deriveMintOperationMethodData<M extends MintMethod>(
+    quote: MintQuote<M>,
+  ): MintMethodData<M> {
+    void quote;
+    return {} as MintMethodData<M>;
   }
 
   private async prepareInitOperation(

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -250,18 +250,11 @@ export class MintOperationService {
       quote.mintUrl,
       { amount, unit: quote.unit },
       quote.method,
-      this.deriveMintOperationMethodData(quote) as MintMethodData,
+      {} as MintMethodData,
       { quoteId: quote.quoteId },
     );
 
     return this.prepareInitOperation(initOperation.id);
-  }
-
-  private deriveMintOperationMethodData<M extends MintMethod>(
-    quote: MintQuote<M>,
-  ): MintMethodData<M> {
-    void quote;
-    return {} as MintMethodData<M>;
   }
 
   private async prepareInitOperation(

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -23,7 +23,11 @@ import {
   type MintQuote,
 } from '../models/MintQuote';
 import { meltQuoteToMethodSnapshot, type MeltQuote } from '../models/MeltQuote';
-import { ProofValidationError, UnknownMintError } from '../models/Error';
+import {
+  ProofValidationError,
+  QuoteIdentityConflictError,
+  UnknownMintError,
+} from '../models/Error';
 import type { MeltQuoteRepository, MintQuoteRepository, ProofRepository } from '../repositories';
 import type { MintService } from '../services/MintService';
 import type { ProofService } from '../services/ProofService';
@@ -43,7 +47,7 @@ import type {
   MintMethodQuoteSnapshot,
   MintMethodRemoteState,
 } from '../operations/mint/MintMethodHandler';
-import type { QuoteIdentity } from '../models/QuoteIdentity';
+import type { MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity';
 
 const MINT_QUOTE_STATE_RANK: Record<string, number> = {
   UNPAID: 0,
@@ -309,6 +313,29 @@ export class QuoteLifecycle {
     }
 
     this.assertMintQuoteCanPrepare(quote, `mint quote ${quoteId}`);
+    return quote;
+  }
+
+  async requireMintQuoteRefForPrepare(ref: MintQuoteRef): Promise<MintQuote> {
+    const quote = await this.mintQuoteRepository.getMintQuoteById({
+      mintUrl: ref.mintUrl,
+      quoteId: ref.quoteId,
+    });
+    if (!quote) {
+      throw new Error(`Mint quote ${ref.quoteId} at ${ref.mintUrl} was not found`);
+    }
+
+    if (quote.method !== ref.method) {
+      throw new QuoteIdentityConflictError(
+        'mint',
+        quote.mintUrl,
+        quote.quoteId,
+        [ref.method, quote.method],
+        `Mint quote ${quote.quoteId} at ${quote.mintUrl} resolved to method ${quote.method}, not requested method ${ref.method}`,
+      );
+    }
+
+    this.assertMintQuoteCanPrepare(quote, `mint quote ${ref.quoteId}`);
     return quote;
   }
 

--- a/packages/core/test/integration/PauseResumeIntegration.test.ts
+++ b/packages/core/test/integration/PauseResumeIntegration.test.ts
@@ -19,10 +19,8 @@ async function prepareMintOperation(manager: Manager, mintUrl: string) {
   });
 
   return manager.ops.mint.prepare({
-    mintUrl,
-    quoteId: quote.quoteId,
-    method: 'bolt11',
-    methodData: {},
+    quote: { mintUrl: quote.mintUrl, method: 'bolt11', quoteId: quote.quoteId },
+    amount: Amount.from(1),
   });
 }
 

--- a/packages/core/test/integration/ReceiveOperationIntegration.test.ts
+++ b/packages/core/test/integration/ReceiveOperationIntegration.test.ts
@@ -70,10 +70,8 @@ describe('ReceiveOperationService integration', () => {
       method: 'bolt11',
     });
     const pendingMint = await sender.ops.mint.prepare({
-      mintUrl,
-      quoteId: quote.quoteId,
-      method: 'bolt11',
-      methodData: {},
+      quote: { mintUrl: quote.mintUrl, method: 'bolt11', quoteId: quote.quoteId },
+      amount: Amount.from(50),
     });
     await sender.ops.mint.execute(pendingMint.id);
 

--- a/packages/core/test/integration/auth-bat.test.ts
+++ b/packages/core/test/integration/auth-bat.test.ts
@@ -81,10 +81,8 @@ describe('Auth BAT (automated — password grant)', () => {
     });
 
     return manager.ops.mint.prepare({
-      mintUrl: mintUrl!,
-      quoteId: quote.quoteId,
-      method: 'bolt11',
-      methodData: {},
+      quote: { mintUrl: quote.mintUrl, method: 'bolt11', quoteId: quote.quoteId },
+      amount: Amount.from(1),
     });
   }
 

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -153,7 +153,7 @@ describe('MintOperationService', () => {
     const response: MintQuoteBolt12Response = {
       quote,
       request: 'lno1test',
-      amount: amounts.amount,
+      amount: amounts.amount ?? null,
       unit: 'sat',
       expiry: amounts.expiry ?? Math.floor(Date.now() / 1000) + 3600,
       pubkey: '02'.padEnd(66, '2'),

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -38,6 +38,7 @@ import type { ProofService } from '../../services/ProofService';
 import type { MintAdapter } from '../../infra/MintAdapter';
 import { serializeOutputData } from '../../utils';
 import type { CoreProof } from '../../types';
+import { QuoteIdentityConflictError } from '../../models/Error';
 
 describe('MintOperationService', () => {
   const mintUrl = 'https://mint.test';
@@ -152,7 +153,7 @@ describe('MintOperationService', () => {
     const response: MintQuoteBolt12Response = {
       quote,
       request: 'lno1test',
-      amount: amounts.amount ?? null,
+      amount: amounts.amount,
       unit: 'sat',
       expiry: amounts.expiry ?? Math.floor(Date.now() / 1000) + 3600,
       pubkey: '02'.padEnd(66, '2'),
@@ -367,7 +368,7 @@ describe('MintOperationService', () => {
       }),
     );
 
-    const pending = await service.prepare(mintUrl, 'bolt11', quote.quoteId);
+    const pending = await service.prepare(quote, Amount.from(10));
 
     expect(pending.state).toBe('pending');
     expect(pending.quoteId).toBe(quote.quoteId);
@@ -394,7 +395,7 @@ describe('MintOperationService', () => {
       }),
     );
 
-    const pending = await service.prepare(mintUrl, 'bolt11', quote.quoteId, {}, 'USD');
+    const pending = await service.prepare(quote, Amount.from(10));
 
     expect(pending.unit).toBe('usd');
     expect(mintService.assertMethodUnitSupported).toHaveBeenCalledWith(mintUrl, 4, 'bolt11', {
@@ -421,10 +422,10 @@ describe('MintOperationService', () => {
     } as unknown as MintMethodHandler<'onchain'>;
     (handlerProvider.get as Mock<any>).mockImplementation(() => onchainHandler);
 
-    const pending = await service.prepare(mintUrl, 'onchain', onchainQuoteId, {}, undefined, {
-      amount: Amount.from(10),
-      unit: 'sat',
-    });
+    const pending = await service.prepare(
+      { mintUrl, method: 'onchain', quoteId: onchainQuoteId },
+      Amount.from(10),
+    );
 
     expect(onchainHandler.validateQuoteForPrepare).toHaveBeenCalled();
     expect(mintService.assertMethodUnitSupported).toHaveBeenCalledWith(
@@ -460,10 +461,10 @@ describe('MintOperationService', () => {
     } as unknown as MintMethodHandler<'bolt12'>;
     (handlerProvider.get as Mock<any>).mockImplementation(() => bolt12Handler);
 
-    const pending = await service.prepare(mintUrl, 'bolt12', bolt12QuoteId, {}, undefined, {
-      amount: Amount.from(10),
-      unit: 'sat',
-    });
+    const pending = await service.prepare(
+      { mintUrl, method: 'bolt12', quoteId: bolt12QuoteId },
+      Amount.from(10),
+    );
 
     expect(bolt12Handler.validateQuoteForPrepare).toHaveBeenCalled();
     expect(pending.method).toBe('bolt12');
@@ -486,10 +487,7 @@ describe('MintOperationService', () => {
     (handlerProvider.get as Mock<any>).mockImplementation(() => onchainHandler);
 
     await expect(
-      service.prepare(mintUrl, 'onchain', onchainQuoteId, {}, undefined, {
-        amount: Amount.from(10),
-        unit: 'sat',
-      }),
+      service.prepare({ mintUrl, method: 'onchain', quoteId: onchainQuoteId }, Amount.from(10)),
     ).rejects.toThrow('Missing NUT-20 mint quote key');
 
     expect(onchainHandler.prepare).not.toHaveBeenCalled();
@@ -514,14 +512,8 @@ describe('MintOperationService', () => {
     } as unknown as MintMethodHandler<'onchain'>;
     (handlerProvider.get as Mock<any>).mockImplementation(() => onchainHandler);
 
-    await service.prepare(mintUrl, 'onchain', onchainQuoteId, {}, undefined, {
-      amount: Amount.from(10),
-      unit: 'sat',
-    });
-    await service.prepare(mintUrl, 'onchain', onchainQuoteId, {}, undefined, {
-      amount: Amount.from(5),
-      unit: 'sat',
-    });
+    await service.prepare({ mintUrl, method: 'onchain', quoteId: onchainQuoteId }, Amount.from(10));
+    await service.prepare({ mintUrl, method: 'onchain', quoteId: onchainQuoteId }, Amount.from(5));
 
     const operations = await operationRepo.getAll();
 
@@ -556,10 +548,7 @@ describe('MintOperationService', () => {
     }) as typeof operationRepo.update;
 
     await expect(
-      service.prepare(mintUrl, 'onchain', onchainQuoteId, {}, undefined, {
-        amount: Amount.from(10),
-        unit: 'sat',
-      }),
+      service.prepare({ mintUrl, method: 'onchain', quoteId: onchainQuoteId }, Amount.from(10)),
     ).rejects.toThrow('pending persistence failed');
 
     expect(consumedCounters).toHaveLength(1);
@@ -755,9 +744,23 @@ describe('MintOperationService', () => {
   });
 
   it('prepare fails before creating an operation when the quote is missing', async () => {
-    await expect(service.prepare(mintUrl, 'bolt11', 'missing-quote', {})).rejects.toThrow(
-      'was not found',
-    );
+    await expect(
+      service.prepare({ mintUrl, method: 'bolt11', quoteId: 'missing-quote' }, Amount.from(10)),
+    ).rejects.toThrow('was not found');
+
+    await expect(operationRepo.getAll()).resolves.toHaveLength(0);
+    expect(handler.prepare).not.toHaveBeenCalled();
+  });
+
+  it('prepare rejects quote refs whose method differs from canonical storage', async () => {
+    await persistQuote('quote-method-conflict');
+
+    await expect(
+      service.prepare(
+        { mintUrl, method: 'onchain', quoteId: 'quote-method-conflict' },
+        Amount.from(10),
+      ),
+    ).rejects.toThrow(QuoteIdentityConflictError);
 
     await expect(operationRepo.getAll()).resolves.toHaveLength(0);
     expect(handler.prepare).not.toHaveBeenCalled();
@@ -775,9 +778,9 @@ describe('MintOperationService', () => {
       }),
     );
 
-    await expect(service.prepare(mintUrl, 'bolt11', 'issued-quote', {})).rejects.toThrow(
-      'quote is terminal',
-    );
+    await expect(
+      service.prepare({ mintUrl, method: 'bolt11', quoteId: 'issued-quote' }, Amount.from(10)),
+    ).rejects.toThrow('quote is terminal');
 
     await expect(operationRepo.getAll()).resolves.toHaveLength(0);
     expect(handler.prepare).not.toHaveBeenCalled();
@@ -797,9 +800,9 @@ describe('MintOperationService', () => {
       }),
     );
 
-    const first = await service.prepare(mintUrl, 'bolt11', quote.quoteId);
+    const first = await service.prepare(quote, Amount.from(10));
 
-    await expect(service.prepare(mintUrl, 'bolt11', quote.quoteId)).rejects.toThrow(
+    await expect(service.prepare(quote, Amount.from(10))).rejects.toThrow(
       `Mint quote ${quote.quoteId} is already tracked by operation ${first.id} in state pending`,
     );
 
@@ -834,7 +837,7 @@ describe('MintOperationService', () => {
     );
 
     const imported = await quoteLifecycle.importMintQuote(mintUrl, 'bolt11', importedQuote);
-    const pending = await service.prepare(imported.mintUrl, imported.method, imported.quoteId);
+    const pending = await service.prepare(imported, Amount.from(12));
 
     expect(pending.state).toBe('pending');
     expect(pending.quoteId).toBe(importedQuote.quote);
@@ -883,7 +886,10 @@ describe('MintOperationService', () => {
     );
 
     await quoteLifecycle.importMintQuote(mintUrl, 'bolt11', staleQuote);
-    const pending = await service.prepare(mintUrl, 'bolt11', staleQuote.quote);
+    const pending = await service.prepare(
+      { mintUrl, method: 'bolt11', quoteId: staleQuote.quote },
+      Amount.from(12),
+    );
     const storedQuote = await quoteRepo.getMintQuote(mintUrl, 'bolt11', staleQuote.quote);
 
     expect(pending.quoteId).toBe(staleQuote.quote);
@@ -925,7 +931,7 @@ describe('MintOperationService', () => {
 
     await persistQuote();
 
-    const pending = await service.prepare(mintUrl, 'bolt11', quoteId);
+    const pending = await service.prepare({ mintUrl, method: 'bolt11', quoteId }, Amount.from(10));
     const finalized = await service.finalize(pending.id);
 
     expect(finalized?.state).toBe('finalized');
@@ -950,7 +956,7 @@ describe('MintOperationService', () => {
   it('finalize is idempotent after finalize', async () => {
     await persistQuote();
 
-    const pending = await service.prepare(mintUrl, 'bolt11', quoteId);
+    const pending = await service.prepare({ mintUrl, method: 'bolt11', quoteId }, Amount.from(10));
     const first = await service.finalize(pending.id);
     const second = await service.finalize(first.id);
 

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -9,6 +9,7 @@ import type {
   PendingMintOperation,
   TerminalMintOperation,
 } from '../../operations/mint/MintOperation.ts';
+import type { MintQuote } from '../../models/MintQuote.ts';
 
 const mintUrl = 'https://mint.test';
 const quoteId = 'quote-1';
@@ -16,26 +17,24 @@ const quoteId = 'quote-1';
 type Assert<T extends true> = T;
 type PrepareMintInput = Parameters<MintOpsApi['prepare']>[0];
 type GetMintByQuoteInput = Parameters<MintOpsApi['getByQuote']>[0];
-type _AssertBolt11PrepareAllowsOmittedMethodData = Assert<
-  Extract<PrepareMintInput, { method: 'bolt11' }> extends {
-    methodData?: Record<string, never>;
-  }
-    ? true
-    : false
->;
-type _AssertOnchainPrepareRequiresAmount = Assert<
-  Extract<PrepareMintInput, { method: 'onchain' }> extends {
+type _AssertPrepareAcceptsQuoteRef = Assert<
+  PrepareMintInput extends {
+    quote: {
+      mintUrl: string;
+      quoteId: string;
+      method: 'bolt11' | 'onchain' | 'bolt12';
+    };
     amount: unknown;
   }
     ? true
     : false
 >;
-type _AssertBolt12PrepareRequiresAmount = Assert<
-  Extract<PrepareMintInput, { method: 'bolt12' }> extends {
-    amount: unknown;
-  }
-    ? true
-    : false
+type _AssertPrepareOmitsLooseMethod = Assert<
+  'method' extends keyof PrepareMintInput ? false : true
+>;
+type _AssertPrepareOmitsLooseUnit = Assert<'unit' extends keyof PrepareMintInput ? false : true>;
+type _AssertPrepareOmitsMethodData = Assert<
+  'methodData' extends keyof PrepareMintInput ? false : true
 >;
 type _AssertGetByQuoteUsesObjectInput = Assert<
   GetMintByQuoteInput extends {
@@ -47,7 +46,7 @@ type _AssertGetByQuoteUsesObjectInput = Assert<
     : false
 >;
 type _AssertDefaultAllowsBolt12Mint = Assert<
-  'bolt12' extends PrepareMintInput['method'] ? true : false
+  'bolt12' extends PrepareMintInput['quote']['method'] ? true : false
 >;
 
 const makePendingOperation = (): PendingMintOperation => ({
@@ -106,78 +105,66 @@ describe('MintOpsApi', () => {
   });
 
   it('prepare targets an existing canonical quote and returns a pending mint operation', async () => {
+    const quote = { mintUrl, quoteId, method: 'bolt11' } as const;
+
     const result = await api.prepare({
-      mintUrl,
-      quoteId,
-      method: 'bolt11',
+      quote,
+      amount: 10,
     });
 
-    expect(mintOperationService.prepare).toHaveBeenCalledWith(
-      mintUrl,
-      'bolt11',
-      quoteId,
-      {},
-      undefined,
-      undefined,
-    );
+    expect(mintOperationService.prepare).toHaveBeenCalledWith(quote, Amount.from(10));
     expect(result).toBe(pendingOperation);
   });
 
-  it('prepare passes methodData and expected units to the service', async () => {
-    await api.prepare({
+  it('prepare accepts a full canonical quote as the quote ref', async () => {
+    const quote: MintQuote<'bolt11'> = {
       mintUrl,
       quoteId,
+      quote: quoteId,
+      request: 'lnbc1test',
       unit: 'usd',
       method: 'bolt11',
-      methodData: {},
+      amount: Amount.from(12),
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      state: 'PAID',
+      lastObservedRemoteState: 'PAID',
+      lastObservedRemoteStateAt: Date.now(),
+      reusable: false,
+      quoteData: {
+        amount: Amount.from(12),
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    await api.prepare({
+      quote,
+      amount: Amount.from(12),
     });
 
-    expect(mintOperationService.prepare).toHaveBeenCalledWith(
-      mintUrl,
-      'bolt11',
-      quoteId,
-      {},
-      'usd',
-      undefined,
-    );
+    expect(mintOperationService.prepare).toHaveBeenCalledWith(quote, Amount.from(12));
   });
 
   it('prepare passes explicit onchain withdrawal amounts to the service', async () => {
+    const quote = { mintUrl, quoteId, method: 'onchain' } as const;
+
     await api.prepare({
-      mintUrl,
-      quoteId,
-      method: 'onchain',
+      quote,
       amount: 10,
-      unit: 'sat',
     });
 
-    expect(mintOperationService.prepare).toHaveBeenCalledWith(
-      mintUrl,
-      'onchain',
-      quoteId,
-      {},
-      'sat',
-      { amount: Amount.from(10), unit: 'sat' },
-    );
+    expect(mintOperationService.prepare).toHaveBeenCalledWith(quote, Amount.from(10));
   });
 
   it('prepare passes explicit BOLT12 mint amounts to the service', async () => {
+    const quote = { mintUrl, quoteId, method: 'bolt12' } as const;
+
     await api.prepare({
-      mintUrl,
-      quoteId,
-      method: 'bolt12',
+      quote,
       amount: 10,
-      unit: 'sat',
     });
 
-    expect(mintOperationService.prepare).toHaveBeenCalledWith(
-      mintUrl,
-      'bolt12',
-      quoteId,
-      {},
-      'sat',
-      { amount: Amount.from(10), unit: 'sat' },
-    );
+    expect(mintOperationService.prepare).toHaveBeenCalledWith(quote, Amount.from(10));
   });
 
   it('execute only allows pending operations', async () => {

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -184,6 +184,16 @@ describe('MintOpsApi', () => {
     await expect(api.execute(pendingOperation.id)).rejects.toThrow("Expected 'pending'");
   });
 
+  it('get and listByQuote delegate to the service', async () => {
+    const operation = await api.get(pendingOperation.id);
+    const operations = await api.listByQuote(mintUrl, quoteId);
+
+    expect(mintOperationService.getOperation).toHaveBeenCalledWith(pendingOperation.id);
+    expect(mintOperationService.listOperationsByQuote).toHaveBeenCalledWith(mintUrl, quoteId);
+    expect(operation).toBe(pendingOperation);
+    expect(operations).toEqual([pendingOperation]);
+  });
+
   it('listPending and listInFlight delegate to separate service methods', async () => {
     const pending = await api.listPending();
     const inFlight = await api.listInFlight();
@@ -207,6 +217,23 @@ describe('MintOpsApi', () => {
       pendingOperation.quoteId,
     );
     expect(result).toBe(pendingOperation);
+  });
+
+  it('checkPayment only allows pending operations', async () => {
+    const result = await api.checkPayment(pendingOperation.id);
+
+    expect(mintOperationService.getOperation).toHaveBeenCalledWith(pendingOperation.id);
+    expect(mintOperationService.checkPendingOperation).toHaveBeenCalledWith(pendingOperation.id);
+    expect(result.category).toBe('waiting');
+
+    (mintOperationService.getOperation as unknown as ReturnType<typeof mock>).mockResolvedValueOnce(
+      {
+        ...pendingOperation,
+        state: 'finalized',
+      } as MintOperation,
+    );
+
+    await expect(api.checkPayment(pendingOperation.id)).rejects.toThrow("Expected 'pending'");
   });
 
   it('refresh reconciles pending and executing operations', async () => {
@@ -237,5 +264,37 @@ describe('MintOpsApi', () => {
 
     expect(mintOperationService.recoverExecutingOperation).toHaveBeenCalledWith(executingOperation);
     expect(refreshedExecuting).toBe(finalizedOperation);
+  });
+
+  it('refresh returns terminal operations as-is', async () => {
+    const finalizedOperation: TerminalMintOperation = {
+      ...pendingOperation,
+      state: 'finalized',
+    };
+    (mintOperationService.getOperation as unknown as ReturnType<typeof mock>).mockResolvedValueOnce(
+      finalizedOperation as MintOperation,
+    );
+
+    const result = await api.refresh(finalizedOperation.id);
+
+    expect(mintOperationService.checkPendingOperation).not.toHaveBeenCalled();
+    expect(mintOperationService.recoverExecutingOperation).not.toHaveBeenCalled();
+    expect(result).toBe(finalizedOperation);
+  });
+
+  it('finalize and helper APIs delegate to the service', async () => {
+    const result = await api.finalize(pendingOperation.id);
+
+    await api.recovery.run();
+    const recoveryInProgress = api.recovery.inProgress();
+    const locked = api.diagnostics.isLocked(pendingOperation.id);
+
+    expect(mintOperationService.finalize).toHaveBeenCalledWith(pendingOperation.id);
+    expect(mintOperationService.recoverPendingOperations).toHaveBeenCalledWith();
+    expect(mintOperationService.isRecoveryInProgress).toHaveBeenCalledWith();
+    expect(mintOperationService.isOperationLocked).toHaveBeenCalledWith(pendingOperation.id);
+    expect(result.state).toBe('finalized');
+    expect(recoveryInProgress).toBe(false);
+    expect(locked).toBe(false);
   });
 });

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -100,9 +100,8 @@ const quote = await coco.quotes.mint.create({
 });
 
 const pending = await coco.ops.mint.prepare({
-  mintUrl,
-  quoteId: quote.quoteId,
-  method: 'bolt11',
+  quote,
+  amount: 100,
 });
 
 showInvoice(pending.request);
@@ -143,17 +142,13 @@ amount to withdraw from the reusable quote.
 
 ```ts
 const first = await coco.ops.mint.prepare({
-  mintUrl,
-  method: 'onchain',
-  quoteId: quote.quoteId,
-  amount: { amount: 25, unit: 'sat' },
+  quote,
+  amount: 25,
 });
 
 const second = await coco.ops.mint.prepare({
-  mintUrl,
-  method: 'onchain',
-  quoteId: quote.quoteId,
-  amount: { amount: 10, unit: 'sat' },
+  quote,
+  amount: 10,
 });
 
 await coco.ops.mint.finalize(first.id);
@@ -177,10 +172,8 @@ const quote = await coco.quotes.mint.create({
 showOffer(quote.request);
 
 const pending = await coco.ops.mint.prepare({
-  mintUrl,
-  method: 'bolt12',
-  quoteId: quote.quoteId,
-  amount: { amount: 10, unit: 'sat' },
+  quote,
+  amount: 10,
 });
 ```
 

--- a/packages/docs/pages/multi-unit-support.md
+++ b/packages/docs/pages/multi-unit-support.md
@@ -19,10 +19,8 @@ const quote = await coco.quotes.mint.create({
 });
 
 await coco.ops.mint.prepare({
-  mintUrl,
-  quoteId: quote.quoteId,
-  unit: 'usd',
-  method: 'bolt11',
+  quote,
+  amount: 25,
 });
 
 const preparedSend = await coco.ops.send.prepare({

--- a/packages/docs/pages/react-hooks.md
+++ b/packages/docs/pages/react-hooks.md
@@ -120,7 +120,7 @@ const quote = await manager.quotes.mint.create({
   method: 'bolt11',
 });
 
-const pendingMint = await prepare({ mintUrl, method: 'bolt11', quoteId: quote.quoteId });
+const pendingMint = await prepare({ quote, amount: 100 });
 
 if (pendingMint.state === 'pending') {
   await checkPayment();

--- a/packages/docs/starting/adding-mints.md
+++ b/packages/docs/starting/adding-mints.md
@@ -34,10 +34,8 @@ const quote = await coco.quotes.mint.create({
 });
 
 const pendingMint = await coco.ops.mint.prepare({
-  mintUrl,
-  quoteId: quote.quoteId,
-  method: 'bolt11',
-  methodData: {},
+  quote,
+  amount: 21,
 });
 ```
 
@@ -59,10 +57,8 @@ const quote = await coco.quotes.mint.create({
 });
 
 const pendingMint = await coco.ops.mint.prepare({
-  mintUrl,
-  quoteId: quote.quoteId,
-  method: 'bolt11',
-  methodData: {},
+  quote,
+  amount: 21,
 });
 ```
 

--- a/packages/docs/starting/migrating-from-alpha.md
+++ b/packages/docs/starting/migrating-from-alpha.md
@@ -176,7 +176,7 @@ const mintQuote = await manager.quotes.mint.create({
   amount: 100,
   method: 'bolt11',
 });
-await manager.ops.mint.prepare({ mintUrl, method: 'bolt11', quoteId: mintQuote.quoteId });
+await manager.ops.mint.prepare({ quote: mintQuote, amount: 100 });
 const meltQuote = await manager.quotes.melt.create({
   mintUrl,
   method: 'bolt11',
@@ -282,7 +282,7 @@ const { prepare, execute, cancel, currentOperation, executeResult, status, error
   useSendOperation();
 
 const quote = await manager.quotes.mint.create({ mintUrl, amount, method: 'bolt11' });
-await prepare({ mintUrl, method: 'bolt11', quoteId: quote.quoteId });
+await prepare({ quote, amount });
 if (userCanceled) {
   await cancel();
 } else {

--- a/packages/docs/starting/migrating-from-v1.md
+++ b/packages/docs/starting/migrating-from-v1.md
@@ -44,7 +44,7 @@ passing method subset type parameters such as `QuoteApi<'bolt11'>` or
 
 `manager.ops.mint.prepare({ mintUrl, amount, unit?, method })` no longer creates
 a remote quote. Create the canonical quote first, then prepare the operation
-from that quote:
+from that quote with `prepare({ quote, amount })`:
 
 ```ts
 const quote = await manager.quotes.mint.create({
@@ -56,9 +56,8 @@ const quote = await manager.quotes.mint.create({
 showInvoice(quote.request);
 
 const operation = await manager.ops.mint.prepare({
-  mintUrl,
-  method: 'bolt11',
-  quoteId: quote.quoteId,
+  quote,
+  amount: 100,
 });
 ```
 
@@ -74,9 +73,8 @@ const quote = await manager.quotes.mint.import({
 });
 
 const operation = await manager.ops.mint.prepare({
-  mintUrl: quote.mintUrl,
-  method: quote.method,
-  quoteId: quote.quoteId,
+  quote,
+  amount: quoteSnapshot.amount,
 });
 ```
 

--- a/packages/docs/starting/minting.md
+++ b/packages/docs/starting/minting.md
@@ -2,8 +2,8 @@
 
 The process of swapping value for a Cashu token is called "minting". To mint
 with Coco you first create a canonical mint quote, then prepare a mint operation
-from that quote. Bare amounts default to sats; for custom units pass
-`{ amount, unit }`.
+from that quote. The mint operation amount uses the canonical quote's stored
+unit.
 
 Before minting, ensure the mint is added and trusted (see [Adding a Mint](./adding-mints.md)):
 
@@ -20,10 +20,8 @@ const quote = await coco.quotes.mint.create({
 
 // Prepare an operation from the quote
 const pendingMint = await coco.ops.mint.prepare({
-  mintUrl: 'https://minturl.com',
-  quoteId: quote.quoteId,
-  method: 'bolt11',
-  methodData: {},
+  quote,
+  amount: 21,
 });
 ```
 
@@ -35,10 +33,8 @@ const customUnitQuote = await coco.quotes.mint.create({
 });
 
 const customUnitMint = await coco.ops.mint.prepare({
-  mintUrl: 'https://minturl.com',
-  quoteId: customUnitQuote.quoteId,
-  unit: 'usd',
-  method: 'bolt11',
+  quote: customUnitQuote,
+  amount: 10,
 });
 ```
 
@@ -57,10 +53,8 @@ const quote = await coco.quotes.mint.create({
 });
 
 const pendingMint = await coco.ops.mint.prepare({
-  mintUrl: 'https://minturl.com',
-  quoteId: quote.quoteId,
-  method: 'bolt11',
-  methodData: {},
+  quote,
+  amount: 21,
 });
 
 console.log('pay this: ', pendingMint.request);
@@ -96,10 +90,8 @@ const claimable = refreshed.quoteData.amountPaid.subtract(refreshed.quoteData.am
 
 if (!claimable.isZero()) {
   const pendingOnchainMint = await coco.ops.mint.prepare({
-    mintUrl: 'https://minturl.com',
-    method: 'onchain',
-    quoteId: quote.quoteId,
-    amount: { amount: 5, unit: 'sat' },
+    quote,
+    amount: 5,
   });
 
   await coco.ops.mint.finalize(pendingOnchainMint.id);
@@ -122,10 +114,8 @@ const offerQuote = await coco.quotes.mint.create({
 console.log('pay this offer:', offerQuote.request);
 
 const pendingOfferMint = await coco.ops.mint.prepare({
-  mintUrl: 'https://minturl.com',
-  method: 'bolt12',
-  quoteId: offerQuote.quoteId,
-  amount: { amount: 10, unit: 'sat' },
+  quote: offerQuote,
+  amount: 10,
 });
 ```
 

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -61,9 +61,12 @@ const MINT_URL = 'https://mint.example';
 const SEND_PREPARE_INPUT: SendOperationPrepareInput = { mintUrl: MINT_URL, amount: 100 };
 const RECEIVE_PREPARE_INPUT: ReceiveOperationPrepareInput = { token: 'cashu-token' };
 const MINT_PREPARE_INPUT: MintOperationPrepareInput = {
-  mintUrl: MINT_URL,
-  quoteId: 'mint-quote-1',
-  method: 'bolt11',
+  quote: {
+    mintUrl: MINT_URL,
+    quoteId: 'mint-quote-1',
+    method: 'bolt11',
+  },
+  amount: 100,
 };
 const MELT_PREPARE_INPUT: MeltOperationPrepareInput = {
   mintUrl: MINT_URL,

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -1016,10 +1016,12 @@ describe('useMintOperation', () => {
       unit: 'usd',
     });
     const input: MintOperationPrepareInput = {
-      mintUrl: MINT_URL,
-      quoteId: 'mint-quote-usd',
-      unit: 'USD',
-      method: 'bolt11',
+      quote: {
+        mintUrl: MINT_URL,
+        quoteId: 'mint-quote-usd',
+        method: 'bolt11',
+      },
+      amount: 50,
     };
 
     mint.prepare.mockResolvedValue(pending);
@@ -1052,10 +1054,12 @@ describe('useMintOperation', () => {
     });
 
     const input: MintOperationPrepareInput = {
-      mintUrl: MINT_URL,
-      method: 'bolt12',
-      quoteId: prepared.quoteId,
-      amount: { amount: 100, unit: 'sat' },
+      quote: {
+        mintUrl: MINT_URL,
+        method: 'bolt12',
+        quoteId: prepared.quoteId,
+      },
+      amount: 100,
     };
 
     mint.prepare.mockResolvedValue(prepared);


### PR DESCRIPTION
## Description

This pull request refactors mint operation preparation so callers pass `prepare({ quote, amount })` using a canonical mint quote or `MintQuoteRef`.

This pull request resolves #200.

## Problem

Mint operation prepare still required callers to pass loose `mintUrl`, `method`, `quoteId`, `unit`, and public `methodData` even though canonical quote storage now owns method and unit state.

## Summary

- Updates `MintOpsApi.prepare` and `MintOperationService.prepare` to use quote refs and required amounts.
- Re-reads canonical mint quotes by `{ mintUrl, quoteId }`, validates ref method against storage, and throws `QuoteIdentityConflictError` on mismatch.
- Keeps operation records persisting internal method/methodData state for recovery and execution.
- Updates tests, integration call sites, React hook tests, docs examples, and adds a changeset.
- Compatibility: public core mint prepare and React hook prepare input shape are breaking.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MintOpsApi.test.ts test/unit/MintOperationService.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run test -- src/lib/hooks/operationHooks.test.tsx` in `packages/react`
- `bun run docs:build`
- `git diff --check`

## Notes

- `bun run typecheck` in `packages/core` still fails on pre-existing `cashu-ts` onchain/melt API type drift unrelated to this slice.
- `packages/react` typecheck currently resolves stale `packages/core/dist` declarations because generated `dist/` was not edited.

## Changeset

- Added `.changeset/mint-prepare-quote-refs.md`.