### PR TITLE
feat(core): add built-in and generic payment method APIs

### DIFF
--- a/.changeset/built-in-payment-methods.md
+++ b/.changeset/built-in-payment-methods.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': major
+---
+
+Refactor payment method types around built-in and generic method APIs.
+
+Built-in mint and melt methods now use explicit `BuiltIn*Method` names, generic quote creation uses dedicated `createGeneric` APIs, and built-in method names are rejected before generic handler routing.

--- a/packages/core/api/MeltOpsApi.ts
+++ b/packages/core/api/MeltOpsApi.ts
@@ -17,6 +17,10 @@ export type PrepareMeltInput<TSupported extends MeltMethod = BuiltInMeltMethod> 
   } & (M extends 'onchain' ? { feeIndex: number } : { feeIndex?: number });
 }[TSupported];
 
+type ExecuteMeltResult<TSupported extends MeltMethod> =
+  | PendingMeltOperation<TSupported>
+  | FinalizedMeltOperation<TSupported>;
+
 export interface MeltRecoveryApi {
   /** Runs the startup-style recovery sweep for melt operations. */
   run(): Promise<void>;
@@ -70,19 +74,18 @@ export class MeltOpsApi<TSupported extends MeltMethod = BuiltInMeltMethod> {
    */
   async execute(
     operationOrId: MeltOperation<TSupported> | string,
-  ): Promise<PendingMeltOperation<TSupported> | FinalizedMeltOperation<TSupported>> {
-    const operation = (await this.resolveOperation(
-      operationOrId as MeltOperation | string,
-    )) as MeltOperation<TSupported>;
+  ): Promise<ExecuteMeltResult<TSupported>>;
+  async execute(
+    operationOrId: MeltOperation<MeltMethod> | string,
+  ): Promise<ExecuteMeltResult<TSupported> | PendingMeltOperation | FinalizedMeltOperation> {
+    const operation = await this.resolveOperation(operationOrId);
     if (operation.state !== 'prepared') {
       throw new Error(
         `Cannot execute operation in state '${operation.state}'. Expected 'prepared'.`,
       );
     }
 
-    return this.meltOperationService.execute(operation.id) as Promise<
-      PendingMeltOperation<TSupported> | FinalizedMeltOperation<TSupported>
-    >;
+    return this.meltOperationService.execute(operation.id);
   }
 
   /** Returns a melt operation by ID, or `null` when it does not exist. */
@@ -174,7 +177,9 @@ export class MeltOpsApi<TSupported extends MeltMethod = BuiltInMeltMethod> {
     await this.meltOperationService.finalize(operationId);
   }
 
-  private async resolveOperation(operationOrId: MeltOperation | string): Promise<MeltOperation> {
+  private async resolveOperation(
+    operationOrId: MeltOperation<MeltMethod> | string,
+  ): Promise<MeltOperation<MeltMethod>> {
     if (typeof operationOrId === 'string') {
       return this.requireOperation(operationOrId);
     }

--- a/packages/core/api/MeltOpsApi.ts
+++ b/packages/core/api/MeltOpsApi.ts
@@ -1,4 +1,5 @@
 import type {
+  BuiltInMeltMethod,
   FinalizedMeltOperation,
   MeltOperation,
   PendingMeltOperation,
@@ -7,10 +8,9 @@ import type {
 import type { MeltMethod, MeltOperationService } from '@core/operations/melt';
 import type { MeltQuoteRef, QuoteIdentity } from '../models/QuoteIdentity.ts';
 
-/** Melt methods supported by the default `Manager` wiring. */
-export type DefaultSupportedMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
+export type { BuiltInMeltMethod };
 
-export type PrepareMeltInput<TSupported extends MeltMethod = DefaultSupportedMeltMethod> = {
+export type PrepareMeltInput<TSupported extends MeltMethod = BuiltInMeltMethod> = {
   [M in TSupported]: {
     /** Existing canonical melt quote or structural quote reference. */
     quote: MeltQuoteRef<M>;
@@ -36,7 +36,7 @@ export interface MeltDiagnosticsApi {
  * execute it, inspect or refresh its state, and recover or roll it back when
  * allowed by the underlying method.
  */
-export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMethod> {
+export class MeltOpsApi<TSupported extends MeltMethod = BuiltInMeltMethod> {
   /** Recovery helpers for melt operations. */
   readonly recovery: MeltRecoveryApi = {
     run: async () => this.meltOperationService.recoverPendingOperations(),
@@ -56,10 +56,10 @@ export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMeth
    * Use this to inspect the generated operation and any quote-related data
    * before committing to the external payment.
    */
-  async prepare(input: PrepareMeltInput<TSupported>): Promise<PreparedMeltOperation> {
+  async prepare(input: PrepareMeltInput<TSupported>): Promise<PreparedMeltOperation<TSupported>> {
     return this.meltOperationService.prepareExistingQuote(input.quote, {
       feeIndex: input.feeIndex,
-    });
+    }) as Promise<PreparedMeltOperation<TSupported>>;
   }
 
   /**
@@ -69,16 +69,20 @@ export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMeth
    * state is always reloaded before execution.
    */
   async execute(
-    operationOrId: MeltOperation | string,
-  ): Promise<PendingMeltOperation | FinalizedMeltOperation> {
-    const operation = await this.resolveOperation(operationOrId);
+    operationOrId: MeltOperation<TSupported> | string,
+  ): Promise<PendingMeltOperation<TSupported> | FinalizedMeltOperation<TSupported>> {
+    const operation = (await this.resolveOperation(
+      operationOrId as MeltOperation | string,
+    )) as MeltOperation<TSupported>;
     if (operation.state !== 'prepared') {
       throw new Error(
         `Cannot execute operation in state '${operation.state}'. Expected 'prepared'.`,
       );
     }
 
-    return this.meltOperationService.execute(operation.id);
+    return this.meltOperationService.execute(operation.id) as Promise<
+      PendingMeltOperation<TSupported> | FinalizedMeltOperation<TSupported>
+    >;
   }
 
   /** Returns a melt operation by ID, or `null` when it does not exist. */

--- a/packages/core/api/MintOpsApi.ts
+++ b/packages/core/api/MintOpsApi.ts
@@ -1,5 +1,6 @@
 import { Amount, type AmountLike } from '@cashu/cashu-ts';
 import type {
+  BuiltInMintMethod,
   MintMethod,
   MintOperation,
   MintOperationService,
@@ -8,10 +9,9 @@ import type {
 } from '@core/operations/mint';
 import type { MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity.ts';
 
-/** Mint methods supported by the default `Manager` wiring. */
-export type DefaultSupportedMintMethod = 'bolt11' | 'onchain' | 'bolt12';
+export type { BuiltInMintMethod };
 
-export type PrepareMintInput<TSupported extends MintMethod = DefaultSupportedMintMethod> = {
+export type PrepareMintInput<TSupported extends MintMethod = BuiltInMintMethod> = {
   /** Existing canonical mint quote or structural quote reference. */
   quote: MintQuoteRef<TSupported>;
   /** Amount to mint using the canonical quote's stored unit. */
@@ -36,7 +36,7 @@ export interface MintDiagnosticsApi {
  * This API makes the mint lifecycle explicit so callers can move a canonical
  * quote into a durable pending operation, execute it, and inspect its progress.
  */
-export class MintOpsApi<TSupported extends MintMethod = DefaultSupportedMintMethod> {
+export class MintOpsApi<TSupported extends MintMethod = BuiltInMintMethod> {
   /** Recovery helpers for mint operations. */
   readonly recovery: MintRecoveryApi = {
     run: async () => this.mintOperationService.recoverPendingOperations(),
@@ -53,8 +53,10 @@ export class MintOpsApi<TSupported extends MintMethod = DefaultSupportedMintMeth
   /**
    * Prepares a mint operation against an existing canonical quote without executing it.
    */
-  async prepare(input: PrepareMintInput<TSupported>): Promise<PendingMintOperation> {
-    return this.mintOperationService.prepare(input.quote, Amount.from(input.amount));
+  async prepare(input: PrepareMintInput<TSupported>): Promise<PendingMintOperation<TSupported>> {
+    return this.mintOperationService.prepare(input.quote, Amount.from(input.amount)) as Promise<
+      PendingMintOperation<TSupported>
+    >;
   }
 
   /**

--- a/packages/core/api/QuoteApi.ts
+++ b/packages/core/api/QuoteApi.ts
@@ -1,15 +1,22 @@
-import type { MeltMethodInputData } from '@core/operations/melt';
-import type { MintMethodQuoteSnapshot } from '@core/operations/mint';
+import type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
+  MeltMethodInputData,
+} from '@core/operations/melt';
+import { assertGenericMeltMethod } from '@core/operations/melt';
+import type {
+  BuiltInMintMethod,
+  GenericMintMethod,
+  MintMethodQuoteSnapshot,
+} from '@core/operations/mint';
+import { assertGenericMintMethod } from '@core/operations/mint';
 import { DEFAULT_UNIT, normalizeUnit, parseUnitAmount, type UnitAmountLike } from '../amounts.ts';
-import type { MeltQuote } from '../models/MeltQuote';
-import type { MintQuote } from '../models/MintQuote';
+import type { GenericMeltQuote, MeltQuote } from '../models/MeltQuote';
+import type { GenericMintQuote, MintQuote } from '../models/MintQuote';
 import type { QuoteIdentity } from '../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../quotes/QuoteLifecycle';
-import type { DefaultSupportedMeltMethod } from './MeltOpsApi.ts';
 
-export type DefaultSupportedMintQuoteMethod = 'bolt11' | 'onchain' | 'bolt12';
-
-export type CreateMintQuoteInput =
+export type CreateMintQuoteInput<M extends BuiltInMintMethod = BuiltInMintMethod> = Extract<
   | {
       mintUrl: string;
       method: 'bolt11';
@@ -27,7 +34,17 @@ export type CreateMintQuoteInput =
       unit?: string;
       amount?: UnitAmountLike;
       description?: string;
-    };
+    },
+  { method: M }
+>;
+
+export type CreateGenericMintQuoteInput<M extends string = string> = {
+  mintUrl: string;
+  method: GenericMintMethod<M>;
+  amount: UnitAmountLike;
+  unit?: string;
+  payload?: Record<string, unknown>;
+};
 
 export type ImportMintQuoteInput = {
   /** Mint that issued the existing quote. */
@@ -39,12 +56,10 @@ export type ImportMintQuoteInput = {
 };
 
 export type ListPendingMintQuotesInput = {
-  method?: DefaultSupportedMintQuoteMethod;
+  method?: BuiltInMintMethod;
 };
 
-export type CreateMeltQuoteInput<
-  TSupported extends DefaultSupportedMeltMethod = DefaultSupportedMeltMethod,
-> = {
+export type CreateMeltQuoteInput<TSupported extends BuiltInMeltMethod = BuiltInMeltMethod> = {
   [M in TSupported]: {
     mintUrl: string;
     method: M;
@@ -53,14 +68,26 @@ export type CreateMeltQuoteInput<
   };
 }[TSupported];
 
+export type CreateGenericMeltQuoteInput<M extends string = string> = {
+  mintUrl: string;
+  method: GenericMeltMethod<M>;
+  request: string;
+  unit?: string;
+  payload?: Record<string, unknown>;
+};
+
 export type ListPendingMeltQuotesInput = {
-  method?: DefaultSupportedMeltMethod;
+  method?: BuiltInMeltMethod;
 };
 
 export class MintQuoteApi {
   constructor(private readonly quoteLifecycle: QuoteLifecycle) {}
 
-  async create(input: CreateMintQuoteInput): Promise<MintQuote> {
+  async create(input: CreateMintQuoteInput<'bolt11'>): Promise<MintQuote<'bolt11'>>;
+  async create(input: CreateMintQuoteInput<'onchain'>): Promise<MintQuote<'onchain'>>;
+  async create(input: CreateMintQuoteInput<'bolt12'>): Promise<MintQuote<'bolt12'>>;
+  async create(input: CreateMintQuoteInput): Promise<MintQuote<BuiltInMintMethod>>;
+  async create(input: CreateMintQuoteInput): Promise<MintQuote<BuiltInMintMethod>> {
     if (input.method === 'bolt11') {
       const parsed = parseUnitAmount(input.amount, { explicitUnit: input.unit });
       return this.quoteLifecycle.createMintQuote(input.mintUrl, input.method, {
@@ -86,6 +113,18 @@ export class MintQuoteApi {
     });
   }
 
+  async createGeneric<M extends string>(
+    input: CreateGenericMintQuoteInput<M>,
+  ): Promise<GenericMintQuote<M>> {
+    assertGenericMintMethod(input.method);
+    const parsed = parseUnitAmount(input.amount, { explicitUnit: input.unit });
+    return this.quoteLifecycle.createMintQuote(input.mintUrl, input.method, {
+      amount: parsed,
+      unit: parsed.unit,
+      payload: input.payload,
+    }) as Promise<GenericMintQuote<M>>;
+  }
+
   get(input: QuoteIdentity): Promise<MintQuote | null> {
     return this.quoteLifecycle.getMintQuoteById(input);
   }
@@ -106,15 +145,28 @@ export class MintQuoteApi {
 export class MeltQuoteApi {
   constructor(private readonly quoteLifecycle: QuoteLifecycle) {}
 
-  create<M extends DefaultSupportedMeltMethod>(
-    input: CreateMeltQuoteInput<M>,
-  ): Promise<MeltQuote<M>> {
+  create<M extends BuiltInMeltMethod>(input: CreateMeltQuoteInput<M>): Promise<MeltQuote<M>> {
     return this.quoteLifecycle.createMeltQuote(
       input.mintUrl,
       input.method,
       input.methodData,
       input.unit,
     );
+  }
+
+  async createGeneric<M extends string>(
+    input: CreateGenericMeltQuoteInput<M>,
+  ): Promise<GenericMeltQuote<M>> {
+    assertGenericMeltMethod(input.method);
+    return this.quoteLifecycle.createMeltQuote(
+      input.mintUrl,
+      input.method,
+      {
+        request: input.request,
+        payload: input.payload,
+      } as MeltMethodInputData<GenericMeltMethod<M>>,
+      input.unit,
+    ) as Promise<GenericMeltQuote<M>>;
   }
 
   get(input: QuoteIdentity): Promise<MeltQuote | null> {

--- a/packages/core/infra/handlers/melt/BaseQuoteMeltHandler.ts
+++ b/packages/core/infra/handlers/melt/BaseQuoteMeltHandler.ts
@@ -18,7 +18,6 @@ import type {
   FinalizeContext,
   FinalizeResult,
   MeltMethodHandler,
-  MeltMethodMeta,
   MeltMethod,
   MeltMethodQuoteSnapshot,
   MeltMethodRemoteState,
@@ -183,7 +182,7 @@ export abstract class BaseQuoteMeltHandler<M extends MeltMethod> implements Melt
    *
    * @returns Prepared operation ready for execution
    */
-  async prepare(ctx: BasePrepareContext<M>): Promise<PreparedMeltOperation & MeltMethodMeta<M>> {
+  async prepare(ctx: BasePrepareContext<M>): Promise<PreparedMeltOperation<M>> {
     const { mintUrl, id: operationId } = ctx.operation;
     ctx.logger?.debug(`Preparing ${this.method} melt operation`, { operationId, mintUrl });
 
@@ -247,7 +246,7 @@ export abstract class BaseQuoteMeltHandler<M extends MeltMethod> implements Melt
     ctx: BasePrepareContext<M>,
     quote: MeltQuoteData,
     selectedProofs: Proof[],
-  ): Promise<PreparedMeltOperation & MeltMethodMeta<M>> {
+  ): Promise<PreparedMeltOperation<M>> {
     const { mintUrl, id: operationId } = ctx.operation;
     const { amount, fee_reserve } = quote;
     const inputSecrets = selectedProofs.map((p) => p.secret);
@@ -293,7 +292,7 @@ export abstract class BaseQuoteMeltHandler<M extends MeltMethod> implements Melt
     ctx: BasePrepareContext<M>,
     quote: MeltQuoteData,
     totalAmount: Amount,
-  ): Promise<PreparedMeltOperation & MeltMethodMeta<M>> {
+  ): Promise<PreparedMeltOperation<M>> {
     const { mintUrl, id: operationId } = ctx.operation;
     const { amount, fee_reserve } = quote;
 

--- a/packages/core/infra/handlers/melt/MeltHandlerProvider.ts
+++ b/packages/core/infra/handlers/melt/MeltHandlerProvider.ts
@@ -1,15 +1,18 @@
 import type {
+  BuiltInMeltMethod,
   MeltMethod,
   MeltMethodHandler,
   MeltMethodHandlerRegistry,
 } from '../../../operations/melt/MeltMethodHandler';
+import { isBuiltInMeltMethod } from '../../../operations/melt/MeltMethodHandler';
 
 /**
  * Runtime registry for melt method handlers.
  * Keeps wiring concerns out of the core melt domain.
  */
 export class MeltHandlerProvider {
-  private registry: Partial<MeltMethodHandlerRegistry> = {};
+  private registry: Partial<Record<BuiltInMeltMethod, MeltMethodHandler<any>>> = {};
+  private genericHandler?: MeltMethodHandler<any>;
 
   constructor(initialHandlers?: Partial<MeltMethodHandlerRegistry>) {
     if (initialHandlers) {
@@ -21,8 +24,12 @@ export class MeltHandlerProvider {
     this.set(method, handler);
   }
 
+  registerGeneric(handler: MeltMethodHandler<any>): void {
+    this.genericHandler = handler;
+  }
+
   registerMany(handlers: Partial<MeltMethodHandlerRegistry>): void {
-    for (const method of Object.keys(handlers) as MeltMethod[]) {
+    for (const method of Object.keys(handlers) as BuiltInMeltMethod[]) {
       const handler = handlers[method];
       if (handler) {
         this.set(method, handler as MeltMethodHandler<typeof method>);
@@ -31,7 +38,7 @@ export class MeltHandlerProvider {
   }
 
   get<M extends MeltMethod>(method: M): MeltMethodHandler<M> {
-    const handler = this.registry[method];
+    const handler = isBuiltInMeltMethod(method) ? this.registry[method] : this.genericHandler;
     if (!handler) {
       throw new Error(`No melt handler registered for method ${method}`);
     }
@@ -43,6 +50,11 @@ export class MeltHandlerProvider {
   }
 
   private set<M extends MeltMethod>(method: M, handler: MeltMethodHandler<M>): void {
+    if (!isBuiltInMeltMethod(method)) {
+      this.genericHandler = handler;
+      return;
+    }
+
     (this.registry as Partial<Record<M, MeltMethodHandler<M>>>)[method] = handler;
   }
 }

--- a/packages/core/infra/handlers/melt/QuoteMeltHandler.utils.ts
+++ b/packages/core/infra/handlers/melt/QuoteMeltHandler.utils.ts
@@ -2,7 +2,6 @@ import type { Amount } from '@cashu/cashu-ts';
 import type {
   ExecutingMeltOperation,
   FinalizeResult,
-  MeltMethodMeta,
   MeltMethod,
   ExecutionResult,
 } from '@core/operations/melt';
@@ -61,7 +60,7 @@ export function getSwapSendSecrets(swapOutputData: SerializedOutputData): string
  * Used when the melt completed successfully.
  */
 export function buildPaidResult<M extends MeltMethod>(
-  operation: ExecutingMeltOperation & MeltMethodMeta<M>,
+  operation: ExecutingMeltOperation<M>,
   finalizeResult: FinalizeResult<M>,
 ): ExecutionResult<M> {
   return {
@@ -80,7 +79,7 @@ export function buildPaidResult<M extends MeltMethod>(
  * Used when the melt is in-flight and awaiting confirmation.
  */
 export function buildPendingResult<M extends MeltMethod>(
-  operation: ExecutingMeltOperation & MeltMethodMeta<M>,
+  operation: ExecutingMeltOperation<M>,
 ): ExecutionResult<M> {
   return {
     status: 'PENDING',
@@ -93,7 +92,7 @@ export function buildPendingResult<M extends MeltMethod>(
  * Used when the melt failed and proofs need recovery.
  */
 export function buildFailedResult<M extends MeltMethod>(
-  operation: ExecutingMeltOperation & MeltMethodMeta<M>,
+  operation: ExecutingMeltOperation<M>,
   error?: string,
 ): ExecutionResult<M> {
   return {

--- a/packages/core/infra/handlers/mint/MintHandlerProvider.ts
+++ b/packages/core/infra/handlers/mint/MintHandlerProvider.ts
@@ -1,14 +1,17 @@
 import type {
+  BuiltInMintMethod,
   MintMethod,
   MintMethodHandler,
   MintMethodHandlerRegistry,
 } from '../../../operations/mint/MintMethodHandler';
+import { isBuiltInMintMethod } from '../../../operations/mint/MintMethodHandler';
 
 /**
  * Runtime registry for mint method handlers.
  */
 export class MintHandlerProvider {
-  private registry: Partial<Record<MintMethod, MintMethodHandler<any>>> = {};
+  private registry: Partial<Record<BuiltInMintMethod, MintMethodHandler<any>>> = {};
+  private genericHandler?: MintMethodHandler<any>;
 
   constructor(initialHandlers?: Partial<MintMethodHandlerRegistry>) {
     if (initialHandlers) {
@@ -20,8 +23,12 @@ export class MintHandlerProvider {
     this.set(method, handler);
   }
 
+  registerGeneric(handler: MintMethodHandler<any>): void {
+    this.genericHandler = handler;
+  }
+
   registerMany(handlers: Partial<MintMethodHandlerRegistry>): void {
-    for (const method of Object.keys(handlers) as MintMethod[]) {
+    for (const method of Object.keys(handlers) as BuiltInMintMethod[]) {
       const handler = handlers[method];
       if (handler) {
         this.set(method, handler as MintMethodHandler<typeof method>);
@@ -30,7 +37,7 @@ export class MintHandlerProvider {
   }
 
   get<M extends MintMethod>(method: M): MintMethodHandler<M> {
-    const handler = this.registry[method];
+    const handler = isBuiltInMintMethod(method) ? this.registry[method] : this.genericHandler;
     if (!handler) {
       throw new Error(`No mint handler registered for method ${method}`);
     }
@@ -42,6 +49,11 @@ export class MintHandlerProvider {
   }
 
   private set<M extends MintMethod>(method: M, handler: MintMethodHandler<M>): void {
+    if (!isBuiltInMintMethod(method)) {
+      this.genericHandler = handler;
+      return;
+    }
+
     (this.registry as Partial<Record<M, MintMethodHandler<M>>>)[method] = handler;
   }
 }

--- a/packages/core/models/MeltQuote.ts
+++ b/packages/core/models/MeltQuote.ts
@@ -8,12 +8,14 @@ import {
   type SerializedBlindedSignature,
 } from '@cashu/cashu-ts';
 import type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
   MeltMethod,
   MeltMethodQuoteSnapshot,
   MeltMethodRemoteState,
 } from '../operations/melt/MeltMethodHandler';
 
-type BoltMeltMethod = Extract<MeltMethod, 'bolt11' | 'bolt12'>;
+type BoltMeltMethod = 'bolt11' | 'bolt12';
 
 interface MeltQuoteBase<M extends MeltMethod> {
   mintUrl: string;
@@ -46,11 +48,19 @@ export interface OnchainMeltQuote extends MeltQuoteBase<'onchain'> {
   outpoint?: string;
 }
 
-export type MeltQuote<M extends MeltMethod = MeltMethod> = M extends 'onchain'
+export interface GenericMeltQuote<M extends string = string> extends MeltQuoteBase<
+  GenericMeltMethod<M>
+> {
+  fee_reserve: Amount;
+  payment_preimage?: string | null;
+  rawQuoteData?: Record<string, unknown>;
+}
+
+export type MeltQuote<M extends MeltMethod = BuiltInMeltMethod> = M extends 'onchain'
   ? OnchainMeltQuote
   : M extends BoltMeltMethod
     ? BoltMeltQuote<M>
-    : never;
+    : GenericMeltQuote<Extract<M, string>>;
 
 type BoltMeltQuoteResponse = MeltQuoteBolt11Response | MeltQuoteBolt12Response;
 
@@ -128,30 +138,48 @@ export function meltQuoteToMethodSnapshot<M extends MeltMethod>(
   quote: MeltQuote<M>,
 ): MeltMethodQuoteSnapshot<M> {
   if (quote.method === 'onchain') {
+    const onchainQuote = quote as MeltQuote<'onchain'>;
     return {
-      quote: quote.quoteId,
-      request: quote.request,
-      amount: quote.amount,
-      unit: quote.unit,
-      fee_options: quote.fee_options,
+      quote: onchainQuote.quoteId,
+      request: onchainQuote.request,
+      amount: onchainQuote.amount,
+      unit: onchainQuote.unit,
+      fee_options: onchainQuote.fee_options,
       selected_fee_index: null,
-      outpoint: quote.outpoint ?? null,
-      expiry: quote.expiry,
-      state: quote.state,
-      change: quote.change,
+      outpoint: onchainQuote.outpoint ?? null,
+      expiry: onchainQuote.expiry,
+      state: onchainQuote.state,
+      change: onchainQuote.change,
     } as MeltMethodQuoteSnapshot<M>;
   }
 
+  if (quote.method === 'bolt11' || quote.method === 'bolt12') {
+    const boltQuote = quote as BoltMeltQuote;
+    return {
+      quote: boltQuote.quoteId,
+      request: boltQuote.request,
+      amount: boltQuote.amount,
+      unit: boltQuote.unit,
+      fee_reserve: boltQuote.fee_reserve,
+      expiry: boltQuote.expiry,
+      state: boltQuote.state,
+      payment_preimage: boltQuote.payment_preimage ?? null,
+      change: boltQuote.change,
+    } as MeltMethodQuoteSnapshot<M>;
+  }
+
+  const genericQuote = quote as GenericMeltQuote;
   return {
-    quote: quote.quoteId,
-    request: quote.request,
-    amount: quote.amount,
-    unit: quote.unit,
-    fee_reserve: quote.fee_reserve,
-    expiry: quote.expiry,
-    state: quote.state,
-    payment_preimage: quote.payment_preimage ?? null,
-    change: quote.change,
+    quote: genericQuote.quoteId,
+    request: genericQuote.request,
+    amount: genericQuote.amount,
+    unit: genericQuote.unit,
+    fee_reserve: genericQuote.fee_reserve,
+    expiry: genericQuote.expiry,
+    state: genericQuote.state,
+    payment_preimage: genericQuote.payment_preimage ?? null,
+    change: genericQuote.change,
+    ...(genericQuote.rawQuoteData ?? {}),
   } as MeltMethodQuoteSnapshot<M>;
 }
 

--- a/packages/core/models/MintQuote.ts
+++ b/packages/core/models/MintQuote.ts
@@ -5,6 +5,8 @@ import {
   type MintQuoteBolt12Response,
 } from '@cashu/cashu-ts';
 import type {
+  BuiltInMintMethod,
+  GenericMintMethod,
   MintMethod,
   MintMethodQuoteData,
   MintMethodQuoteSnapshot,
@@ -56,13 +58,22 @@ export type Bolt12MintQuote = MintQuoteBase<'bolt12'> & {
   reusable: true;
 };
 
-export type MintQuote<M extends MintMethod = MintMethod> = M extends 'bolt11'
+export type GenericMintQuote<M extends string = string> = MintQuoteBase<GenericMintMethod<M>> & {
+  amount?: never;
+  state?: never;
+  lastObservedRemoteState?: never;
+  lastObservedRemoteStateAt?: number;
+  reusable: true;
+  rawQuoteData?: Record<string, unknown>;
+};
+
+export type MintQuote<M extends MintMethod = BuiltInMintMethod> = M extends 'bolt11'
   ? Bolt11MintQuote
   : M extends 'onchain'
     ? OnchainMintQuote
     : M extends 'bolt12'
       ? Bolt12MintQuote
-      : never;
+      : GenericMintQuote<Extract<M, string>>;
 
 export function isStatefulMintQuote(quote: MintQuote): quote is MintQuote<'bolt11'> {
   return quote.method === 'bolt11';
@@ -194,37 +205,54 @@ export function mintQuoteToMethodSnapshot<M extends MintMethod>(
   quote: MintQuote<M>,
 ): MintMethodQuoteSnapshot<M> {
   if (quote.method === 'bolt11') {
+    const bolt11Quote = quote as MintQuote<'bolt11'>;
     return {
-      quote: quote.quoteId,
-      request: quote.request,
-      amount: quote.amount,
-      unit: quote.unit,
-      expiry: quote.expiry,
-      pubkey: quote.pubkey,
-      state: quote.state,
+      quote: bolt11Quote.quoteId,
+      request: bolt11Quote.request,
+      amount: bolt11Quote.amount,
+      unit: bolt11Quote.unit,
+      expiry: bolt11Quote.expiry,
+      pubkey: bolt11Quote.pubkey,
+      state: bolt11Quote.state,
     } as MintMethodQuoteSnapshot<M>;
   }
 
   if (quote.method === 'onchain') {
+    const onchainQuote = quote as MintQuote<'onchain'>;
     return {
-      quote: quote.quoteId,
-      request: quote.request,
-      unit: quote.unit,
-      expiry: quote.expiry,
-      pubkey: quote.quoteData.pubkey,
-      amount_paid: quote.quoteData.amountPaid,
-      amount_issued: quote.quoteData.amountIssued,
+      quote: onchainQuote.quoteId,
+      request: onchainQuote.request,
+      unit: onchainQuote.unit,
+      expiry: onchainQuote.expiry,
+      pubkey: onchainQuote.quoteData.pubkey,
+      amount_paid: onchainQuote.quoteData.amountPaid,
+      amount_issued: onchainQuote.quoteData.amountIssued,
     } as MintMethodQuoteSnapshot<M>;
   }
 
+  if (quote.method === 'bolt12') {
+    const bolt12Quote = quote as MintQuote<'bolt12'>;
+    return {
+      quote: bolt12Quote.quoteId,
+      request: bolt12Quote.request,
+      amount: bolt12Quote.amount,
+      unit: bolt12Quote.unit,
+      expiry: bolt12Quote.expiry,
+      pubkey: bolt12Quote.quoteData.pubkey,
+      amount_paid: bolt12Quote.quoteData.amountPaid,
+      amount_issued: bolt12Quote.quoteData.amountIssued,
+    } as MintMethodQuoteSnapshot<M>;
+  }
+
+  const genericQuote = quote as GenericMintQuote;
   return {
-    quote: quote.quoteId,
-    request: quote.request,
-    amount: quote.amount,
-    unit: quote.unit,
-    expiry: quote.expiry,
-    pubkey: quote.quoteData.pubkey,
-    amount_paid: quote.quoteData.amountPaid,
-    amount_issued: quote.quoteData.amountIssued,
+    quote: genericQuote.quoteId,
+    request: genericQuote.request,
+    unit: genericQuote.unit,
+    expiry: genericQuote.expiry,
+    pubkey: genericQuote.quoteData.pubkey,
+    amount_paid: genericQuote.quoteData.amountPaid,
+    amount_issued: genericQuote.quoteData.amountIssued,
+    ...(genericQuote.rawQuoteData ?? {}),
   } as MintMethodQuoteSnapshot<M>;
 }

--- a/packages/core/operations/index.ts
+++ b/packages/core/operations/index.ts
@@ -1,9 +1,17 @@
 export type { MeltOperation, MeltOperationState } from './melt/MeltOperation.ts';
-export type { MeltMethod, MeltMethodData, MeltMethodInputData } from './melt/MeltMethodHandler.ts';
+export type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
+  MeltMethod,
+  MeltMethodData,
+  MeltMethodInputData,
+} from './melt/MeltMethodHandler.ts';
 export { normalizeMeltMethodData } from './melt/MeltMethodHandler.ts';
 export { MeltOperationService } from './melt/MeltOperationService.ts';
 export type { MintOperation, MintOperationState } from './mint/MintOperation.ts';
 export type {
+  BuiltInMintMethod,
+  GenericMintMethod,
   MintMethod,
   MintMethodData,
   MintMethodRemoteState,

--- a/packages/core/operations/melt/MeltMethodHandler.ts
+++ b/packages/core/operations/melt/MeltMethodHandler.ts
@@ -27,46 +27,77 @@ import type {
 import type { MintAdapter } from '@core/infra';
 import type { MeltQuote } from '../../models/MeltQuote';
 
-/**
- * Registry of supported melt methods and their public input payload shapes.
- * Extend via declaration merging if you need to add methods externally.
- */
-export interface MeltMethodInputDefinitions {
+export type BuiltInMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
+export type MeltMethod = BuiltInMeltMethod | (string & {});
+export type GenericMeltMethod<M extends string = string> = M extends BuiltInMeltMethod ? never : M;
+
+export const BUILT_IN_MELT_METHODS = ['bolt11', 'bolt12', 'onchain'] as const;
+
+export function isBuiltInMeltMethod(method: string): method is BuiltInMeltMethod {
+  return (BUILT_IN_MELT_METHODS as readonly string[]).includes(method);
+}
+
+export function assertGenericMeltMethod(method: string): void {
+  if (isBuiltInMeltMethod(method)) {
+    throw new Error(`Built-in melt method ${method} must use the built-in melt quote API`);
+  }
+}
+
+export type GenericMeltMethodInputData = {
+  request: string;
+  payload?: Record<string, unknown>;
+};
+
+export type GenericMeltMethodData = GenericMeltMethodInputData;
+
+export type GenericMeltQuoteSnapshot = {
+  quote: string;
+  request: string;
+  amount: Amount;
+  unit: string;
+  fee_reserve?: AmountLike;
+  expiry: number;
+  state: 'UNPAID' | 'PENDING' | 'PAID';
+  payment_preimage?: string | null;
+  change?: MeltQuoteBolt11Response['change'];
+} & Record<string, unknown>;
+
+type BuiltInMeltMethodInputMap = {
   bolt11: { invoice: string; amountSats?: AmountLike };
   bolt12: { offer: string; amountSats?: AmountLike };
   onchain: { address: string; amountSats: AmountLike };
-}
+};
 
 /**
  * Registry of supported melt methods and their normalized operation payload shapes.
  * Amount values are normalized at the operation boundary.
  */
-export interface MeltMethodDefinitions {
+type BuiltInMeltMethodDataMap = {
   bolt11: { invoice: string; amountSats?: Amount };
   bolt12: { offer: string; amountSats?: Amount };
   onchain: { address: string; amountSats: Amount; feeIndex?: number };
-}
+};
 
-export type MeltMethod = keyof MeltMethodDefinitions;
-
-export type MeltMethodData<M extends MeltMethod = MeltMethod> = MeltMethodDefinitions[M];
-
-export interface MeltMethodQuoteDefinitions {
+type BuiltInMeltMethodQuoteMap = {
   bolt11: MeltQuoteBolt11Response;
   bolt12: MeltQuoteBolt12Response;
   onchain: MeltQuoteOnchainResponse;
-}
+};
 
-export type MeltMethodInputData<M extends MeltMethod = MeltMethod> =
-  M extends keyof MeltMethodInputDefinitions ? MeltMethodInputDefinitions[M] : never;
+export type MeltMethodInputData<M extends MeltMethod = BuiltInMeltMethod> =
+  M extends BuiltInMeltMethod ? BuiltInMeltMethodInputMap[M] : GenericMeltMethodInputData;
 
-export type MeltMethodRemoteState<M extends MeltMethod = MeltMethod> =
-  MeltMethodQuoteDefinitions[M]['state'];
+export type MeltMethodData<M extends MeltMethod = BuiltInMeltMethod> = M extends BuiltInMeltMethod
+  ? BuiltInMeltMethodDataMap[M]
+  : GenericMeltMethodData;
 
-export type MeltMethodQuoteSnapshot<M extends MeltMethod = MeltMethod> =
-  MeltMethodQuoteDefinitions[M];
+export type MeltMethodRemoteState<M extends MeltMethod = BuiltInMeltMethod> =
+  MeltMethodQuoteSnapshot<M>['state'];
 
-export interface MeltMethodMeta<M extends MeltMethod = MeltMethod> {
+export type MeltMethodQuoteSnapshot<M extends MeltMethod = BuiltInMeltMethod> =
+  M extends BuiltInMeltMethod ? BuiltInMeltMethodQuoteMap[M] : GenericMeltQuoteSnapshot;
+
+export interface MeltMethodMeta<M extends MeltMethod = BuiltInMeltMethod> {
   method: M;
   methodData: MeltMethodData<M>;
 }
@@ -103,46 +134,51 @@ export interface BaseHandlerDeps {
   logger?: Logger;
 }
 
-export interface CreateMeltQuoteContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
+export interface CreateMeltQuoteContext<
+  M extends MeltMethod = BuiltInMeltMethod,
+> extends BaseHandlerDeps {
   mintUrl: string;
+  method: M;
   methodData: MeltMethodData<M>;
   unit: string;
   wallet: Wallet;
 }
 
 export interface FetchRemoteMeltQuoteContext<
-  M extends MeltMethod = MeltMethod,
+  M extends MeltMethod = BuiltInMeltMethod,
 > extends BaseHandlerDeps {
   quote: MeltQuote<M>;
 }
 
-export interface BasePrepareContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
-  operation: InitMeltOperation & MeltMethodMeta<M>;
+export interface BasePrepareContext<
+  M extends MeltMethod = BuiltInMeltMethod,
+> extends BaseHandlerDeps {
+  operation: InitMeltOperation<M>;
   wallet: Wallet;
   quote: MeltMethodQuoteSnapshot<M>;
 }
 
-export interface PreparedContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
-  operation: PreparedMeltOperation & MeltMethodMeta<M>;
+export interface PreparedContext<M extends MeltMethod = BuiltInMeltMethod> extends BaseHandlerDeps {
+  operation: PreparedMeltOperation<M>;
   wallet: Wallet;
 }
 
-export interface ExecuteContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
-  operation: ExecutingMeltOperation & MeltMethodMeta<M>;
+export interface ExecuteContext<M extends MeltMethod = BuiltInMeltMethod> extends BaseHandlerDeps {
+  operation: ExecutingMeltOperation<M>;
   wallet: Wallet;
   reservedProofs: Proof[];
 }
 
-export interface PendingContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
-  operation: PendingMeltOperation & MeltMethodMeta<M>;
+export interface PendingContext<M extends MeltMethod = BuiltInMeltMethod> extends BaseHandlerDeps {
+  operation: PendingMeltOperation<M>;
   wallet: Wallet;
 }
 
-export interface FinalizeContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
-  operation: PendingMeltOperation & MeltMethodMeta<M>;
+export interface FinalizeContext<M extends MeltMethod = BuiltInMeltMethod> extends BaseHandlerDeps {
+  operation: PendingMeltOperation<M>;
 }
 
-export type FinalizeResult<M extends MeltMethod = MeltMethod> = {
+export type FinalizeResult<M extends MeltMethod = BuiltInMeltMethod> = {
   /** Total amount returned as change by the mint */
   changeAmount?: Amount;
   /** Actual fee impact after settlement */
@@ -151,19 +187,19 @@ export type FinalizeResult<M extends MeltMethod = MeltMethod> = {
   finalizedData?: MeltMethodFinalizedData<M>;
 };
 
-export interface RollbackContext<M extends MeltMethod = MeltMethod> extends BaseHandlerDeps {
-  operation: PreparedOrLaterOperation & MeltMethodMeta<M>;
+export interface RollbackContext<M extends MeltMethod = BuiltInMeltMethod> extends BaseHandlerDeps {
+  operation: PreparedOrLaterOperation<M>;
   wallet: Wallet;
 }
 
 export interface RecoverExecutingContext<
-  M extends MeltMethod = MeltMethod,
+  M extends MeltMethod = BuiltInMeltMethod,
 > extends BaseHandlerDeps {
-  operation: ExecutingMeltOperation & MeltMethodMeta<M>;
+  operation: ExecutingMeltOperation<M>;
   wallet: Wallet;
 }
 
-export type ExecutionResult<M extends MeltMethod = MeltMethod> =
+export type ExecutionResult<M extends MeltMethod = BuiltInMeltMethod> =
   | {
       status: 'PAID';
       finalized: FinalizedMeltOperation<M>;
@@ -172,23 +208,23 @@ export type ExecutionResult<M extends MeltMethod = MeltMethod> =
     }
   | {
       status: 'PENDING';
-      pending: PendingMeltOperation & MeltMethodMeta<M>;
+      pending: PendingMeltOperation<M>;
       sendProofs?: Proof[];
       keepProofs?: Proof[];
     }
   | {
       status: 'FAILED';
-      failed: FailedMeltOperation & MeltMethodMeta<M>;
+      failed: FailedMeltOperation<M>;
       sendProofs?: Proof[];
       keepProofs?: Proof[];
     };
 
 export type PendingCheckResult = 'finalize' | 'stay_pending' | 'rollback';
 
-export interface MeltMethodHandler<M extends MeltMethod = MeltMethod> {
+export interface MeltMethodHandler<M extends MeltMethod = BuiltInMeltMethod> {
   createQuote(ctx: CreateMeltQuoteContext<M>): Promise<MeltQuote<M>>;
   fetchRemoteQuote(ctx: FetchRemoteMeltQuoteContext<M>): Promise<MeltQuote<M>>;
-  prepare(ctx: BasePrepareContext<M>): Promise<PreparedMeltOperation & MeltMethodMeta<M>>;
+  prepare(ctx: BasePrepareContext<M>): Promise<PreparedMeltOperation<M>>;
   execute(ctx: ExecuteContext<M>): Promise<ExecutionResult<M>>;
   finalize?(ctx: FinalizeContext<M>): Promise<FinalizeResult<M>>;
   rollback?(ctx: RollbackContext<M>): Promise<void>;
@@ -200,4 +236,6 @@ export interface MeltMethodHandler<M extends MeltMethod = MeltMethod> {
   recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<ExecutionResult<M>>;
 }
 
-export type MeltMethodHandlerRegistry = Record<MeltMethod, MeltMethodHandler<any>>;
+export type MeltMethodHandlerRegistry = {
+  [M in BuiltInMeltMethod]: MeltMethodHandler<M>;
+};

--- a/packages/core/operations/melt/MeltMethodHandler.ts
+++ b/packages/core/operations/melt/MeltMethodHandler.ts
@@ -102,7 +102,7 @@ export interface MeltMethodMeta<M extends MeltMethod = BuiltInMeltMethod> {
   methodData: MeltMethodData<M>;
 }
 
-export function normalizeMeltMethodData<M extends MeltMethod>(
+export function normalizeMeltMethodData<M extends MeltMethod = BuiltInMeltMethod>(
   methodData: MeltMethodInputData<M> | MeltMethodData<M>,
 ): MeltMethodData<M> {
   if (

--- a/packages/core/operations/melt/MeltOperation.ts
+++ b/packages/core/operations/melt/MeltOperation.ts
@@ -30,7 +30,12 @@ export type MeltOperationState =
 
 import type { Amount } from '@cashu/cashu-ts';
 import { getSecretsFromSerializedOutputData, type SerializedOutputData } from '../../utils';
-import type { MeltMethod, MeltMethodData, MeltMethodMeta } from './MeltMethodHandler';
+import type {
+  BuiltInMeltMethod,
+  MeltMethod,
+  MeltMethodData,
+  MeltMethodMeta,
+} from './MeltMethodHandler';
 import { DEFAULT_UNIT, normalizeUnit } from '../../amounts.ts';
 
 // ============================================================================
@@ -40,7 +45,7 @@ import { DEFAULT_UNIT, normalizeUnit } from '../../amounts.ts';
 /**
  * Base fields present in all melt operations
  */
-interface MeltOperationBase extends MeltMethodMeta {
+interface MeltOperationBase<M extends MeltMethod = BuiltInMeltMethod> extends MeltMethodMeta<M> {
   /** Unique identifier for this operation */
   id: string;
 
@@ -99,7 +104,7 @@ interface PreparedData {
 /**
  * Method-specific data that may be available once a melt has settled.
  */
-export interface MeltMethodFinalizedDataMap {
+type BuiltInMeltMethodFinalizedDataMap = {
   bolt11: {
     preimage?: string;
     outpoint?: never;
@@ -112,10 +117,16 @@ export interface MeltMethodFinalizedDataMap {
     preimage?: never;
     outpoint?: string;
   };
-}
+};
 
-export type MeltMethodFinalizedData<M extends MeltMethod = MeltMethod> =
-  MeltMethodFinalizedDataMap[M];
+export type GenericMeltMethodFinalizedData = {
+  rawFinalResponseData?: Record<string, unknown>;
+};
+
+export type MeltMethodFinalizedData<M extends MeltMethod = BuiltInMeltMethod> =
+  M extends keyof BuiltInMeltMethodFinalizedDataMap
+    ? BuiltInMeltMethodFinalizedDataMap[M]
+    : GenericMeltMethodFinalizedData;
 
 // ============================================================================
 // State-specific Operation Types
@@ -124,7 +135,9 @@ export type MeltMethodFinalizedData<M extends MeltMethod = MeltMethod> =
 /**
  * Initial state - operation just created, nothing reserved yet
  */
-export interface InitMeltOperation extends MeltOperationBase {
+export interface InitMeltOperation<
+  M extends MeltMethod = BuiltInMeltMethod,
+> extends MeltOperationBase<M> {
   state: 'init';
   /** Existing canonical quote to prepare against. */
   quoteId?: string;
@@ -133,21 +146,24 @@ export interface InitMeltOperation extends MeltOperationBase {
 /**
  * Prepared state - proofs reserved, outputs calculated, ready to execute
  */
-export interface PreparedMeltOperation extends MeltOperationBase, PreparedData {
+export interface PreparedMeltOperation<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'prepared';
 }
 
 /**
  * Executing state - swap/token creation in progress
  */
-export interface ExecutingMeltOperation extends MeltOperationBase, PreparedData {
+export interface ExecutingMeltOperation<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'executing';
 }
 
 /**
  * Pending state - token returned, awaiting confirmation that proofs are spent
  */
-export interface PendingMeltOperation extends MeltOperationBase, PreparedData {
+export interface PendingMeltOperation<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'pending';
 }
 
@@ -155,7 +171,8 @@ export interface PendingMeltOperation extends MeltOperationBase, PreparedData {
  * Finalized state - sent proofs confirmed spent, operation finalized.
  * Contains actual settlement amounts after the melt is complete.
  */
-interface FinalizedMeltOperationBase extends MeltOperationBase, PreparedData {
+interface FinalizedMeltOperationBase<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'finalized';
 
   /**
@@ -176,15 +193,16 @@ interface FinalizedMeltOperationBase extends MeltOperationBase, PreparedData {
   effectiveFee?: Amount;
 }
 
-export type FinalizedMeltOperation<M extends MeltMethod = MeltMethod> = FinalizedMeltOperationBase &
-  MeltMethodMeta<M> & {
+export type FinalizedMeltOperation<M extends MeltMethod = BuiltInMeltMethod> =
+  FinalizedMeltOperationBase<M> & {
     finalizedData?: MeltMethodFinalizedData<M>;
   };
 
 /**
  * Failed state - melt failed, proofs reclaimed
  */
-export interface FailedMeltOperation extends MeltOperationBase, PreparedData {
+export interface FailedMeltOperation<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'failed';
 }
 
@@ -193,7 +211,8 @@ export interface FailedMeltOperation extends MeltOperationBase, PreparedData {
  * This is a transient state used to prevent race conditions with ProofStateWatcher.
  * Only used when rolling back from 'pending' state (which requires a reclaim swap).
  */
-export interface RollingBackMeltOperation extends MeltOperationBase, PreparedData {
+export interface RollingBackMeltOperation<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'rolling_back';
 }
 
@@ -201,7 +220,8 @@ export interface RollingBackMeltOperation extends MeltOperationBase, PreparedDat
  * Rolled back state - operation cancelled, proofs reclaimed
  * Can be rolled back from prepared, executing, or pending states
  */
-export interface RolledBackMeltOperation extends MeltOperationBase, PreparedData {
+export interface RolledBackMeltOperation<M extends MeltMethod = BuiltInMeltMethod>
+  extends MeltOperationBase<M>, PreparedData {
   state: 'rolled_back';
 }
 
@@ -213,15 +233,15 @@ export interface RolledBackMeltOperation extends MeltOperationBase, PreparedData
  * Discriminated union of all melt operation states.
  * TypeScript will narrow the type based on the `state` field.
  */
-export type MeltOperation =
-  | InitMeltOperation
-  | PreparedMeltOperation
-  | ExecutingMeltOperation
-  | PendingMeltOperation
-  | FinalizedMeltOperation
-  | FailedMeltOperation
-  | RollingBackMeltOperation
-  | RolledBackMeltOperation;
+export type MeltOperation<M extends MeltMethod = BuiltInMeltMethod> =
+  | InitMeltOperation<M>
+  | PreparedMeltOperation<M>
+  | ExecutingMeltOperation<M>
+  | PendingMeltOperation<M>
+  | FinalizedMeltOperation<M>
+  | FailedMeltOperation<M>
+  | RollingBackMeltOperation<M>
+  | RolledBackMeltOperation<M>;
 
 // ============================================================================
 // Utility Types
@@ -230,67 +250,85 @@ export type MeltOperation =
 /**
  * Any operation that has been prepared (has PreparedData)
  */
-export type PreparedOrLaterOperation =
-  | PreparedMeltOperation
-  | ExecutingMeltOperation
-  | PendingMeltOperation
-  | FinalizedMeltOperation
-  | FailedMeltOperation
-  | RollingBackMeltOperation
-  | RolledBackMeltOperation;
+export type PreparedOrLaterOperation<M extends MeltMethod = BuiltInMeltMethod> =
+  | PreparedMeltOperation<M>
+  | ExecutingMeltOperation<M>
+  | PendingMeltOperation<M>
+  | FinalizedMeltOperation<M>
+  | FailedMeltOperation<M>
+  | RollingBackMeltOperation<M>
+  | RolledBackMeltOperation<M>;
 
 /**
  * Terminal states - operation is finished
  * Note: 'rolling_back' is NOT terminal - it's a transient state that needs recovery
  */
-export type TerminalMeltOperation =
-  | FinalizedMeltOperation
-  | RolledBackMeltOperation
-  | FailedMeltOperation;
+export type TerminalMeltOperation<M extends MeltMethod = BuiltInMeltMethod> =
+  | FinalizedMeltOperation<M>
+  | RolledBackMeltOperation<M>
+  | FailedMeltOperation<M>;
 
 // ============================================================================
 // Type Guards
 // ============================================================================
 
-export function isInitOperation(op: MeltOperation): op is InitMeltOperation {
+export function isInitOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is InitMeltOperation<M> {
   return op.state === 'init';
 }
 
-export function isPreparedOperation(op: MeltOperation): op is PreparedMeltOperation {
+export function isPreparedOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is PreparedMeltOperation<M> {
   return op.state === 'prepared';
 }
 
-export function isExecutingOperation(op: MeltOperation): op is ExecutingMeltOperation {
+export function isExecutingOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is ExecutingMeltOperation<M> {
   return op.state === 'executing';
 }
 
-export function isPendingOperation(op: MeltOperation): op is PendingMeltOperation {
+export function isPendingOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is PendingMeltOperation<M> {
   return op.state === 'pending';
 }
 
-export function isFinalizedOperation(op: MeltOperation): op is FinalizedMeltOperation {
+export function isFinalizedOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is FinalizedMeltOperation<M> {
   return op.state === 'finalized';
 }
 
-export function isRollingBackOperation(op: MeltOperation): op is RollingBackMeltOperation {
+export function isRollingBackOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is RollingBackMeltOperation<M> {
   return op.state === 'rolling_back';
 }
 
-export function isRolledBackOperation(op: MeltOperation): op is RolledBackMeltOperation {
+export function isRolledBackOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is RolledBackMeltOperation<M> {
   return op.state === 'rolled_back';
 }
 
 /**
  * Check if operation has PreparedData (any state after init)
  */
-export function hasPreparedData(op: MeltOperation): op is PreparedOrLaterOperation {
+export function hasPreparedData<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is PreparedOrLaterOperation<M> {
   return op.state !== 'init';
 }
 
 /**
  * Check if operation is in a terminal state
  */
-export function isTerminalOperation(op: MeltOperation): op is TerminalMeltOperation {
+export function isTerminalOperation<M extends MeltMethod>(
+  op: MeltOperation<M>,
+): op is TerminalMeltOperation<M> {
   return op.state === 'finalized' || op.state === 'rolled_back' || op.state === 'failed';
 }
 
@@ -301,13 +339,13 @@ export function isTerminalOperation(op: MeltOperation): op is TerminalMeltOperat
 /**
  * Creates a new SendOperation in init state
  */
-export function createMeltOperation(
+export function createMeltOperation<M extends MeltMethod>(
   id: string,
   mintUrl: string,
-  meta: MeltMethodMeta,
+  meta: MeltMethodMeta<M>,
   unit = DEFAULT_UNIT,
   options?: { quoteId?: string },
-): InitMeltOperation {
+): InitMeltOperation<M> {
   const now = Date.now();
   return {
     ...meta,

--- a/packages/core/operations/melt/MeltOperationService.ts
+++ b/packages/core/operations/melt/MeltOperationService.ts
@@ -147,7 +147,7 @@ export class MeltOperationService {
         },
         normalizedUnit,
         operationQuoteId ? { quoteId: operationQuoteId } : undefined,
-      );
+      ) as InitMeltOperation;
 
       await this.meltOperationRepository.create(operation);
       return operation;
@@ -238,10 +238,11 @@ export class MeltOperationService {
       case 'bolt12':
         return { offer: quote.request };
       case 'onchain': {
-        const { feeIndex } = resolveOnchainMeltFeeOption(quote, options.feeIndex);
+        const onchainQuote = quote as MeltQuote<'onchain'>;
+        const { feeIndex } = resolveOnchainMeltFeeOption(onchainQuote, options.feeIndex);
         return {
-          address: quote.request,
-          amountSats: quote.amount,
+          address: onchainQuote.request,
+          amountSats: onchainQuote.amount,
           feeIndex,
         };
       }

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -1,5 +1,6 @@
 import type {
   Amount,
+  AmountLike,
   MintQuoteBolt11Response,
   MintQuoteOnchainResponse,
   MintQuoteBolt12Response,
@@ -23,11 +24,45 @@ import type { MintAdapter } from '../../infra/MintAdapter';
 import type { UnitAmount } from '../../amounts.ts';
 import type { MintQuote } from '../../models/MintQuote';
 
-/**
- * Registry of supported mint methods and payload shapes.
- * Extend via declaration merging to support additional methods.
- */
-export interface MintMethodDefinitions {
+export type BuiltInMintMethod = 'bolt11' | 'onchain' | 'bolt12';
+export type MintMethod = BuiltInMintMethod | (string & {});
+export type GenericMintMethod<M extends string = string> = M extends BuiltInMintMethod ? never : M;
+
+export const BUILT_IN_MINT_METHODS = ['bolt11', 'onchain', 'bolt12'] as const;
+
+export function isBuiltInMintMethod(method: string): method is BuiltInMintMethod {
+  return (BUILT_IN_MINT_METHODS as readonly string[]).includes(method);
+}
+
+export function assertGenericMintMethod(method: string): void {
+  if (isBuiltInMintMethod(method)) {
+    throw new Error(`Built-in mint method ${method} must use the built-in mint quote API`);
+  }
+}
+
+export type GenericMintQuoteCreateData = {
+  amount: UnitAmount;
+  unit: string;
+  payload?: Record<string, unknown>;
+};
+
+export type GenericMintQuoteData = {
+  pubkey?: string;
+  amountPaid: Amount;
+  amountIssued: Amount;
+};
+
+export type GenericMintQuoteSnapshot = {
+  quote: string;
+  request: string;
+  unit: string;
+  expiry?: number | null;
+  pubkey?: string;
+  amount_paid: AmountLike;
+  amount_issued: AmountLike;
+} & Record<string, unknown>;
+
+type BuiltInMintMethodMap = {
   bolt11: {
     methodData: Record<string, never>;
     createQuoteData: { amount: UnitAmount };
@@ -66,21 +101,32 @@ export interface MintMethodDefinitions {
     remoteState: never;
     quote: MintQuoteBolt12Response;
   };
-}
+};
 
-export type MintMethod = keyof MintMethodDefinitions;
-export type MintMethodData<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['methodData'];
-export type MintMethodCreateQuoteData<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['createQuoteData'];
-export type MintMethodQuoteData<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['quoteData'];
-export type MintMethodRemoteState<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['remoteState'];
-export type MintMethodQuoteSnapshot<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['quote'];
+type GenericMintMethodDefinition = {
+  methodData: Record<string, unknown>;
+  createQuoteData: GenericMintQuoteCreateData;
+  quoteData: GenericMintQuoteData;
+  remoteState: never;
+  quote: GenericMintQuoteSnapshot;
+};
 
-export interface MintMethodMeta<M extends MintMethod = MintMethod> {
+type MintMethodDefinition<M extends MintMethod> = M extends BuiltInMintMethod
+  ? BuiltInMintMethodMap[M]
+  : GenericMintMethodDefinition;
+
+export type MintMethodData<M extends MintMethod = BuiltInMintMethod> =
+  MintMethodDefinition<M>['methodData'];
+export type MintMethodCreateQuoteData<M extends MintMethod = BuiltInMintMethod> =
+  MintMethodDefinition<M>['createQuoteData'];
+export type MintMethodQuoteData<M extends MintMethod = BuiltInMintMethod> =
+  MintMethodDefinition<M>['quoteData'];
+export type MintMethodRemoteState<M extends MintMethod = BuiltInMintMethod> =
+  MintMethodDefinition<M>['remoteState'];
+export type MintMethodQuoteSnapshot<M extends MintMethod = BuiltInMintMethod> =
+  MintMethodDefinition<M>['quote'];
+
+export interface MintMethodMeta<M extends MintMethod = BuiltInMintMethod> {
   method: M;
   methodData: MintMethodData<M>;
 }
@@ -95,37 +141,40 @@ export interface BaseHandlerDeps {
   logger?: Logger;
 }
 
-export interface CreateMintQuoteContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+export interface CreateMintQuoteContext<
+  M extends MintMethod = BuiltInMintMethod,
+> extends BaseHandlerDeps {
   mintUrl: string;
+  method: M;
   createQuoteData: MintMethodCreateQuoteData<M>;
   wallet: Wallet;
 }
 
 export interface FetchRemoteMintQuoteContext<
-  M extends MintMethod = MintMethod,
+  M extends MintMethod = BuiltInMintMethod,
 > extends BaseHandlerDeps {
   quote: MintQuote<M>;
 }
 
-export interface PrepareContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+export interface PrepareContext<M extends MintMethod = BuiltInMintMethod> extends BaseHandlerDeps {
   operation: InitMintOperation<M>;
   wallet: Wallet;
   importedQuote?: MintMethodQuoteSnapshot<M>;
 }
 
-export interface ExecuteContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+export interface ExecuteContext<M extends MintMethod = BuiltInMintMethod> extends BaseHandlerDeps {
   operation: ExecutingMintOperation<M>;
   wallet: Wallet;
 }
 
 export interface RecoverExecutingContext<
-  M extends MintMethod = MintMethod,
+  M extends MintMethod = BuiltInMintMethod,
 > extends BaseHandlerDeps {
   operation: ExecutingMintOperation<M>;
   wallet: Wallet;
 }
 
-export interface PendingContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+export interface PendingContext<M extends MintMethod = BuiltInMintMethod> extends BaseHandlerDeps {
   operation: PendingMintOperation<M>;
   wallet: Wallet;
 }
@@ -150,7 +199,7 @@ export type RecoverExecutingResult =
 
 export type PendingMintCheckCategory = 'waiting' | 'ready' | 'completed' | 'terminal';
 
-export interface PendingMintCheckResult<M extends MintMethod = MintMethod> {
+export interface PendingMintCheckResult<M extends MintMethod = BuiltInMintMethod> {
   observedRemoteState?: MintMethodRemoteState<M>;
   observedRemoteStateAt: number;
   quoteSnapshot?: MintMethodQuoteSnapshot<M>;
@@ -158,7 +207,7 @@ export interface PendingMintCheckResult<M extends MintMethod = MintMethod> {
   terminalFailure?: MintOperationFailure;
 }
 
-export interface MintMethodHandler<M extends MintMethod = MintMethod> {
+export interface MintMethodHandler<M extends MintMethod = BuiltInMintMethod> {
   createQuote(ctx: CreateMintQuoteContext<M>): Promise<MintQuote<M>>;
   fetchRemoteQuote(ctx: FetchRemoteMintQuoteContext<M>): Promise<MintQuote<M>>;
   validateQuoteForPrepare?(quote: MintQuote<M>): Promise<void> | void;
@@ -169,5 +218,5 @@ export interface MintMethodHandler<M extends MintMethod = MintMethod> {
 }
 
 export type MintMethodHandlerRegistry = {
-  [M in MintMethod]: MintMethodHandler<M>;
+  [M in BuiltInMintMethod]: MintMethodHandler<M>;
 };

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -35,9 +35,8 @@ export function isBuiltInMintMethod(method: string): method is BuiltInMintMethod
 }
 
 export function assertGenericMintMethod(method: string): void {
-  if (isBuiltInMintMethod(method)) {
-    throw new Error(`Built-in mint method ${method} must use the built-in mint quote API`);
-  }
+  if (!isBuiltInMintMethod(method)) return;
+  throw new Error(`Built-in mint method ${method} must use the built-in mint quote API`);
 }
 
 export type GenericMintQuoteCreateData = {

--- a/packages/core/operations/mint/MintOperation.ts
+++ b/packages/core/operations/mint/MintOperation.ts
@@ -16,10 +16,10 @@ export type MintOperationState = 'init' | 'pending' | 'executing' | 'finalized' 
 import type { Amount } from '@cashu/cashu-ts';
 import type { SerializedOutputData } from '../../utils';
 import { getSecretsFromSerializedOutputData } from '../../utils';
-import type { MintMethod, MintMethodMeta } from './MintMethodHandler';
+import type { BuiltInMintMethod, MintMethod, MintMethodMeta } from './MintMethodHandler';
 import { normalizeUnit, type UnitAmount } from '../../amounts.ts';
 
-interface MintOperationBase<M extends MintMethod = MintMethod> extends MintMethodMeta<M> {
+interface MintOperationBase<M extends MintMethod = BuiltInMintMethod> extends MintMethodMeta<M> {
   id: string;
   mintUrl: string;
   createdAt: number;
@@ -51,46 +51,46 @@ interface PendingData {
   outputData: SerializedOutputData;
 }
 
-export interface InitMintOperation<M extends MintMethod = MintMethod>
+export interface InitMintOperation<M extends MintMethod = BuiltInMintMethod>
   extends MintOperationBase<M>, MintIntentData {
   state: 'init';
   quoteId: string;
 }
 
-export interface PendingMintOperation<M extends MintMethod = MintMethod>
+export interface PendingMintOperation<M extends MintMethod = BuiltInMintMethod>
   extends MintOperationBase<M>, MintIntentData, MintQuoteSnapshot, PendingData {
   state: 'pending';
 }
 
-export interface ExecutingMintOperation<M extends MintMethod = MintMethod>
+export interface ExecutingMintOperation<M extends MintMethod = BuiltInMintMethod>
   extends MintOperationBase<M>, MintIntentData, MintQuoteSnapshot, PendingData {
   state: 'executing';
 }
 
-export interface FinalizedMintOperation<M extends MintMethod = MintMethod>
+export interface FinalizedMintOperation<M extends MintMethod = BuiltInMintMethod>
   extends MintOperationBase<M>, MintIntentData, MintQuoteSnapshot, PendingData {
   state: 'finalized';
 }
 
-export interface FailedMintOperation<M extends MintMethod = MintMethod>
+export interface FailedMintOperation<M extends MintMethod = BuiltInMintMethod>
   extends MintOperationBase<M>, MintIntentData, MintQuoteSnapshot, PendingData {
   state: 'failed';
 }
 
-export type MintOperation<M extends MintMethod = MintMethod> =
+export type MintOperation<M extends MintMethod = BuiltInMintMethod> =
   | InitMintOperation<M>
   | PendingMintOperation<M>
   | ExecutingMintOperation<M>
   | FinalizedMintOperation<M>
   | FailedMintOperation<M>;
 
-export type PendingOrLaterOperation<M extends MintMethod = MintMethod> =
+export type PendingOrLaterOperation<M extends MintMethod = BuiltInMintMethod> =
   | PendingMintOperation<M>
   | ExecutingMintOperation<M>
   | FinalizedMintOperation<M>
   | FailedMintOperation<M>;
 
-export type TerminalMintOperation<M extends MintMethod = MintMethod> =
+export type TerminalMintOperation<M extends MintMethod = BuiltInMintMethod> =
   | FinalizedMintOperation<M>
   | FailedMintOperation<M>;
 

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -42,6 +42,7 @@ import type {
 import { normalizeMeltMethodData } from '../operations/melt/MeltMethodHandler';
 import type { InitMintOperation, PendingOrLaterOperation } from '../operations/mint/MintOperation';
 import type {
+  BuiltInMintMethod,
   MintMethod,
   MintMethodCreateQuoteData,
   MintMethodQuoteSnapshot,
@@ -242,13 +243,15 @@ export class QuoteLifecycle {
     const quote = await handler.createQuote({
       ...this.buildDeps(),
       mintUrl,
+      method,
       createQuoteData,
       wallet,
     } as any);
 
-    await this.mintQuoteRepository.upsertMintQuote(quote);
+    await this.mintQuoteRepository.upsertMintQuote(quote as MintQuote);
     const persistedQuote =
-      (await this.mintQuoteRepository.getMintQuote(mintUrl, method, quote.quoteId)) ?? quote;
+      (await this.mintQuoteRepository.getMintQuote(mintUrl, method, quote.quoteId)) ??
+      (quote as MintQuote);
     this.logger?.info('Mint quote created', {
       mintUrl: persistedQuote.mintUrl,
       quoteId: persistedQuote.quoteId,
@@ -262,7 +265,7 @@ export class QuoteLifecycle {
       quoteId: persistedQuote.quoteId,
       quote: persistedQuote,
     });
-    return persistedQuote;
+    return persistedQuote as MintQuote;
   }
 
   getMintQuote(mintUrl: string, method: MintMethod, quoteId: string): Promise<MintQuote | null> {
@@ -369,7 +372,7 @@ export class QuoteLifecycle {
     return mintQuoteToMethodSnapshot(quote);
   }
 
-  async importMintQuote<M extends MintMethod>(
+  async importMintQuote<M extends BuiltInMintMethod>(
     mintUrl: string,
     method: M,
     quote: MintMethodQuoteSnapshot<M>,
@@ -392,7 +395,7 @@ export class QuoteLifecycle {
 
   private async resolveAndPersistMintQuoteSnapshot(
     mintUrl: string,
-    method: MintMethod,
+    method: BuiltInMintMethod,
     quote: MintMethodQuoteSnapshot,
     beforePersist?: (quote: MintQuote) => Promise<void>,
   ): Promise<{ quote: MintQuote; remoteStateChanged: boolean }> {
@@ -450,17 +453,22 @@ export class QuoteLifecycle {
       };
     }
     if (existing?.reusable && canonicalQuote.reusable) {
+      const reusableExisting = existing as Extract<MintQuote, { reusable: true }>;
+      const reusableCanonicalQuote = canonicalQuote as Extract<MintQuote, { reusable: true }>;
       canonicalQuote = {
-        ...canonicalQuote,
+        ...reusableCanonicalQuote,
         quoteData: {
-          ...canonicalQuote.quoteData,
-          amountPaid: maxAmount(existing.quoteData.amountPaid, canonicalQuote.quoteData.amountPaid),
+          ...reusableCanonicalQuote.quoteData,
+          amountPaid: maxAmount(
+            reusableExisting.quoteData.amountPaid,
+            reusableCanonicalQuote.quoteData.amountPaid,
+          ),
           amountIssued: maxAmount(
-            existing.quoteData.amountIssued,
-            canonicalQuote.quoteData.amountIssued,
+            reusableExisting.quoteData.amountIssued,
+            reusableCanonicalQuote.quoteData.amountIssued,
           ),
         },
-      };
+      } as MintQuote;
     }
 
     const remoteStateChanged = getRemoteStateChange(existing, canonicalQuote, quote);
@@ -471,7 +479,7 @@ export class QuoteLifecycle {
 
   async recordMintQuoteSnapshot(
     mintUrl: string,
-    method: MintMethod,
+    method: BuiltInMintMethod,
     snapshot: MintMethodQuoteSnapshot,
   ): Promise<MintQuote> {
     const { quote, remoteStateChanged } = await this.resolveAndPersistMintQuoteSnapshot(
@@ -551,6 +559,7 @@ export class QuoteLifecycle {
     const quote = await handler.createQuote({
       ...this.buildDeps(),
       mintUrl,
+      method,
       methodData: normalizedMethodData,
       unit: normalizedUnit,
       wallet,
@@ -561,9 +570,10 @@ export class QuoteLifecycle {
       );
     }
 
-    await this.meltQuoteRepository.upsertMeltQuote(quote);
+    await this.meltQuoteRepository.upsertMeltQuote(quote as MeltQuote);
     const persistedQuote =
-      (await this.meltQuoteRepository.getMeltQuote(mintUrl, method, quote.quoteId)) ?? quote;
+      (await this.meltQuoteRepository.getMeltQuote(mintUrl, method, quote.quoteId)) ??
+      (quote as MeltQuote);
     return persistedQuote as MeltQuote<M>;
   }
 
@@ -736,23 +746,24 @@ export class QuoteLifecycle {
       );
     }
 
+    const bolt11Operation = operation as PendingOrLaterOperation<'bolt11'>;
     await this.mintQuoteRepository.upsertMintQuote({
-      mintUrl: operation.mintUrl,
-      method: operation.method,
-      quoteId: operation.quoteId,
-      quote: operation.quoteId,
-      request: operation.request,
-      unit: operation.unit,
-      amount: operation.amount,
-      expiry: operation.expiry,
-      pubkey: operation.pubkey,
+      mintUrl: bolt11Operation.mintUrl,
+      method: 'bolt11',
+      quoteId: bolt11Operation.quoteId,
+      quote: bolt11Operation.quoteId,
+      request: bolt11Operation.request,
+      unit: bolt11Operation.unit,
+      amount: bolt11Operation.amount,
+      expiry: bolt11Operation.expiry,
+      pubkey: bolt11Operation.pubkey,
       state: 'UNPAID',
       reusable: false,
       quoteData: {
-        amount: operation.amount,
+        amount: bolt11Operation.amount,
       },
-      createdAt: operation.createdAt,
-      updatedAt: operation.updatedAt,
+      createdAt: bolt11Operation.createdAt,
+      updatedAt: bolt11Operation.updatedAt,
     });
   }
 }

--- a/packages/core/services/watchers/MintOperationWatcherService.ts
+++ b/packages/core/services/watchers/MintOperationWatcherService.ts
@@ -3,7 +3,7 @@ import type { Logger } from '../../logging/Logger.ts';
 import type { SubscriptionManager, UnsubscribeHandler } from '@core/infra/SubscriptionManager.ts';
 import type { MintService } from '../MintService';
 import type {
-  MintMethod,
+  BuiltInMintMethod,
   MintMethodQuoteSnapshot,
   MintOperationService,
   PendingMintOperation,
@@ -26,7 +26,7 @@ function isExpiredMintQuoteSnapshot(snapshot: { expiry?: number | null }): boole
   );
 }
 
-interface MintQuoteWatchPolicy<M extends MintMethod = MintMethod> {
+interface MintQuoteWatchPolicy<M extends BuiltInMintMethod = BuiltInMintMethod> {
   subscriptionKind: SubscriptionKind;
   getPayloadQuoteId(payload: MintMethodQuoteSnapshot<M>): string | undefined;
   shouldRecordPayload(payload: MintMethodQuoteSnapshot<M>): boolean;
@@ -35,7 +35,7 @@ interface MintQuoteWatchPolicy<M extends MintMethod = MintMethod> {
 }
 
 const mintQuoteWatchPolicies: {
-  [M in MintMethod]?: MintQuoteWatchPolicy<M>;
+  [M in BuiltInMintMethod]?: MintQuoteWatchPolicy<M>;
 } = {
   bolt11: {
     subscriptionKind: 'bolt11_mint_quote',
@@ -69,7 +69,7 @@ export interface MintOperationWatcherOptions {
   watchExistingPendingQuotesOnStart?: boolean;
 }
 
-type WatchableMintQuote<M extends MintMethod = MintMethod> = Pick<
+type WatchableMintQuote<M extends BuiltInMintMethod = BuiltInMintMethod> = Pick<
   MintQuote<M>,
   'mintUrl' | 'method' | 'quoteId'
 > & {
@@ -83,7 +83,7 @@ interface WatchMintQuoteInterest {
 
 interface QuoteWatchRecord {
   mintUrl: string;
-  method: MintMethod;
+  method: BuiltInMintMethod;
   quoteId: string;
   subscriptionKind: SubscriptionKind;
   canonical: boolean;
@@ -459,7 +459,7 @@ export class MintOperationWatcherService {
     }
   }
 
-  private getPolicy<M extends MintMethod>(method: M): MintQuoteWatchPolicy<M> | undefined {
+  private getPolicy<M extends BuiltInMintMethod>(method: M): MintQuoteWatchPolicy<M> | undefined {
     return mintQuoteWatchPolicies[method] as MintQuoteWatchPolicy<M> | undefined;
   }
 

--- a/packages/core/test/unit/HandlerProvider.test.ts
+++ b/packages/core/test/unit/HandlerProvider.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import { MeltHandlerProvider } from '../../infra/handlers/melt';
+import { MintHandlerProvider } from '../../infra/handlers/mint';
+import type { MeltMethodHandler } from '../../operations/melt';
+import type { MintMethodHandler } from '../../operations/mint';
+
+describe('method handler providers', () => {
+  it('routes mint built-in methods through the built-in registry and generic methods through the generic handler', () => {
+    const builtInHandler = {} as MintMethodHandler<'bolt11'>;
+    const genericHandler = {} as MintMethodHandler<'fedimint'>;
+    const registeredGenericHandler = {} as MintMethodHandler<'fedimint-v2'>;
+    const provider = new MintHandlerProvider({ bolt11: builtInHandler });
+
+    provider.registerGeneric(genericHandler);
+
+    expect(provider.get('bolt11')).toBe(builtInHandler);
+    expect(provider.get('fedimint')).toBe(genericHandler);
+    expect(() => provider.get('bolt12')).toThrow('No mint handler registered for method bolt12');
+    expect(provider.getAll().bolt11).toBe(builtInHandler);
+
+    provider.register('fedimint-v2', registeredGenericHandler);
+
+    expect(provider.get('fedimint-v2')).toBe(registeredGenericHandler);
+  });
+
+  it('routes melt built-in methods through the built-in registry and generic methods through the generic handler', () => {
+    const builtInHandler = {} as MeltMethodHandler<'bolt11'>;
+    const genericHandler = {} as MeltMethodHandler<'gift-card'>;
+    const registeredGenericHandler = {} as MeltMethodHandler<'gift-card-v2'>;
+    const provider = new MeltHandlerProvider({ bolt11: builtInHandler });
+
+    provider.registerGeneric(genericHandler);
+
+    expect(provider.get('bolt11')).toBe(builtInHandler);
+    expect(provider.get('gift-card')).toBe(genericHandler);
+    expect(() => provider.get('bolt12')).toThrow('No melt handler registered for method bolt12');
+    expect(provider.getAll().bolt11).toBe(builtInHandler);
+
+    provider.register('gift-card-v2', registeredGenericHandler);
+
+    expect(provider.get('gift-card-v2')).toBe(registeredGenericHandler);
+  });
+});

--- a/packages/core/test/unit/MeltBolt11Handler.test.ts
+++ b/packages/core/test/unit/MeltBolt11Handler.test.ts
@@ -313,6 +313,7 @@ describe('MeltBolt11Handler', () => {
     methodData: { invoice: string; amountSats?: Amount } = { invoice },
   ): CreateMeltQuoteContext<'bolt11'> => ({
     mintUrl,
+    method: 'bolt11',
     methodData,
     unit: 'sat',
     wallet: mockWallet,

--- a/packages/core/test/unit/MeltBolt12Handler.test.ts
+++ b/packages/core/test/unit/MeltBolt12Handler.test.ts
@@ -152,6 +152,7 @@ describe('MeltBolt12Handler', () => {
     const created = await handler.createQuote({
       ...prepareContext(initOperation({ methodData: { offer, amountSats: Amount.from(123) } })),
       mintUrl,
+      method: 'bolt12',
       methodData: { offer, amountSats: Amount.from(123) },
       unit: 'sat',
     });

--- a/packages/core/test/unit/MeltOnchainHandler.test.ts
+++ b/packages/core/test/unit/MeltOnchainHandler.test.ts
@@ -98,6 +98,7 @@ describe('MeltOnchainHandler', () => {
     const ctx = {
       ...baseDeps(),
       mintUrl,
+      method: 'onchain',
       methodData: { address: 'bc1ptest', amountSats: Amount.from(21) },
       unit: 'sat',
       wallet,

--- a/packages/core/test/unit/MeltOperation.test.ts
+++ b/packages/core/test/unit/MeltOperation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  hasPreparedData,
+  isExecutingOperation,
+  isFinalizedOperation,
+  isInitOperation,
+  isPendingOperation,
+  isPreparedOperation,
+  isRolledBackOperation,
+  isRollingBackOperation,
+  isTerminalOperation,
+  type MeltOperation,
+} from '../../operations/melt';
+
+const operationWithState = (state: MeltOperation['state']): MeltOperation =>
+  ({ state }) as MeltOperation;
+
+describe('MeltOperation guards', () => {
+  it('narrows individual melt operation states', () => {
+    expect(isInitOperation(operationWithState('init'))).toBe(true);
+    expect(isPreparedOperation(operationWithState('prepared'))).toBe(true);
+    expect(isExecutingOperation(operationWithState('executing'))).toBe(true);
+    expect(isPendingOperation(operationWithState('pending'))).toBe(true);
+    expect(isFinalizedOperation(operationWithState('finalized'))).toBe(true);
+    expect(isRollingBackOperation(operationWithState('rolling_back'))).toBe(true);
+    expect(isRolledBackOperation(operationWithState('rolled_back'))).toBe(true);
+
+    expect(isInitOperation(operationWithState('prepared'))).toBe(false);
+    expect(isPendingOperation(operationWithState('executing'))).toBe(false);
+  });
+
+  it('detects prepared-or-later and terminal melt operation states', () => {
+    expect(hasPreparedData(operationWithState('init'))).toBe(false);
+    expect(hasPreparedData(operationWithState('prepared'))).toBe(true);
+
+    expect(isTerminalOperation(operationWithState('finalized'))).toBe(true);
+    expect(isTerminalOperation(operationWithState('rolled_back'))).toBe(true);
+    expect(isTerminalOperation(operationWithState('failed'))).toBe(true);
+    expect(isTerminalOperation(operationWithState('pending'))).toBe(false);
+  });
+});

--- a/packages/core/test/unit/MeltOpsApi.test.ts
+++ b/packages/core/test/unit/MeltOpsApi.test.ts
@@ -65,6 +65,23 @@ type _AssertGetByQuoteUsesObjectInput = Assert<
     ? true
     : false
 >;
+type GenericPrepareMeltInput = Parameters<MeltOpsApi<'gift-card'>['prepare']>[0];
+type GenericPrepareMeltReturn = Awaited<ReturnType<MeltOpsApi<'gift-card'>['prepare']>>;
+type _AssertGenericMeltPrepareAcceptsArbitraryMethod = Assert<
+  GenericPrepareMeltInput extends {
+    quote: {
+      mintUrl: string;
+      quoteId: string;
+      method: 'gift-card';
+    };
+    feeIndex?: number;
+  }
+    ? true
+    : false
+>;
+type _AssertGenericMeltPrepareReturnPreservesMethod = Assert<
+  GenericPrepareMeltReturn extends PreparedMeltOperation<'gift-card'> ? true : false
+>;
 
 const supportedPrepareInput: PrepareMeltInput = {
   quote: {

--- a/packages/core/test/unit/MeltQuote.test.ts
+++ b/packages/core/test/unit/MeltQuote.test.ts
@@ -1,8 +1,10 @@
 import { Amount, type MeltQuoteOnchainResponse } from '@cashu/cashu-ts';
 import { describe, expect, it } from 'bun:test';
 import {
+  meltQuoteToMethodSnapshot,
   meltQuoteFromOnchainResponse,
   resolveOnchainMeltFeeOption,
+  type GenericMeltQuote,
   type MeltQuote,
 } from '../../models/MeltQuote.ts';
 
@@ -107,5 +109,38 @@ describe('MeltQuote model', () => {
         }),
       ),
     ).toThrow('invalid estimated_blocks');
+  });
+
+  it('projects generic melt quotes into generic method snapshots', () => {
+    const quote: GenericMeltQuote<'gift-card'> = {
+      mintUrl,
+      method: 'gift-card',
+      quoteId: 'generic-melt-quote',
+      quote: 'generic-melt-quote',
+      request: 'gift-card-request',
+      amount: Amount.from(25),
+      unit: 'sat',
+      fee_reserve: Amount.from(2),
+      expiry: 123,
+      state: 'PENDING',
+      payment_preimage: null,
+      rawQuoteData: {
+        provider: 'gift-card-provider',
+      },
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    const snapshot = meltQuoteToMethodSnapshot(quote);
+
+    expect(snapshot.quote).toBe('generic-melt-quote');
+    expect(snapshot.request).toBe('gift-card-request');
+    expect(snapshot.amount.equals(Amount.from(25))).toBe(true);
+    expect(snapshot.unit).toBe('sat');
+    expect(Amount.from(snapshot.fee_reserve ?? 0).equals(Amount.from(2))).toBe(true);
+    expect(snapshot.expiry).toBe(123);
+    expect(snapshot.state).toBe('PENDING');
+    expect(snapshot.payment_preimage).toBeNull();
+    expect(snapshot.provider).toBe('gift-card-provider');
   });
 });

--- a/packages/core/test/unit/MintBolt11Handler.test.ts
+++ b/packages/core/test/unit/MintBolt11Handler.test.ts
@@ -95,6 +95,7 @@ describe('MintBolt11Handler', () => {
 
   const buildCreateQuoteContext = (): CreateMintQuoteContext<'bolt11'> => ({
     mintUrl,
+    method: 'bolt11',
     createQuoteData: { amount: { amount: Amount.from(10), unit: 'sat' } },
     wallet,
     mintAdapter,

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -157,6 +157,7 @@ describe('MintBolt12Handler', () => {
     const result = await handler.createQuote({
       ...buildPrepareContext(),
       mintUrl,
+      method: 'bolt12',
       createQuoteData: {
         unit: 'sat',
         amount: { amount: Amount.from(10), unit: 'sat' },
@@ -182,6 +183,7 @@ describe('MintBolt12Handler', () => {
       handler.createQuote({
         ...buildPrepareContext(),
         mintUrl,
+        method: 'bolt12',
         createQuoteData: {
           unit: 'sat',
           amount: { amount: Amount.from(10), unit: 'sat' },
@@ -199,6 +201,7 @@ describe('MintBolt12Handler', () => {
       handler.createQuote({
         ...buildPrepareContext(),
         mintUrl,
+        method: 'bolt12',
         createQuoteData: {
           unit: 'sat',
           amount: { amount: Amount.from(10), unit: 'sat' },
@@ -216,6 +219,7 @@ describe('MintBolt12Handler', () => {
       handler.createQuote({
         ...buildPrepareContext(),
         mintUrl,
+        method: 'bolt12',
         createQuoteData: {
           unit: 'sat',
           amount: { amount: Amount.from(10), unit: 'sat' },
@@ -232,6 +236,7 @@ describe('MintBolt12Handler', () => {
     const result = await handler.createQuote({
       ...buildPrepareContext(),
       mintUrl,
+      method: 'bolt12',
       createQuoteData: {
         unit: 'sat',
         description: 'pay any amount',

--- a/packages/core/test/unit/MintOnchainHandler.test.ts
+++ b/packages/core/test/unit/MintOnchainHandler.test.ts
@@ -62,6 +62,7 @@ describe('MintOnchainHandler', () => {
 
   const buildCreateQuoteContext = (): CreateMintQuoteContext<'onchain'> => ({
     mintUrl,
+    method: 'onchain',
     createQuoteData: { unit: 'sat' },
     wallet,
     mintAdapter,

--- a/packages/core/test/unit/MintOpsApi.test.ts
+++ b/packages/core/test/unit/MintOpsApi.test.ts
@@ -44,6 +44,23 @@ type _AssertListByQuoteUsesQuoteIdentity = Assert<
 type _AssertDefaultAllowsBolt12Mint = Assert<
   'bolt12' extends PrepareMintInput['quote']['method'] ? true : false
 >;
+type GenericPrepareMintInput = Parameters<MintOpsApi<'fedimint'>['prepare']>[0];
+type GenericPrepareMintReturn = Awaited<ReturnType<MintOpsApi<'fedimint'>['prepare']>>;
+type _AssertGenericMintPrepareAcceptsArbitraryMethod = Assert<
+  GenericPrepareMintInput extends {
+    quote: {
+      mintUrl: string;
+      quoteId: string;
+      method: 'fedimint';
+    };
+    amount: unknown;
+  }
+    ? true
+    : false
+>;
+type _AssertGenericMintPrepareReturnPreservesMethod = Assert<
+  GenericPrepareMintReturn extends PendingMintOperation<'fedimint'> ? true : false
+>;
 
 const makePendingOperation = (): PendingMintOperation => ({
   id: 'op-1',

--- a/packages/core/test/unit/MintQuote.test.ts
+++ b/packages/core/test/unit/MintQuote.test.ts
@@ -6,7 +6,12 @@ import {
 import { describe, expect, it } from 'bun:test';
 
 import {
+  getMintQuoteAvailableAmount,
   getMintQuoteAmount,
+  isMintQuotePending,
+  mintQuoteToMethodSnapshot,
+  type GenericMintQuote,
+  type MintQuote,
   mintQuoteFromBolt11Response,
   mintQuoteFromBolt12Response,
 } from '../../models/MintQuote';
@@ -41,5 +46,41 @@ describe('MintQuote model', () => {
     expect(quote.amount?.equals(Amount.from(21))).toBe(true);
     expect(quote.quoteData.amount?.equals(Amount.from(21))).toBe(true);
     expect(getMintQuoteAmount(quote)).toBeUndefined();
+  });
+
+  it('projects generic mint quotes into generic method snapshots', () => {
+    const quote: GenericMintQuote<'fedimint'> = {
+      mintUrl: 'https://mint.test',
+      method: 'fedimint',
+      quoteId: 'generic-mint-quote',
+      quote: 'generic-mint-quote',
+      request: 'fedimint-request',
+      unit: 'sat',
+      expiry: null,
+      reusable: true,
+      quoteData: {
+        pubkey: 'pubkey',
+        amountPaid: Amount.from(100),
+        amountIssued: Amount.from(40),
+      },
+      rawQuoteData: {
+        route: 'federation-1',
+      },
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    const snapshot = mintQuoteToMethodSnapshot(quote);
+    const quoteForBuiltInHelpers = quote as unknown as MintQuote;
+
+    expect(snapshot.quote).toBe('generic-mint-quote');
+    expect(snapshot.request).toBe('fedimint-request');
+    expect(snapshot.unit).toBe('sat');
+    expect(snapshot.pubkey).toBe('pubkey');
+    expect(Amount.from(snapshot.amount_paid).equals(Amount.from(100))).toBe(true);
+    expect(Amount.from(snapshot.amount_issued).equals(Amount.from(40))).toBe(true);
+    expect(snapshot.route).toBe('federation-1');
+    expect(getMintQuoteAvailableAmount(quoteForBuiltInHelpers).equals(Amount.from(60))).toBe(true);
+    expect(isMintQuotePending(quoteForBuiltInHelpers)).toBe(true);
   });
 });

--- a/packages/core/test/unit/QuoteApi.test.ts
+++ b/packages/core/test/unit/QuoteApi.test.ts
@@ -2,8 +2,8 @@ import { Amount } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { QuoteApi } from '../../api/QuoteApi.ts';
 import type { MeltOpsApi } from '../../api/MeltOpsApi.ts';
-import type { MeltQuote } from '../../models/MeltQuote.ts';
-import type { MintQuote } from '../../models/MintQuote.ts';
+import type { GenericMeltQuote, MeltQuote } from '../../models/MeltQuote.ts';
+import type { GenericMintQuote, MintQuote } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 
 const mintUrl = 'https://mint.test';
@@ -12,6 +12,77 @@ const quoteId = 'quote-1';
 type MintCreateInput = Parameters<QuoteApi['mint']['create']>[0];
 type MintImportInput = Parameters<QuoteApi['mint']['import']>[0];
 type MeltCreateInput = Parameters<QuoteApi['melt']['create']>[0];
+type Assert<T extends true> = T;
+type IsNever<T> = [T] extends [never] ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+async function assertBuiltInAndGenericQuoteTypes(api: QuoteApi): Promise<void> {
+  const bolt11MintQuote = await api.mint.create({
+    mintUrl,
+    method: 'bolt11',
+    amount: Amount.from(10),
+  });
+  const bolt11MintMethod: 'bolt11' = bolt11MintQuote.method;
+  const bolt12MintQuote = await api.mint.create({ mintUrl, method: 'bolt12', unit: 'sat' });
+  const bolt12MintMethod: 'bolt12' = bolt12MintQuote.method;
+  const onchainMintQuote = await api.mint.create({ mintUrl, method: 'onchain', unit: 'sat' });
+  const onchainMintMethod: 'onchain' = onchainMintQuote.method;
+
+  const genericMintQuote = await api.mint.createGeneric({
+    mintUrl,
+    method: 'fedimint',
+    amount: Amount.from(10),
+    payload: { memo: 'coffee' },
+  });
+  const genericMintMethod: 'fedimint' = genericMintQuote.method;
+  type _AssertGenericMintQuote = Assert<
+    IsNever<typeof genericMintQuote> extends false
+      ? IsAny<typeof genericMintQuote> extends false
+        ? typeof genericMintQuote extends GenericMintQuote<'fedimint'>
+          ? true
+          : false
+        : false
+      : false
+  >;
+
+  const bolt11MeltQuote = await api.melt.create({
+    mintUrl,
+    method: 'bolt11',
+    methodData: { invoice: 'lnbc1melt' },
+  });
+  const bolt11MeltMethod: 'bolt11' = bolt11MeltQuote.method;
+
+  const genericMeltQuote = await api.melt.createGeneric({
+    mintUrl,
+    method: 'gift-card',
+    request: 'gift-card-request',
+    payload: { destination: 'acct_123' },
+  });
+  const genericMeltMethod: 'gift-card' = genericMeltQuote.method;
+  type _AssertGenericMeltQuote = Assert<
+    IsNever<typeof genericMeltQuote> extends false
+      ? IsAny<typeof genericMeltQuote> extends false
+        ? typeof genericMeltQuote extends GenericMeltQuote<'gift-card'>
+          ? true
+          : false
+        : false
+      : false
+  >;
+
+  // @ts-expect-error Built-in mint methods must use the built-in quote creation API.
+  await api.mint.createGeneric({ mintUrl, method: 'bolt11', amount: Amount.from(10) });
+  // @ts-expect-error Built-in melt methods must use the built-in quote creation API.
+  await api.melt.createGeneric({ mintUrl, method: 'onchain', request: 'bc1q...' });
+
+  void [
+    bolt11MintMethod,
+    bolt12MintMethod,
+    onchainMintMethod,
+    genericMintMethod,
+    bolt11MeltMethod,
+    genericMeltMethod,
+  ];
+}
 
 function assertMethodRequirementsRemain(): void {
   // @ts-expect-error Mint quote creation still requires method.
@@ -52,6 +123,48 @@ const makeMintQuote = (): MintQuote<'bolt11'> => ({
   quoteData: {
     amount: Amount.from(10),
   },
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+});
+
+const makeOnchainMintQuote = (): MintQuote<'onchain'> => ({
+  mintUrl,
+  method: 'onchain',
+  quoteId,
+  quote: quoteId,
+  request: 'bc1qmint',
+  unit: 'sat',
+  expiry: Math.floor(Date.now() / 1000) + 3600,
+  pubkey: 'pubkey',
+  reusable: true,
+  quoteData: {
+    pubkey: 'pubkey',
+    amountPaid: Amount.zero(),
+    amountIssued: Amount.zero(),
+  },
+  lastObservedRemoteStateAt: Date.now(),
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+});
+
+const makeBolt12MintQuote = (): MintQuote<'bolt12'> => ({
+  mintUrl,
+  method: 'bolt12',
+  quoteId,
+  quote: quoteId,
+  request: 'lno1mint',
+  unit: 'sat',
+  amount: Amount.from(10),
+  expiry: Math.floor(Date.now() / 1000) + 3600,
+  pubkey: 'pubkey',
+  reusable: true,
+  quoteData: {
+    pubkey: 'pubkey',
+    amount: Amount.from(10),
+    amountPaid: Amount.zero(),
+    amountIssued: Amount.zero(),
+  },
+  lastObservedRemoteStateAt: Date.now(),
   createdAt: Date.now(),
   updatedAt: Date.now(),
 });
@@ -139,8 +252,11 @@ describe('QuoteApi', () => {
   });
 
   it('delegates onchain mint quote creation without an amount', async () => {
+    const onchainQuote = makeOnchainMintQuote();
+    (quoteLifecycle.createMintQuote as any).mockImplementationOnce(async () => onchainQuote);
+
     await expect(api.mint.create({ mintUrl, method: 'onchain', unit: 'sat' })).resolves.toBe(
-      mintQuote,
+      onchainQuote,
     );
 
     expect(quoteLifecycle.createMintQuote).toHaveBeenCalledWith(mintUrl, 'onchain', {
@@ -149,6 +265,9 @@ describe('QuoteApi', () => {
   });
 
   it('delegates BOLT12 mint quote creation with optional amount data', async () => {
+    const bolt12Quote = makeBolt12MintQuote();
+    (quoteLifecycle.createMintQuote as any).mockImplementationOnce(async () => bolt12Quote);
+
     await expect(
       api.mint.create({
         mintUrl,
@@ -157,7 +276,7 @@ describe('QuoteApi', () => {
         amount: Amount.from(10),
         description: 'coffee',
       }),
-    ).resolves.toBe(mintQuote);
+    ).resolves.toBe(bolt12Quote);
 
     expect(quoteLifecycle.createMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt12', {
       unit: 'sat',
@@ -167,6 +286,9 @@ describe('QuoteApi', () => {
   });
 
   it('delegates amountless BOLT12 mint quote creation without undefined amount', async () => {
+    const bolt12Quote = makeBolt12MintQuote();
+    (quoteLifecycle.createMintQuote as any).mockImplementationOnce(async () => bolt12Quote);
+
     await expect(
       api.mint.create({
         mintUrl,
@@ -174,7 +296,7 @@ describe('QuoteApi', () => {
         unit: 'sat',
         description: 'coffee',
       }),
-    ).resolves.toBe(mintQuote);
+    ).resolves.toBe(bolt12Quote);
 
     expect(quoteLifecycle.createMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt12', {
       unit: 'sat',
@@ -233,5 +355,18 @@ describe('QuoteApi', () => {
 
   it('keeps method required for quote creation and import inputs', () => {
     assertMethodRequirementsRemain();
+    void assertBuiltInAndGenericQuoteTypes;
+  });
+
+  it('rejects built-in method names on generic quote APIs before routing to lifecycle', async () => {
+    await expect(
+      api.mint.createGeneric({ mintUrl, method: 'bolt11', amount: Amount.from(10) } as any),
+    ).rejects.toThrow('Built-in mint method bolt11 must use the built-in mint quote API');
+    await expect(
+      api.melt.createGeneric({ mintUrl, method: 'onchain', request: 'bc1q...' } as any),
+    ).rejects.toThrow('Built-in melt method onchain must use the built-in melt quote API');
+
+    expect(quoteLifecycle.createMintQuote).not.toHaveBeenCalled();
+    expect(quoteLifecycle.createMeltQuote).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

This pull request resolves #234 and adds explicit built-in and generic payment method type surfaces for core quote and operation APIs.

## Problem

Payment method extension needed a public type model that distinguishes built-in methods from arbitrary generic method strings. Without that split, generic quote and operation inputs were hard to type safely, and built-in method names could leak into generic routing paths.

## Summary

- Adds built-in and generic mint/melt method types across `QuoteApi`, mint/melt quote models, and operation inputs.
- Validates generic method strings through mint and melt handler providers so built-in method names are rejected from generic paths.
- Adds runtime and type-focused unit coverage for generic quote inputs and payment method routing.
- Compatibility note: this changes released public API types for `@cashu/coco-core` and is marked as a major changeset.

## Verification

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test:unit`

## Changeset

- Added `.changeset/payment-method-types.md` with a major bump for `@cashu/coco-core`.