### PR TITLE
refactor(sql): add shared SQL storage contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,13 @@
         "react": "^19",
       },
     },
+    "packages/sql-storage": {
+      "name": "@cashu/coco-sql-storage",
+      "version": "1.0.0",
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
     "packages/sqlite-bun": {
       "name": "@cashu/coco-sqlite-bun",
       "version": "1.0.0",
@@ -392,6 +399,8 @@
     "@cashu/coco-indexeddb": ["@cashu/coco-indexeddb@workspace:packages/indexeddb"],
 
     "@cashu/coco-react": ["@cashu/coco-react@workspace:packages/react"],
+
+    "@cashu/coco-sql-storage": ["@cashu/coco-sql-storage@workspace:packages/sql-storage"],
 
     "@cashu/coco-sqlite": ["@cashu/coco-sqlite@workspace:packages/sqlite3"],
 

--- a/packages/sql-storage/package.json
+++ b/packages/sql-storage/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@cashu/coco-sql-storage",
+  "version": "1.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cashubtc/coco",
+    "directory": "packages/sql-storage"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./test": {
+      "types": "./dist/test/index.d.ts",
+      "import": "./dist/test/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "sideEffects": false
+}

--- a/packages/sql-storage/src/env.d.ts
+++ b/packages/sql-storage/src/env.d.ts
@@ -1,0 +1,25 @@
+declare module 'bun:test' {
+  export function describe(name: string, fn: () => void): void;
+  export function it(name: string, fn: () => void | Promise<void>, timeout?: number): void;
+  export const expect: any;
+}
+
+declare module 'bun:sqlite' {
+  export interface StatementRunResult {
+    lastInsertRowid: number | bigint;
+    changes: number;
+  }
+
+  export class Statement {
+    run(...params: any[]): StatementRunResult;
+    get(...params: any[]): unknown;
+    all(...params: any[]): unknown[];
+  }
+
+  export class Database {
+    constructor(filename?: string);
+    prepare(sql: string): Statement;
+    exec(sql: string): void;
+    close(): void;
+  }
+}

--- a/packages/sql-storage/src/index.ts
+++ b/packages/sql-storage/src/index.ts
@@ -10,11 +10,11 @@ export interface SqlRunResult {
 export interface SqlDatabase {
   exec(sql: string): Promise<void>;
   run(sql: string, params?: SqlParams): Promise<SqlRunResult>;
-  get<Row extends Record<string, unknown> = Record<string, unknown>>(
+  get<Row extends object = Record<string, unknown>>(
     sql: string,
     params?: SqlParams,
   ): Promise<Row | undefined>;
-  all<Row extends Record<string, unknown> = Record<string, unknown>>(
+  all<Row extends object = Record<string, unknown>>(
     sql: string,
     params?: SqlParams,
   ): Promise<Row[]>;

--- a/packages/sql-storage/src/index.ts
+++ b/packages/sql-storage/src/index.ts
@@ -1,0 +1,22 @@
+export type SqlValue = string | number | bigint | Uint8Array | null;
+
+export type SqlParams = readonly SqlValue[];
+
+export interface SqlRunResult {
+  readonly lastInsertRowId: number;
+  readonly changes: number;
+}
+
+export interface SqlDatabase {
+  exec(sql: string): Promise<void>;
+  run(sql: string, params?: SqlParams): Promise<SqlRunResult>;
+  get<Row extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: SqlParams,
+  ): Promise<Row | undefined>;
+  all<Row extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: SqlParams,
+  ): Promise<Row[]>;
+  transaction<T>(fn: (tx: SqlDatabase) => Promise<T>): Promise<T>;
+}

--- a/packages/sql-storage/src/test/bunSqlDatabase.ts
+++ b/packages/sql-storage/src/test/bunSqlDatabase.ts
@@ -1,0 +1,148 @@
+import type { Database, Statement } from 'bun:sqlite';
+import type { SqlDatabase, SqlParams, SqlRunResult } from '../index.ts';
+
+interface BunSqlDatabaseRootState {
+  readonly database: Database;
+  readonly statementCache: Map<string, Statement>;
+  transactionQueue: Promise<void>;
+  currentScope: symbol | null;
+  scopeDepth: number;
+  pendingTransactionCount: number;
+}
+
+export class BunSqlDatabase implements SqlDatabase {
+  private readonly root: BunSqlDatabaseRootState;
+  private readonly scopeToken: symbol | null;
+
+  constructor(root: BunSqlDatabaseRootState, scopeToken: symbol | null = null) {
+    this.root = root;
+    this.scopeToken = scopeToken;
+  }
+
+  private getStatement(sql: string): Statement {
+    let statement = this.root.statementCache.get(sql);
+    if (!statement) {
+      statement = this.root.database.prepare(sql);
+      this.root.statementCache.set(sql, statement);
+    }
+
+    return statement;
+  }
+
+  private shouldWaitForTransaction(): boolean {
+    return (
+      this.root.pendingTransactionCount > 0 &&
+      (!this.scopeToken || this.root.currentScope !== this.scopeToken)
+    );
+  }
+
+  private async waitForActiveTransaction(): Promise<void> {
+    while (this.shouldWaitForTransaction()) {
+      await this.root.transactionQueue;
+    }
+  }
+
+  async exec(sql: string): Promise<void> {
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
+
+    this.root.database.exec(sql);
+  }
+
+  async run(sql: string, params: SqlParams = []): Promise<SqlRunResult> {
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
+
+    const result = this.getStatement(sql).run(...params);
+
+    return {
+      lastInsertRowId: Number(result.lastInsertRowid),
+      changes: result.changes,
+    };
+  }
+
+  async get<Row extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params: SqlParams = [],
+  ): Promise<Row | undefined> {
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
+
+    return (this.getStatement(sql).get(...params) ?? undefined) as Row | undefined;
+  }
+
+  async all<Row extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params: SqlParams = [],
+  ): Promise<Row[]> {
+    if (this.shouldWaitForTransaction()) {
+      await this.waitForActiveTransaction();
+    }
+
+    return this.getStatement(sql).all(...params) as Row[];
+  }
+
+  async transaction<T>(fn: (tx: SqlDatabase) => Promise<T>): Promise<T> {
+    const { root } = this;
+
+    if (this.scopeToken && root.currentScope === this.scopeToken) {
+      root.scopeDepth++;
+      try {
+        return await fn(this);
+      } finally {
+        root.scopeDepth--;
+      }
+    }
+
+    const scopeToken = Symbol('bun-sql-test-transaction');
+    const scopedDatabase = new BunSqlDatabase(root, scopeToken);
+    const previousTransaction = root.transactionQueue;
+    let releaseTransaction!: () => void;
+
+    root.transactionQueue = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    root.pendingTransactionCount++;
+
+    try {
+      await previousTransaction;
+
+      root.currentScope = scopeToken;
+      root.scopeDepth = 1;
+      await scopedDatabase.exec('BEGIN');
+
+      try {
+        const result = await fn(scopedDatabase);
+        await scopedDatabase.exec('COMMIT');
+        return result;
+      } catch (error) {
+        try {
+          await scopedDatabase.exec('ROLLBACK');
+        } catch {
+          // Ignore rollback errors so the original transaction error is preserved.
+        }
+
+        throw error;
+      }
+    } finally {
+      root.scopeDepth = 0;
+      root.currentScope = null;
+      root.pendingTransactionCount--;
+      releaseTransaction();
+    }
+  }
+}
+
+export function createBunSqlDatabase(database: Database): BunSqlDatabase {
+  return new BunSqlDatabase({
+    database,
+    statementCache: new Map(),
+    transactionQueue: Promise.resolve(),
+    currentScope: null,
+    scopeDepth: 0,
+    pendingTransactionCount: 0,
+  });
+}

--- a/packages/sql-storage/src/test/bunSqlDatabase.ts
+++ b/packages/sql-storage/src/test/bunSqlDatabase.ts
@@ -63,7 +63,7 @@ export class BunSqlDatabase implements SqlDatabase {
     };
   }
 
