### PR TITLE
docs: refresh v2 quote workflow examples

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -199,7 +199,7 @@ In-memory reference implementations are provided under `repositories/memory/` fo
   `refresh`, `cancel`, `reclaim`, plus `recovery` and `diagnostics`
 - `receive`: `prepare`, `execute`, `get`, `listPrepared`, `listInFlight`,
   `refresh`, `cancel`, plus `recovery` and `diagnostics`
-- `mint`: `prepare`, `execute`, `get`, `getByQuote`, `listByQuote`,
+- `mint`: `prepare`, `execute`, `get`, `listByQuote`,
   `listPending`, `listInFlight`, `checkPayment`, `refresh`, `finalize`, plus
   `recovery` and `diagnostics`. Built-in methods: `bolt11`, `onchain`,
   `bolt12`.
@@ -207,6 +207,32 @@ In-memory reference implementations are provided under `repositories/memory/` fo
   `listPrepared`, `listInFlight`, `refresh`, `cancel`, `reclaim`, `finalize`,
   plus `recovery` and `diagnostics`. Built-in methods: `bolt11`, `bolt12`,
   `onchain`.
+
+Mint and melt quote lookups use `QuoteIdentity`, the methodless object shape
+`{ mintUrl, quoteId }`:
+
+```ts
+const mintIdentity = { mintUrl: mintQuote.mintUrl, quoteId: mintQuote.quoteId };
+
+await manager.quotes.mint.get(mintIdentity);
+await manager.quotes.mint.refresh(mintIdentity);
+await manager.ops.mint.listByQuote(mintIdentity);
+
+const meltIdentity = { mintUrl: meltQuote.mintUrl, quoteId: meltQuote.quoteId };
+
+await manager.quotes.melt.get(meltIdentity);
+await manager.quotes.melt.refresh(meltIdentity);
+await manager.ops.melt.getByQuote(meltIdentity);
+await manager.ops.melt.listByQuote(meltIdentity);
+```
+
+Operation preparation accepts structural quote refs. `MintQuoteRef` and
+`MeltQuoteRef` are `{ mintUrl, quoteId, method }`, and full canonical quote
+objects already satisfy those types. Mint prepare uses
+`prepare({ quote, amount })`; BOLT melt prepare uses `prepare({ quote })`; and
+onchain melt prepare uses `prepare({ quote, feeIndex })`. Public operation
+prepare inputs do not accept sibling `unit`, `method`, or `methodData` fields;
+those details are derived from canonical quote storage.
 
 ### MintApi
 

--- a/packages/docs/pages/melt-operations.md
+++ b/packages/docs/pages/melt-operations.md
@@ -18,7 +18,8 @@ The canonical API is exposed through `coco.ops.melt`:
 - `prepare({ quote })` prepares a BOLT11 or BOLT12 operation from a canonical melt quote or quote ref
 - `prepare({ quote, feeIndex })` prepares an onchain melt from a canonical NUT-30 quote or quote ref
 - `execute(operationOrId)` executes the prepared operation
-- `getByQuote({ mintUrl, method, quoteId })` resolves an operation from a persisted quote id
+- `getByQuote({ mintUrl, quoteId })` resolves an operation from a persisted quote identity
+- `listByQuote({ mintUrl, quoteId })` lists operations for a persisted quote identity
 - `refresh(operationId)` checks a pending melt and returns the latest operation state
 - `cancel(operationId)` cancels a prepared melt
 - `reclaim(operationId)` reclaims a pending melt when rollback is allowed
@@ -33,6 +34,25 @@ preparing a melt operation:
 - `listPending({ method? })` lists canonical quote rows that have not reached `PAID`
 - `refresh({ mintUrl, quoteId })` checks the remote quote state and persists
   the canonical quote update
