### PR TITLE
refactor(sqlite-bun): compose shared SQL repositories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -116,6 +116,7 @@
       "name": "@cashu/coco-sql-storage",
       "version": "1.0.0",
       "peerDependencies": {
+        "@cashu/cashu-ts": "4.5",
         "@cashu/coco-core": "1.0.0",
         "typescript": "^5",
       },

--- a/packages/sql-storage/package.json
+++ b/packages/sql-storage/package.json
@@ -31,6 +31,7 @@
     "test": "bun test"
   },
   "peerDependencies": {
+    "@cashu/cashu-ts": "4.5",
     "@cashu/coco-core": "1.0.0",
     "typescript": "^5"
   },

--- a/packages/sql-storage/src/index.ts
+++ b/packages/sql-storage/src/index.ts
@@ -21,5 +21,25 @@ export interface SqlDatabase {
   transaction<T>(fn: (tx: SqlDatabase) => Promise<T>): Promise<T>;
 }
 
+export {
+  SqlStorageRepositories,
+  SqliteMintRepository,
+  SqliteKeyRingRepository,
+  SqliteKeysetRepository,
+  SqliteCounterRepository,
+  SqliteProofRepository,
+  SqliteMeltQuoteRepository,
+  SqliteMintQuoteRepository,
+  SqliteLegacyMintQuoteRepository,
+  SqliteHistoryRepository,
+  SqliteSendOperationRepository,
+  SqliteMeltOperationRepository,
+  SqliteAuthSessionRepository,
+  SqliteMintOperationRepository,
+  SqliteReceiveOperationRepository,
+  SqlitePaymentRequestReceiveOperationRepository,
+  SqlitePaymentRequestReceiveAttemptRepository,
+} from './repositories.ts';
+export type { SqlStorageRepositoriesOptions } from './repositories.ts';
 export { ensureSchema, ensureSchemaUpTo, MIGRATIONS } from './schema.ts';
 export type { Migration } from './schema.ts';

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -1,0 +1,139 @@
+import type {
+  Repositories,
+  RepositoryTransactionScope,
+  MintRepository,
+  KeysetRepository,
+  KeyRingRepository,
+  CounterRepository,
+  ProofRepository,
+  MeltQuoteRepository,
+  MintQuoteRepository,
+  LegacyMintQuoteRepository,
+  HistoryProjectionRepository,
+  SendOperationRepository,
+  MeltOperationRepository,
+  AuthSessionRepository,
+  MintOperationRepository,
+  ReceiveOperationRepository,
+  PaymentRequestReceiveAttemptRepository,
+  PaymentRequestReceiveOperationRepository,
+} from '@cashu/coco-core';
+import type { SqlDatabase } from './index.ts';
+import { ensureSchema } from './schema.ts';
+import { SqliteMintRepository } from './repositories/MintRepository.ts';
+import { SqliteKeysetRepository } from './repositories/KeysetRepository.ts';
+import { SqliteKeyRingRepository } from './repositories/KeyRingRepository.ts';
+import { SqliteCounterRepository } from './repositories/CounterRepository.ts';
+import { SqliteProofRepository } from './repositories/ProofRepository.ts';
+import { SqliteMeltQuoteRepository } from './repositories/MeltQuoteRepository.ts';
+import { SqliteMintQuoteRepository } from './repositories/MintQuoteRepository.ts';
+import { SqliteLegacyMintQuoteRepository } from './repositories/LegacyMintQuoteRepository.ts';
+import { SqliteHistoryRepository } from './repositories/HistoryRepository.ts';
+import { SqliteSendOperationRepository } from './repositories/SendOperationRepository.ts';
+import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
+import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
+import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
+import {
+  SqlitePaymentRequestReceiveAttemptRepository,
+  SqlitePaymentRequestReceiveOperationRepository,
+} from './repositories/PaymentRequestReceiveRepository.ts';
+
+export interface SqlStorageRepositoriesOptions {
+  database: SqlDatabase;
+}
+
+function createRepositoryScope(database: SqlDatabase): RepositoryTransactionScope {
+  return {
+    mintRepository: new SqliteMintRepository(database),
+    keyRingRepository: new SqliteKeyRingRepository(database),
+    counterRepository: new SqliteCounterRepository(database),
+    keysetRepository: new SqliteKeysetRepository(database),
+    proofRepository: new SqliteProofRepository(database),
+    meltQuoteRepository: new SqliteMeltQuoteRepository(database),
+    mintQuoteRepository: new SqliteMintQuoteRepository(database),
+    legacyMintQuoteRepository: new SqliteLegacyMintQuoteRepository(database),
+    historyRepository: new SqliteHistoryRepository(database),
+    sendOperationRepository: new SqliteSendOperationRepository(database),
+    meltOperationRepository: new SqliteMeltOperationRepository(database),
+    authSessionRepository: new SqliteAuthSessionRepository(database),
+    mintOperationRepository: new SqliteMintOperationRepository(database),
+    receiveOperationRepository: new SqliteReceiveOperationRepository(database),
+    paymentRequestReceiveOperationRepository: new SqlitePaymentRequestReceiveOperationRepository(
+      database,
+    ),
+    paymentRequestReceiveAttemptRepository: new SqlitePaymentRequestReceiveAttemptRepository(
+      database,
+    ),
+  };
+}
+
+export class SqlStorageRepositories implements Repositories {
+  readonly mintRepository: MintRepository;
+  readonly keyRingRepository: KeyRingRepository;
+  readonly counterRepository: CounterRepository;
+  readonly keysetRepository: KeysetRepository;
+  readonly proofRepository: ProofRepository;
+  readonly meltQuoteRepository: MeltQuoteRepository;
+  readonly mintQuoteRepository: MintQuoteRepository;
+  readonly legacyMintQuoteRepository: LegacyMintQuoteRepository;
+  readonly historyRepository: HistoryProjectionRepository;
+  readonly sendOperationRepository: SendOperationRepository;
+  readonly meltOperationRepository: MeltOperationRepository;
+  readonly authSessionRepository: AuthSessionRepository;
+  readonly mintOperationRepository: MintOperationRepository;
+  readonly receiveOperationRepository: ReceiveOperationRepository;
+  readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
+  readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
+  readonly database: SqlDatabase;
+
+  constructor(options: SqlStorageRepositoriesOptions) {
+    this.database = options.database;
+    const repositories = createRepositoryScope(this.database);
+    this.mintRepository = repositories.mintRepository;
+    this.keyRingRepository = repositories.keyRingRepository;
+    this.counterRepository = repositories.counterRepository;
+    this.keysetRepository = repositories.keysetRepository;
+    this.proofRepository = repositories.proofRepository;
+    this.meltQuoteRepository = repositories.meltQuoteRepository;
+    this.mintQuoteRepository = repositories.mintQuoteRepository;
+    this.legacyMintQuoteRepository = repositories.legacyMintQuoteRepository;
+    this.historyRepository = repositories.historyRepository;
+    this.sendOperationRepository = repositories.sendOperationRepository;
+    this.meltOperationRepository = repositories.meltOperationRepository;
+    this.authSessionRepository = repositories.authSessionRepository;
+    this.mintOperationRepository = repositories.mintOperationRepository;
+    this.receiveOperationRepository = repositories.receiveOperationRepository;
+    this.paymentRequestReceiveOperationRepository =
+      repositories.paymentRequestReceiveOperationRepository;
+    this.paymentRequestReceiveAttemptRepository =
+      repositories.paymentRequestReceiveAttemptRepository;
+  }
+
+  async init(): Promise<void> {
+    await ensureSchema(this.database);
+  }
+
+  async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
+    return this.database.transaction((txDatabase) => fn(createRepositoryScope(txDatabase)));
+  }
+}
+
+export {
+  SqliteMintRepository,
+  SqliteKeyRingRepository,
+  SqliteKeysetRepository,
+  SqliteCounterRepository,
+  SqliteProofRepository,
+  SqliteMeltQuoteRepository,
+  SqliteMintQuoteRepository,
+  SqliteLegacyMintQuoteRepository,
+  SqliteHistoryRepository,
+  SqliteSendOperationRepository,
+  SqliteMeltOperationRepository,
+  SqliteAuthSessionRepository,
+  SqliteMintOperationRepository,
+  SqliteReceiveOperationRepository,
+  SqlitePaymentRequestReceiveOperationRepository,
+  SqlitePaymentRequestReceiveAttemptRepository,
+};

