### PR TITLE
refactor: narrow sqlite adapter exports

### DIFF
--- a/.changeset/narrow-sqlite-adapter-exports.md
+++ b/.changeset/narrow-sqlite-adapter-exports.md
@@ -1,0 +1,11 @@
+---
+'@cashu/coco-sqlite': major
+'@cashu/coco-sqlite-bun': major
+'@cashu/coco-expo-sqlite': major
+---
+
+Narrow SQLite adapter package exports to the repository aggregate and option types.
+
+Applications should use `SqliteRepositories` as the adapter entry point. The packages no longer
+export individual repository classes, database wrapper classes, migration arrays, or schema helper
+functions.

--- a/packages/expo-sqlite/src/index.ts
+++ b/packages/expo-sqlite/src/index.ts
@@ -1,9 +1,11 @@
+import type { SQLiteDatabase } from 'expo-sqlite';
 import type { Repositories, RepositoryTransactionScope } from '@cashu/coco-core';
 import { SqlStorageRepositories } from '@cashu/coco-sql-storage';
-import type { Migration } from '@cashu/coco-sql-storage';
-import { ExpoSqliteDb, type ExpoSqliteDbOptions } from './db.ts';
+import { ExpoSqliteDb } from './db.ts';
 
-export interface SqliteRepositoriesOptions extends ExpoSqliteDbOptions {}
+export interface SqliteRepositoriesOptions {
+  database: SQLiteDatabase;
+}
 
 export class SqliteRepositories implements Repositories {
   readonly mintRepository: Repositories['mintRepository'];
@@ -22,7 +24,7 @@ export class SqliteRepositories implements Repositories {
   readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
   readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
   readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
-  readonly db: ExpoSqliteDb;
+  private readonly db: ExpoSqliteDb;
 
   private readonly repositories: SqlStorageRepositories;
 
@@ -60,28 +62,3 @@ export class SqliteRepositories implements Repositories {
 
 export type ExpoSqliteRepositoriesOptions = SqliteRepositoriesOptions;
 export { SqliteRepositories as ExpoSqliteRepositories };
-
-export { ExpoSqliteDb };
-export {
-  ensureSchema,
-  ensureSchemaUpTo,
-  MIGRATIONS,
-  SqliteMintRepository as ExpoMintRepository,
-  SqliteKeyRingRepository as ExpoKeyRingRepository,
-  SqliteKeysetRepository as ExpoKeysetRepository,
-  SqliteCounterRepository as ExpoCounterRepository,
-  SqliteProofRepository as ExpoProofRepository,
-  SqliteMeltQuoteRepository as ExpoMeltQuoteRepository,
-  SqliteMintQuoteRepository as ExpoMintQuoteRepository,
-  SqliteLegacyMintQuoteRepository as ExpoLegacyMintQuoteRepository,
-  SqliteHistoryRepository as ExpoHistoryRepository,
-  SqliteSendOperationRepository as ExpoSendOperationRepository,
-  SqliteMeltOperationRepository as ExpoMeltOperationRepository,
-  SqliteAuthSessionRepository as ExpoAuthSessionRepository,
-  SqliteMintOperationRepository as ExpoMintOperationRepository,
-  SqliteReceiveOperationRepository as ExpoReceiveOperationRepository,
-  SqlitePaymentRequestReceiveOperationRepository as ExpoPaymentRequestReceiveOperationRepository,
-  SqlitePaymentRequestReceiveAttemptRepository as ExpoPaymentRequestReceiveAttemptRepository,
-} from '@cashu/coco-sql-storage';
-
-export type { Migration };

--- a/packages/expo-sqlite/src/test/MeltOperationRepository.test.ts
+++ b/packages/expo-sqlite/src/test/MeltOperationRepository.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { Amount, type MeltOperation } from '@cashu/coco-core';
 import { SqliteRepositories, type SqliteRepositoriesOptions } from '../index.ts';
+import { ExpoSqliteDb } from '../db.ts';
 
 type FinalizedMeltOperation = Extract<MeltOperation, { state: 'finalized' }>;
 
@@ -81,10 +82,14 @@ function makeFinalizedMeltOperation(): FinalizedMeltOperation {
 
 describe('ExpoMeltOperationRepository', () => {
   let database: BunExpoSqliteDatabaseShim;
+  let sqlDatabase: ExpoSqliteDb;
   let repositories: SqliteRepositories;
 
   beforeEach(async () => {
     database = new BunExpoSqliteDatabaseShim();
+    sqlDatabase = new ExpoSqliteDb({
+      database: database as unknown as SqliteRepositoriesOptions['database'],
+    });
     repositories = new SqliteRepositories({
       database: database as unknown as SqliteRepositoriesOptions['database'],
     });
@@ -92,7 +97,7 @@ describe('ExpoMeltOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.raw.closeAsync?.();
+    await database.closeAsync();
   });
 
   it('round-trips settlement amounts for finalized operations', async () => {
@@ -104,7 +109,7 @@ describe('ExpoMeltOperationRepository', () => {
   });
 
   it('defaults legacy finalized rows without unit to sat', async () => {
-    await repositories.db.run(
+    await sqlDatabase.run(
       `INSERT INTO coco_cashu_melt_operations
          (id, mintUrl, state, createdAt, updatedAt, error, method, methodDataJson, quoteId, amount, fee_reserve, swap_fee, needsSwap, inputAmount, inputProofSecretsJson, changeOutputDataJson, swapOutputDataJson, changeAmount, effectiveFee, finalizedDataJson)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/packages/expo-sqlite/src/test/MintOperationRepository.test.ts
+++ b/packages/expo-sqlite/src/test/MintOperationRepository.test.ts
@@ -88,7 +88,7 @@ describe('ExpoMintOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.raw.closeAsync?.();
+    await database.closeAsync();
   });
 
   it('round-trips quote snapshot fields for pending operations', async () => {

--- a/packages/expo-sqlite/src/test/SendOperationRepository.test.ts
+++ b/packages/expo-sqlite/src/test/SendOperationRepository.test.ts
@@ -111,7 +111,7 @@ describe('ExpoSendOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.raw.closeAsync?.();
+    await database.closeAsync();
   });
 
   it('loads rolling_back operations from repository read methods', async () => {

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -15,8 +15,9 @@ import {
   createDummyProof,
 } from '@cashu/coco-adapter-tests';
 import { runSqlDatabaseContract } from '@cashu/coco-sql-storage/test';
-import { ExpoSqliteDb, SqliteRepositories as Repositories } from '../index.ts';
+import { SqliteRepositories as Repositories } from '../index.ts';
 import type { SqliteRepositoriesOptions } from '../index.ts';
+import { ExpoSqliteDb } from '../db.ts';
 
 type RunResult = { changes: number; lastInsertRowId: number; lastInsertRowid: number };
 
@@ -129,16 +130,20 @@ function createDeferred<T = void>() {
 }
 
 async function createRepositories() {
-  const database = new BunExpoSqliteDatabaseShim();
+  const rawDatabase = new BunExpoSqliteDatabaseShim();
+  const database = new ExpoSqliteDb({
+    database: rawDatabase as unknown as SqliteRepositoriesOptions['database'],
+  });
   const repositories = new Repositories({
-    database: database as unknown as SqliteRepositoriesOptions['database'],
+    database: rawDatabase as unknown as SqliteRepositoriesOptions['database'],
   });
   await repositories.init();
   return {
     repositories,
     dispose: async () => {
-      await repositories.db.raw.closeAsync?.();
+      await rawDatabase.closeAsync();
     },
+    database,
   } as const;
 }
 
@@ -172,11 +177,11 @@ async function expectRejects(fn: () => Promise<void>) {
 }
 
 async function insertMintQuoteRow(
-  repositories: Repositories,
+  database: ExpoSqliteDb,
   method: string,
   quoteId: string,
 ): Promise<void> {
-  await repositories.db.run(
+  await database.run(
     `INSERT INTO coco_cashu_canonical_mint_quotes
        (mintUrl, method, quoteId, state, request, amount, unit, quoteDataJson, reusable, createdAt, updatedAt)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -199,11 +204,11 @@ async function insertMintQuoteRow(
 }
 
 async function insertMeltQuoteRow(
-  repositories: Repositories,
+  database: ExpoSqliteDb,
   method: string,
   quoteId: string,
 ): Promise<void> {
-  await repositories.db.run(
+  await database.run(
     `INSERT INTO coco_cashu_melt_quotes
        (mintUrl, method, quoteId, state, request, amount, unit, expiry, fee_reserve, createdAt, updatedAt)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -237,20 +242,20 @@ runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, i
 
 describe('expo-sqlite quote storage constraints', () => {
   it('rejects persisted mint quote method siblings for one identity', async () => {
-    const { repositories, dispose } = await createRepositories();
+    const { database, dispose } = await createRepositories();
     try {
-      await insertMintQuoteRow(repositories, 'bolt11', 'duplicate-mint-quote');
-      await expectRejects(() => insertMintQuoteRow(repositories, 'bolt12', 'duplicate-mint-quote'));
+      await insertMintQuoteRow(database, 'bolt11', 'duplicate-mint-quote');
+      await expectRejects(() => insertMintQuoteRow(database, 'bolt12', 'duplicate-mint-quote'));
     } finally {
       await dispose();
     }
   });
 
   it('rejects persisted melt quote method siblings for one identity', async () => {
-    const { repositories, dispose } = await createRepositories();
+    const { database, dispose } = await createRepositories();
     try {
-      await insertMeltQuoteRow(repositories, 'bolt11', 'duplicate-melt-quote');
-      await expectRejects(() => insertMeltQuoteRow(repositories, 'bolt12', 'duplicate-melt-quote'));
+      await insertMeltQuoteRow(database, 'bolt11', 'duplicate-melt-quote');
+      await expectRejects(() => insertMeltQuoteRow(database, 'bolt12', 'duplicate-melt-quote'));
     } finally {
       await dispose();
     }
@@ -373,7 +378,7 @@ describe('expo-sqlite web transaction compatibility', () => {
       expect(database.transactionCalls).toBe(1);
       await expect(repositories.mintRepository.getAllMints()).resolves.toHaveLength(1);
     } finally {
-      await repositories.db.raw.closeAsync?.();
+      await database.closeAsync();
       restoreGlobalProperty('window', windowDescriptor);
       restoreGlobalProperty('document', documentDescriptor);
     }
@@ -400,7 +405,7 @@ describe('expo-sqlite native transaction compatibility', () => {
       expect(database.transactionCalls).toBe(0);
       await expect(repositories.mintRepository.getAllMints()).resolves.toHaveLength(1);
     } finally {
-      await repositories.db.raw.closeAsync?.();
+      await database.closeAsync();
     }
   });
 });

--- a/packages/expo-sqlite/src/test/integration.test.ts
+++ b/packages/expo-sqlite/src/test/integration.test.ts
@@ -80,7 +80,7 @@ async function createRepositories() {
   return {
     repositories,
     dispose: async () => {
-      await repositories.db.raw.closeAsync?.();
+      await database.closeAsync();
     },
   } as const;
 }

--- a/packages/sqlite-bun/src/index.ts
+++ b/packages/sqlite-bun/src/index.ts
@@ -1,9 +1,11 @@
+import type { Database } from 'bun:sqlite';
 import type { Repositories, RepositoryTransactionScope } from '@cashu/coco-core';
 import { SqlStorageRepositories } from '@cashu/coco-sql-storage';
-import type { Migration } from '@cashu/coco-sql-storage';
-import { SqliteDb, type SqliteDbOptions } from './db.ts';
+import { SqliteDb } from './db.ts';
 
-export interface SqliteRepositoriesOptions extends SqliteDbOptions {}
+export interface SqliteRepositoriesOptions {
+  database: Database;
+}
 
 export class SqliteRepositories implements Repositories {
   readonly mintRepository: Repositories['mintRepository'];
@@ -22,7 +24,7 @@ export class SqliteRepositories implements Repositories {
   readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
   readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
   readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
-  readonly db: SqliteDb;
+  private readonly db: SqliteDb;
 
   private readonly repositories: SqlStorageRepositories;
 
@@ -57,27 +59,3 @@ export class SqliteRepositories implements Repositories {
     return this.repositories.withTransaction(fn);
   }
 }
-
-export { SqliteDb };
-export {
-  ensureSchema,
-  ensureSchemaUpTo,
-  MIGRATIONS,
-  SqliteMintRepository,
-  SqliteKeyRingRepository,
-  SqliteKeysetRepository,
-  SqliteCounterRepository,
-  SqliteProofRepository,
-  SqliteMeltQuoteRepository,
-  SqliteMintQuoteRepository,
-  SqliteLegacyMintQuoteRepository,
-  SqliteHistoryRepository,
-  SqliteSendOperationRepository,
-  SqliteMeltOperationRepository,
-  SqliteAuthSessionRepository,
-  SqliteMintOperationRepository,
-  SqliteReceiveOperationRepository,
-  SqlitePaymentRequestReceiveOperationRepository,
-  SqlitePaymentRequestReceiveAttemptRepository,
-} from '@cashu/coco-sql-storage';
-export type { Migration };

--- a/packages/sqlite-bun/src/test/MeltOperationRepository.test.ts
+++ b/packages/sqlite-bun/src/test/MeltOperationRepository.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { Amount, type MeltOperation } from '@cashu/coco-core';
 import { SqliteRepositories } from '../index.ts';
+import { SqliteDb } from '../db.ts';
 
 type FinalizedMeltOperation = Extract<MeltOperation, { state: 'finalized' }>;
 
@@ -35,16 +36,18 @@ function makeFinalizedMeltOperation(): FinalizedMeltOperation {
 
 describe('SqliteMeltOperationRepository', () => {
   let database: Database;
+  let sqlDatabase: SqliteDb;
   let repositories: SqliteRepositories;
 
   beforeEach(async () => {
     database = new Database(':memory:');
+    sqlDatabase = new SqliteDb({ database });
     repositories = new SqliteRepositories({ database });
     await repositories.init();
   });
 
   afterEach(async () => {
-    await repositories.db.close();
+    database.close();
   });
 
   it('round-trips settlement amounts for finalized operations', async () => {
@@ -56,7 +59,7 @@ describe('SqliteMeltOperationRepository', () => {
   });
 
   it('defaults legacy finalized rows without unit to sat', async () => {
-    await repositories.db.run(
+    await sqlDatabase.run(
       `INSERT INTO coco_cashu_melt_operations
          (id, mintUrl, state, createdAt, updatedAt, error, method, methodDataJson, quoteId, amount, fee_reserve, swap_fee, needsSwap, inputAmount, inputProofSecretsJson, changeOutputDataJson, swapOutputDataJson, changeAmount, effectiveFee, finalizedDataJson)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/packages/sqlite-bun/src/test/MintOperationRepository.test.ts
+++ b/packages/sqlite-bun/src/test/MintOperationRepository.test.ts
@@ -19,7 +19,7 @@ describe('SqliteMintOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.close();
+    database.close();
   });
 
   it('persists and loads supported mint operation states', async () => {

--- a/packages/sqlite-bun/src/test/SendOperationRepository.test.ts
+++ b/packages/sqlite-bun/src/test/SendOperationRepository.test.ts
@@ -63,7 +63,7 @@ describe('SqliteSendOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.close();
+    database.close();
   });
 
   it('loads rolling_back operations from repository read methods', async () => {

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -15,7 +15,8 @@ import {
   createDummyProof,
 } from '@cashu/coco-adapter-tests';
 import { runSqlDatabaseContract } from '@cashu/coco-sql-storage/test';
-import { SqliteDb, SqliteRepositories as Repositories } from '../index.ts';
+import { SqliteRepositories as Repositories } from '../index.ts';
+import { SqliteDb } from '../db.ts';
 
 function createDeferred<T = void>() {
   let resolve!: (value: T) => void;
@@ -28,13 +29,15 @@ function createDeferred<T = void>() {
 }
 
 async function createRepositories() {
-  const database = new Database(':memory:');
-  const repositories = new Repositories({ database });
+  const rawDatabase = new Database(':memory:');
+  const database = new SqliteDb({ database: rawDatabase });
+  const repositories = new Repositories({ database: rawDatabase });
   await repositories.init();
   return {
     repositories,
+    database,
     dispose: async () => {
-      repositories.db.close();
+      database.close();
     },
   };
 }
@@ -65,11 +68,11 @@ async function expectRejects(fn: () => Promise<void>) {
 }
 
 async function insertMintQuoteRow(
-  repositories: Repositories,
+  database: SqliteDb,
   method: string,
   quoteId: string,
 ): Promise<void> {
-  await repositories.db.run(
+  await database.run(
     `INSERT INTO coco_cashu_canonical_mint_quotes
        (mintUrl, method, quoteId, state, request, amount, unit, quoteDataJson, reusable, createdAt, updatedAt)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -92,11 +95,11 @@ async function insertMintQuoteRow(
 }
 
 async function insertMeltQuoteRow(
-  repositories: Repositories,
+  database: SqliteDb,
   method: string,
   quoteId: string,
 ): Promise<void> {
-  await repositories.db.run(
+  await database.run(
     `INSERT INTO coco_cashu_melt_quotes
        (mintUrl, method, quoteId, state, request, amount, unit, expiry, fee_reserve, createdAt, updatedAt)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -130,20 +133,20 @@ runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, i
 
 describe('sqlite-bun quote storage constraints', () => {
   it('rejects persisted mint quote method siblings for one identity', async () => {
-    const { repositories, dispose } = await createRepositories();
+    const { database, dispose } = await createRepositories();
     try {
-      await insertMintQuoteRow(repositories, 'bolt11', 'duplicate-mint-quote');
-      await expectRejects(() => insertMintQuoteRow(repositories, 'bolt12', 'duplicate-mint-quote'));
+      await insertMintQuoteRow(database, 'bolt11', 'duplicate-mint-quote');
+      await expectRejects(() => insertMintQuoteRow(database, 'bolt12', 'duplicate-mint-quote'));
     } finally {
       await dispose();
     }
   });
 
   it('rejects persisted melt quote method siblings for one identity', async () => {
-    const { repositories, dispose } = await createRepositories();
+    const { database, dispose } = await createRepositories();
     try {
-      await insertMeltQuoteRow(repositories, 'bolt11', 'duplicate-melt-quote');
-      await expectRejects(() => insertMeltQuoteRow(repositories, 'bolt12', 'duplicate-melt-quote'));
+      await insertMeltQuoteRow(database, 'bolt11', 'duplicate-melt-quote');
+      await expectRejects(() => insertMeltQuoteRow(database, 'bolt12', 'duplicate-melt-quote'));
     } finally {
       await dispose();
     }

--- a/packages/sqlite-bun/src/test/integration.test.ts
+++ b/packages/sqlite-bun/src/test/integration.test.ts
@@ -31,7 +31,7 @@ async function createRepositories() {
   return {
     repositories,
     dispose: async () => {
-      repositories.db.close();
+      database.close();
     },
   };
 }

--- a/packages/sqlite3/src/index.ts
+++ b/packages/sqlite3/src/index.ts
@@ -1,9 +1,11 @@
 import type { Repositories, RepositoryTransactionScope } from '@cashu/coco-core';
+import type { Database } from 'better-sqlite3';
 import { SqlStorageRepositories } from '@cashu/coco-sql-storage';
-import type { Migration } from '@cashu/coco-sql-storage';
-import { SqliteDb, type SqliteDbOptions } from './db.ts';
+import { SqliteDb } from './db.ts';
 
-export interface SqliteRepositoriesOptions extends SqliteDbOptions {}
+export interface SqliteRepositoriesOptions {
+  database: Database;
+}
 
 export class SqliteRepositories implements Repositories {
   readonly mintRepository: Repositories['mintRepository'];
@@ -22,7 +24,7 @@ export class SqliteRepositories implements Repositories {
   readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
   readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
   readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
-  readonly db: SqliteDb;
+  private readonly db: SqliteDb;
 
   private readonly repositories: SqlStorageRepositories;
 
@@ -57,28 +59,3 @@ export class SqliteRepositories implements Repositories {
     return this.repositories.withTransaction(fn);
   }
 }
-
-export { SqliteDb };
-export {
-  ensureSchema,
-  ensureSchemaUpTo,
-  MIGRATIONS,
-  SqliteMintRepository,
-  SqliteKeyRingRepository,
-  SqliteKeysetRepository,
-  SqliteCounterRepository,
-  SqliteProofRepository,
-  SqliteMeltQuoteRepository,
-  SqliteMintQuoteRepository,
-  SqliteLegacyMintQuoteRepository,
-  SqliteHistoryRepository,
-  SqliteSendOperationRepository,
-  SqliteMeltOperationRepository,
-  SqliteAuthSessionRepository,
-  SqliteMintOperationRepository,
-  SqliteReceiveOperationRepository,
-  SqlitePaymentRequestReceiveOperationRepository,
-  SqlitePaymentRequestReceiveAttemptRepository,
-} from '@cashu/coco-sql-storage';
-
-export type { Migration };

--- a/packages/sqlite3/src/test/MeltOperationRepository.test.ts
+++ b/packages/sqlite3/src/test/MeltOperationRepository.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database, { type Database as BetterSqlite3Database } from 'better-sqlite3';
 import { Amount, type MeltOperation } from '@cashu/coco-core';
 import { SqliteRepositories } from '../index.ts';
+import { SqliteDb } from '../db.ts';
 
 type FinalizedMeltOperation = Extract<MeltOperation, { state: 'finalized' }>;
 
@@ -31,16 +32,18 @@ function makeFinalizedMeltOperation(): FinalizedMeltOperation {
 
 describe('SqliteMeltOperationRepository', () => {
   let database: BetterSqlite3Database;
+  let sqlDatabase: SqliteDb;
   let repositories: SqliteRepositories;
 
   beforeEach(async () => {
     database = new Database(':memory:');
+    sqlDatabase = new SqliteDb({ database });
     repositories = new SqliteRepositories({ database });
     await repositories.init();
   });
 
   afterEach(async () => {
-    await repositories.db.close();
+    database.close();
   });
 
   it('round-trips settlement amounts for finalized operations', async () => {
@@ -54,7 +57,7 @@ describe('SqliteMeltOperationRepository', () => {
   });
 
   it('defaults legacy finalized rows without unit to sat', async () => {
-    await repositories.db.run(
+    await sqlDatabase.run(
       `INSERT INTO coco_cashu_melt_operations
          (id, mintUrl, state, createdAt, updatedAt, error, method, methodDataJson, quoteId, amount, fee_reserve, swap_fee, needsSwap, inputAmount, inputProofSecretsJson, changeOutputDataJson, swapOutputDataJson, changeAmount, effectiveFee, finalizedDataJson)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/packages/sqlite3/src/test/MintOperationRepository.test.ts
+++ b/packages/sqlite3/src/test/MintOperationRepository.test.ts
@@ -15,7 +15,7 @@ describe('SqliteMintOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.close();
+    database.close();
   });
 
   it('persists and loads supported mint operation states', async () => {

--- a/packages/sqlite3/src/test/SendOperationRepository.test.ts
+++ b/packages/sqlite3/src/test/SendOperationRepository.test.ts
@@ -59,7 +59,7 @@ describe('SqliteSendOperationRepository', () => {
   });
 
   afterEach(async () => {
-    await repositories.db.close();
+    database.close();
   });
 
   it('loads rolling_back operations from repository read methods', async () => {

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -15,7 +15,8 @@ import {
   createDummyProof,
 } from '@cashu/coco-adapter-tests';
 import { runSqlDatabaseContract } from '@cashu/coco-sql-storage/test';
-import { SqliteDb, SqliteRepositories as Repositories } from '../index.ts';
+import { SqliteRepositories as Repositories } from '../index.ts';
+import { SqliteDb } from '../db.ts';
 
 function createDeferred<T = void>() {
   let resolve!: (value: T) => void;
@@ -28,13 +29,15 @@ function createDeferred<T = void>() {
 }
 
 async function createRepositories() {
-  const database = new Database(':memory:');
-  const repositories = new Repositories({ database });
+  const rawDatabase = new Database(':memory:');
+  const database = new SqliteDb({ database: rawDatabase });
+  const repositories = new Repositories({ database: rawDatabase });
   await repositories.init();
   return {
     repositories,
+    database,
     dispose: async () => {
-      await repositories.db.close();
+      await database.close();
     },
   };
 }
@@ -65,11 +68,11 @@ async function expectRejects(fn: () => Promise<void>) {
 }
 
 async function insertMintQuoteRow(
-  repositories: Repositories,
+  database: SqliteDb,
   method: string,
   quoteId: string,
 ): Promise<void> {
-  await repositories.db.run(
+  await database.run(
     `INSERT INTO coco_cashu_canonical_mint_quotes
        (mintUrl, method, quoteId, state, request, amount, unit, quoteDataJson, reusable, createdAt, updatedAt)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -92,11 +95,11 @@ async function insertMintQuoteRow(
 }
 
 async function insertMeltQuoteRow(
-  repositories: Repositories,
+  database: SqliteDb,
   method: string,
   quoteId: string,
 ): Promise<void> {
-  await repositories.db.run(
+  await database.run(
     `INSERT INTO coco_cashu_melt_quotes
        (mintUrl, method, quoteId, state, request, amount, unit, expiry, fee_reserve, createdAt, updatedAt)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -130,20 +133,20 @@ runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, i
 
 describe('sqlite3 quote storage constraints', () => {
   it('rejects persisted mint quote method siblings for one identity', async () => {
-    const { repositories, dispose } = await createRepositories();
+    const { database, dispose } = await createRepositories();
     try {
-      await insertMintQuoteRow(repositories, 'bolt11', 'duplicate-mint-quote');
-      await expectRejects(() => insertMintQuoteRow(repositories, 'bolt12', 'duplicate-mint-quote'));
+      await insertMintQuoteRow(database, 'bolt11', 'duplicate-mint-quote');
+      await expectRejects(() => insertMintQuoteRow(database, 'bolt12', 'duplicate-mint-quote'));
     } finally {
       await dispose();
     }
   });
 
   it('rejects persisted melt quote method siblings for one identity', async () => {
-    const { repositories, dispose } = await createRepositories();
+    const { database, dispose } = await createRepositories();
     try {
-      await insertMeltQuoteRow(repositories, 'bolt11', 'duplicate-melt-quote');
-      await expectRejects(() => insertMeltQuoteRow(repositories, 'bolt12', 'duplicate-melt-quote'));
+      await insertMeltQuoteRow(database, 'bolt11', 'duplicate-melt-quote');
+      await expectRejects(() => insertMeltQuoteRow(database, 'bolt12', 'duplicate-melt-quote'));
     } finally {
       await dispose();
     }

--- a/packages/sqlite3/src/test/integration.test.ts
+++ b/packages/sqlite3/src/test/integration.test.ts
@@ -28,7 +28,7 @@ async function createRepositories() {
   return {
     repositories,
     dispose: async () => {
-      await repositories.db.close();
+      database.close();
     },
   };
 }


### PR DESCRIPTION
This pull request resolves #214.

## Problem

The SQLite adapter packages still exposed implementation details after the shared SQL storage conversion: runtime database wrappers, individual repository classes, migration arrays, and schema helpers. That kept internal storage organization in the public API surface for the major release.

## Summary

- Narrowed `@cashu/coco-sqlite`, `@cashu/coco-sqlite-bun`, and `@cashu/coco-expo-sqlite` root exports to `SqliteRepositories` and `SqliteRepositoriesOptions`.
- Kept the Expo migration aliases `ExpoSqliteRepositories` and `ExpoSqliteRepositoriesOptions`.
- Made aggregate database wrappers internal and updated adapter tests to import wrapper classes from package-internal modules or use caller-owned raw database handles.
- Added a major changeset for the three public SQLite adapter packages.

## Verification

- `bun run --filter='@cashu/coco-sqlite-bun' typecheck`
- `bun run --filter='@cashu/coco-sqlite' typecheck`
- `bun run --filter='@cashu/coco-expo-sqlite' typecheck`
- `bun run --filter='@cashu/coco-sqlite-bun' build`
- `bun run --filter='@cashu/coco-sqlite' build`
- `bun run --filter='@cashu/coco-expo-sqlite' build`
- `bun run --filter='@cashu/coco-sqlite-bun' test -- src/test/contract.test.ts src/test/MintOperationRepository.test.ts src/test/MeltOperationRepository.test.ts src/test/SendOperationRepository.test.ts`
- `bun run --filter='@cashu/coco-sqlite' test -- src/test/contract.test.ts src/test/MintOperationRepository.test.ts src/test/MeltOperationRepository.test.ts src/test/SendOperationRepository.test.ts`
- `bun run --filter='@cashu/coco-expo-sqlite' test -- src/test/contract.test.ts src/test/MintOperationRepository.test.ts src/test/MeltOperationRepository.test.ts src/test/SendOperationRepository.test.ts`
- inspected generated `dist/index.d.ts` exports after targeted builds

## Changeset

- Added `.changeset/narrow-sqlite-adapter-exports.md`