### PR TITLE
feat: update quote operation query APIs

### DIFF
--- a/.changeset/quote-operation-queries.md
+++ b/.changeset/quote-operation-queries.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': major
+---
+
+Update quote-backed operation query APIs to use `QuoteIdentity` object inputs, remove
+`MintOpsApi.getByQuote`, and resolve melt operation lookup through canonical quote identity.

--- a/.changeset/react-quote-operation-queries.md
+++ b/.changeset/react-quote-operation-queries.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-react': major
+---
+
+Update operation hooks for quote identity query APIs and remove the mint operation
+`getByQuote` hook helper.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -1310,7 +1310,6 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         const byQuote = await mgr!.ops.melt.getByQuote({
           mintUrl,
-          method: 'bolt11',
           quoteId: prepared.quoteId,
         });
         expect(byQuote?.id).toBe(prepared.id);
@@ -1400,7 +1399,6 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
 
         const byQuote = await mgr!.ops.melt.getByQuote({
           mintUrl,
-          method: 'bolt11',
           quoteId: prepared.quoteId,
         });
         expect(byQuote?.id).toBeDefined();
@@ -1488,7 +1486,6 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
       it('should return null when resolving a missing melt quote', async () => {
         const missingOperation = await mgr!.ops.melt.getByQuote({
           mintUrl,
-          method: 'bolt11',
           quoteId: 'missing-quote',
         });
         expect(missingOperation).toBe(null);

--- a/packages/core/api/MeltOpsApi.ts
+++ b/packages/core/api/MeltOpsApi.ts
@@ -5,7 +5,7 @@ import type {
   PreparedMeltOperation,
 } from '@core/operations/melt';
 import type { MeltMethod, MeltOperationService } from '@core/operations/melt';
-import type { MeltQuoteRef } from '../models/QuoteIdentity.ts';
+import type { MeltQuoteRef, QuoteIdentity } from '../models/QuoteIdentity.ts';
 
 /** Melt methods supported by the default `Manager` wiring. */
 export type DefaultSupportedMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
@@ -15,17 +15,6 @@ export type PrepareMeltInput<TSupported extends MeltMethod = DefaultSupportedMel
     /** Existing canonical melt quote or structural quote reference. */
     quote: MeltQuoteRef<M>;
   } & (M extends 'onchain' ? { feeIndex: number } : { feeIndex?: number });
-}[TSupported];
-
-export type GetMeltByQuoteInput<TSupported extends MeltMethod = DefaultSupportedMeltMethod> = {
-  [M in TSupported]: {
-    /** Mint that owns the melt operation. */
-    mintUrl: string;
-    /** Melt method to resolve, for example `bolt11`. */
-    method: M;
-    /** Canonical melt quote ID. */
-    quoteId: string;
-  };
 }[TSupported];
 
 export interface MeltRecoveryApi {
@@ -97,18 +86,14 @@ export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMeth
     return this.meltOperationService.getOperation(operationId);
   }
 
