### PR TITLE
feat(core): expose payment method capability APIs

### DIFF
--- a/.changeset/payment-method-capabilities.md
+++ b/.changeset/payment-method-capabilities.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': minor
+---
+
+Expose mint and melt Payment Method Capability checks and listings on the mint API.

--- a/packages/core/api/MintApi.ts
+++ b/packages/core/api/MintApi.ts
@@ -1,4 +1,10 @@
-import type { MintService } from '@core/services';
+import type {
+  CheckPaymentMethodCapabilityInput,
+  ListPaymentMethodCapabilitiesInput,
+  MintService,
+  PaymentMethodCapability,
+  PaymentMethodCapabilityCheck,
+} from '@core/services';
 import type { Mint, Keyset } from '@core/models';
 import type { MintInfo } from '@core/types';
 
@@ -17,6 +23,20 @@ export class MintApi {
 
   async getMintInfo(mintUrl: string): Promise<MintInfo> {
     return this.mintService.getMintInfo(mintUrl);
+  }
+
+  /** Check whether a mint supports one method/unit pair for minting or melting. */
+  async checkPaymentMethodCapability(
+    input: CheckPaymentMethodCapabilityInput,
+  ): Promise<PaymentMethodCapabilityCheck> {
+    return this.mintService.checkPaymentMethodCapability(input);
+  }
+
+  /** List enabled Payment Method Capabilities advertised by NUT-04/NUT-05 mint metadata. */
+  async listPaymentMethodCapabilities(
+    input: ListPaymentMethodCapabilitiesInput,
+  ): Promise<PaymentMethodCapability[]> {
+    return this.mintService.listPaymentMethodCapabilities(input);
   }
 
   async isTrustedMint(mintUrl: string): Promise<boolean> {

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -31,6 +31,42 @@ export interface MethodUnitCapability {
   reason?: string;
 }
 
+/** Operation side for Payment Method Capability discovery. */
+export type PaymentMethodCapabilityOperationKind = 'mint' | 'melt';
+
+/** Input for checking whether one method/unit pair is supported by mint metadata. */
+export interface CheckPaymentMethodCapabilityInput {
+  mintUrl: string;
+  operation: PaymentMethodCapabilityOperationKind;
+  method: string;
+  unit: string;
+}
+
+/** Input for listing actionable Payment Method Capabilities advertised by a mint. */
+export interface ListPaymentMethodCapabilitiesInput {
+  mintUrl: string;
+  operation?: PaymentMethodCapabilityOperationKind;
+  unit?: string;
+}
+
+/** Actionable Payment Method Capability advertised through enabled NUT-04/NUT-05 metadata. */
+export interface PaymentMethodCapability {
+  operation: PaymentMethodCapabilityOperationKind;
+  nut: 4 | 5;
+  method: string;
+  unit: string;
+  minAmount?: Amount | null;
+  maxAmount?: Amount | null;
+  options?: unknown;
+}
+
+/** Result for a single Payment Method Capability check, including unsupported reasons. */
+export interface PaymentMethodCapabilityCheck extends PaymentMethodCapability {
+  supported: boolean;
+  disabled: boolean;
+  reason?: string;
+}
+
 type NutMethodSetting = {
   method: string;
   unit: string;
@@ -185,6 +221,24 @@ export class MintService {
     return mint.mintInfo;
   }
 
+  async checkPaymentMethodCapability(
+    input: CheckPaymentMethodCapabilityInput,
+  ): Promise<PaymentMethodCapabilityCheck> {
+    const operation = this.assertPaymentMethodCapabilityOperation(input.operation);
+    const nut = this.nutForPaymentMethodCapabilityOperation(operation);
+    const capability = await this.getMintMethodUnitCapability(
+      input.mintUrl,
+      nut,
+      input.method,
+      input.unit,
+    );
+
+    return {
+      ...capability,
+      operation,
+    };
+  }
+
   async getMintMethodUnitCapability(
     mintUrl: string,
     nut: 4 | 5,
@@ -196,20 +250,27 @@ export class MintService {
     const normalizedUnit = normalizeUnit(unit, { defaultUnit: DEFAULT_UNIT });
     const mintInfo = await this.getMintInfo(normalizedMintUrl);
     const settings = this.getNutMethodSettings(mintInfo, nut);
+    const nutName = this.formatNut(nut);
 
-    if (
-      !settings ||
-      !settings.methods ||
-      !Array.isArray(settings.methods) ||
-      settings.disabled === true
-    ) {
+    if (settings?.disabled === true) {
       return {
         supported: false,
         disabled: true,
         nut,
         method,
         unit: normalizedUnit,
-        reason: `NUT-${nut} is disabled`,
+        reason: `${nutName} is disabled`,
+      };
+    }
+
+    if (!settings || !Array.isArray(settings.methods)) {
+      return {
+        supported: false,
+        disabled: false,
+        nut,
+        method,
+        unit: normalizedUnit,
+        reason: `${nutName} method metadata is missing`,
       };
     }
 
@@ -228,7 +289,7 @@ export class MintService {
         nut,
         method,
         unit: normalizedUnit,
-        reason: `NUT-${nut} method ${method} does not support unit ${normalizedUnit}`,
+        reason: `${nutName} method ${method} does not support unit ${normalizedUnit}`,
       };
     }
 
@@ -242,6 +303,48 @@ export class MintService {
       maxAmount: this.parseOptionalAmount(matchingMethod.max_amount),
       options: matchingMethod.options,
     };
+  }
+
+  async listPaymentMethodCapabilities(
+    input: ListPaymentMethodCapabilitiesInput,
+  ): Promise<PaymentMethodCapability[]> {
+    const operations =
+      input.operation === undefined
+        ? (['mint', 'melt'] as const)
+        : [this.assertPaymentMethodCapabilityOperation(input.operation)];
+    const unitFilter = input.unit === undefined ? undefined : normalizeUnit(input.unit);
+    const mintInfo = await this.getMintInfo(input.mintUrl);
+    const capabilities: PaymentMethodCapability[] = [];
+
+    for (const operation of operations) {
+      const nut = this.nutForPaymentMethodCapabilityOperation(operation);
+      const settings = this.getNutMethodSettings(mintInfo, nut);
+      if (!settings || settings.disabled === true || !Array.isArray(settings.methods)) {
+        continue;
+      }
+
+      for (const entry of settings.methods) {
+        let unit: string;
+        try {
+          unit = normalizeUnit(entry.unit);
+        } catch {
+          continue;
+        }
+        if (unitFilter !== undefined && unit !== unitFilter) continue;
+
+        capabilities.push({
+          operation,
+          nut,
+          method: entry.method,
+          unit,
+          minAmount: this.parseOptionalAmount(entry.min_amount),
+          maxAmount: this.parseOptionalAmount(entry.max_amount),
+          options: entry.options,
+        });
+      }
+    }
+
+    return capabilities;
   }
 
   async assertMethodUnitSupported(
@@ -262,20 +365,22 @@ export class MintService {
     const capability = await this.getMintMethodUnitCapability(mintUrl, nut, method, unit);
     if (!capability.supported) {
       throw new ProofValidationError(
-        capability.reason ?? `NUT-${nut} method ${method} does not support unit ${capability.unit}`,
+        capability.reason ??
+          `${this.formatNut(nut)} method ${method} does not support unit ${capability.unit}`,
       );
     }
 
     if (requestedAmount === undefined) return;
 
+    const amountRequirement = `${this.formatNut(nut)} method ${method} unit ${capability.unit}`;
     if (capability.minAmount && requestedAmount.lessThan(capability.minAmount)) {
       throw new ProofValidationError(
-        `NUT-${nut} method ${method} unit ${capability.unit} requires amount >= ${capability.minAmount}`,
+        `${amountRequirement} requires amount >= ${capability.minAmount}`,
       );
     }
     if (capability.maxAmount && requestedAmount.greaterThan(capability.maxAmount)) {
       throw new ProofValidationError(
-        `NUT-${nut} method ${method} unit ${capability.unit} requires amount <= ${capability.maxAmount}`,
+        `${amountRequirement} requires amount <= ${capability.maxAmount}`,
       );
     }
   }
@@ -317,6 +422,27 @@ export class MintService {
         `NUT-${nut} does not define method-unit capabilities; use NUT-04 or NUT-05 method metadata`,
       );
     }
+  }
+
+  private formatNut(nut: 4 | 5): string {
+    return `NUT-0${nut}`;
+  }
+
+  private assertPaymentMethodCapabilityOperation(
+    operation: string,
+  ): PaymentMethodCapabilityOperationKind {
+    if (operation !== 'mint' && operation !== 'melt') {
+      throw new ProofValidationError(
+        `Invalid payment method capability operation ${operation}; use mint or melt`,
+      );
+    }
+    return operation;
+  }
+
+  private nutForPaymentMethodCapabilityOperation(
+    operation: PaymentMethodCapabilityOperationKind,
+  ): 4 | 5 {
+    return operation === 'mint' ? 4 : 5;
   }
 
   private parseOptionalAmount(amount: AmountLike | null | undefined): Amount | null {

--- a/packages/core/test/unit/MintApi.test.ts
+++ b/packages/core/test/unit/MintApi.test.ts
@@ -1,0 +1,297 @@
+import { Amount } from '@cashu/cashu-ts';
+import { describe, expect, it, mock } from 'bun:test';
+
+import { MintApi } from '../../api/MintApi';
+import { ProofValidationError } from '../../models/Error';
+import {
+  MintService,
+  type CheckPaymentMethodCapabilityInput,
+  type ListPaymentMethodCapabilitiesInput,
+  type PaymentMethodCapability,
+  type PaymentMethodCapabilityCheck,
+} from '../../services/MintService';
+import { MemoryKeysetRepository } from '../../repositories/memory/MemoryKeysetRepository';
+import { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository';
+import type { Mint } from '../../models/Mint';
+import type { MintAdapter } from '../../infra/MintAdapter';
+import type { MintInfo } from '../../types';
+
+describe('MintApi payment method capabilities', () => {
+  const mintUrl = 'https://mint.test';
+  const now = Math.floor(Date.now() / 1000);
+
+  const keysets = [
+    {
+      id: 'keyset-1',
+      unit: 'sat',
+      active: true,
+      input_fee_ppk: 0,
+    },
+  ];
+
+  const makeMintInfo = (nuts: Record<string, unknown>): MintInfo =>
+    ({
+      name: 'Capability Mint',
+      version: '1.0.0',
+      pubkey: 'pubkey',
+      contact: [],
+      nuts,
+    }) as unknown as MintInfo;
+
+  const createApi = async (mintInfo: MintInfo, updatedAt = now) => {
+    const mintRepo = new MemoryMintRepository();
+    const keysetRepo = new MemoryKeysetRepository();
+    const adapter = {
+      fetchMintInfo: mock(async () => mintInfo),
+      fetchKeysets: mock(async () => ({ keysets })),
+      fetchKeysForId: mock(async () => ({ '1': 'key-1' })),
+    } as unknown as MintAdapter;
+    const service = new MintService(mintRepo, keysetRepo, adapter);
+    await mintRepo.addOrUpdateMint({
+      mintUrl,
+      name: mintUrl,
+      mintInfo,
+      trusted: true,
+      createdAt: now,
+      updatedAt,
+    } satisfies Mint);
+
+    return { api: new MintApi(service), adapter };
+  };
+
+  it('delegates public capability calls to the mint service', async () => {
+    const checkInput: CheckPaymentMethodCapabilityInput = {
+      mintUrl,
+      operation: 'mint',
+      method: 'custom-pay',
+      unit: 'sat',
+    };
+    const listInput: ListPaymentMethodCapabilitiesInput = {
+      mintUrl,
+      operation: 'melt',
+      unit: 'sat',
+    };
+    const checkResult: PaymentMethodCapabilityCheck = {
+      supported: true,
+      disabled: false,
+      operation: 'mint',
+      nut: 4,
+      method: 'custom-pay',
+      unit: 'sat',
+    };
+    const listResult: PaymentMethodCapability[] = [
+      {
+        operation: 'melt',
+        nut: 5,
+        method: 'custom-payout',
+        unit: 'sat',
+      },
+    ];
+    const checkPaymentMethodCapability = mock(async () => checkResult);
+    const listPaymentMethodCapabilities = mock(async () => listResult);
+    const api = new MintApi({
+      checkPaymentMethodCapability,
+      listPaymentMethodCapabilities,
+    } as unknown as MintService);
+
+    await expect(api.checkPaymentMethodCapability(checkInput)).resolves.toBe(checkResult);
+    await expect(api.listPaymentMethodCapabilities(listInput)).resolves.toBe(listResult);
+    expect(checkPaymentMethodCapability).toHaveBeenCalledWith(checkInput);
+    expect(listPaymentMethodCapabilities).toHaveBeenCalledWith(listInput);
+  });
+
+  it('checks mint capabilities from cached NUT-04 metadata', async () => {
+    const { api, adapter } = await createApi(
+      makeMintInfo({
+        '4': {
+          disabled: false,
+          methods: [
+            {
+              method: 'lnurl',
+              unit: 'SAT',
+              min_amount: 10,
+              max_amount: 1000,
+              options: { reusable: true },
+            },
+          ],
+        },
+      }),
+    );
+
+    const capability = await api.checkPaymentMethodCapability({
+      mintUrl,
+      operation: 'mint',
+      method: 'lnurl',
+      unit: 'sat',
+    });
+
+    expect(capability).toMatchObject({
+      supported: true,
+      disabled: false,
+      operation: 'mint',
+      nut: 4,
+      method: 'lnurl',
+      unit: 'sat',
+      options: { reusable: true },
+    });
+    expect(capability.minAmount?.equals(Amount.from(10))).toBe(true);
+    expect(capability.maxAmount?.equals(Amount.from(1000))).toBe(true);
+    expect(adapter.fetchMintInfo).not.toHaveBeenCalled();
+  });
+
+  it('lists actionable capabilities with operation and unit filters', async () => {
+    const { api } = await createApi(
+      makeMintInfo({
+        '4': {
+          disabled: false,
+          methods: [
+            { method: 'bolt11', unit: 'sat' },
+            { method: 'lnurl', unit: 'usd', min_amount: 5 },
+          ],
+        },
+        '5': {
+          disabled: false,
+          methods: [
+            { method: 'bolt11', unit: 'sat' },
+            { method: 'pix', unit: 'usd', max_amount: 500 },
+          ],
+        },
+      }),
+    );
+
+    await expect(api.listPaymentMethodCapabilities({ mintUrl })).resolves.toMatchObject([
+      { operation: 'mint', nut: 4, method: 'bolt11', unit: 'sat' },
+      { operation: 'mint', nut: 4, method: 'lnurl', unit: 'usd' },
+      { operation: 'melt', nut: 5, method: 'bolt11', unit: 'sat' },
+      { operation: 'melt', nut: 5, method: 'pix', unit: 'usd' },
+    ]);
+
+    const usdMeltCapabilities = await api.listPaymentMethodCapabilities({
+      mintUrl,
+      operation: 'melt',
+      unit: 'USD',
+    });
+
+    expect(usdMeltCapabilities).toHaveLength(1);
+    expect(usdMeltCapabilities[0]).toMatchObject({
+      operation: 'melt',
+      nut: 5,
+      method: 'pix',
+      unit: 'usd',
+    });
+    expect(usdMeltCapabilities[0]?.maxAmount?.equals(Amount.from(500))).toBe(true);
+  });
+
+  it('returns diagnostic details for unsupported, disabled, and missing capabilities', async () => {
+    const { api: unsupportedApi } = await createApi(
+      makeMintInfo({
+        '4': {
+          disabled: false,
+          methods: [{ method: 'custom-pay', unit: 'sat' }],
+        },
+      }),
+    );
+
+    const unsupported = await unsupportedApi.checkPaymentMethodCapability({
+      mintUrl,
+      operation: 'mint',
+      method: 'custom-pay',
+      unit: 'usd',
+    });
+
+    expect(unsupported).toMatchObject({
+      supported: false,
+      disabled: false,
+      operation: 'mint',
+      nut: 4,
+      method: 'custom-pay',
+      unit: 'usd',
+    });
+    expect(unsupported.reason).toContain('NUT-04 method custom-pay does not support unit usd');
+
+    const { api: disabledApi } = await createApi(
+      makeMintInfo({
+        '5': {
+          disabled: true,
+          methods: [{ method: 'custom-payout', unit: 'sat' }],
+        },
+      }),
+    );
+
+    const disabled = await disabledApi.checkPaymentMethodCapability({
+      mintUrl,
+      operation: 'melt',
+      method: 'custom-payout',
+      unit: 'sat',
+    });
+
+    expect(disabled).toMatchObject({
+      supported: false,
+      disabled: true,
+      operation: 'melt',
+      nut: 5,
+      method: 'custom-payout',
+      unit: 'sat',
+    });
+    expect(disabled.reason).toContain('NUT-05 is disabled');
+
+    const { api: missingApi } = await createApi(makeMintInfo({}));
+
+    const missing = await missingApi.checkPaymentMethodCapability({
+      mintUrl,
+      operation: 'mint',
+      method: 'custom-pay',
+      unit: 'sat',
+    });
+
+    expect(missing).toMatchObject({
+      supported: false,
+      disabled: false,
+      operation: 'mint',
+      nut: 4,
+      method: 'custom-pay',
+      unit: 'sat',
+    });
+    expect(missing.reason).toContain('NUT-04 method metadata is missing');
+  });
+
+  it('omits disabled NUT settings from capability listings', async () => {
+    const { api } = await createApi(
+      makeMintInfo({
+        '4': {
+          disabled: true,
+          methods: [{ method: 'custom-pay', unit: 'sat' }],
+        },
+        '5': {
+          disabled: false,
+          methods: [{ method: 'custom-payout', unit: 'sat' }],
+        },
+      }),
+    );
+
+    await expect(api.listPaymentMethodCapabilities({ mintUrl })).resolves.toMatchObject([
+      { operation: 'melt', nut: 5, method: 'custom-payout', unit: 'sat' },
+    ]);
+  });
+
+  it('rejects invalid public operation inputs', async () => {
+    const { api } = await createApi(makeMintInfo({}));
+    const invalidOperation = 'swap' as never;
+
+    await expect(
+      api.checkPaymentMethodCapability({
+        mintUrl,
+        operation: invalidOperation,
+        method: 'custom-pay',
+        unit: 'sat',
+      }),
+    ).rejects.toThrow(ProofValidationError);
+
+    await expect(
+      api.listPaymentMethodCapabilities({
+        mintUrl,
+        operation: invalidOperation,
+      }),
+    ).rejects.toThrow(ProofValidationError);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds public `MintApi` methods to check one Payment Method Capability and list actionable capabilities from mint metadata.
- Maps `mint` capability discovery to NUT-04 and `melt` discovery to NUT-05 while reusing existing mint-info TTL behavior.
- Adds unit coverage for enabled, unsupported, disabled, missing metadata, unit filtering, arbitrary method strings, and invalid public operation inputs.
- Adds a core changeset for the new public API surface.

## Problem

Applications need to discover and validate mint-advertised Payment Method Capabilities before creating Generic Payment Method quotes. Without a focused public API, callers have to inspect raw mint metadata themselves and duplicate NUT-04/NUT-05 mapping logic.

This pull request resolves #233.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --cwd packages/core typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `./node_modules/.bin/prettier --check .changeset/payment-method-capabilities.md packages/core/api/MintApi.ts packages/core/services/MintService.ts packages/core/test/unit/MintApi.test.ts`

## Changeset

- Added `.changeset/payment-method-capabilities.md`.