### PR TITLE
fix(core): resolve unrecoverable receive recovery

### DIFF
--- a/.changeset/receive-recovery-spent-inputs.md
+++ b/.changeset/receive-recovery-spent-inputs.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Resolve receive recovery operations when spent inputs have no recoverable outputs.

--- a/packages/core/operations/receive/ReceiveOperationService.ts
+++ b/packages/core/operations/receive/ReceiveOperationService.ts
@@ -597,6 +597,13 @@ export class ReceiveOperationService {
           await this.markAsFinalized(executing);
           return;
         }
+        if (recovered.length === 0) {
+          await this.markAsRolledBack(
+            executing,
+            'Recovered: input proofs spent without recoverable outputs',
+          );
+          return;
+        }
         this.logger?.warn('Receive outputs not persisted after recovery attempt', {
           operationId: executing.id,
           mintUrl: executing.mintUrl,

--- a/packages/core/test/unit/ReceiveOperationService.recovery.test.ts
+++ b/packages/core/test/unit/ReceiveOperationService.recovery.test.ts
@@ -16,6 +16,7 @@ import type { ProofState as CashuProofState, Proof } from '@cashu/cashu-ts';
 import type { CoreProof } from '../../types';
 import { MintOperationError, ProofValidationError } from '../../models/Error';
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
+import { ReceiveOpsApi } from '../../api/ReceiveOpsApi.ts';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
 import { ReceiveOperationService } from '../../operations/receive/ReceiveOperationService';
 import { MemoryReceiveOperationRepository } from '../../repositories/memory/MemoryReceiveOperationRepository';
@@ -33,6 +34,7 @@ describe('ReceiveOperationService - recoverPendingOperations', () => {
   let tokenService: TokenService;
   let eventBus: EventBus<CoreEvents>;
   let service: ReceiveOperationService;
+  let api: ReceiveOpsApi;
 
   let mockCheckProofsStates: Mock<(mintUrl: string, ys: string[]) => Promise<CashuProofState[]>>;
   let mockWalletReceive: Mock<(...args: any[]) => Promise<Proof[]>>;
@@ -135,6 +137,7 @@ describe('ReceiveOperationService - recoverPendingOperations', () => {
       tokenService,
       eventBus,
     );
+    api = new ReceiveOpsApi(service);
   });
 
   it('cleans up init operations', async () => {
@@ -205,6 +208,23 @@ describe('ReceiveOperationService - recoverPendingOperations', () => {
     expect((proofService.recoverProofsFromOutputData as Mock<any>).mock.calls.length).toBe(1);
     expect(mockCheckProofsStates.mock.calls.length).toBeGreaterThan(0);
     expect(mockWalletReceive.mock.calls.length).toBe(0);
+  });
+
+  it('rolls back an executing receive when spent inputs have no recoverable outputs', async () => {
+    const proofs = [makeProof('p1')];
+    const op = makeExecutingOp('exec-op-spent-unrecoverable', proofs);
+    await receiveOpRepo.create(op);
+
+    mockCheckProofsStates.mockImplementation(async (_mintUrl: string, ys: string[]) =>
+      ys.map(() => ({ state: 'SPENT' }) as CashuProofState),
+    );
+
+    await api.recovery.run();
+
+    const stored = await api.get(op.id);
+    expect(stored?.state).toBe('rolled_back');
+    expect(stored?.error).toBe('Recovered: input proofs spent without recoverable outputs');
+    expect((await api.listInFlight()).map((operation) => operation.id)).not.toContain(op.id);
   });
 
   it('properly propagates errors from checkProofsStates as executing', async () => {


### PR DESCRIPTION
## Description

This pull request fixes receive recovery for the case where input proofs are conclusively spent but no output proofs can be restored for the receive operation.

This pull request resolves #226.

## Problem

Receive recovery could leave an operation permanently `executing` after the token inputs were spent elsewhere and the operation's deterministic outputs had no recoverable proofs. That kept the operation in `listInFlight()` indefinitely.

## Summary

- Roll back executing receive operations when spent inputs recover zero usable outputs.
- Add regression coverage through `ReceiveOpsApi.recovery.run()` and `listInFlight()`.
- Add a patch changeset for `@cashu/coco-core`.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/ReceiveOperationService.recovery.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test:unit`
- `git diff --check`

## Changeset

- Added `.changeset/receive-recovery-spent-inputs.md`