-  async get<Row extends Record<string, unknown> = Record<string, unknown>>(
+  async get<Row extends object = Record<string, unknown>>(
     sql: string,
     params: SqlParams = [],
   ): Promise<Row | undefined> {
@@ -74,7 +74,7 @@ export class BunSqlDatabase implements SqlDatabase {
     return (this.getStatement(sql).get(...params) ?? undefined) as Row | undefined;
   }
 
-  async all<Row extends Record<string, unknown> = Record<string, unknown>>(
+  async all<Row extends object = Record<string, unknown>>(
     sql: string,
     params: SqlParams = [],
   ): Promise<Row[]> {

--- a/packages/sql-storage/src/test/index.ts
+++ b/packages/sql-storage/src/test/index.ts
@@ -1,0 +1,6 @@
+export { runSqlDatabaseContract } from './sqlDatabaseContract.ts';
+export type {
+  SqlDatabaseContractOptions,
+  SqlDatabaseContractTestApi,
+  SqlDatabaseTestHandle,
+} from './sqlDatabaseContract.ts';

--- a/packages/sql-storage/src/test/sqlDatabaseContract.test.ts
+++ b/packages/sql-storage/src/test/sqlDatabaseContract.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { runSqlDatabaseContract } from './index.ts';
+import { createBunSqlDatabase } from './bunSqlDatabase.ts';
+
+runSqlDatabaseContract(
+  {
+    createDatabase() {
+      const rawDatabase = new Database(':memory:');
+      const database = createBunSqlDatabase(rawDatabase);
+
+      return {
+        database,
+        dispose() {
+          rawDatabase.close();
+        },
+      };
+    },
+  },
+  { describe, expect, it },
+);

--- a/packages/sql-storage/src/test/sqlDatabaseContract.ts
+++ b/packages/sql-storage/src/test/sqlDatabaseContract.ts
@@ -21,6 +21,10 @@ interface Expect {
   (actual: unknown): Matcher;
 }
 
+interface ContractLabelRow {
+  label: string;
+}
+
 export interface SqlDatabaseContractTestApi {
   describe(name: string, fn: () => void): void;
   it(name: string, fn: () => TestResult, timeout?: number): void;
@@ -78,7 +82,7 @@ export function runSqlDatabaseContract(
           INSERT INTO contract_items (label) VALUES ('beta');
         `);
 
-        const rows = await database.all<{ label: string }>(
+        const rows = await database.all<ContractLabelRow>(
           'SELECT label FROM contract_items ORDER BY id ASC',
         );
 
@@ -168,14 +172,14 @@ export function runSqlDatabaseContract(
           INSERT INTO contract_query_results (label) VALUES ('beta');
         `);
 
-        const first = await database.get<{ label: string }>(
+        const first = await database.get<ContractLabelRow>(
           'SELECT label FROM contract_query_results ORDER BY id ASC',
         );
-        const missing = await database.get<{ label: string }>(
+        const missing = await database.get<ContractLabelRow>(
           'SELECT label FROM contract_query_results WHERE label = ?',
           ['missing'],
         );
-        const all = await database.all<{ label: string }>(
+        const all = await database.all<ContractLabelRow>(
           'SELECT label FROM contract_query_results ORDER BY id ASC',
         );
 
@@ -198,7 +202,7 @@ export function runSqlDatabaseContract(
           await tx.run('INSERT INTO contract_transactions (label) VALUES (?)', ['alpha']);
         });
 
-        const rows = await database.all<{ label: string }>(
+        const rows = await database.all<ContractLabelRow>(
           'SELECT label FROM contract_transactions',
         );
         expect(rows).toEqual([{ label: 'alpha' }]);
@@ -223,7 +227,7 @@ export function runSqlDatabaseContract(
           });
         });
 
-        const rows = await database.all<{ label: string }>(
+        const rows = await database.all<ContractLabelRow>(
           'SELECT label FROM contract_transaction_rollbacks',
         );
         expect(didReject).toBe(true);
@@ -251,7 +255,7 @@ export function runSqlDatabaseContract(
           });
         });
 
-        const rows = await database.all<{ label: string }>(
+        const rows = await database.all<ContractLabelRow>(
           'SELECT label FROM contract_nested_transactions ORDER BY id ASC',
         );
         expect(rows).toEqual([{ label: 'outer' }, { label: 'inner' }]);
@@ -289,7 +293,7 @@ export function runSqlDatabaseContract(
         releaseFirst.resolve();
         await Promise.all([firstTransaction, secondTransaction]);
 
-        const rows = await database.all<{ label: string }>(
+        const rows = await database.all<ContractLabelRow>(
           'SELECT label FROM contract_concurrent_transactions ORDER BY id ASC',
         );
         expect(rows).toEqual([{ label: 'first' }, { label: 'second' }]);

--- a/packages/sql-storage/src/test/sqlDatabaseContract.ts
+++ b/packages/sql-storage/src/test/sqlDatabaseContract.ts
@@ -198,7 +198,9 @@ export function runSqlDatabaseContract(
           await tx.run('INSERT INTO contract_transactions (label) VALUES (?)', ['alpha']);
         });
 
-        const rows = await database.all<{ label: string }>('SELECT label FROM contract_transactions');
+        const rows = await database.all<{ label: string }>(
+          'SELECT label FROM contract_transactions',
+        );
         expect(rows).toEqual([{ label: 'alpha' }]);
       });
     });

--- a/packages/sql-storage/src/test/sqlDatabaseContract.ts
+++ b/packages/sql-storage/src/test/sqlDatabaseContract.ts
@@ -1,0 +1,297 @@
+import type { SqlDatabase } from '../index.ts';
+
+export interface SqlDatabaseTestHandle {
+  readonly database: SqlDatabase;
+  dispose?(): void | Promise<void>;
+}
+
+export interface SqlDatabaseContractOptions {
+  createDatabase(): SqlDatabaseTestHandle | Promise<SqlDatabaseTestHandle>;
+}
+
+type TestResult = void | Promise<void>;
+
+interface Matcher {
+  toBe(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toHaveLength(expected: number): void;
+}
+
+interface Expect {
+  (actual: unknown): Matcher;
+}
+
+export interface SqlDatabaseContractTestApi {
+  describe(name: string, fn: () => void): void;
+  it(name: string, fn: () => TestResult, timeout?: number): void;
+  expect: Expect;
+}
+
+async function withDatabase<T>(
+  options: SqlDatabaseContractOptions,
+  fn: (database: SqlDatabase) => Promise<T>,
+): Promise<T> {
+  const handle = await options.createDatabase();
+  try {
+    return await fn(handle.database);
+  } finally {
+    await handle.dispose?.();
+  }
+}
+
+async function expectRejects(fn: () => Promise<unknown>): Promise<boolean> {
+  try {
+    await fn();
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject } as const;
+}
+
+export function runSqlDatabaseContract(
+  options: SqlDatabaseContractOptions,
+  api: SqlDatabaseContractTestApi,
+): void {
+  const { describe, expect, it } = api;
+
+  describe('SQL database driver contract', () => {
+    it('executes multiple statements with exec', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+
+          INSERT INTO contract_items (label) VALUES ('alpha');
+          INSERT INTO contract_items (label) VALUES ('beta');
+        `);
+
+        const rows = await database.all<{ label: string }>(
+          'SELECT label FROM contract_items ORDER BY id ASC',
+        );
+
+        expect(rows).toEqual([{ label: 'alpha' }, { label: 'beta' }]);
+      });
+    });
+
+    it('binds readonly positional parameters', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_params (
+            text_value TEXT NOT NULL,
+            number_value INTEGER NOT NULL,
+            bigint_value INTEGER NOT NULL,
+            bytes_value BLOB NOT NULL,
+            null_value TEXT
+          );
+        `);
+
+        const params = ['alpha', 7, 9n, new Uint8Array([1, 2, 3]), null] as const;
+        await database.run(
+          `INSERT INTO contract_params
+            (text_value, number_value, bigint_value, bytes_value, null_value)
+           VALUES (?, ?, ?, ?, ?)`,
+          params,
+        );
+
+        const row = await database.get<{
+          text_value: string;
+          number_value: number;
+          bigint_value: number;
+          bytes_length: number;
+          null_value: null;
+        }>(
+          `SELECT
+             text_value,
+             number_value,
+             bigint_value,
+             LENGTH(bytes_value) AS bytes_length,
+             null_value
+           FROM contract_params`,
+        );
+
+        expect(row).toEqual({
+          text_value: 'alpha',
+          number_value: 7,
+          bigint_value: 9,
+          bytes_length: 3,
+          null_value: null,
+        });
+      });
+    });
+
+    it('normalizes run results', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_run_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+        `);
+
+        const insertResult = await database.run(
+          'INSERT INTO contract_run_results (label) VALUES (?)',
+          ['alpha'],
+        );
+        const updateResult = await database.run(
+          'UPDATE contract_run_results SET label = ? WHERE id = ?',
+          ['beta', insertResult.lastInsertRowId],
+        );
+
+        expect(insertResult.lastInsertRowId).toBe(1);
+        expect(insertResult.changes).toBe(1);
+        expect(updateResult.changes).toBe(1);
+      });
+    });
+
+    it('returns one row from get and all rows from all', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_query_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+
+          INSERT INTO contract_query_results (label) VALUES ('alpha');
+          INSERT INTO contract_query_results (label) VALUES ('beta');
+        `);
+
+        const first = await database.get<{ label: string }>(
+          'SELECT label FROM contract_query_results ORDER BY id ASC',
+        );
+        const missing = await database.get<{ label: string }>(
+          'SELECT label FROM contract_query_results WHERE label = ?',
+          ['missing'],
+        );
+        const all = await database.all<{ label: string }>(
+          'SELECT label FROM contract_query_results ORDER BY id ASC',
+        );
+
+        expect(first).toEqual({ label: 'alpha' });
+        expect(missing).toBe(undefined);
+        expect(all).toEqual([{ label: 'alpha' }, { label: 'beta' }]);
+      });
+    });
+
+    it('commits successful transactions', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+        `);
+
+        await database.transaction(async (tx) => {
+          await tx.run('INSERT INTO contract_transactions (label) VALUES (?)', ['alpha']);
+        });
+
+        const rows = await database.all<{ label: string }>('SELECT label FROM contract_transactions');
+        expect(rows).toEqual([{ label: 'alpha' }]);
+      });
+    });
+
+    it('rolls back failed transactions', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_transaction_rollbacks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+        `);
+
+        const didReject = await expectRejects(async () => {
+          await database.transaction(async (tx) => {
+            await tx.run('INSERT INTO contract_transaction_rollbacks (label) VALUES (?)', [
+              'alpha',
+            ]);
+            throw new Error('rollback');
+          });
+        });
+
+        const rows = await database.all<{ label: string }>(
+          'SELECT label FROM contract_transaction_rollbacks',
+        );
+        expect(didReject).toBe(true);
+        expect(rows).toHaveLength(0);
+      });
+    });
+
+    it('rolls nested transactions into the parent transaction', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_nested_transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+        `);
+
+        await database.transaction(async (outerTx) => {
+          await outerTx.run('INSERT INTO contract_nested_transactions (label) VALUES (?)', [
+            'outer',
+          ]);
+          await outerTx.transaction(async (innerTx) => {
+            await innerTx.run('INSERT INTO contract_nested_transactions (label) VALUES (?)', [
+              'inner',
+            ]);
+          });
+        });
+
+        const rows = await database.all<{ label: string }>(
+          'SELECT label FROM contract_nested_transactions ORDER BY id ASC',
+        );
+        expect(rows).toEqual([{ label: 'outer' }, { label: 'inner' }]);
+      });
+    });
+
+    it('serializes or isolates concurrent root transactions', async () => {
+      await withDatabase(options, async (database) => {
+        await database.exec(`
+          CREATE TABLE contract_concurrent_transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            label TEXT NOT NULL
+          );
+        `);
+
+        const firstEntered = createDeferred();
+        const releaseFirst = createDeferred();
+
+        const firstTransaction = database.transaction(async (tx) => {
+          await tx.run('INSERT INTO contract_concurrent_transactions (label) VALUES (?)', [
+            'first',
+          ]);
+          firstEntered.resolve();
+          await releaseFirst.promise;
+        });
+
+        await firstEntered.promise;
+
+        const secondTransaction = database.transaction(async (tx) => {
+          await tx.run('INSERT INTO contract_concurrent_transactions (label) VALUES (?)', [
+            'second',
+          ]);
+        });
+
+        releaseFirst.resolve();
+        await Promise.all([firstTransaction, secondTransaction]);
+
+        const rows = await database.all<{ label: string }>(
+          'SELECT label FROM contract_concurrent_transactions ORDER BY id ASC',
+        );
+        expect(rows).toEqual([{ label: 'first' }, { label: 'second' }]);
+      });
+    });
+  });
+}

--- a/packages/sql-storage/tsconfig.json
+++ b/packages/sql-storage/tsconfig.json
@@ -10,7 +10,6 @@
     "preserveSymlinks": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "types": ["bun"],
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,

--- a/packages/sql-storage/tsconfig.json
+++ b/packages/sql-storage/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "preserveSymlinks": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "types": ["bun"],
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/sql-storage/tsdown.config.ts
+++ b/packages/sql-storage/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['./src/index.ts', './src/test/index.ts'],
+  format: ['esm'],
+  platform: 'neutral',
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});


### PR DESCRIPTION
This pull request resolves #209.

## Description

This pull request adds the private shared SQL storage package and establishes the driver-agnostic database contract for later SQLite adapter extraction.

## Problem

The SQLite adapters need a shared storage seam before schema and repository code can move without coupling the shared package to Bun, Node SQLite, or Expo SQLite drivers.

## Summary

- Adds private `@cashu/coco-sql-storage` workspace package.
- Defines `SqlDatabase` with only `exec`, `run`, `get`, `all`, and `transaction`.
- Adds exported `./test` SQL driver contract plus Bun-backed package-local contract coverage.
- Keeps concrete driver imports out of runtime source; `bun:sqlite` appears only in package-local test files.

## Verification

- `bun run typecheck`
- `bun run format:check`
- `bun run --filter='@cashu/coco-sql-storage' test`
- `bun run --filter='@cashu/coco-sql-storage' build`
- `git diff --check`

## Changeset

- No changeset added: the new package is private and does not change a published public package API.