### PR TITLE
feat: prepare melt operations from quote refs

### DIFF
--- a/.changeset/melt-prepare-quote-refs.md
+++ b/.changeset/melt-prepare-quote-refs.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-react': major
+'@cashu/coco-adapter-tests': patch
+---
+
+Refactor melt operation prepare to accept `{ quote }` for BOLT quotes and `{ quote, feeIndex }` for onchain quotes, deriving method data from stored canonical melt quote state.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -491,7 +491,11 @@ async function prepareMeltOperation(
 ) {
   const quote = await createMeltQuote(manager, mintUrl, invoice, unit);
   return manager.ops.melt.prepare({
-    quote,
+    quote: {
+      mintUrl: quote.mintUrl,
+      method: 'bolt11',
+      quoteId: quote.quoteId,
+    },
   });
 }
 

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -491,10 +491,7 @@ async function prepareMeltOperation(
 ) {
   const quote = await createMeltQuote(manager, mintUrl, invoice, unit);
   return manager.ops.melt.prepare({
-    mintUrl,
-    method: 'bolt11',
-    quoteId: quote.quoteId,
-    unit,
+    quote,
   });
 }
 

--- a/packages/core/api/MeltOpsApi.ts
+++ b/packages/core/api/MeltOpsApi.ts
@@ -5,21 +5,16 @@ import type {
   PreparedMeltOperation,
 } from '@core/operations/melt';
 import type { MeltMethod, MeltOperationService } from '@core/operations/melt';