--- a/packages/sql-storage/src/repositories/AuthSessionRepository.ts
+++ b/packages/sql-storage/src/repositories/AuthSessionRepository.ts
@@ -1,6 +1,6 @@
 import type { AuthSessionRepository, AuthSession } from '@cashu/coco-core';
 import { deserializeAmount } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 interface AuthSessionRow {
   mintUrl: string;
@@ -32,9 +32,9 @@ function rowToSession(row: AuthSessionRow): AuthSession {
 }
 
 export class SqliteAuthSessionRepository implements AuthSessionRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/CounterRepository.ts
+++ b/packages/sql-storage/src/repositories/CounterRepository.ts
@@ -1,10 +1,10 @@
 import type { CounterRepository, Counter } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 export class SqliteCounterRepository implements CounterRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/HistoryRepository.ts
+++ b/packages/sql-storage/src/repositories/HistoryRepository.ts
@@ -12,7 +12,7 @@ import {
   parseHistoryEntryId,
   projectLegacyHistoryRow,
 } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 type HistoryProjectionRow = {
   source: 'operation' | 'legacy';
@@ -251,9 +251,9 @@ function parseReceiveSourceMetadata(sourceJson: string | null): Record<string, s
 }
 
 export class SqliteHistoryRepository implements HistoryRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/KeyRingRepository.ts
+++ b/packages/sql-storage/src/repositories/KeyRingRepository.ts
@@ -1,5 +1,5 @@
 import type { KeyRingRepository, Keypair, KeypairPurpose } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 import { hexToBytes, bytesToHex } from '../utils.ts';
 
 const DEFAULT_KEYPAIR_PURPOSE: KeypairPurpose = 'p2pk';
@@ -21,9 +21,9 @@ function rowToKeypair(row: KeypairRow): Keypair {
 }
 
 export class SqliteKeyRingRepository implements KeyRingRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/KeysetRepository.ts
+++ b/packages/sql-storage/src/repositories/KeysetRepository.ts
@@ -1,10 +1,11 @@
 import type { KeysetRepository, Keyset } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 export class SqliteKeysetRepository implements KeysetRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/LegacyMintQuoteRepository.ts
+++ b/packages/sql-storage/src/repositories/LegacyMintQuoteRepository.ts
@@ -4,10 +4,10 @@ import {
   type LegacyMintQuoteRepository,
   type MintQuote,
 } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 export class SqliteLegacyMintQuoteRepository implements LegacyMintQuoteRepository {
-  constructor(private readonly db: SqliteDb) {}
+  constructor(private readonly db: SqlDatabase) {}
 
   async getPendingLegacyMintQuotes(mintUrl?: string): Promise<MintQuote[]> {
     const normalizedMintUrl = mintUrl ? normalizeMintUrl(mintUrl) : undefined;

--- a/packages/sql-storage/src/repositories/MeltOperationRepository.ts
+++ b/packages/sql-storage/src/repositories/MeltOperationRepository.ts
@@ -6,7 +6,8 @@ import {
   serializeAmount,
   stringifyJson,
 } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 type MeltOperation = NonNullable<Awaited<ReturnType<MeltOperationRepository['getById']>>>;
 type MeltOperationState = Parameters<MeltOperationRepository['getByState']>[0];
@@ -111,7 +112,7 @@ const rowToOperation = (row: MeltOperationRow): MeltOperation => {
   return operation as MeltOperation;
 };
 
-const operationToParams = (operation: MeltOperation): unknown[] => {
+const operationToParams = (operation: MeltOperation): SqlValue[] => {
   const createdAtSeconds = Math.floor(operation.createdAt / 1000);
   const updatedAtSeconds = Math.floor(operation.updatedAt / 1000);
   const methodDataJson = stringifyJson(operation.methodData);
@@ -182,9 +183,9 @@ const operationToParams = (operation: MeltOperation): unknown[] => {
 };
 
 export class SqliteMeltOperationRepository implements MeltOperationRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
+++ b/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
@@ -8,7 +8,7 @@ import {
   type MeltQuoteRepository,
   type QuoteIdentity,
 } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 type MeltQuoteRow = {
   mintUrl: string;
@@ -79,7 +79,7 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
 }
 
 export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
-  constructor(private readonly db: SqliteDb) {}
+  constructor(private readonly db: SqlDatabase) {}
 
   async getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null> {
     const normalizedMintUrl = normalizeMintUrl(identity.mintUrl);

--- a/packages/sql-storage/src/repositories/MintOperationRepository.ts
+++ b/packages/sql-storage/src/repositories/MintOperationRepository.ts
@@ -1,6 +1,7 @@
 import type { MintOperationRepository } from '@cashu/coco-core';
 import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 type MintOperation = NonNullable<Awaited<ReturnType<MintOperationRepository['getById']>>>;
 type MintOperationState = Parameters<MintOperationRepository['getByState']>[0];
@@ -90,7 +91,7 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
   } as MintOperation;
 };
 
-const operationToParams = (operation: MintOperation): unknown[] => {
+const operationToParams = (operation: MintOperation): SqlValue[] => {
   const createdAtSeconds = Math.floor(operation.createdAt / 1000);
   const updatedAtSeconds = Math.floor(operation.updatedAt / 1000);
   const methodDataJson = stringifyJson(operation.methodData);
@@ -141,9 +142,9 @@ const operationToParams = (operation: MintOperation): unknown[] => {
 };
 
 export class SqliteMintOperationRepository implements MintOperationRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/MintQuoteRepository.ts
+++ b/packages/sql-storage/src/repositories/MintQuoteRepository.ts
@@ -13,7 +13,7 @@ import {
   type MintQuoteRepository,
   type QuoteIdentity,
 } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 type MintQuoteRow = {
   mintUrl: string;
@@ -123,9 +123,9 @@ function serializeQuoteData(quote: MintQuote): string {
 }
 
 export class SqliteMintQuoteRepository implements MintQuoteRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/MintRepository.ts
+++ b/packages/sql-storage/src/repositories/MintRepository.ts
@@ -1,10 +1,10 @@
 import type { MintRepository, Mint } from '@cashu/coco-core';
-import { SqliteDb } from '../db.ts';
+import type { SqlDatabase } from '../index.ts';
 
 export class SqliteMintRepository implements MintRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/PaymentRequestReceiveRepository.ts
+++ b/packages/sql-storage/src/repositories/PaymentRequestReceiveRepository.ts
@@ -8,7 +8,8 @@ import type {
   PaymentRequestReceiveTransport,
 } from '@cashu/coco-core';
 import { deserializeAmount, serializeAmount } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 interface OperationRow {
   id: string;
@@ -139,7 +140,7 @@ function rowToAttempt(row: AttemptRow): PaymentRequestReceiveAttempt {
 }
 
 export class SqlitePaymentRequestReceiveOperationRepository implements PaymentRequestReceiveOperationRepository {
-  constructor(private readonly db: SqliteDb) {}
+  constructor(private readonly db: SqlDatabase) {}
 
   async create(operation: PaymentRequestReceiveOperation): Promise<void> {
     const row = operationToRow(operation);
@@ -216,7 +217,7 @@ export class SqlitePaymentRequestReceiveOperationRepository implements PaymentRe
 }
 
 export class SqlitePaymentRequestReceiveAttemptRepository implements PaymentRequestReceiveAttemptRepository {
-  constructor(private readonly db: SqliteDb) {}
+  constructor(private readonly db: SqlDatabase) {}
 
   async create(attempt: PaymentRequestReceiveAttempt): Promise<void> {
     const row = attemptToRow(attempt);

--- a/packages/sql-storage/src/repositories/ProofRepository.ts
+++ b/packages/sql-storage/src/repositories/ProofRepository.ts
@@ -8,7 +8,8 @@ import {
   type CoreProof,
   type ProofState,
 } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 interface ProofRow {
   mintUrl: string;
@@ -39,11 +40,12 @@ function getUnitFilter(filter?: ProofUnitFilter): string[] | undefined {
   return Array.from(new Set(units.map((unit) => normalizeUnit(unit))));
 }
 
-function appendUnitFilter(sql: string, params: unknown[], filter?: ProofUnitFilter): string {
+function appendUnitFilter(sql: string, params: SqlValue[], filter?: ProofUnitFilter): string {
   const units = getUnitFilter(filter);
   if (!units || units.length === 0) return sql;
   if (units.length === 1) {
-    params.push(units[0]);
+    const [unit] = units as [string];
+    params.push(unit);
     return `${sql} AND unit = ?`;
   }
   params.push(...units);
@@ -70,9 +72,9 @@ function rowToProof(r: ProofRow): CoreProof {
 }
 
 export class SqliteProofRepository implements ProofRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 
@@ -116,7 +118,7 @@ export class SqliteProofRepository implements ProofRepository {
   }
 
   async getReadyProofs(mintUrl: string, filter?: ProofUnitFilter): Promise<CoreProof[]> {
-    const params: unknown[] = [mintUrl];
+    const params: SqlValue[] = [mintUrl];
     const rows = await this.db.all<ProofRow>(
       appendUnitFilter(
         `SELECT ${PROOF_COLUMNS} FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready'`,
@@ -130,7 +132,7 @@ export class SqliteProofRepository implements ProofRepository {
 
   async getInflightProofs(mintUrls?: string[], filter?: ProofUnitFilter): Promise<CoreProof[]> {
     if (!mintUrls || mintUrls.length === 0) {
-      const params: unknown[] = [];
+      const params: SqlValue[] = [];
       const rows = await this.db.all<ProofRow>(
         appendUnitFilter(
           `SELECT ${PROOF_COLUMNS} FROM coco_cashu_proofs WHERE state = 'inflight'`,
@@ -145,7 +147,7 @@ export class SqliteProofRepository implements ProofRepository {
     if (mintUrlList.length === 0) return [];
     const uniqueMintUrls = Array.from(new Set(mintUrlList));
     const placeholders = uniqueMintUrls.map(() => '?').join(', ');
-    const params: unknown[] = uniqueMintUrls;
+    const params: SqlValue[] = uniqueMintUrls;
     const rows = await this.db.all<ProofRow>(
       appendUnitFilter(
         `SELECT ${PROOF_COLUMNS} FROM coco_cashu_proofs WHERE state = 'inflight' AND mintUrl IN (${placeholders})`,
@@ -158,7 +160,7 @@ export class SqliteProofRepository implements ProofRepository {
   }
 
   async getAllReadyProofs(filter?: ProofUnitFilter): Promise<CoreProof[]> {
-    const params: unknown[] = [];
+    const params: SqlValue[] = [];
     const rows = await this.db.all<ProofRow>(
       appendUnitFilter(
         `SELECT ${PROOF_COLUMNS} FROM coco_cashu_proofs WHERE state = 'ready'`,
@@ -175,7 +177,7 @@ export class SqliteProofRepository implements ProofRepository {
     keysetId: string,
     filter?: ProofUnitFilter,
   ): Promise<CoreProof[]> {
-    const params: unknown[] = [mintUrl, keysetId];
+    const params: SqlValue[] = [mintUrl, keysetId];
     const rows = await this.db.all<ProofRow>(
       appendUnitFilter(
         `SELECT ${PROOF_COLUMNS} FROM coco_cashu_proofs WHERE mintUrl = ? AND id = ? AND state = 'ready'`,
@@ -317,7 +319,7 @@ export class SqliteProofRepository implements ProofRepository {
   }
 
   async getAvailableProofs(mintUrl: string, filter?: ProofUnitFilter): Promise<CoreProof[]> {
-    const params: unknown[] = [mintUrl];
+    const params: SqlValue[] = [mintUrl];
     const rows = await this.db.all<ProofRow>(
       appendUnitFilter(
         `SELECT ${PROOF_COLUMNS} FROM coco_cashu_proofs WHERE mintUrl = ? AND state = 'ready' AND usedByOperationId IS NULL`,

--- a/packages/sql-storage/src/repositories/ReceiveOperationRepository.ts
+++ b/packages/sql-storage/src/repositories/ReceiveOperationRepository.ts
@@ -4,7 +4,8 @@ import type {
   ReceiveOperationState,
 } from '@cashu/coco-core';
 import { deserializeAmount, serializeAmount } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 function getOperationUnit(op: ReceiveOperation): string {
   return (op as ReceiveOperation & { unit?: string }).unit ?? 'sat';
@@ -71,7 +72,7 @@ function rowToOperation(row: ReceiveOperationRow): ReceiveOperation {
   }
 }
 
-function operationToParams(op: ReceiveOperation): unknown[] {
+function operationToParams(op: ReceiveOperation): SqlValue[] {
   const createdAtSeconds = Math.floor(op.createdAt / 1000);
   const updatedAtSeconds = Math.floor(op.updatedAt / 1000);
 
@@ -109,9 +110,9 @@ function operationToParams(op: ReceiveOperation): unknown[] {
 }
 
 export class SqliteReceiveOperationRepository implements ReceiveOperationRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/repositories/SendOperationRepository.ts
+++ b/packages/sql-storage/src/repositories/SendOperationRepository.ts
@@ -11,7 +11,8 @@ import {
   serializeAmount,
   stringifyJson,
 } from '@cashu/coco-core';
-import { SqliteDb, getUnixTimeSeconds } from '../db.ts';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+import { getUnixTimeSeconds } from '../utils.ts';
 
 interface SendOperationRow {
   id: string;
@@ -105,7 +106,7 @@ function rowToOperation(row: SendOperationRow): SendOperation {
   }
 }
 
-function operationToParams(op: SendOperation): unknown[] {
+function operationToParams(op: SendOperation): SqlValue[] {
   const createdAtSeconds = Math.floor(op.createdAt / 1000);
   const updatedAtSeconds = Math.floor(op.updatedAt / 1000);
 
@@ -152,9 +153,9 @@ function operationToParams(op: SendOperation): unknown[] {
 }
 
 export class SqliteSendOperationRepository implements SendOperationRepository {
-  private readonly db: SqliteDb;
+  private readonly db: SqlDatabase;
 
-  constructor(db: SqliteDb) {
+  constructor(db: SqlDatabase) {
     this.db = db;
   }
 

--- a/packages/sql-storage/src/utils.ts
+++ b/packages/sql-storage/src/utils.ts
@@ -1,29 +1,24 @@
-/**
- * Safely converts a hex string to Uint8Array with validation
- * @throws Error if the hex string is invalid or malformed
- */
+export function getUnixTimeSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
 export function hexToBytes(hexString: string): Uint8Array {
-  // Validate hex string format
   if (!/^[0-9a-fA-F]+$/.test(hexString)) {
-    throw new Error(`Invalid hex string: contains non-hex characters`);
+    throw new Error('Invalid hex string: contains non-hex characters');
   }
 
   if (hexString.length % 2 !== 0) {
     throw new Error(`Invalid hex string: odd length (${hexString.length})`);
   }
 
-  // Safe conversion with validation
   const matches = hexString.match(/.{2}/g);
   if (!matches) {
-    throw new Error(`Failed to parse hex string`);
+    throw new Error('Failed to parse hex string');
   }
 
   return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
 }
 
-/**
- * Converts a Uint8Array to hex string
- */
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, '0'))

--- a/packages/sqlite-bun/src/db.ts
+++ b/packages/sqlite-bun/src/db.ts
@@ -1,10 +1,8 @@
 import type { Database, Statement } from 'bun:sqlite';
+import type { SqlDatabase, SqlParams, SqlRunResult } from '@cashu/coco-sql-storage';
 
-type SqliteParams = readonly unknown[];
-type SqliteRunResult = {
+type SqliteRunResult = SqlRunResult & {
   readonly lastID: number;
-  readonly lastInsertRowId: number;
-  readonly changes: number;
 };
 
 export interface SqliteDbOptions {
@@ -38,7 +36,7 @@ interface SqliteDbRootState {
  * - Concurrent transactions from different scopes are queued and executed serially
  * - Each top-level transaction gets a unique scope token for identification
  */
-export class SqliteDb {
+export class SqliteDb implements SqlDatabase {
   private readonly root: SqliteDbRootState;
   /** Unique identifier for this instance's transaction scope (null for root instances) */
   private readonly scopeToken: symbol | null;
@@ -113,7 +111,7 @@ export class SqliteDb {
     });
   }
 
-  async run(sql: string, params: SqliteParams = []): Promise<SqliteRunResult> {
+  async run(sql: string, params: SqlParams = []): Promise<SqliteRunResult> {
     if (this.shouldWaitForTransaction()) {
       await this.waitForActiveTransaction();
     }
@@ -135,7 +133,7 @@ export class SqliteDb {
 
   async get<Row extends object = Record<string, unknown>>(
     sql: string,
-    params: SqliteParams = [],
+    params: SqlParams = [],
   ): Promise<Row | undefined> {
     if (this.shouldWaitForTransaction()) {
       await this.waitForActiveTransaction();
@@ -143,8 +141,12 @@ export class SqliteDb {
     return new Promise((resolve, reject) => {
       try {
         const statement = this.getCachedStatement(sql);
-        const result = statement.get(...params) as Row | undefined;
-        resolve(result);
+        const result = statement.get(...params);
+        if (result === null || result === undefined) {
+          resolve(undefined);
+          return;
+        }
+        resolve(result as Row);
       } catch (err) {
         reject(err);
       }
@@ -153,7 +155,7 @@ export class SqliteDb {
 
   async all<Row extends object = Record<string, unknown>>(
     sql: string,
-    params: SqliteParams = [],
+    params: SqlParams = [],
   ): Promise<Row[]> {
     if (this.shouldWaitForTransaction()) {
       await this.waitForActiveTransaction();

--- a/packages/sqlite-bun/src/index.ts
+++ b/packages/sqlite-bun/src/index.ts
@@ -1,123 +1,65 @@
-import type {
-  Repositories,
-  MintRepository,
-  KeysetRepository,
-  KeyRingRepository,
-  CounterRepository,
-  ProofRepository,
-  MeltQuoteRepository,
-  MintQuoteRepository,
-  LegacyMintQuoteRepository,
-  SendOperationRepository,
-  MeltOperationRepository,
-  AuthSessionRepository,
-  MintOperationRepository,
-  PaymentRequestReceiveAttemptRepository,
-  PaymentRequestReceiveOperationRepository,
-  ReceiveOperationRepository,
-  RepositoryTransactionScope,
-} from '@cashu/coco-core';
-import { ensureSchema, ensureSchemaUpTo, MIGRATIONS } from '@cashu/coco-sql-storage';
+import type { Repositories, RepositoryTransactionScope } from '@cashu/coco-core';
+import { SqlStorageRepositories } from '@cashu/coco-sql-storage';
 import type { Migration } from '@cashu/coco-sql-storage';
 import { SqliteDb, type SqliteDbOptions } from './db.ts';
-import { SqliteMintRepository } from './repositories/MintRepository.ts';
-import { SqliteKeysetRepository } from './repositories/KeysetRepository.ts';
-import { SqliteKeyRingRepository } from './repositories/KeyRingRepository.ts';
-import { SqliteCounterRepository } from './repositories/CounterRepository.ts';
-import { SqliteProofRepository } from './repositories/ProofRepository.ts';
-import { SqliteMeltQuoteRepository } from './repositories/MeltQuoteRepository.ts';
-import { SqliteMintQuoteRepository } from './repositories/MintQuoteRepository.ts';
-import { SqliteLegacyMintQuoteRepository } from './repositories/LegacyMintQuoteRepository.ts';
-import { SqliteHistoryRepository } from './repositories/HistoryRepository.ts';
-import { SqliteSendOperationRepository } from './repositories/SendOperationRepository.ts';
-import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
-import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
-import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
-import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
-import {
-  SqlitePaymentRequestReceiveAttemptRepository,
-  SqlitePaymentRequestReceiveOperationRepository,
-} from './repositories/PaymentRequestReceiveRepository.ts';
 
 export interface SqliteRepositoriesOptions extends SqliteDbOptions {}
 
 export class SqliteRepositories implements Repositories {
-  readonly mintRepository: MintRepository;
-  readonly keyRingRepository: KeyRingRepository;
-  readonly counterRepository: CounterRepository;
-  readonly keysetRepository: KeysetRepository;
-  readonly proofRepository: ProofRepository;
-  readonly meltQuoteRepository: MeltQuoteRepository;
-  readonly mintQuoteRepository: MintQuoteRepository;
-  readonly legacyMintQuoteRepository: LegacyMintQuoteRepository;
-  readonly historyRepository: SqliteHistoryRepository;
-  readonly sendOperationRepository: SendOperationRepository;
-  readonly meltOperationRepository: MeltOperationRepository;
-  readonly authSessionRepository: AuthSessionRepository;
-  readonly mintOperationRepository: MintOperationRepository;
-  readonly receiveOperationRepository: ReceiveOperationRepository;
-  readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
-  readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
+  readonly mintRepository: Repositories['mintRepository'];
+  readonly keyRingRepository: Repositories['keyRingRepository'];
+  readonly counterRepository: Repositories['counterRepository'];
+  readonly keysetRepository: Repositories['keysetRepository'];
+  readonly proofRepository: Repositories['proofRepository'];
+  readonly meltQuoteRepository: Repositories['meltQuoteRepository'];
+  readonly mintQuoteRepository: Repositories['mintQuoteRepository'];
+  readonly legacyMintQuoteRepository: Repositories['legacyMintQuoteRepository'];
+  readonly historyRepository: Repositories['historyRepository'];
+  readonly sendOperationRepository: Repositories['sendOperationRepository'];
+  readonly meltOperationRepository: Repositories['meltOperationRepository'];
+  readonly authSessionRepository: Repositories['authSessionRepository'];
+  readonly mintOperationRepository: Repositories['mintOperationRepository'];
+  readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
+  readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
+  readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
   readonly db: SqliteDb;
+
+  private readonly repositories: SqlStorageRepositories;
 
   constructor(options: SqliteRepositoriesOptions) {
     this.db = new SqliteDb(options);
-    this.mintRepository = new SqliteMintRepository(this.db);
-    this.keyRingRepository = new SqliteKeyRingRepository(this.db);
-    this.counterRepository = new SqliteCounterRepository(this.db);
-    this.keysetRepository = new SqliteKeysetRepository(this.db);
-    this.proofRepository = new SqliteProofRepository(this.db);
-    this.meltQuoteRepository = new SqliteMeltQuoteRepository(this.db);
-    this.mintQuoteRepository = new SqliteMintQuoteRepository(this.db);
-    this.legacyMintQuoteRepository = new SqliteLegacyMintQuoteRepository(this.db);
-    this.historyRepository = new SqliteHistoryRepository(this.db);
-    this.sendOperationRepository = new SqliteSendOperationRepository(this.db);
-    this.meltOperationRepository = new SqliteMeltOperationRepository(this.db);
-    this.authSessionRepository = new SqliteAuthSessionRepository(this.db);
-    this.mintOperationRepository = new SqliteMintOperationRepository(this.db);
-    this.receiveOperationRepository = new SqliteReceiveOperationRepository(this.db);
+    this.repositories = new SqlStorageRepositories({ database: this.db });
+    this.mintRepository = this.repositories.mintRepository;
+    this.keyRingRepository = this.repositories.keyRingRepository;
+    this.counterRepository = this.repositories.counterRepository;
+    this.keysetRepository = this.repositories.keysetRepository;
+    this.proofRepository = this.repositories.proofRepository;
+    this.meltQuoteRepository = this.repositories.meltQuoteRepository;
+    this.mintQuoteRepository = this.repositories.mintQuoteRepository;
+    this.legacyMintQuoteRepository = this.repositories.legacyMintQuoteRepository;
+    this.historyRepository = this.repositories.historyRepository;
+    this.sendOperationRepository = this.repositories.sendOperationRepository;
+    this.meltOperationRepository = this.repositories.meltOperationRepository;
+    this.authSessionRepository = this.repositories.authSessionRepository;
+    this.mintOperationRepository = this.repositories.mintOperationRepository;
+    this.receiveOperationRepository = this.repositories.receiveOperationRepository;
     this.paymentRequestReceiveOperationRepository =
-      new SqlitePaymentRequestReceiveOperationRepository(this.db);
-    this.paymentRequestReceiveAttemptRepository = new SqlitePaymentRequestReceiveAttemptRepository(
-      this.db,
-    );
+      this.repositories.paymentRequestReceiveOperationRepository;
+    this.paymentRequestReceiveAttemptRepository =
+      this.repositories.paymentRequestReceiveAttemptRepository;
   }
 
   async init(): Promise<void> {
-    await ensureSchema(this.db);
+    await this.repositories.init();
   }
 
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
-    return this.db.transaction(async (txDb) => {
-      const scopedRepositories: RepositoryTransactionScope = {
-        mintRepository: new SqliteMintRepository(txDb),
-        keyRingRepository: new SqliteKeyRingRepository(txDb),
-        counterRepository: new SqliteCounterRepository(txDb),
-        keysetRepository: new SqliteKeysetRepository(txDb),
-        proofRepository: new SqliteProofRepository(txDb),
-        meltQuoteRepository: new SqliteMeltQuoteRepository(txDb),
-        mintQuoteRepository: new SqliteMintQuoteRepository(txDb),
-        legacyMintQuoteRepository: new SqliteLegacyMintQuoteRepository(txDb),
-        historyRepository: new SqliteHistoryRepository(txDb),
-        sendOperationRepository: new SqliteSendOperationRepository(txDb),
-        meltOperationRepository: new SqliteMeltOperationRepository(txDb),
-        authSessionRepository: new SqliteAuthSessionRepository(txDb),
-        mintOperationRepository: new SqliteMintOperationRepository(txDb),
-        receiveOperationRepository: new SqliteReceiveOperationRepository(txDb),
-        paymentRequestReceiveOperationRepository:
-          new SqlitePaymentRequestReceiveOperationRepository(txDb),
-        paymentRequestReceiveAttemptRepository: new SqlitePaymentRequestReceiveAttemptRepository(
-          txDb,
-        ),
-      };
-
-      return fn(scopedRepositories);
-    });
+    return this.repositories.withTransaction(fn);
   }
 }
 
+export { SqliteDb };
 export {
-  SqliteDb,
   ensureSchema,
   ensureSchemaUpTo,
   MIGRATIONS,
@@ -137,6 +79,5 @@ export {
   SqliteReceiveOperationRepository,
   SqlitePaymentRequestReceiveOperationRepository,
   SqlitePaymentRequestReceiveAttemptRepository,
-};
-
+} from '@cashu/coco-sql-storage';
 export type { Migration };

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -14,7 +14,8 @@ import {
   createDummyKeyset,
   createDummyProof,
 } from '@cashu/coco-adapter-tests';
-import { SqliteRepositories as Repositories } from '../index.ts';
+import { runSqlDatabaseContract } from '@cashu/coco-sql-storage/test';
+import { SqliteDb, SqliteRepositories as Repositories } from '../index.ts';
 
 function createDeferred<T = void>() {
   let resolve!: (value: T) => void;
@@ -37,6 +38,21 @@ async function createRepositories() {
     },
   };
 }
+
+runSqlDatabaseContract(
+  {
+    createDatabase() {
+      const rawDatabase = new Database(':memory:');
+      const database = new SqliteDb({ database: rawDatabase });
+
+      return {
+        database,
+        dispose: () => database.close(),
+      };
+    },
+  },
+  { describe, it, expect },
+);
 
 async function expectRejects(fn: () => Promise<void>) {
   let didThrow = false;

--- a/packages/sqlite-bun/tsconfig.json
+++ b/packages/sqlite-bun/tsconfig.json
@@ -29,7 +29,8 @@
     "noPropertyAccessFromIndexSignature": false,
     "baseUrl": ".",
     "paths": {
-      "@cashu/coco-sql-storage": ["../sql-storage/src/index.ts"]
+      "@cashu/coco-sql-storage": ["../sql-storage/src/index.ts"],
+      "@cashu/coco-sql-storage/test": ["../sql-storage/src/test/index.ts"]
     }
   }
 }


### PR DESCRIPTION
This pull request moves the Bun SQLite adapter onto the shared SQL repository implementation while keeping Bun-specific database adaptation and transaction behavior in `@cashu/coco-sqlite-bun`.

This pull request resolves #211.

## Problem

The Bun SQLite adapter still duplicated SQL repository implementations after the shared schema and database contract were extracted, keeping drift risk in place for future SQL repository fixes.

## Summary

- Adds shared SQL repository implementations and `SqlStorageRepositories` under `packages/sql-storage`.
- Converts `SqliteRepositories` in `packages/sqlite-bun` to compose the shared aggregate through Bun's `SqliteDb`.
- Adds the shared SQL database driver contract for Bun and preserves existing Bun repository class export names as shared re-exports.

## Verification

- `bun run build` in `packages/sql-storage`
- `bun run build` in `packages/sqlite-bun`
- `bun run typecheck` in `packages/sql-storage`
- `bun run typecheck` in `packages/sqlite-bun`
- `bun run test` in `packages/sql-storage`
- `bun test src/test/contract.test.ts src/test/MeltOperationRepository.test.ts src/test/MintOperationRepository.test.ts src/test/SendOperationRepository.test.ts` in `packages/sqlite-bun`
- `bun run test` in `packages/sqlite-bun` fails only at `MINT_URL is not set` for the external-mint integration test

## Changeset

No changeset added; this is an internal refactor preserving the Bun aggregate behavior and compatibility exports.
