### PR TITLE
docs: record generic payment method decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,6 +29,40 @@ _Avoid_: Added mint, cached mint
 A known mint approved for wallet operations.
 _Avoid_: Active mint
 
+**Built-in Payment Method**:
+A payment method that coco models with method-specific behavior and validation. The built-in payment
+methods are `bolt11`, `bolt12`, and `onchain`.
+_Avoid_: Default method, native method
+
+**Generic Payment Method**:
+A base quote struct compatible payment method that a mint advertises but coco does not model as a
+Built-in Payment Method. Generic Payment Methods preserve the mint's method string; their mint
+quotes are reusable, locked to a wallet-controlled quote key, and claimable according to the paid
+amount that has not yet been issued.
+_Avoid_: Runtime payment method, custom payment method
+
+**Payment Method Handler**:
+A method-specific or generic implementation of coco's quote-backed payment lifecycle. Built-in
+payment methods use dedicated handlers; Generic Payment Methods use generic mint and melt handlers
+while preserving the advertised method string.
+_Avoid_: Payment plugin, method switch
+
+**Quote-backed Operation**:
+A wallet operation whose local lifecycle is anchored to a mint quote. Payment methods can vary in
+quote parameters and endpoint fields, but quote-backed minting and melting share the same durable
+saga shape for outputs, inputs, proof state, and recovery.
+_Avoid_: Method flow, payment workflow
+
+**Payment Method Capability**:
+A mint-advertised statement that a payment method supports a unit for minting or melting. Coco
+derives payment method capabilities from NUT-04 and NUT-05 mint metadata.
+_Avoid_: Payment option, method support flag
+
+**Melt Quote State**:
+The mint's settlement state for a melt quote. `PAID` is terminal, while `PENDING` can return to
+`UNPAID` when settlement fails.
+_Avoid_: Payment status, melt lifecycle
+
 **Restore**:
 The act of reconstructing a wallet's proofs for a mint from the wallet's deterministic secrets and the mint's state. Restore is distinct from operation recovery and does not create a persistent restored state.
 _Avoid_: Recovery, import, restored mint, restored wallet

--- a/docs/adr/0001-generic-mint-quotes-are-reusable-and-key-locked.md
+++ b/docs/adr/0001-generic-mint-quotes-are-reusable-and-key-locked.md
@@ -1,0 +1,7 @@
+# Generic mint quotes are reusable and key locked
+
+Generic Payment Method mint quotes are accepted only when they provide reusable quote accounting:
+the paid amount and the issued amount. Coco generates the wallet-controlled quote key for these
+quotes and rejects generic mint quote responses that omit the reusable accounting fields, because
+operation recovery and safe claim calculation depend on coco owning the quote key and knowing the
+unissued paid value.

--- a/docs/adr/0002-keep-built-in-methods-first-class-while-allowing-generic-method-strings.md
+++ b/docs/adr/0002-keep-built-in-methods-first-class-while-allowing-generic-method-strings.md
@@ -1,0 +1,7 @@
+# Keep built-in methods first-class while allowing generic method strings
+
+Coco keeps `bolt11`, `bolt12`, and `onchain` as Built-in Payment Methods with narrow typed inputs
+and return types, while adding Generic Payment Method entry points that accept arbitrary method
+strings through an explicit generic payload shape. This is a breaking public API change, so coco
+will use clear built-in/generic method type names rather than preserving compatibility aliases that
+obscure the distinction.

--- a/docs/adr/0003-preserve-raw-generic-quote-responses.md
+++ b/docs/adr/0003-preserve-raw-generic-quote-responses.md
@@ -1,0 +1,6 @@
+# Preserve raw generic quote responses
+
+Generic Payment Method quotes expose `rawQuoteData` as the JSON object returned by the mint before
+coco converts lifecycle fields into domain values. Generic quote adapter calls therefore need
+access to the raw mint response as well as parsed lifecycle fields, because callers use Generic
+Payment Methods precisely when method-specific response fields are not known to coco.


### PR DESCRIPTION
## Summary

- Adds Generic Payment Method vocabulary to `CONTEXT.md`.
- Records ADRs for reusable/key-locked generic mint quotes, keeping built-in methods first-class, and preserving raw generic quote responses.
- Provides design context for the Generic Payment Methods PRD in #232 before implementation slices land.

## Verification

- `./node_modules/.bin/prettier --check CONTEXT.md docs/adr/0001-generic-mint-quotes-are-reusable-and-key-locked.md docs/adr/0002-keep-built-in-methods-first-class-while-allowing-generic-method-strings.md docs/adr/0003-preserve-raw-generic-quote-responses.md`
- `git diff --check`