+import type { MeltQuoteRef } from '../models/QuoteIdentity.ts';
 
 /** Melt methods supported by the default `Manager` wiring. */
 export type DefaultSupportedMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
 
 export type PrepareMeltInput<TSupported extends MeltMethod = DefaultSupportedMeltMethod> = {
   [M in TSupported]: {
-    /** Mint that will execute the melt. */
-    mintUrl: string;
-    /** Melt method to prepare, for example `bolt11`. */
-    method: M;
-    /** Existing canonical melt quote ID to prepare against. */
-    quoteId: string;
-    /** Unit to melt. Defaults to `sat`. */
-    unit?: string;
-  } & (M extends 'onchain' ? { feeIndex?: number } : {});
+    /** Existing canonical melt quote or structural quote reference. */
+    quote: MeltQuoteRef<M>;
+  } & (M extends 'onchain' ? { feeIndex: number } : { feeIndex?: number });
 }[TSupported];
 
 export type GetMeltByQuoteInput<TSupported extends MeltMethod = DefaultSupportedMeltMethod> = {
@@ -73,18 +68,9 @@ export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMeth
    * before committing to the external payment.
    */
   async prepare(input: PrepareMeltInput<TSupported>): Promise<PreparedMeltOperation> {
-    return this.meltOperationService.prepareExistingQuote(
-      input.mintUrl,
-      input.method,
-      input.quoteId,
-      {
-        expectedUnit: input.unit,
-        feeIndex:
-          input.method === 'onchain'
-            ? (input as PrepareMeltInput<Extract<TSupported, 'onchain'>>).feeIndex
-            : undefined,
-      },
-    );
+    return this.meltOperationService.prepareExistingQuote(input.quote, {
+      feeIndex: input.feeIndex,
+    });
   }
 
   /**

--- a/packages/core/api/QuoteApi.ts
+++ b/packages/core/api/QuoteApi.ts
@@ -42,14 +42,16 @@ export type ListPendingMintQuotesInput = {
   method?: DefaultSupportedMintQuoteMethod;
 };
 
-export type CreateMeltQuoteInput = {
-  [M in DefaultSupportedMeltMethod]: {
+export type CreateMeltQuoteInput<
+  TSupported extends DefaultSupportedMeltMethod = DefaultSupportedMeltMethod,
+> = {
+  [M in TSupported]: {
     mintUrl: string;
     method: M;
     methodData: MeltMethodInputData<M>;
     unit?: string;
   };
-}[DefaultSupportedMeltMethod];
+}[TSupported];
 
 export type ListPendingMeltQuotesInput = {
   method?: DefaultSupportedMeltMethod;
@@ -104,7 +106,9 @@ export class MintQuoteApi {
 export class MeltQuoteApi {
   constructor(private readonly quoteLifecycle: QuoteLifecycle) {}
 
-  create(input: CreateMeltQuoteInput): Promise<MeltQuote> {
+  create<M extends DefaultSupportedMeltMethod>(
+    input: CreateMeltQuoteInput<M>,
+  ): Promise<MeltQuote<M>> {
     return this.quoteLifecycle.createMeltQuote(
       input.mintUrl,
       input.method,

--- a/packages/core/models/MeltQuote.ts
+++ b/packages/core/models/MeltQuote.ts
@@ -164,20 +164,18 @@ export function resolveOnchainMeltFeeOption(
     throw new Error(`Melt quote ${quote.quoteId} has no onchain fee options`);
   }
 
-  const resolvedFeeIndex =
-    feeIndex ?? (feeOptions.length === 1 ? feeOptions[0]!.fee_index : undefined);
-  if (resolvedFeeIndex === undefined) {
+  if (feeIndex === undefined) {
     throw new Error(`Melt quote ${quote.quoteId} requires an explicit feeIndex`);
   }
 
-  const feeOption = feeOptions.find((option) => option.fee_index === resolvedFeeIndex);
+  const feeOption = feeOptions.find((option) => option.fee_index === feeIndex);
   if (!feeOption) {
     throw new Error(
-      `Melt quote ${quote.quoteId} does not include onchain fee option ${resolvedFeeIndex}`,
+      `Melt quote ${quote.quoteId} does not include onchain fee option ${feeIndex}`,
     );
   }
 
-  return { feeIndex: resolvedFeeIndex, feeOption };
+  return { feeIndex, feeOption };
 }
 
 function normalizeOnchainFeeOptions(

--- a/packages/core/models/MeltQuote.ts
+++ b/packages/core/models/MeltQuote.ts
@@ -170,9 +170,7 @@ export function resolveOnchainMeltFeeOption(
 
   const feeOption = feeOptions.find((option) => option.fee_index === feeIndex);
   if (!feeOption) {
-    throw new Error(
-      `Melt quote ${quote.quoteId} does not include onchain fee option ${feeIndex}`,
-    );
+    throw new Error(`Melt quote ${quote.quoteId} does not include onchain fee option ${feeIndex}`);
   }
 
   return { feeIndex, feeOption };

--- a/packages/core/operations/melt/MeltOperationService.ts
+++ b/packages/core/operations/melt/MeltOperationService.ts
@@ -34,6 +34,7 @@ import { OperationIdLock } from '../OperationIdLock';
 import { DEFAULT_UNIT, normalizeUnit } from '../../amounts.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 import { resolveOnchainMeltFeeOption, type MeltQuote } from '../../models/MeltQuote.ts';
+import type { MeltQuoteRef } from '../../models/QuoteIdentity.ts';
 
 /**
  * MeltOperationService orchestrates melt sagas while delegating
@@ -216,19 +217,12 @@ export class MeltOperationService {
   }
 
   async prepareExistingQuote(
-    mintUrl: string,
-    method: MeltMethod,
-    quoteId: string,
-    options: { expectedUnit?: string; feeIndex?: number } = {},
+    quoteRef: MeltQuoteRef,
+    options: { feeIndex?: number } = {},
   ): Promise<PreparedMeltOperation> {
-    const quote = await this.quoteLifecycle.requireMeltQuoteForPrepare(
-      mintUrl,
-      method,
-      quoteId,
-      options.expectedUnit,
-    );
+    const quote = await this.quoteLifecycle.requireMeltQuoteRefForPrepare(quoteRef);
     const methodData = this.methodDataFromMeltQuote(quote, options);
-    const initOperation = await this.init(quote.mintUrl, method, methodData, quote.unit, {
+    const initOperation = await this.init(quote.mintUrl, quote.method, methodData, quote.unit, {
       quoteId: quote.quoteId,
     });
     return this.prepare(initOperation.id);

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -520,12 +520,12 @@ export class QuoteLifecycle {
     return quote;
   }
 
-  async createMeltQuote(
+  async createMeltQuote<M extends MeltMethod>(
     mintUrl: string,
-    method: MeltMethod,
-    methodData: MeltMethodInputData,
+    method: M,
+    methodData: MeltMethodInputData<M>,
     unit = DEFAULT_UNIT,
-  ): Promise<MeltQuote> {
+  ): Promise<MeltQuote<M>> {
     const normalizedUnit = normalizeUnit(unit, { defaultUnit: DEFAULT_UNIT });
     const trusted = await this.mintService.isTrustedMint(mintUrl);
     if (!trusted) {
@@ -562,7 +562,9 @@ export class QuoteLifecycle {
     }
 
     await this.meltQuoteRepository.upsertMeltQuote(quote);
-    return (await this.meltQuoteRepository.getMeltQuote(mintUrl, method, quote.quoteId)) ?? quote;
+    const persistedQuote =
+      (await this.meltQuoteRepository.getMeltQuote(mintUrl, method, quote.quoteId)) ?? quote;
+    return persistedQuote as MeltQuote<M>;
   }
 
   getMeltQuote(mintUrl: string, method: MeltMethod, quoteId: string): Promise<MeltQuote | null> {

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -47,7 +47,7 @@ import type {
   MintMethodQuoteSnapshot,
   MintMethodRemoteState,
 } from '../operations/mint/MintMethodHandler';
-import type { MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity';
+import type { MeltQuoteRef, MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity';
 
 const MINT_QUOTE_STATE_RANK: Record<string, number> = {
   UNPAID: 0,
@@ -613,6 +613,29 @@ export class QuoteLifecycle {
     }
 
     this.assertMeltQuoteCanPrepare(quote, `melt quote ${quoteId}`);
+    return quote;
+  }
+
+  async requireMeltQuoteRefForPrepare(ref: MeltQuoteRef): Promise<MeltQuote> {
+    const quote = await this.meltQuoteRepository.getMeltQuoteById({
+      mintUrl: ref.mintUrl,
+      quoteId: ref.quoteId,
+    });
+    if (!quote) {
+      throw new Error(`Melt quote ${ref.quoteId} at ${ref.mintUrl} was not found`);
+    }
+
+    if (quote.method !== ref.method) {
+      throw new QuoteIdentityConflictError(
+        'melt',
+        quote.mintUrl,
+        quote.quoteId,
+        [ref.method, quote.method],
+        `Melt quote ${quote.quoteId} at ${quote.mintUrl} resolved to method ${quote.method}, not requested method ${ref.method}`,
+      );
+    }
+
+    this.assertMeltQuoteCanPrepare(quote, `melt quote ${ref.quoteId}`);
     return quote;
   }
 

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -486,19 +486,22 @@ describe('MeltOperationService', () => {
       });
     });
 
-    it('defaults onchain fee index only when the quote has one fee option', async () => {
+    it('rejects missing onchain fee index even when the quote has one fee option', async () => {
       await persistOnchainMeltQuote('single-option-onchain-quote', [
         { fee_index: 3, fee_reserve: Amount.from(4), estimated_blocks: 6 },
       ]);
 
-      const prepared = await service.prepareExistingQuote({
-        mintUrl,
-        method: 'onchain',
-        quoteId: 'single-option-onchain-quote',
-      });
+      await expect(
+        service.prepareExistingQuote({
+          mintUrl,
+          method: 'onchain',
+          quoteId: 'single-option-onchain-quote',
+        }),
+      ).rejects.toThrow('requires an explicit feeIndex');
 
-      expect(prepared.method).toBe('onchain');
-      expect((prepared.methodData as { feeIndex: number }).feeIndex).toBe(3);
+      expect(
+        await service.getOperationByQuote(mintUrl, 'onchain', 'single-option-onchain-quote'),
+      ).toBeNull();
     });
 
     it('rejects missing onchain fee index for multi-option quotes before creating operations', async () => {

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -32,6 +32,7 @@ import {
   UnknownMintError,
   ProofValidationError,
   OperationInProgressError,
+  QuoteIdentityConflictError,
 } from '../../models/Error.ts';
 
 describe('MeltOperationService', () => {
@@ -422,11 +423,11 @@ describe('MeltOperationService', () => {
 
   describe('prepare', () => {
     it('prepares existing quotes using the canonical quote mint URL', async () => {
-      const prepared = await service.prepareExistingQuote(
-        'https://MINT.test/',
-        'bolt11',
-        'quote-1',
-      );
+      const prepared = await service.prepareExistingQuote({
+        mintUrl: 'https://MINT.test/',
+        method: 'bolt11',
+        quoteId: 'quote-1',
+      });
 
       const stored = await meltOperationRepository.getById(prepared.id);
       const byQuote = await service.getOperationByQuote(mintUrl, 'bolt11', 'quote-1');
@@ -455,7 +456,11 @@ describe('MeltOperationService', () => {
         updatedAt: Date.now(),
       });
 
-      const prepared = await service.prepareExistingQuote(mintUrl, 'bolt12', 'quote-bolt12');
+      const prepared = await service.prepareExistingQuote({
+        mintUrl,
+        method: 'bolt12',
+        quoteId: 'quote-bolt12',
+      });
 
       expect(prepared.method).toBe('bolt12');
       expect(prepared.methodData).toEqual({ offer: 'lno1offer' });
@@ -464,9 +469,14 @@ describe('MeltOperationService', () => {
     it('prepares onchain melt quotes with the selected fee index in operation data', async () => {
       await persistOnchainMeltQuote();
 
-      const prepared = await service.prepareExistingQuote(mintUrl, 'onchain', 'onchain-quote', {
-        feeIndex: 7,
-      });
+      const prepared = await service.prepareExistingQuote(
+        {
+          mintUrl,
+          method: 'onchain',
+          quoteId: 'onchain-quote',
+        },
+        { feeIndex: 7 },
+      );
 
       expect(prepared.method).toBe('onchain');
       expect(prepared.methodData).toEqual({
@@ -481,11 +491,11 @@ describe('MeltOperationService', () => {
         { fee_index: 3, fee_reserve: Amount.from(4), estimated_blocks: 6 },
       ]);
 
-      const prepared = await service.prepareExistingQuote(
+      const prepared = await service.prepareExistingQuote({
         mintUrl,
-        'onchain',
-        'single-option-onchain-quote',
-      );
+        method: 'onchain',
+        quoteId: 'single-option-onchain-quote',
+      });
 
       expect(prepared.method).toBe('onchain');
       expect((prepared.methodData as { feeIndex: number }).feeIndex).toBe(3);
@@ -495,16 +505,68 @@ describe('MeltOperationService', () => {
       await persistOnchainMeltQuote();
 
       await expect(
-        service.prepareExistingQuote(mintUrl, 'onchain', 'onchain-quote'),
+        service.prepareExistingQuote({
+          mintUrl,
+          method: 'onchain',
+          quoteId: 'onchain-quote',
+        }),
       ).rejects.toThrow('requires an explicit feeIndex');
 
       expect(await service.getOperationByQuote(mintUrl, 'onchain', 'onchain-quote')).toBeNull();
     });
 
-    it('rejects duplicate prepares for the same canonical quote', async () => {
-      const first = await service.prepareExistingQuote('https://MINT.test/', 'bolt11', 'quote-1');
+    it('rejects invalid onchain fee index before creating operations', async () => {
+      await persistOnchainMeltQuote();
 
-      await expect(service.prepareExistingQuote(mintUrl, 'bolt11', 'quote-1')).rejects.toThrow(
+      await expect(
+        service.prepareExistingQuote(
+          {
+            mintUrl,
+            method: 'onchain',
+            quoteId: 'onchain-quote',
+          },
+          { feeIndex: 99 },
+        ),
+      ).rejects.toThrow('does not include onchain fee option 99');
+
+      expect(await service.getOperationByQuote(mintUrl, 'onchain', 'onchain-quote')).toBeNull();
+    });
+
+    it('throws quote identity conflict when the input ref method differs from storage', async () => {
+      await expect(
+        service.prepareExistingQuote({
+          mintUrl,
+          method: 'bolt12',
+          quoteId: 'quote-1',
+        }),
+      ).rejects.toThrow(QuoteIdentityConflictError);
+
+      expect(await service.getOperationByQuote(mintUrl, 'bolt11', 'quote-1')).toBeNull();
+    });
+
+    it('accepts full canonical melt quotes as quote refs', async () => {
+      const quote = await quoteLifecycle.getMeltQuoteById({ mintUrl, quoteId: 'quote-1' });
+      if (!quote) {
+        throw new Error('Expected test quote to exist');
+      }
+
+      const prepared = await service.prepareExistingQuote(quote);
+
+      expect(prepared.quoteId).toBe(quote.quoteId);
+      expect(prepared.method).toBe(quote.method);
+      expect(prepared.methodData).toEqual({ invoice: quote.request });
+    });
+
+    it('rejects duplicate prepares for the same canonical quote', async () => {
+      const first = await service.prepareExistingQuote({
+        mintUrl: 'https://MINT.test/',
+        method: 'bolt11',
+        quoteId: 'quote-1',
+      });
+
+      await expect(
+        service.prepareExistingQuote({ mintUrl, method: 'bolt11', quoteId: 'quote-1' }),
+      ).rejects.toThrow(
         `Melt quote quote-1 is already tracked by operation ${first.id} in state prepared`,
       );
 

--- a/packages/core/test/unit/MeltOpsApi.test.ts
+++ b/packages/core/test/unit/MeltOpsApi.test.ts
@@ -9,25 +9,68 @@ import type {
 } from '../../operations/melt/MeltOperation.ts';
 import type { MeltOperationService } from '../../operations/melt/MeltOperationService.ts';
 import { MeltOpsApi } from '../../api/MeltOpsApi.ts';
+import type { MeltQuote } from '../../models/MeltQuote.ts';
 
 const mintUrl = 'https://mint.test';
+const quoteId = 'quote-1';
 
 type Assert<T extends true> = T;
 type PrepareMeltInput = Parameters<MeltOpsApi['prepare']>[0];
-type PrepareMeltMethod = PrepareMeltInput['method'];
+type GetMeltByQuoteInput = Parameters<MeltOpsApi['getByQuote']>[0];
+type OnchainPrepareMeltInput = Extract<PrepareMeltInput, { quote: { method: 'onchain' } }>;
+type Bolt11PrepareMeltInput = Extract<PrepareMeltInput, { quote: { method: 'bolt11' } }>;
 type _AssertDefaultBoltMethods = Assert<
-  Exclude<PrepareMeltMethod, 'bolt11' | 'bolt12' | 'onchain'> extends never ? true : false
+  Exclude<PrepareMeltInput['quote']['method'], 'bolt11' | 'bolt12' | 'onchain'> extends never
+    ? true
+    : false
 >;
 type CustomPrepareMeltInput = Parameters<MeltOpsApi<'bolt11' | 'bolt12'>['prepare']>[0];
-type _AssertAllowsBolt12 = Assert<'bolt12' extends CustomPrepareMeltInput['method'] ? true : false>;
+type _AssertAllowsBolt12 = Assert<
+  'bolt12' extends CustomPrepareMeltInput['quote']['method'] ? true : false
+>;
+type _AssertPrepareAcceptsQuoteRef = Assert<
+  PrepareMeltInput extends {
+    quote: {
+      mintUrl: string;
+      quoteId: string;
+      method: 'bolt11' | 'bolt12' | 'onchain';
+    };
+  }
+    ? true
+    : false
+>;
+type _AssertPrepareOmitsLooseMethod = Assert<
+  'method' extends keyof PrepareMeltInput ? false : true
+>;
+type _AssertPrepareOmitsLooseUnit = Assert<'unit' extends keyof PrepareMeltInput ? false : true>;
+type _AssertPrepareOmitsMethodData = Assert<
+  'methodData' extends keyof PrepareMeltInput ? false : true
+>;
+type _AssertOnchainRequiresFeeIndex = Assert<
+  OnchainPrepareMeltInput extends { feeIndex: number } ? true : false
+>;
+type _AssertBoltFeeIndexOptional = Assert<
+  Bolt11PrepareMeltInput extends { feeIndex?: number } ? true : false
+>;
 type _AssertListByQuoteUsesMintAndQuoteArgs = Assert<
   Parameters<MeltOpsApi['listByQuote']> extends [string, string] ? true : false
 >;
+type _AssertGetByQuoteUsesObjectInput = Assert<
+  GetMeltByQuoteInput extends {
+    mintUrl: string;
+    method: 'bolt11' | 'bolt12' | 'onchain';
+    quoteId: string;
+  }
+    ? true
+    : false
+>;
 
 const supportedPrepareInput: PrepareMeltInput = {
-  mintUrl,
-  method: 'bolt11',
-  quoteId: 'quote-1',
+  quote: {
+    mintUrl,
+    method: 'bolt11',
+    quoteId,
+  },
 };
 void supportedPrepareInput;
 
@@ -39,7 +82,7 @@ const makePreparedOperation = (): PreparedMeltOperation => ({
   methodData: { invoice: 'lnbc1test' },
   createdAt: Date.now(),
   updatedAt: Date.now(),
-  quoteId: 'quote-1',
+  quoteId,
   unit: 'sat',
   amount: Amount.from(100),
   fee_reserve: Amount.from(0),
@@ -94,44 +137,64 @@ describe('MeltOpsApi', () => {
     const result = await api.prepare(supportedPrepareInput);
 
     expect(meltOperationService.prepareExistingQuote).toHaveBeenCalledWith(
-      mintUrl,
-      'bolt11',
-      'quote-1',
-      { expectedUnit: undefined, feeIndex: undefined },
+      supportedPrepareInput.quote,
+      { feeIndex: undefined },
     );
     expect(result).toBe(preparedOperation);
   });
 
-  it('prepare passes non-sat units to the service', async () => {
-    await api.prepare({
+  it('prepare accepts a full canonical quote as the quote ref', async () => {
+    const quote: MeltQuote<'bolt11'> = {
       mintUrl,
+      quoteId,
+      quote: quoteId,
+      request: 'lnbc1test',
+      unit: 'usd',
       method: 'bolt11',
-      quoteId: 'quote-1',
-      unit: 'USD',
+      amount: Amount.from(12),
+      fee_reserve: Amount.from(1),
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      state: 'UNPAID',
+      lastObservedRemoteState: 'UNPAID',
+      lastObservedRemoteStateAt: Date.now(),
+      payment_preimage: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    await api.prepare({
+      quote,
     });
 
-    expect(meltOperationService.prepareExistingQuote).toHaveBeenCalledWith(
-      mintUrl,
-      'bolt11',
-      'quote-1',
-      { expectedUnit: 'USD', feeIndex: undefined },
-    );
+    expect(meltOperationService.prepareExistingQuote).toHaveBeenCalledWith(quote, {
+      feeIndex: undefined,
+    });
   });
 
   it('prepare passes onchain feeIndex to the service', async () => {
+    const quote = { mintUrl, method: 'onchain', quoteId } as const;
+
     await api.prepare({
-      mintUrl,
-      method: 'onchain',
-      quoteId: 'quote-1',
+      quote,
       feeIndex: 2,
     });
 
-    expect(meltOperationService.prepareExistingQuote).toHaveBeenCalledWith(
-      mintUrl,
-      'onchain',
-      'quote-1',
-      { expectedUnit: undefined, feeIndex: 2 },
-    );
+    expect(meltOperationService.prepareExistingQuote).toHaveBeenCalledWith(quote, {
+      feeIndex: 2,
+    });
+  });
+
+  it('prepare ignores extra BOLT feeIndex at the API boundary', async () => {
+    const quote = { mintUrl, method: 'bolt12', quoteId } as const;
+
+    await api.prepare({
+      quote,
+      feeIndex: 9,
+    });
+
+    expect(meltOperationService.prepareExistingQuote).toHaveBeenCalledWith(quote, {
+      feeIndex: 9,
+    });
   });
 
   it('execute resolves ids before executing', async () => {

--- a/packages/core/test/unit/MeltQuote.test.ts
+++ b/packages/core/test/unit/MeltQuote.test.ts
@@ -46,24 +46,17 @@ function makeOnchainQuote(overrides: Partial<MeltQuote<'onchain'>> = {}): MeltQu
 }
 
 describe('MeltQuote model', () => {
-  it('defaults a single onchain fee option when no fee index is provided', () => {
-    const resolved = resolveOnchainMeltFeeOption(makeOnchainQuote());
+  it('requires an explicit onchain fee index', () => {
+    expect(() => resolveOnchainMeltFeeOption(makeOnchainQuote())).toThrow(
+      'requires an explicit feeIndex',
+    );
+  });
+
+  it('resolves an explicit onchain fee index', () => {
+    const resolved = resolveOnchainMeltFeeOption(makeOnchainQuote(), 1);
 
     expect(resolved.feeIndex).toBe(1);
     expect(resolved.feeOption.fee_reserve).toEqual(Amount.from(2));
-  });
-
-  it('requires an explicit onchain fee index for multi-option quotes', () => {
-    expect(() =>
-      resolveOnchainMeltFeeOption(
-        makeOnchainQuote({
-          fee_options: [
-            { fee_index: 1, fee_reserve: Amount.from(2), estimated_blocks: 6 },
-            { fee_index: 2, fee_reserve: Amount.from(3), estimated_blocks: 3 },
-          ],
-        }),
-      ),
-    ).toThrow('requires an explicit feeIndex');
   });
 
   it('rejects empty or missing onchain fee options', () => {

--- a/packages/core/test/unit/QuoteApi.test.ts
+++ b/packages/core/test/unit/QuoteApi.test.ts
@@ -1,6 +1,7 @@
 import { Amount } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { QuoteApi } from '../../api/QuoteApi.ts';
+import type { MeltOpsApi } from '../../api/MeltOpsApi.ts';
 import type { MeltQuote } from '../../models/MeltQuote.ts';
 import type { MintQuote } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
@@ -212,6 +213,22 @@ describe('QuoteApi', () => {
     expect(quoteLifecycle.getMeltQuoteById).toHaveBeenCalledWith({ mintUrl, quoteId });
     expect(quoteLifecycle.getPendingMeltQuotes).toHaveBeenCalledWith('bolt11');
     expect(quoteLifecycle.refreshMeltQuoteById).toHaveBeenCalledWith({ mintUrl, quoteId });
+  });
+
+  it('types created BOLT melt quotes as direct prepare inputs', async () => {
+    const meltOps = {
+      prepare: mock(async () => undefined),
+    } as unknown as Pick<MeltOpsApi, 'prepare'>;
+
+    const quote = await api.melt.create({
+      mintUrl,
+      method: 'bolt11',
+      methodData: { invoice: 'lnbc1melt' },
+    });
+
+    await meltOps.prepare({ quote });
+
+    expect(meltOps.prepare).toHaveBeenCalledWith({ quote });
   });
 
   it('keeps method required for quote creation and import inputs', () => {

--- a/packages/docs/pages/melt-operations.md
+++ b/packages/docs/pages/melt-operations.md
@@ -15,9 +15,8 @@ The melt operation saga provides:
 
 The canonical API is exposed through `coco.ops.melt`:
 
-- `prepare({ mintUrl, method: 'bolt11', quoteId })` prepares an operation from a canonical melt quote
-- `prepare({ mintUrl, method: 'bolt12', quoteId })` prepares a BOLT12 offer melt from a canonical melt quote
-- `prepare({ mintUrl, method: 'onchain', quoteId, feeIndex? })` prepares an onchain melt from a canonical NUT-30 quote
+- `prepare({ quote })` prepares a BOLT11 or BOLT12 operation from a canonical melt quote or quote ref
+- `prepare({ quote, feeIndex })` prepares an onchain melt from a canonical NUT-30 quote or quote ref
 - `execute(operationOrId)` executes the prepared operation
 - `getByQuote({ mintUrl, method, quoteId })` resolves an operation from a persisted quote id
 - `refresh(operationId)` checks a pending melt and returns the latest operation state
@@ -74,9 +73,7 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt11',
-  quoteId: quote.quoteId,
+  quote,
 });
 
 console.log('Quote:', prepared.quoteId);
@@ -96,9 +93,7 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt12',
-  quoteId: quote.quoteId,
+  quote,
 });
 ```
 
@@ -112,18 +107,14 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'onchain',
-  quoteId: quote.quoteId,
+  quote,
   feeIndex: quote.fee_options[0].fee_index,
 });
 ```
 
-If the onchain quote has exactly one fee option, `feeIndex` may be omitted. If
-there are multiple fee options, pass one of the advertised
-`quote.fee_options[].fee_index` values. The selected fee option's `fee_reserve`
-is copied onto the prepared operation for proof selection; the selected
-`feeIndex` is operation data, not quote data.
+Pass one of the advertised `quote.fee_options[].fee_index` values. The selected
+fee option's `fee_reserve` is copied onto the prepared operation for proof
+selection; the selected `feeIndex` is operation data, not quote data.
 
 Internally, the service:
 

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -11,9 +11,9 @@ create history; history starts when an operation exists.
 
 The operation lifecycle API is exposed through `coco.ops.mint`:
 
-- `prepare({ mintUrl, method, quoteId, unit?, methodData?, amount? })` prepares
-  a pending mint operation from an existing canonical quote. Reusable onchain
-  quotes require `amount` because one quote can fund multiple operations.
+- `prepare({ quote, amount })` prepares a pending mint operation from an
+  existing canonical quote or quote ref. Reusable onchain quotes require
+  `amount` because one quote can fund multiple operations.
 - `execute(operationOrId)` redeems a paid quote and returns the terminal state
 - `checkPayment(operationId)` checks the remote quote state for a pending
   operation
@@ -26,9 +26,9 @@ The operation lifecycle API is exposed through `coco.ops.mint`:
   operation identity; a `quoteId` is remote quote identity and can be shared by
   more than one local operation.
 
-Built-in mint methods are `bolt11`, `onchain`, and `bolt12`. Quote lookups use
-the full `{ mintUrl, method, quoteId }` identity so reused quote IDs remain
-scoped by method.
+Built-in mint methods are `bolt11`, `onchain`, and `bolt12`. Public quote
+lookups use `{ mintUrl, quoteId }`; operation preparation accepts the full
+canonical quote or a structural quote ref with `{ mintUrl, quoteId, method }`.
 
 ## Quote Resurfacing (`coco.quotes.mint`)
 

--- a/packages/docs/pages/multi-unit-support.md
+++ b/packages/docs/pages/multi-unit-support.md
@@ -82,9 +82,7 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt11',
-  quoteId: quote.quoteId,
+  quote,
 });
 
 console.log(prepared.amount, prepared.unit, prepared.fee_reserve);

--- a/packages/docs/pages/react-hooks.md
+++ b/packages/docs/pages/react-hooks.md
@@ -149,7 +149,7 @@ const quote = await manager.quotes.melt.create({
   methodData: { invoice },
 });
 
-const preparedMelt = await prepare({ mintUrl, method: 'bolt11', quoteId: quote.quoteId });
+const preparedMelt = await prepare({ quote });
 
 if (preparedMelt.state === 'prepared') {
   await execute();

--- a/packages/docs/starting/melting.md
+++ b/packages/docs/starting/melting.md
@@ -14,9 +14,7 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt11',
-  quoteId: quote.quoteId,
+  quote,
 });
 
 console.log('Quote:', prepared.quoteId);
@@ -63,9 +61,7 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt12',
-  quoteId: quote.quoteId,
+  quote,
 });
 
 const result = await coco.ops.melt.execute(prepared.id);
@@ -88,9 +84,7 @@ const quote = await coco.quotes.melt.create({
 });
 
 const prepared = await coco.ops.melt.prepare({
-  mintUrl,
-  method: 'onchain',
-  quoteId: quote.quoteId,
+  quote,
   feeIndex: quote.fee_options[0].fee_index,
 });
 
@@ -102,10 +96,8 @@ if (executed.state === 'pending') {
 }
 ```
 
-If the quote has exactly one fee option, `feeIndex` may be omitted and Coco will
-use that option's `fee_index`. If multiple fee options are present, pass one of
-the advertised `quote.fee_options[].fee_index` values. Onchain melts are usually
-asynchronous, but intramint melt/mint settlement can finalize immediately; handle
-both `pending` and `finalized` execution results.
+Pass one of the advertised `quote.fee_options[].fee_index` values. Onchain melts
+are usually asynchronous, but intramint melt/mint settlement can finalize
+immediately; handle both `pending` and `finalized` execution results.
 
 > For the full saga walkthrough, see [Melt Operations](../pages/melt-operations.md).

--- a/packages/docs/starting/migrating-from-alpha.md
+++ b/packages/docs/starting/migrating-from-alpha.md
@@ -182,7 +182,7 @@ const meltQuote = await manager.quotes.melt.create({
   method: 'bolt11',
   methodData: { invoice },
 });
-await manager.ops.melt.prepare({ mintUrl, method: 'bolt11', quoteId: meltQuote.quoteId });
+await manager.ops.melt.prepare({ quote: meltQuote });
 
 const balancesByMint = await manager.wallet.balances.byMint();
 const trustedBalancesByMint = await manager.wallet.balances.byMint({ trustedOnly: true });

--- a/packages/docs/starting/migrating-from-v1.md
+++ b/packages/docs/starting/migrating-from-v1.md
@@ -106,9 +106,7 @@ const quote = await manager.quotes.melt.create({
 });
 
 const prepared = await manager.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt11',
-  quoteId: quote.quoteId,
+  quote,
 });
 ```
 

--- a/packages/docs/starting/sending-receiving.md
+++ b/packages/docs/starting/sending-receiving.md
@@ -115,7 +115,7 @@ await coco.ops.send.finalize(operationId);
 Use melt operations to pay BOLT11 invoices via `coco.ops.melt`:
 
 - `quotes.melt.create({ mintUrl, method: 'bolt11', methodData: { invoice } }): Promise<MeltQuote>`
-- `prepare({ mintUrl, method: 'bolt11', quoteId }): Promise<PreparedMeltOperation>`
+- `prepare({ quote }): Promise<PreparedMeltOperation>`
 - `execute(operationOrId): Promise<PendingMeltOperation | FinalizedMeltOperation>`
 - `getByQuote({ mintUrl, method, quoteId }): Promise<MeltOperation | null>`
 - `refresh(operationId: string): Promise<MeltOperation>`

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -69,9 +69,11 @@ const MINT_PREPARE_INPUT: MintOperationPrepareInput = {
   amount: 100,
 };
 const MELT_PREPARE_INPUT: MeltOperationPrepareInput = {
-  mintUrl: MINT_URL,
-  method: 'bolt11',
-  quoteId: 'melt-quote-1',
+  quote: {
+    mintUrl: MINT_URL,
+    method: 'bolt11',
+    quoteId: 'melt-quote-1',
+  },
 };
 
 function createEventBusMock() {
@@ -1323,7 +1325,7 @@ describe('useMintOperation', () => {
 });
 
 describe('useMeltOperation', () => {
-  it('passes custom-unit melt inputs through to melt prepare', async () => {
+  it('passes custom-unit melt quote inputs through to melt prepare', async () => {
     const { manager, melt } = createMeltManagerMock();
     const prepared = createPreparedMeltOperation({ unit: 'usd' });
     melt.prepare.mockResolvedValue(prepared);
@@ -1332,12 +1334,22 @@ describe('useMeltOperation', () => {
       wrapper: createHookWrapper(manager),
     });
 
-    const input: MeltOperationPrepareInput = {
+    const quote = {
       mintUrl: MINT_URL,
-      method: 'bolt11',
       quoteId: 'melt-quote-1',
+      quote: 'melt-quote-1',
+      request: 'lnbc1test',
       unit: 'USD',
-    };
+      method: 'bolt11',
+      amount: Amount.from(100),
+      fee_reserve: Amount.from(1),
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      state: 'UNPAID',
+      payment_preimage: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as const;
+    const input: MeltOperationPrepareInput = { quote };
 
     await act(async () => {
       await result.current.prepare(input);
@@ -1363,9 +1375,11 @@ describe('useMeltOperation', () => {
     });
 
     const input: MeltOperationPrepareInput = {
-      mintUrl: MINT_URL,
-      method: 'bolt12',
-      quoteId: prepared.quoteId,
+      quote: {
+        mintUrl: MINT_URL,
+        method: 'bolt12',
+        quoteId: prepared.quoteId,
+      },
     };
 
     melt.prepare.mockResolvedValue(prepared);


### PR DESCRIPTION
This pull request resolves #201 by changing melt operation preparation to accept canonical melt quote refs, while deriving operation method data from stored canonical quote state.

## Problem

Melt prepare still accepted loose `mintUrl`, `method`, `quoteId`, and `unit` inputs after quote identity moved to canonical `{ mintUrl, quoteId }` lookup. That kept method and quote-derived data duplicated at the public operation boundary.

## Summary

- Refactors `MeltOpsApi.prepare` to accept `{ quote }` for BOLT quotes and `{ quote, feeIndex }` for onchain quotes.
- Adds melt quote-ref prepare resolution with identity re-read and `QuoteIdentityConflictError` on method mismatch.
- Requires explicit onchain `feeIndex` at runtime and before operation creation.
- Updates adapter test helpers, React hook fixtures, docs examples, and adds a changeset.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MeltQuote.test.ts test/unit/MeltOpsApi.test.ts test/unit/MeltOperationService.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-core' build`
- `(cd packages/core && bun run typecheck)`
- `(cd packages/react && bun run typecheck)`
- `(cd packages/react && bun run test -- src/lib/hooks/operationHooks.test.tsx)`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run docs:build`

Full core `test` was attempted, but integration tests require `MINT_URL`/auth env and reachable test mints, so that command failed for environment/network reasons.

## Changeset

- Added `.changeset/melt-prepare-quote-refs.md` for core/react major changes and adapter-tests patch.