+
+## Quote Identity and Refs
+
+`QuoteIdentity` is the methodless lookup shape `{ mintUrl, quoteId }`. Use it
+for canonical quote get/refresh calls and quote-based operation queries:
+
+```ts
+const quoteIdentity = { mintUrl, quoteId: quote.quoteId };
+
+const currentQuote = await coco.quotes.melt.get(quoteIdentity);
+const refreshedQuote = await coco.quotes.melt.refresh(quoteIdentity);
+const operation = await coco.ops.melt.getByQuote(quoteIdentity);
+const operations = await coco.ops.melt.listByQuote(quoteIdentity);
+```
+
+Operation preparation accepts a `MeltQuoteRef`, which is structurally
+`{ mintUrl, quoteId, method }`. Full canonical melt quote objects already
+satisfy that ref type, so pass the quote object directly. BOLT11 and BOLT12
+prepare calls use only `{ quote }`; onchain prepare also requires `feeIndex`.
 
 ## Operation States
 

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -21,7 +21,7 @@ The operation lifecycle API is exposed through `coco.ops.mint`:
   stored state
 - `finalize(operationId)` executes or recovers the operation until it reaches a
   terminal state when possible
-- `get(operationId)`, `getByQuote({ mintUrl, method, quoteId })`, `listPending()`, and
+- `get(operationId)`, `listByQuote({ mintUrl, quoteId })`, `listPending()`, and
   `listInFlight()` load persisted operation state. Use `operationId` for local
   operation identity; a `quoteId` is remote quote identity and can be shared by
   more than one local operation.
@@ -29,6 +29,42 @@ The operation lifecycle API is exposed through `coco.ops.mint`:
 Built-in mint methods are `bolt11`, `onchain`, and `bolt12`. Public quote
 lookups use `{ mintUrl, quoteId }`; operation preparation accepts the full
 canonical quote or a structural quote ref with `{ mintUrl, quoteId, method }`.
+The old single-operation quote lookup was removed because reusable quotes can
+back multiple mint operations; use `listByQuote({ mintUrl, quoteId })` instead.
+
+## Quote Identity and Refs
+
+`QuoteIdentity` is the methodless lookup shape `{ mintUrl, quoteId }`. Use it
+for canonical quote get/refresh calls and for quote-based operation queries:
+
+```ts
+const quoteIdentity = { mintUrl, quoteId: quote.quoteId };
+
+const currentQuote = await coco.quotes.mint.get(quoteIdentity);
+const refreshedQuote = await coco.quotes.mint.refresh(quoteIdentity);
+const operations = await coco.ops.mint.listByQuote(quoteIdentity);
+```
+
+Operation preparation accepts a `MintQuoteRef`, which is structurally
+`{ mintUrl, quoteId, method }`. Full canonical mint quote objects already
+satisfy that ref type, so pass the quote object directly:
+
+```ts
+const quote = await coco.quotes.mint.create({
+  mintUrl,
+  amount: 100,
+  method: 'bolt11',
+});
+
+const pending = await coco.ops.mint.prepare({
+  quote,
+  amount: 100,
+});
+```
+
+`prepare({ quote, amount })` derives the quote unit, method data, and request
+details from canonical quote storage. Do not pass public `unit`, `method`, or
+`methodData` siblings to mint operation prepare.
 
 ## Quote Resurfacing (`coco.quotes.mint`)
 

--- a/packages/docs/starting/melting.md
+++ b/packages/docs/starting/melting.md
@@ -42,14 +42,16 @@ For newly finalized melts, `changeAmount` and `effectiveFee` show the actual set
 ## Resume by quote
 
 ```ts
-const operation = await coco.ops.melt.getByQuote({ mintUrl, method: 'bolt11', quoteId });
+const operation = await coco.ops.melt.getByQuote({ mintUrl, quoteId });
 
 if (operation) {
   const result = await coco.ops.melt.execute(operation.id);
 }
 ```
 
-Use this when you only persisted the quote id (for example after a restart).
+Use this when you persisted the quote identity but not the operation id. Quote
+identity is `{ mintUrl, quoteId }`; the stored canonical quote supplies the
+method.
 
 ## Pay a BOLT12 offer
 