-  /** Returns a melt operation by mint URL, method, and quote ID, or `null` if not found. */
-  async getByQuote(input: GetMeltByQuoteInput<TSupported>): Promise<MeltOperation | null> {
-    return this.meltOperationService.getOperationByQuote(
-      input.mintUrl,
-      input.method,
-      input.quoteId,
-    );
+  /** Returns the tracked melt operation for a canonical quote identity, or `null`. */
+  async getByQuote(input: QuoteIdentity): Promise<MeltOperation | null> {
+    return this.meltOperationService.getOperationByQuoteIdentity(input);
   }
 
   /** Lists melt operations for a mint URL and quote ID. */
-  async listByQuote(mintUrl: string, quoteId: string): Promise<MeltOperation[]> {
-    return this.meltOperationService.listOperationsByQuote(mintUrl, quoteId);
+  async listByQuote(input: QuoteIdentity): Promise<MeltOperation[]> {
+    return this.meltOperationService.listOperationsByQuote(input.mintUrl, input.quoteId);
   }
 
   /** Lists melt operations that are prepared and ready to execute or cancel. */

--- a/packages/core/api/MintOpsApi.ts
+++ b/packages/core/api/MintOpsApi.ts
@@ -6,7 +6,7 @@ import type {
   PendingMintCheckResult,
   PendingMintOperation,
 } from '@core/operations/mint';
-import type { MintQuoteRef } from '../models/QuoteIdentity.ts';
+import type { MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity.ts';
 
 /** Mint methods supported by the default `Manager` wiring. */
 export type DefaultSupportedMintMethod = 'bolt11' | 'onchain' | 'bolt12';
@@ -17,17 +17,6 @@ export type PrepareMintInput<TSupported extends MintMethod = DefaultSupportedMin
   /** Amount to mint using the canonical quote's stored unit. */
   amount: AmountLike;
 };
-
-export type GetMintByQuoteInput<TSupported extends MintMethod = DefaultSupportedMintMethod> = {
-  [M in TSupported]: {
-    /** Mint that owns the mint operation. */
-    mintUrl: string;
-    /** Mint method to resolve, for example `bolt11`. */
-    method: M;
-    /** Canonical mint quote ID. */
-    quoteId: string;
-  };
-}[TSupported];
 
 export interface MintRecoveryApi {
   /** Runs the startup-style recovery sweep for mint operations. */
@@ -87,18 +76,9 @@ export class MintOpsApi<TSupported extends MintMethod = DefaultSupportedMintMeth
     return this.mintOperationService.getOperation(operationId);
   }
 
-  /** Returns a mint operation by mint URL, method, and quote ID, or `null` if not found. */
-  async getByQuote(input: GetMintByQuoteInput<TSupported>): Promise<MintOperation | null> {
-    return this.mintOperationService.getOperationByQuote(
-      input.mintUrl,
-      input.method,
-      input.quoteId,
-    );
-  }
-
   /** Lists mint operations for a mint URL and quote ID. */
-  async listByQuote(mintUrl: string, quoteId: string): Promise<MintOperation[]> {
-    return this.mintOperationService.listOperationsByQuote(mintUrl, quoteId);
+  async listByQuote(input: QuoteIdentity): Promise<MintOperation[]> {
+    return this.mintOperationService.listOperationsByQuote(input.mintUrl, input.quoteId);
   }
 
   /** Lists mint operations that are pending redemption or remote settlement. */

--- a/packages/core/operations/melt/MeltOperationService.ts
+++ b/packages/core/operations/melt/MeltOperationService.ts
@@ -34,7 +34,7 @@ import { OperationIdLock } from '../OperationIdLock';
 import { DEFAULT_UNIT, normalizeUnit } from '../../amounts.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 import { resolveOnchainMeltFeeOption, type MeltQuote } from '../../models/MeltQuote.ts';
-import type { MeltQuoteRef } from '../../models/QuoteIdentity.ts';
+import type { MeltQuoteRef, QuoteIdentity } from '../../models/QuoteIdentity.ts';
 
 /**
  * MeltOperationService orchestrates melt sagas while delegating
@@ -884,6 +884,30 @@ export class MeltOperationService {
     }
 
     return matching[0]!;
+  }
+
+  async getOperationByQuoteIdentity(identity: QuoteIdentity): Promise<MeltOperation | null> {
+    const quote = await this.quoteLifecycle.getMeltQuoteById(identity);
+    if (!quote) {
+      return null;
+    }
+
+    const operations = await this.meltOperationRepository.getByQuoteId(
+      normalizeMintUrl(quote.mintUrl),
+      quote.quoteId,
+    );
+
+    if (operations.length === 0) {
+      return null;
+    }
+
+    if (operations.length > 1) {
+      throw new Error(
+        `Found ${operations.length} melt operations for mint ${quote.mintUrl} and quote ${quote.quoteId}`,
+      );
+    }
+
+    return operations[0]!;
   }
 
   async listOperationsByQuote(mintUrl: string, quoteId: string): Promise<MeltOperation[]> {

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -1094,10 +1094,7 @@ describe('MeltOperationService', () => {
 
     it('throws by quote identity when multiple operations are tracked', async () => {
       const mockedRepository = {
-        getByQuoteId: mock(async () => [
-          makeInitOp('op-dupe-1'),
-          makeInitOp('op-dupe-2'),
-        ]),
+        getByQuoteId: mock(async () => [makeInitOp('op-dupe-1'), makeInitOp('op-dupe-2')]),
       } as unknown as MeltOperationRepository;
       const duplicateService = new MeltOperationService(
         handlerProvider,

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -13,6 +13,7 @@ import type { Logger } from '../../logging/Logger.ts';
 import type { MeltHandlerProvider } from '../../infra/handlers/melt/index.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import type { CoreProof } from '../../types.ts';
+import type { MeltOperationRepository } from '../../repositories/index.ts';
 import { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 import type {
   InitMeltOperation,
@@ -1042,6 +1043,78 @@ describe('MeltOperationService', () => {
       const operation = await service.getOperationByQuote(mintUrl, 'bolt11', 'missing-quote');
 
       expect(operation).toBeNull();
+    });
+
+    it('returns tracked init operations by canonical quote identity', async () => {
+      const init = makeInitOp('op-init-query');
+      await meltOperationRepository.create(init);
+
+      const operation = await service.getOperationByQuoteIdentity({
+        mintUrl,
+        quoteId: init.quoteId!,
+      });
+
+      expect(operation?.id).toBe(init.id);
+      expect(operation?.state).toBe('init');
+    });
+
+    it('returns tracked early-failed init operations by canonical quote identity', async () => {
+      const init = makeInitOp('op-init-failed-query', { error: 'prepare failed' });
+      await meltOperationRepository.create(init);
+
+      const operation = await service.getOperationByQuoteIdentity({
+        mintUrl,
+        quoteId: init.quoteId!,
+      });
+
+      expect(operation?.id).toBe(init.id);
+      expect(operation?.state).toBe('init');
+      expect(operation?.error).toBe('prepare failed');
+    });
+
+    it('returns null by quote identity when no canonical quote exists', async () => {
+      const operation = await service.getOperationByQuoteIdentity({
+        mintUrl,
+        quoteId: 'missing-quote',
+      });
+
+      expect(operation).toBeNull();
+    });
+
+    it('returns null by quote identity when no operation is tracked', async () => {
+      await persistMeltQuote('untracked-quote');
+
+      const operation = await service.getOperationByQuoteIdentity({
+        mintUrl,
+        quoteId: 'untracked-quote',
+      });
+
+      expect(operation).toBeNull();
+    });
+
+    it('throws by quote identity when multiple operations are tracked', async () => {
+      const mockedRepository = {
+        getByQuoteId: mock(async () => [
+          makeInitOp('op-dupe-1'),
+          makeInitOp('op-dupe-2'),
+        ]),
+      } as unknown as MeltOperationRepository;
+      const duplicateService = new MeltOperationService(
+        handlerProvider,
+        mockedRepository,
+        quoteLifecycle,
+        proofRepository,
+        proofService,
+        mintService,
+        walletService,
+        mintAdapter,
+        eventBus,
+        logger,
+      );
+
+      await expect(
+        duplicateService.getOperationByQuoteIdentity({ mintUrl, quoteId: 'quote-1' }),
+      ).rejects.toThrow('Found 2 melt operations');
     });
 
     it('rejects repository writes when multiple operations share a quote id', async () => {

--- a/packages/core/test/unit/MeltOpsApi.test.ts
+++ b/packages/core/test/unit/MeltOpsApi.test.ts
@@ -52,13 +52,14 @@ type _AssertOnchainRequiresFeeIndex = Assert<
 type _AssertBoltFeeIndexOptional = Assert<
   Bolt11PrepareMeltInput extends { feeIndex?: number } ? true : false
 >;
-type _AssertListByQuoteUsesMintAndQuoteArgs = Assert<
-  Parameters<MeltOpsApi['listByQuote']> extends [string, string] ? true : false
+type _AssertListByQuoteUsesQuoteIdentity = Assert<
+  Parameters<MeltOpsApi['listByQuote']> extends [{ mintUrl: string; quoteId: string }]
+    ? true
+    : false
 >;
 type _AssertGetByQuoteUsesObjectInput = Assert<
   GetMeltByQuoteInput extends {
     mintUrl: string;
-    method: 'bolt11' | 'bolt12' | 'onchain';
     quoteId: string;
   }
     ? true
@@ -116,7 +117,7 @@ describe('MeltOpsApi', () => {
       prepare: mock(async () => preparedOperation),
       execute: mock(async () => pendingOperation),
       getOperation: mock(async () => preparedOperation),
-      getOperationByQuote: mock(async () => preparedOperation),
+      getOperationByQuoteIdentity: mock(async () => preparedOperation),
       listOperationsByQuote: mock(async () => [preparedOperation]),
       prepareExistingQuote: mock(async () => preparedOperation),
       getPreparedOperations: mock(async () => [preparedOperation]),
@@ -208,20 +209,18 @@ describe('MeltOpsApi', () => {
   it('getByQuote forwards to the service', async () => {
     const result = await api.getByQuote({
       mintUrl,
-      method: 'bolt11',
       quoteId: preparedOperation.quoteId,
     });
 
-    expect(meltOperationService.getOperationByQuote).toHaveBeenCalledWith(
+    expect(meltOperationService.getOperationByQuoteIdentity).toHaveBeenCalledWith({
       mintUrl,
-      'bolt11',
-      preparedOperation.quoteId,
-    );
+      quoteId: preparedOperation.quoteId,
+    });
     expect(result).toBe(preparedOperation);
   });
 
   it('listByQuote forwards to the service', async () => {
-    const result = await api.listByQuote(mintUrl, preparedOperation.quoteId);
+    const result = await api.listByQuote({ mintUrl, quoteId: preparedOperation.quoteId });
 
     expect(meltOperationService.listOperationsByQuote).toHaveBeenCalledWith(
       mintUrl,

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -16,7 +16,6 @@ const quoteId = 'quote-1';
 
 type Assert<T extends true> = T;
 type PrepareMintInput = Parameters<MintOpsApi['prepare']>[0];
-type GetMintByQuoteInput = Parameters<MintOpsApi['getByQuote']>[0];
 type _AssertPrepareAcceptsQuoteRef = Assert<
   PrepareMintInput extends {
     quote: {
@@ -36,12 +35,9 @@ type _AssertPrepareOmitsLooseUnit = Assert<'unit' extends keyof PrepareMintInput
 type _AssertPrepareOmitsMethodData = Assert<
   'methodData' extends keyof PrepareMintInput ? false : true
 >;
-type _AssertGetByQuoteUsesObjectInput = Assert<
-  GetMintByQuoteInput extends {
-    mintUrl: string;
-    method: 'bolt11' | 'onchain' | 'bolt12';
-    quoteId: string;
-  }
+type _AssertGetByQuoteRemoved = Assert<'getByQuote' extends keyof MintOpsApi ? false : true>;
+type _AssertListByQuoteUsesQuoteIdentity = Assert<
+  Parameters<MintOpsApi['listByQuote']> extends [{ mintUrl: string; quoteId: string }]
     ? true
     : false
 >;
@@ -186,7 +182,7 @@ describe('MintOpsApi', () => {
 
   it('get and listByQuote delegate to the service', async () => {
     const operation = await api.get(pendingOperation.id);
-    const operations = await api.listByQuote(mintUrl, quoteId);
+    const operations = await api.listByQuote({ mintUrl, quoteId });
 
     expect(mintOperationService.getOperation).toHaveBeenCalledWith(pendingOperation.id);
     expect(mintOperationService.listOperationsByQuote).toHaveBeenCalledWith(mintUrl, quoteId);
@@ -202,21 +198,6 @@ describe('MintOpsApi', () => {
     expect(mintOperationService.getInFlightOperations).toHaveBeenCalledWith();
     expect(pending).toEqual([pendingOperation]);
     expect(inFlight).toHaveLength(2);
-  });
-
-  it('getByQuote forwards object input to the service', async () => {
-    const result = await api.getByQuote({
-      mintUrl,
-      method: 'bolt11',
-      quoteId: pendingOperation.quoteId,
-    });
-
-    expect(mintOperationService.getOperationByQuote).toHaveBeenCalledWith(
-      mintUrl,
-      'bolt11',
-      pendingOperation.quoteId,
-    );
-    expect(result).toBe(pendingOperation);
   });
 
   it('checkPayment only allows pending operations', async () => {

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -178,7 +178,6 @@ function createMintManagerMock() {
     prepare: vi.fn(),
     execute: vi.fn(),
     get: vi.fn(),
-    getByQuote: vi.fn(),
     listByQuote: vi.fn(),
     listPending: vi.fn(),
     listInFlight: vi.fn(),
@@ -1043,19 +1042,13 @@ describe('useMintOperation', () => {
     expect(result.current.currentOperation).toEqual(pending);
   });
 
-  it('passes BOLT12 mint inputs and quote lookup helpers through without rebinding', async () => {
+  it('passes BOLT12 mint inputs and quote list helpers through without rebinding', async () => {
     const { manager, mint } = createMintManagerMock();
     const prepared = createPendingMintOperation({
       method: 'bolt12',
       methodData: {},
       quoteId: 'shared-mint-quote',
       request: 'lno1mintoffer',
-    });
-    const latest = createPendingMintOperation({
-      id: 'mint-op-latest',
-      method: 'bolt12',
-      quoteId: prepared.quoteId,
-      updatedAt: prepared.updatedAt + 1,
     });
 
     const input: MintOperationPrepareInput = {
@@ -1068,8 +1061,7 @@ describe('useMintOperation', () => {
     };
 
     mint.prepare.mockResolvedValue(prepared);
-    mint.getByQuote.mockResolvedValue(latest);
-    mint.listByQuote.mockResolvedValue([prepared, latest]);
+    mint.listByQuote.mockResolvedValue([prepared]);
 
     const { result } = renderHook(() => useMintOperation(), {
       wrapper: createHookWrapper(manager),
@@ -1079,22 +1071,17 @@ describe('useMintOperation', () => {
       await result.current.prepare(input);
     });
 
-    const byQuote = await result.current.getByQuote({
+    const listByQuote = await result.current.listByQuote({
       mintUrl: MINT_URL,
-      method: 'bolt12',
       quoteId: prepared.quoteId,
     });
-    const listByQuote = await result.current.listByQuote(MINT_URL, prepared.quoteId);
 
     expect(mint.prepare).toHaveBeenCalledWith(input);
-    expect(mint.getByQuote).toHaveBeenCalledWith({
+    expect(mint.listByQuote).toHaveBeenCalledWith({
       mintUrl: MINT_URL,
-      method: 'bolt12',
       quoteId: prepared.quoteId,
     });
-    expect(mint.listByQuote).toHaveBeenCalledWith(MINT_URL, prepared.quoteId);
-    expect(byQuote).toEqual(latest);
-    expect(listByQuote).toEqual([prepared, latest]);
+    expect(listByQuote).toEqual([prepared]);
     expect(result.current.currentOperation).toEqual(prepared);
   });
 
@@ -1396,18 +1383,22 @@ describe('useMeltOperation', () => {
 
     const byQuote = await result.current.getByQuote({
       mintUrl: MINT_URL,
-      method: 'bolt12',
       quoteId: prepared.quoteId,
     });
-    const listByQuote = await result.current.listByQuote(MINT_URL, prepared.quoteId);
+    const listByQuote = await result.current.listByQuote({
+      mintUrl: MINT_URL,
+      quoteId: prepared.quoteId,
+    });
 
     expect(melt.prepare).toHaveBeenCalledWith(input);
     expect(melt.getByQuote).toHaveBeenCalledWith({
       mintUrl: MINT_URL,
-      method: 'bolt12',
       quoteId: prepared.quoteId,
     });
-    expect(melt.listByQuote).toHaveBeenCalledWith(MINT_URL, prepared.quoteId);
+    expect(melt.listByQuote).toHaveBeenCalledWith({
+      mintUrl: MINT_URL,
+      quoteId: prepared.quoteId,
+    });
     expect(byQuote).toEqual(latest);
     expect(listByQuote).toEqual([prepared, latest]);
     expect(result.current.currentOperation).toEqual(prepared);

--- a/packages/react/src/lib/hooks/useMeltOperation.ts
+++ b/packages/react/src/lib/hooks/useMeltOperation.ts
@@ -20,6 +20,7 @@ export type MeltOperationPrepareResult = Awaited<ReturnType<MeltOps['prepare']>>
 export type MeltOperationExecuteResult = Awaited<ReturnType<MeltOps['execute']>>;
 export type MeltOperationByQuoteInput = Parameters<MeltOps['getByQuote']>[0];
 export type MeltOperationByQuoteResult = Awaited<ReturnType<MeltOps['getByQuote']>>;
+export type MeltOperationListByQuoteInput = Parameters<MeltOps['listByQuote']>[0];
 export type MeltOperationListByQuoteResult = Awaited<ReturnType<MeltOps['listByQuote']>>;
 
 export interface UseMeltOperationResult extends OperationHookResult<
@@ -32,7 +33,7 @@ export interface UseMeltOperationResult extends OperationHookResult<
   reclaim(): Promise<void>;
   finalize(): Promise<void>;
   getByQuote(input: MeltOperationByQuoteInput): Promise<MeltOperationByQuoteResult>;
-  listByQuote(mintUrl: string, quoteId: string): Promise<MeltOperationListByQuoteResult>;
+  listByQuote(input: MeltOperationListByQuoteInput): Promise<MeltOperationListByQuoteResult>;
   listPrepared(): Promise<MeltOperationPrepareResult[]>;
   listInFlight(): Promise<MeltOperation[]>;
 }
@@ -227,8 +228,8 @@ export function useMeltOperation(
   );
 
   const listByQuote = useCallback(
-    async (mintUrl: string, quoteId: string): Promise<MeltOperationListByQuoteResult> => {
-      return manager.ops.melt.listByQuote(mintUrl, quoteId);
+    async (input: MeltOperationListByQuoteInput): Promise<MeltOperationListByQuoteResult> => {
+      return manager.ops.melt.listByQuote(input);
     },
     [manager],
   );

--- a/packages/react/src/lib/hooks/useMintOperation.ts
+++ b/packages/react/src/lib/hooks/useMintOperation.ts
@@ -21,8 +21,7 @@ export type MintOperationPrepareResult = Awaited<ReturnType<MintOps['prepare']>>
 export type MintOperationExecuteResult = Awaited<ReturnType<MintOps['execute']>>;
 export type MintOperationCheckPaymentResult = Awaited<ReturnType<MintOps['checkPayment']>>;
 export type MintOperationFinalizeResult = Awaited<ReturnType<MintOps['finalize']>>;
-export type MintOperationByQuoteInput = Parameters<MintOps['getByQuote']>[0];
-export type MintOperationByQuoteResult = Awaited<ReturnType<MintOps['getByQuote']>>;
+export type MintOperationListByQuoteInput = Parameters<MintOps['listByQuote']>[0];
 export type MintOperationListByQuoteResult = Awaited<ReturnType<MintOps['listByQuote']>>;
 export type MintOperationPendingList = Awaited<ReturnType<MintOps['listPending']>>;
 
@@ -34,8 +33,7 @@ export interface UseMintOperationResult extends OperationHookResult<
   execute(): Promise<MintOperationExecuteResult>;
   checkPayment(): Promise<MintOperationCheckPaymentResult>;
   finalize(): Promise<MintOperationFinalizeResult>;
-  getByQuote(input: MintOperationByQuoteInput): Promise<MintOperationByQuoteResult>;
-  listByQuote(mintUrl: string, quoteId: string): Promise<MintOperationListByQuoteResult>;
+  listByQuote(input: MintOperationListByQuoteInput): Promise<MintOperationListByQuoteResult>;
   listPending(): Promise<MintOperationPendingList>;
   listInFlight(): Promise<MintOperation[]>;
 }
@@ -201,16 +199,9 @@ export function useMintOperation(
     );
   }, [bindOperation, getCurrentOperation, manager, runStatefulAction]);
 
-  const getByQuote = useCallback(
-    async (input: MintOperationByQuoteInput): Promise<MintOperationByQuoteResult> => {
-      return manager.ops.mint.getByQuote(input);
-    },
-    [manager],
-  );
-
   const listByQuote = useCallback(
-    async (mintUrl: string, quoteId: string): Promise<MintOperationListByQuoteResult> => {
-      return manager.ops.mint.listByQuote(mintUrl, quoteId);
+    async (input: MintOperationListByQuoteInput): Promise<MintOperationListByQuoteResult> => {
+      return manager.ops.mint.listByQuote(input);
     },
     [manager],
   );
@@ -240,7 +231,6 @@ export function useMintOperation(
     execute,
     checkPayment,
     finalize,
-    getByQuote,
     listByQuote,
     listPending,
     listInFlight,


### PR DESCRIPTION
## Description

This pull request updates quote-backed operation query APIs to use canonical `QuoteIdentity` object inputs. This pull request resolves #202.

## Problem

Quote operation queries still exposed method-sibling or positional quote identity parameters, and mint exposed an ambiguous single-result `getByQuote` API even though reusable mint quotes can track multiple operations.

## Summary

- Removes public `MintOpsApi.getByQuote` and changes mint/melt `listByQuote` to accept `{ mintUrl, quoteId }`.
- Changes public melt `getByQuote` to resolve canonical quote identity and return tracked operations in any state, including init/early-failed init.
- Updates React operation hooks, adapter integration usage, and public API/service tests.
- Adds major changesets for `@cashu/coco-core` and `@cashu/coco-react`.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit -- test/unit/MintOpsApi.test.ts test/unit/MeltOpsApi.test.ts test/unit/MeltOperationService.test.ts`
- `bun run test -- src/lib/hooks/operationHooks.test.tsx` in `packages/react`
- `bun run typecheck`
- `bun run --filter='@cashu/coco-react' lint`
- `bun run build`
- `git diff --check master..HEAD`

## Changeset

- Added `.changeset/quote-operation-queries.md`
- Added `.changeset/react-quote-operation-queries.md`