### PR TITLE
[codex] docs(sqlite adapters): document shared storage API

### DIFF
--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -14,6 +14,21 @@ const coco = await initializeCoco({
 
 Some storage implementations are maintained as part of the cashubtc/coco repository, but technically you can use any class that implements the `Repositories` interface.
 
+## SQLite adapter public API
+
+The SQLite adapter packages share the same public shape. Import
+`SqliteRepositories` from the package that matches your runtime, open the
+database with that runtime's SQLite driver, and pass the already-opened database
+instance through the `database` option.
+
+Your application owns the database lifecycle. The Coco adapter creates schema
+and runs migrations when you call `repo.init()`, but it does not open or close
+the underlying database.
+
+The public SQLite adapter packages expose the repository aggregate and its
+option type. Migration helpers, database wrapper classes, and individual
+repository classes are internal implementation details.
+
 ## @cashu/coco-indexeddb
 
 Implements Repositories using the IndexedDB Browser API.
@@ -54,15 +69,19 @@ import { initializeCoco } from '@cashu/coco-core';
 import { SqliteRepositories } from '@cashu/coco-expo-sqlite';
 import { openDatabaseAsync } from 'expo-sqlite';
 
-// First we create an expo-sqlite client
+// Open the Expo SQLite database in your application
 const db = await openDatabaseAsync('coco-demo.db');
-// Then we pass it to our storage implementation
+// Pass the already-opened database to the storage implementation
 const repo = new SqliteRepositories({ database: db });
 const coco = await initializeCoco({
   repo,
   seedGetter,
 });
 ```
+
+`ExpoSqliteRepositories` and `ExpoSqliteRepositoriesOptions` are available as
+soft-migration aliases for `SqliteRepositories` and
+`SqliteRepositoriesOptions`.
 
 ## @cashu/coco-sqlite
 
@@ -80,9 +99,9 @@ import { initializeCoco } from '@cashu/coco-core';
 import { SqliteRepositories } from '@cashu/coco-sqlite';
 import Database from 'better-sqlite3';
 
-// First we create a better-sqlite3 client
+// Open the better-sqlite3 database in your application
 const db = new Database('./test.db');
-// Then we pass it to our storage implementation
+// Pass the already-opened database to the storage implementation
 const repo = new SqliteRepositories({ database: db });
 const coco = await initializeCoco({
   repo,
@@ -107,9 +126,9 @@ import { initializeCoco } from '@cashu/coco-core';
 import { SqliteRepositories } from '@cashu/coco-sqlite-bun';
 import { Database } from 'bun:sqlite';
 
-// First we create a bun:sqlite client
+// Open the bun:sqlite database in your application
 const db = new Database('./test.db');
-// Then we pass it to our storage implementation
+// Pass the already-opened database to the storage implementation
 const repo = new SqliteRepositories({ database: db });
 const coco = await initializeCoco({
   repo,

--- a/packages/docs/starting/migrating-from-v1.md
+++ b/packages/docs/starting/migrating-from-v1.md
@@ -142,6 +142,18 @@ The bundled adapters migrate existing data automatically:
 - melt quote rows become method-aware canonical quote rows
 - operation quote lookups become method-aware
 
+The SQLite adapter packages now expose a narrower public surface for the major
+release. Import `SqliteRepositories` from the runtime-specific package
+(`@cashu/coco-sqlite`, `@cashu/coco-sqlite-bun`, or
+`@cashu/coco-expo-sqlite`), pass an already-opened database instance, and call
+`repositories.init()` before using the manager. Migration helpers, database
+wrapper classes, and individual repository classes are no longer public adapter
+exports.
+
+For Expo, `ExpoSqliteRepositories` and `ExpoSqliteRepositoriesOptions` remain
+available as soft-migration aliases for `SqliteRepositories` and
+`SqliteRepositoriesOptions`.
+
 Custom repository implementations must provide the current repository contract:
 
 - `MintQuoteRepository` with `{ mintUrl, quoteId }` identity helpers and

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -5,6 +5,10 @@
 
 Expo SQLite storage adapter for Coco in React Native and Expo applications.
 
+The public entry point is `SqliteRepositories`. Open the `expo-sqlite` database
+in your application, pass that already-opened database instance to the adapter,
+and keep ownership of the database lifecycle.
+
 ## Install
 
 ```bash
@@ -28,6 +32,23 @@ const manager = await initializeCoco({
   seedGetter,
 });
 ```
+
+The adapter does not close a database that it did not open. Keep the Expo
+database lifecycle under your application code.
+
+## Public API
+
+- Import `SqliteRepositories` and `SqliteRepositoriesOptions` from
+  `@cashu/coco-expo-sqlite`.
+- Pass an already-opened `expo-sqlite` database with the `database` option.
+- Call `repositories.init()` before using the manager so schema creation and
+  migrations run.
+- `ExpoSqliteRepositories` remains available as an alias for
+  `SqliteRepositories`.
+- `ExpoSqliteRepositoriesOptions` remains available as an alias for
+  `SqliteRepositoriesOptions`.
+- Migration helpers, database wrapper classes, and individual repository classes
+  are internal implementation details and are not public adapter exports.
 
 ## Notes
 

--- a/packages/sqlite-bun/README.md
+++ b/packages/sqlite-bun/README.md
@@ -5,6 +5,10 @@
 
 SQLite adapter for Coco using Bun's built-in `bun:sqlite` module.
 
+The public entry point is `SqliteRepositories`. Open the `bun:sqlite` database
+in your application, pass that already-opened database instance to the adapter,
+and keep ownership of the database lifecycle.
+
 ## Install
 
 ```bash
@@ -27,6 +31,19 @@ const manager = await initializeCoco({
   seedGetter,
 });
 ```
+
+When your application shuts down, close `database` from your own code. The
+adapter does not close a database that it did not open.
+
+## Public API
+
+- Import `SqliteRepositories` and `SqliteRepositoriesOptions` from
+  `@cashu/coco-sqlite-bun`.
+- Pass an already-opened `bun:sqlite` database with the `database` option.
+- Call `repositories.init()` before using the manager so schema creation and
+  migrations run.
+- Migration helpers, database wrapper classes, and individual repository classes
+  are internal implementation details and are not public adapter exports.
 
 ## Notes
 

--- a/packages/sqlite3/README.md
+++ b/packages/sqlite3/README.md
@@ -5,6 +5,10 @@
 
 Node storage adapter for Coco built on `better-sqlite3`.
 
+The public entry point is `SqliteRepositories`. Open the `better-sqlite3`
+database in your application, pass that already-opened database instance to the
+adapter, and keep ownership of the database lifecycle.
+
 ## Install
 
 ```bash
@@ -27,6 +31,19 @@ const manager = await initializeCoco({
   seedGetter,
 });
 ```
+
+When your application shuts down, close `database` from your own code. The
+adapter does not close a database that it did not open.
+
+## Public API
+
+- Import `SqliteRepositories` and `SqliteRepositoriesOptions` from
+  `@cashu/coco-sqlite`.
+- Pass an already-opened `better-sqlite3` database with the `database` option.
+- Call `repositories.init()` before using the manager so schema creation and
+  migrations run.
+- Migration helpers, database wrapper classes, and individual repository classes
+  are internal implementation details and are not public adapter exports.
 
 ## Notes
 


### PR DESCRIPTION
This pull request resolves #216.

## Problem

The SQLite adapter docs still needed to describe the post-shared-storage public API: users should import the aggregate from the runtime-specific package, pass an already-opened database instance, and avoid relying on internal migration helpers, wrapper classes, or individual repository classes.

## Summary

- Documents `SqliteRepositories` and database lifecycle ownership in the Node, Bun, and Expo SQLite adapter READMEs.
- Updates the storage adapter docs with the shared SQLite public API shape and Expo soft-migration aliases.
- Adds a v1 migration note for the narrowed SQLite adapter exports.

## Verification

- `bun run docs:build`

## Changeset

- No new changeset added; this is documentation for the major adapter export change already covered by `.changeset/narrow-sqlite-adapter-exports.md`.