@@ -68,8 +70,8 @@ const result = await coco.ops.melt.execute(prepared.id);
 ```
 
 `amountSats` is optional and is intended for amountless BOLT12 offers.
-Use `listByQuote(mintUrl, quoteId)` when a quote id may map to more than one
-operation.
+Use `listByQuote({ mintUrl, quoteId })` when a quote id may map to more than
+one operation.
 
 ## Pay an onchain address
 

--- a/packages/docs/starting/migrating-from-v1.md
+++ b/packages/docs/starting/migrating-from-v1.md
@@ -32,7 +32,8 @@ For BOLT11 quotes, the invoice is exposed as `quote.request`.
 
 Store quote identity as `{ mintUrl, quoteId }`. `quoteId` is no longer a
 sufficient lookup key on its own, and it should not be treated as an operation
-id.
+id. Full canonical quote objects structurally satisfy the operation quote ref
+types because they include `{ mintUrl, quoteId, method }`.
 
 TypeScript supported-method generics were removed from the quote API facade and
 input aliases. Use the concrete `QuoteApi`, `MintQuoteApi`, `MeltQuoteApi`,
@@ -42,9 +43,9 @@ passing method subset type parameters such as `QuoteApi<'bolt11'>` or
 
 ## Mint quote migration
 
-`manager.ops.mint.prepare({ mintUrl, amount, unit?, method })` no longer creates
-a remote quote. Create the canonical quote first, then prepare the operation
-from that quote with `prepare({ quote, amount })`:
+Mint operation prepare no longer creates a remote quote. Create the canonical
+quote first, then prepare the operation from that quote with
+`prepare({ quote, amount })`:
 
 ```ts
 const quote = await manager.quotes.mint.create({
@@ -91,14 +92,6 @@ pass the invoice directly to `prepare()` must now create the canonical quote
 first:
 
 ```ts
-// before
-const prepared = await manager.ops.melt.prepare({
-  mintUrl,
-  method: 'bolt11',
-  methodData: { invoice },
-});
-
-// after
 const quote = await manager.quotes.melt.create({
   mintUrl,
   method: 'bolt11',
@@ -112,7 +105,9 @@ const prepared = await manager.ops.melt.prepare({
 
 `manager.ops.melt.prepare()` now reserves proofs and calculates fees from an
 existing canonical melt quote. Use `manager.ops.melt.getByQuote({ mintUrl,
-method, quoteId })` when resolving a melt operation by quote.
+quoteId })` when resolving a melt operation by quote identity. Use
+`manager.ops.melt.listByQuote({ mintUrl, quoteId })` when multiple tracked
+operations are possible.
 
 ## Quote events
 

--- a/packages/docs/starting/sending-receiving.md
+++ b/packages/docs/starting/sending-receiving.md
@@ -117,7 +117,8 @@ Use melt operations to pay BOLT11 invoices via `coco.ops.melt`:
 - `quotes.melt.create({ mintUrl, method: 'bolt11', methodData: { invoice } }): Promise<MeltQuote>`
 - `prepare({ quote }): Promise<PreparedMeltOperation>`
 - `execute(operationOrId): Promise<PendingMeltOperation | FinalizedMeltOperation>`
-- `getByQuote({ mintUrl, method, quoteId }): Promise<MeltOperation | null>`
+- `getByQuote({ mintUrl, quoteId }): Promise<MeltOperation | null>`
+- `listByQuote({ mintUrl, quoteId }): Promise<MeltOperation[]>`
 - `refresh(operationId: string): Promise<MeltOperation>`
 
 Finalized melt operations include `changeAmount` and `effectiveFee` when that settlement data is available.


### PR DESCRIPTION
## Description

This pull request updates the public docs and core README for the v2 quote identity workflow.

This pull request resolves #203.

## Problem

The docs still showed pre-refactor quote-backed operation APIs in a few places, including method-sibling quote lookups and stale mint quote operation lookup guidance.

## Summary

- Documents `QuoteIdentity`, `MintQuoteRef`, and `MeltQuoteRef`.
- Updates mint and melt operation examples to use canonical quote objects as `quote` refs.
- Replaces stale quote query examples with `{ mintUrl, quoteId }` inputs and removes the old mint single-operation lookup guidance.

## Verification

- `bun run docs:build`
- `git diff --check`
- Targeted stale-pattern `rg` checks for removed quote-backed operation forms.

## Changeset

- No changeset added; this is a docs/examples-only update.