### PR TITLE
feat(core): add built-in and generic payment method types

### DIFF
--- a/.changeset/payment-method-types.md
+++ b/.changeset/payment-method-types.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': major
+---
+
+Prefactor payment method public types around Built-in Payment Methods and explicit Generic Payment Method shapes.

--- a/packages/core/api/MeltOpsApi.ts
+++ b/packages/core/api/MeltOpsApi.ts
@@ -1,4 +1,5 @@
 import type {
+  BuiltInMeltMethod,
   FinalizedMeltOperation,
   MeltOperation,
   PendingMeltOperation,
@@ -7,10 +8,7 @@ import type {
 import type { MeltMethod, MeltOperationService } from '@core/operations/melt';
 import type { MeltQuoteRef, QuoteIdentity } from '../models/QuoteIdentity.ts';
 
-/** Melt methods supported by the default `Manager` wiring. */
-export type DefaultSupportedMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
-
-export type PrepareMeltInput<TSupported extends MeltMethod = DefaultSupportedMeltMethod> = {
+export type PrepareMeltInput<TSupported extends MeltMethod = BuiltInMeltMethod> = {
   [M in TSupported]: {
     /** Existing canonical melt quote or structural quote reference. */
     quote: MeltQuoteRef<M>;
@@ -36,7 +34,7 @@ export interface MeltDiagnosticsApi {
  * execute it, inspect or refresh its state, and recover or roll it back when
  * allowed by the underlying method.
  */
-export class MeltOpsApi<TSupported extends MeltMethod = DefaultSupportedMeltMethod> {
+export class MeltOpsApi<TSupported extends MeltMethod = BuiltInMeltMethod> {
   /** Recovery helpers for melt operations. */
   readonly recovery: MeltRecoveryApi = {
     run: async () => this.meltOperationService.recoverPendingOperations(),

--- a/packages/core/api/MintOpsApi.ts
+++ b/packages/core/api/MintOpsApi.ts
@@ -1,5 +1,6 @@
 import { Amount, type AmountLike } from '@cashu/cashu-ts';
 import type {
+  BuiltInMintMethod,
   MintMethod,
   MintOperation,
   MintOperationService,
@@ -8,10 +9,7 @@ import type {
 } from '@core/operations/mint';
 import type { MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity.ts';
 
-/** Mint methods supported by the default `Manager` wiring. */
-export type DefaultSupportedMintMethod = 'bolt11' | 'onchain' | 'bolt12';
-
-export type PrepareMintInput<TSupported extends MintMethod = DefaultSupportedMintMethod> = {
+export type PrepareMintInput<TSupported extends MintMethod = BuiltInMintMethod> = {
   /** Existing canonical mint quote or structural quote reference. */
   quote: MintQuoteRef<TSupported>;
   /** Amount to mint using the canonical quote's stored unit. */
@@ -36,7 +34,7 @@ export interface MintDiagnosticsApi {
  * This API makes the mint lifecycle explicit so callers can move a canonical
  * quote into a durable pending operation, execute it, and inspect its progress.
  */
-export class MintOpsApi<TSupported extends MintMethod = DefaultSupportedMintMethod> {
+export class MintOpsApi<TSupported extends MintMethod = BuiltInMintMethod> {
   /** Recovery helpers for mint operations. */
   readonly recovery: MintRecoveryApi = {
     run: async () => this.mintOperationService.recoverPendingOperations(),

--- a/packages/core/api/QuoteApi.ts
+++ b/packages/core/api/QuoteApi.ts
@@ -1,11 +1,13 @@
 import type {
   BuiltInMeltMethod,
   GenericMeltMethod,
+  GenericMeltMethodValue,
   MeltMethodInputData,
 } from '@core/operations/melt';
 import type {
   BuiltInMintMethod,
   GenericMintMethod,
+  GenericMintMethodValue,
   GenericMintQuoteCreatePayload,
   MintMethodQuoteSnapshot,
 } from '@core/operations/mint';
@@ -39,7 +41,7 @@ export type CreateMintQuoteInput<M extends BuiltInMintMethod = BuiltInMintMethod
 
 export type CreateGenericMintQuoteInput<M extends string> = {
   mintUrl: string;
-  method: GenericMintMethod<M>;
+  method: GenericMintMethodValue<M>;
   amount: UnitAmountLike;
   unit?: string;
   payload?: GenericMintQuoteCreatePayload;
@@ -47,16 +49,16 @@ export type CreateGenericMintQuoteInput<M extends string> = {
 
 export type CreateGenericMeltQuoteInput<M extends string> = {
   mintUrl: string;
-  method: GenericMeltMethod<M>;
-  methodData: MeltMethodInputData<GenericMeltMethod<M>>;
+  method: GenericMeltMethodValue<M>;
+  methodData: MeltMethodInputData<GenericMeltMethodValue<M>>;
   unit?: string;
 };
 
 export type GenericMintQuoteCreateResult<M extends string> =
-  GenericMintMethod<M> extends never ? never : GenericMintQuote<GenericMintMethod<M>>;
+  GenericMintMethodValue<M> extends never ? never : GenericMintQuote<GenericMintMethodValue<M>>;
 
 export type GenericMeltQuoteCreateResult<M extends string> =
-  GenericMeltMethod<M> extends never ? never : GenericMeltQuote<GenericMeltMethod<M>>;
+  GenericMeltMethodValue<M> extends never ? never : GenericMeltQuote<GenericMeltMethodValue<M>>;
 
 export interface GenericQuoteApiShapes {
   createMint<M extends string>(

--- a/packages/core/api/QuoteApi.ts
+++ b/packages/core/api/QuoteApi.ts
@@ -37,7 +37,7 @@ export type CreateMintQuoteInput<M extends BuiltInMintMethod = BuiltInMintMethod
   { method: M }
 >;
 
-export type CreateGenericMintQuoteInput<M extends string = string> = {
+export type CreateGenericMintQuoteInput<M extends string> = {
   mintUrl: string;
   method: GenericMintMethod<M>;
   amount: UnitAmountLike;
@@ -45,7 +45,7 @@ export type CreateGenericMintQuoteInput<M extends string = string> = {
   payload?: GenericMintQuoteCreatePayload;
 };
 
-export type CreateGenericMeltQuoteInput<M extends string = string> = {
+export type CreateGenericMeltQuoteInput<M extends string> = {
   mintUrl: string;
   method: GenericMeltMethod<M>;
   methodData: MeltMethodInputData<GenericMeltMethod<M>>;

--- a/packages/core/api/QuoteApi.ts
+++ b/packages/core/api/QuoteApi.ts
@@ -1,15 +1,21 @@
-import type { MeltMethodInputData } from '@core/operations/melt';
-import type { MintMethodQuoteSnapshot } from '@core/operations/mint';
+import type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
+  MeltMethodInputData,
+} from '@core/operations/melt';
+import type {
+  BuiltInMintMethod,
+  GenericMintMethod,
+  GenericMintQuoteCreatePayload,
+  MintMethodQuoteSnapshot,
+} from '@core/operations/mint';
 import { DEFAULT_UNIT, normalizeUnit, parseUnitAmount, type UnitAmountLike } from '../amounts.ts';
-import type { MeltQuote } from '../models/MeltQuote';
-import type { MintQuote } from '../models/MintQuote';
+import type { GenericMeltQuote, MeltQuote } from '../models/MeltQuote';
+import type { GenericMintQuote, MintQuote } from '../models/MintQuote';
 import type { QuoteIdentity } from '../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../quotes/QuoteLifecycle';
-import type { DefaultSupportedMeltMethod } from './MeltOpsApi.ts';
 
-export type DefaultSupportedMintQuoteMethod = 'bolt11' | 'onchain' | 'bolt12';
-
-export type CreateMintQuoteInput =
+export type CreateMintQuoteInput<M extends BuiltInMintMethod = BuiltInMintMethod> = Extract<
   | {
       mintUrl: string;
       method: 'bolt11';
@@ -27,7 +33,39 @@ export type CreateMintQuoteInput =
       unit?: string;
       amount?: UnitAmountLike;
       description?: string;
-    };
+    },
+  { method: M }
+>;
+
+export type CreateGenericMintQuoteInput<M extends string = string> = {
+  mintUrl: string;
+  method: GenericMintMethod<M>;
+  amount: UnitAmountLike;
+  unit?: string;
+  payload?: GenericMintQuoteCreatePayload;
+};
+
+export type CreateGenericMeltQuoteInput<M extends string = string> = {
+  mintUrl: string;
+  method: GenericMeltMethod<M>;
+  methodData: MeltMethodInputData<GenericMeltMethod<M>>;
+  unit?: string;
+};
+
+export type GenericMintQuoteCreateResult<M extends string> =
+  GenericMintMethod<M> extends never ? never : GenericMintQuote<GenericMintMethod<M>>;
+
+export type GenericMeltQuoteCreateResult<M extends string> =
+  GenericMeltMethod<M> extends never ? never : GenericMeltQuote<GenericMeltMethod<M>>;
+
+export interface GenericQuoteApiShapes {
+  createMint<M extends string>(
+    input: CreateGenericMintQuoteInput<M>,
+  ): Promise<GenericMintQuoteCreateResult<M>>;
+  createMelt<M extends string>(
+    input: CreateGenericMeltQuoteInput<M>,
+  ): Promise<GenericMeltQuoteCreateResult<M>>;
+}
 
 export type ImportMintQuoteInput = {
   /** Mint that issued the existing quote. */
@@ -39,12 +77,10 @@ export type ImportMintQuoteInput = {
 };
 
 export type ListPendingMintQuotesInput = {
-  method?: DefaultSupportedMintQuoteMethod;
+  method?: BuiltInMintMethod;
 };
 
-export type CreateMeltQuoteInput<
-  TSupported extends DefaultSupportedMeltMethod = DefaultSupportedMeltMethod,
-> = {
+export type CreateMeltQuoteInput<TSupported extends BuiltInMeltMethod = BuiltInMeltMethod> = {
   [M in TSupported]: {
     mintUrl: string;
     method: M;
@@ -54,7 +90,7 @@ export type CreateMeltQuoteInput<
 }[TSupported];
 
 export type ListPendingMeltQuotesInput = {
-  method?: DefaultSupportedMeltMethod;
+  method?: BuiltInMeltMethod;
 };
 
 export class MintQuoteApi {
@@ -106,9 +142,7 @@ export class MintQuoteApi {
 export class MeltQuoteApi {
   constructor(private readonly quoteLifecycle: QuoteLifecycle) {}
 
-  create<M extends DefaultSupportedMeltMethod>(
-    input: CreateMeltQuoteInput<M>,
-  ): Promise<MeltQuote<M>> {
+  create<M extends BuiltInMeltMethod>(input: CreateMeltQuoteInput<M>): Promise<MeltQuote<M>> {
     return this.quoteLifecycle.createMeltQuote(
       input.mintUrl,
       input.method,

--- a/packages/core/infra/handlers/melt/BaseQuoteMeltHandler.ts
+++ b/packages/core/infra/handlers/melt/BaseQuoteMeltHandler.ts
@@ -444,12 +444,7 @@ export abstract class BaseQuoteMeltHandler<M extends MeltMethod> implements Melt
    */
   private async handleMeltResponse(
     ctx: ExecuteContext<M>,
-    response: {
-      state: 'PAID' | 'UNPAID' | 'PENDING';
-      change?: SerializedBlindedSignature[];
-      payment_preimage?: string | null;
-      outpoint?: string | null;
-    },
+    response: QuoteMeltResponse<M>,
     proofsToMelt: Proof[],
   ): Promise<ExecutionResult<M>> {
     const { mintUrl } = ctx.operation;

--- a/packages/core/infra/handlers/melt/MeltHandlerProvider.ts
+++ b/packages/core/infra/handlers/melt/MeltHandlerProvider.ts
@@ -4,6 +4,7 @@ import type {
   MeltMethod,
   MeltMethodHandler,
   MeltMethodHandlerRegistry,
+  ValidatedGenericMeltMethod,
 } from '../../../operations/melt/MeltMethodHandler';
 
 const BUILT_IN_MELT_METHODS = new Set<string>(['bolt11', 'bolt12', 'onchain']);
@@ -18,6 +19,11 @@ export function assertGenericMeltMethod<M extends string>(
   if (isBuiltInMeltMethod(method)) {
     throw new Error(`Built-in melt method ${method} must use its built-in handler path`);
   }
+}
+
+export function toGenericMeltMethod(method: string): ValidatedGenericMeltMethod {
+  assertGenericMeltMethod(method);
+  return method as ValidatedGenericMeltMethod;
 }
 
 /**

--- a/packages/core/infra/handlers/melt/MeltHandlerProvider.ts
+++ b/packages/core/infra/handlers/melt/MeltHandlerProvider.ts
@@ -1,8 +1,24 @@
 import type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
   MeltMethod,
   MeltMethodHandler,
   MeltMethodHandlerRegistry,
 } from '../../../operations/melt/MeltMethodHandler';
+
+const BUILT_IN_MELT_METHODS = new Set<string>(['bolt11', 'bolt12', 'onchain']);
+
+export function isBuiltInMeltMethod(method: string): method is BuiltInMeltMethod {
+  return BUILT_IN_MELT_METHODS.has(method);
+}
+
+export function assertGenericMeltMethod<M extends string>(
+  method: M,
+): asserts method is GenericMeltMethod<M> {
+  if (isBuiltInMeltMethod(method)) {
+    throw new Error(`Built-in melt method ${method} must use its built-in handler path`);
+  }
+}
 
 /**
  * Runtime registry for melt method handlers.

--- a/packages/core/infra/handlers/mint/MintHandlerProvider.ts
+++ b/packages/core/infra/handlers/mint/MintHandlerProvider.ts
@@ -1,8 +1,24 @@
 import type {
+  BuiltInMintMethod,
+  GenericMintMethod,
   MintMethod,
   MintMethodHandler,
   MintMethodHandlerRegistry,
 } from '../../../operations/mint/MintMethodHandler';
+
+const BUILT_IN_MINT_METHODS = new Set<string>(['bolt11', 'onchain', 'bolt12']);
+
+export function isBuiltInMintMethod(method: string): method is BuiltInMintMethod {
+  return BUILT_IN_MINT_METHODS.has(method);
+}
+
+export function assertGenericMintMethod<M extends string>(
+  method: M,
+): asserts method is GenericMintMethod<M> {
+  if (isBuiltInMintMethod(method)) {
+    throw new Error(`Built-in mint method ${method} must use its built-in handler path`);
+  }
+}
 
 /**
  * Runtime registry for mint method handlers.

--- a/packages/core/infra/handlers/mint/MintHandlerProvider.ts
+++ b/packages/core/infra/handlers/mint/MintHandlerProvider.ts
@@ -4,6 +4,7 @@ import type {
   MintMethod,
   MintMethodHandler,
   MintMethodHandlerRegistry,
+  ValidatedGenericMintMethod,
 } from '../../../operations/mint/MintMethodHandler';
 
 const BUILT_IN_MINT_METHODS = new Set<string>(['bolt11', 'onchain', 'bolt12']);
@@ -18,6 +19,11 @@ export function assertGenericMintMethod<M extends string>(
   if (isBuiltInMintMethod(method)) {
     throw new Error(`Built-in mint method ${method} must use its built-in handler path`);
   }
+}
+
+export function toGenericMintMethod(method: string): ValidatedGenericMintMethod {
+  assertGenericMintMethod(method);
+  return method as ValidatedGenericMintMethod;
 }
 
 /**

--- a/packages/core/models/MeltQuote.ts
+++ b/packages/core/models/MeltQuote.ts
@@ -8,6 +8,8 @@ import {
   type SerializedBlindedSignature,
 } from '@cashu/cashu-ts';
 import type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
   MeltMethod,
   MeltMethodQuoteSnapshot,
   MeltMethodRemoteState,
@@ -15,7 +17,7 @@ import type {
 
 type BoltMeltMethod = Extract<MeltMethod, 'bolt11' | 'bolt12'>;
 
-interface MeltQuoteBase<M extends MeltMethod> {
+interface MeltQuoteBase<M extends string> {
   mintUrl: string;
   method: M;
   quoteId: string;
@@ -46,11 +48,21 @@ export interface OnchainMeltQuote extends MeltQuoteBase<'onchain'> {
   outpoint?: string;
 }
 
-export type MeltQuote<M extends MeltMethod = MeltMethod> = M extends 'onchain'
+export interface GenericMeltQuote<M extends string = string> extends MeltQuoteBase<
+  GenericMeltMethod<M>
+> {
+  fee_reserve: Amount;
+  payment_preimage?: string | null;
+  rawQuoteData: Record<string, unknown>;
+}
+
+export type MeltQuote<M extends string = BuiltInMeltMethod> = M extends 'onchain'
   ? OnchainMeltQuote
   : M extends BoltMeltMethod
     ? BoltMeltQuote<M>
-    : never;
+    : GenericMeltMethod<M> extends never
+      ? never
+      : GenericMeltQuote<GenericMeltMethod<M>>;
 
 type BoltMeltQuoteResponse = MeltQuoteBolt11Response | MeltQuoteBolt12Response;
 

--- a/packages/core/models/MintQuote.ts
+++ b/packages/core/models/MintQuote.ts
@@ -5,7 +5,8 @@ import {
   type MintQuoteBolt12Response,
 } from '@cashu/cashu-ts';
 import type {
-  MintMethod,
+  BuiltInMintMethod,
+  GenericMintMethod,
   MintMethodQuoteData,
   MintMethodQuoteSnapshot,
   MintMethodRemoteState,
@@ -13,7 +14,7 @@ import type {
 
 export type MintQuoteOnchainResponse = MintMethodQuoteSnapshot<'onchain'>;
 
-interface MintQuoteBase<M extends MintMethod> {
+interface MintQuoteBase<M extends string> {
   mintUrl: string;
   method: M;
   quoteId: string;
@@ -56,13 +57,24 @@ export type Bolt12MintQuote = MintQuoteBase<'bolt12'> & {
   reusable: true;
 };
 
-export type MintQuote<M extends MintMethod = MintMethod> = M extends 'bolt11'
+export type GenericMintQuote<M extends string = string> = MintQuoteBase<GenericMintMethod<M>> & {
+  amount?: never;
+  state?: never;
+  lastObservedRemoteState?: never;
+  lastObservedRemoteStateAt?: number;
+  reusable: true;
+  rawQuoteData: Record<string, unknown>;
+};
+
+export type MintQuote<M extends string = BuiltInMintMethod> = M extends 'bolt11'
   ? Bolt11MintQuote
   : M extends 'onchain'
     ? OnchainMintQuote
     : M extends 'bolt12'
       ? Bolt12MintQuote
-      : never;
+      : GenericMintMethod<M> extends never
+        ? never
+        : GenericMintQuote<GenericMintMethod<M>>;
 
 export function isStatefulMintQuote(quote: MintQuote): quote is MintQuote<'bolt11'> {
   return quote.method === 'bolt11';
@@ -190,7 +202,7 @@ export function mintQuoteFromBolt12Response(
   };
 }
 
-export function mintQuoteToMethodSnapshot<M extends MintMethod>(
+export function mintQuoteToMethodSnapshot<M extends BuiltInMintMethod>(
   quote: MintQuote<M>,
 ): MintMethodQuoteSnapshot<M> {
   if (quote.method === 'bolt11') {

--- a/packages/core/operations/melt/MeltMethodHandler.ts
+++ b/packages/core/operations/melt/MeltMethodHandler.ts
@@ -6,6 +6,7 @@ import {
   type MeltQuoteOnchainResponse,
   type Wallet,
   type Proof,
+  type SerializedBlindedSignature,
 } from '@cashu/cashu-ts';
 import type { ProofRepository } from '../../repositories';
 import type { ProofService } from '../../services/ProofService';
@@ -27,44 +28,76 @@ import type {
 import type { MintAdapter } from '@core/infra';
 import type { MeltQuote } from '../../models/MeltQuote';
 
-/**
- * Registry of supported melt methods and their public input payload shapes.
- * Extend via declaration merging if you need to add methods externally.
- */
-export interface MeltMethodInputDefinitions {
+export type BuiltInMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
+
+export type GenericMeltMethod<M extends string = string> = M extends BuiltInMeltMethod ? never : M;
+
+export type GenericMeltMethodInputData = {
+  request: string;
+  unit?: never;
+} & Record<string, unknown>;
+
+export interface GenericMeltMethodData {
+  request: string;
+  [key: string]: unknown;
+}
+
+export interface GenericMeltQuoteSnapshot {
+  quote: string;
+  request: string;
+  amount: Amount;
+  unit: string;
+  expiry: number;
+  state: 'UNPAID' | 'PENDING' | 'PAID';
+  fee_reserve?: Amount;
+  payment_preimage?: string | null;
+  change?: SerializedBlindedSignature[];
+  [key: string]: unknown;
+}
+
+type BuiltInMeltMethodInputDefinitions = {
   bolt11: { invoice: string; amountSats?: AmountLike };
   bolt12: { offer: string; amountSats?: AmountLike };
   onchain: { address: string; amountSats: AmountLike };
-}
+};
 
-/**
- * Registry of supported melt methods and their normalized operation payload shapes.
- * Amount values are normalized at the operation boundary.
- */
-export interface MeltMethodDefinitions {
+type BuiltInMeltMethodDefinitions = {
   bolt11: { invoice: string; amountSats?: Amount };
   bolt12: { offer: string; amountSats?: Amount };
   onchain: { address: string; amountSats: Amount; feeIndex?: number };
-}
+};
 
-export type MeltMethod = keyof MeltMethodDefinitions;
+export type MeltMethod = BuiltInMeltMethod;
 
-export type MeltMethodData<M extends MeltMethod = MeltMethod> = MeltMethodDefinitions[M];
+export type MeltMethodData<M extends string = MeltMethod> = M extends BuiltInMeltMethod
+  ? BuiltInMeltMethodDefinitions[M]
+  : GenericMeltMethod<M> extends never
+    ? never
+    : GenericMeltMethodData;
 
-export interface MeltMethodQuoteDefinitions {
+type BuiltInMeltMethodQuoteDefinitions = {
   bolt11: MeltQuoteBolt11Response;
   bolt12: MeltQuoteBolt12Response;
   onchain: MeltQuoteOnchainResponse;
-}
+};
 
-export type MeltMethodInputData<M extends MeltMethod = MeltMethod> =
-  M extends keyof MeltMethodInputDefinitions ? MeltMethodInputDefinitions[M] : never;
+export type MeltMethodInputData<M extends string = MeltMethod> = M extends BuiltInMeltMethod
+  ? BuiltInMeltMethodInputDefinitions[M]
+  : GenericMeltMethod<M> extends never
+    ? never
+    : GenericMeltMethodInputData;
 
-export type MeltMethodRemoteState<M extends MeltMethod = MeltMethod> =
-  MeltMethodQuoteDefinitions[M]['state'];
+export type MeltMethodRemoteState<M extends string = MeltMethod> = M extends BuiltInMeltMethod
+  ? BuiltInMeltMethodQuoteDefinitions[M]['state']
+  : GenericMeltMethod<M> extends never
+    ? never
+    : GenericMeltQuoteSnapshot['state'];
 
-export type MeltMethodQuoteSnapshot<M extends MeltMethod = MeltMethod> =
-  MeltMethodQuoteDefinitions[M];
+export type MeltMethodQuoteSnapshot<M extends string = MeltMethod> = M extends BuiltInMeltMethod
+  ? BuiltInMeltMethodQuoteDefinitions[M]
+  : GenericMeltMethod<M> extends never
+    ? never
+    : GenericMeltQuoteSnapshot;
 
 export interface MeltMethodMeta<M extends MeltMethod = MeltMethod> {
   method: M;

--- a/packages/core/operations/melt/MeltMethodHandler.ts
+++ b/packages/core/operations/melt/MeltMethodHandler.ts
@@ -30,7 +30,28 @@ import type { MeltQuote } from '../../models/MeltQuote';
 
 export type BuiltInMeltMethod = 'bolt11' | 'bolt12' | 'onchain';
 
-export type GenericMeltMethod<M extends string = string> = M extends BuiltInMeltMethod ? never : M;
+declare const validatedGenericMeltMethodBrand: unique symbol;
+
+export type ValidatedGenericMeltMethod = string & {
+  readonly [validatedGenericMeltMethodBrand]: true;
+};
+
+export type GenericMeltMethod<M extends string = ValidatedGenericMeltMethod> =
+  M extends ValidatedGenericMeltMethod
+    ? M
+    : string extends M
+      ? never
+      : Extract<M, BuiltInMeltMethod> extends never
+        ? M
+        : never;
+
+export type GenericMeltMethodValue<M extends string> = M extends ValidatedGenericMeltMethod
+  ? M
+  : Extract<M, BuiltInMeltMethod> extends never
+    ? string extends M
+      ? ValidatedGenericMeltMethod
+      : GenericMeltMethod<M>
+    : never;
 
 export type GenericMeltMethodInputData = {
   request: string;

--- a/packages/core/operations/melt/MeltOperation.ts
+++ b/packages/core/operations/melt/MeltOperation.ts
@@ -30,7 +30,13 @@ export type MeltOperationState =
 
 import type { Amount } from '@cashu/cashu-ts';
 import { getSecretsFromSerializedOutputData, type SerializedOutputData } from '../../utils';
-import type { MeltMethod, MeltMethodData, MeltMethodMeta } from './MeltMethodHandler';
+import type {
+  BuiltInMeltMethod,
+  GenericMeltMethod,
+  MeltMethod,
+  MeltMethodData,
+  MeltMethodMeta,
+} from './MeltMethodHandler';
 import { DEFAULT_UNIT, normalizeUnit } from '../../amounts.ts';
 
 // ============================================================================
@@ -99,7 +105,7 @@ interface PreparedData {
 /**
  * Method-specific data that may be available once a melt has settled.
  */
-export interface MeltMethodFinalizedDataMap {
+type BuiltInMeltMethodFinalizedDataMap = {
   bolt11: {
     preimage?: string;
     outpoint?: never;
@@ -112,10 +118,17 @@ export interface MeltMethodFinalizedDataMap {
     preimage?: never;
     outpoint?: string;
   };
-}
+};
 
-export type MeltMethodFinalizedData<M extends MeltMethod = MeltMethod> =
-  MeltMethodFinalizedDataMap[M];
+export type GenericMeltFinalizedData = {
+  rawFinalResponseData: Record<string, unknown>;
+};
+
+export type MeltMethodFinalizedData<M extends string = MeltMethod> = M extends BuiltInMeltMethod
+  ? BuiltInMeltMethodFinalizedDataMap[M]
+  : GenericMeltMethod<M> extends never
+    ? never
+    : GenericMeltFinalizedData;
 
 // ============================================================================
 // State-specific Operation Types

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -25,7 +25,28 @@ import type { MintQuote } from '../../models/MintQuote';
 
 export type BuiltInMintMethod = 'bolt11' | 'onchain' | 'bolt12';
 
-export type GenericMintMethod<M extends string = string> = M extends BuiltInMintMethod ? never : M;
+declare const validatedGenericMintMethodBrand: unique symbol;
+
+export type ValidatedGenericMintMethod = string & {
+  readonly [validatedGenericMintMethodBrand]: true;
+};
+
+export type GenericMintMethod<M extends string = ValidatedGenericMintMethod> =
+  M extends ValidatedGenericMintMethod
+    ? M
+    : string extends M
+      ? never
+      : Extract<M, BuiltInMintMethod> extends never
+        ? M
+        : never;
+
+export type GenericMintMethodValue<M extends string> = M extends ValidatedGenericMintMethod
+  ? M
+  : Extract<M, BuiltInMintMethod> extends never
+    ? string extends M
+      ? ValidatedGenericMintMethod
+      : GenericMintMethod<M>
+    : never;
 
 export interface GenericMintQuoteSnapshot {
   quote: string;

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -23,11 +23,39 @@ import type { MintAdapter } from '../../infra/MintAdapter';
 import type { UnitAmount } from '../../amounts.ts';
 import type { MintQuote } from '../../models/MintQuote';
 
-/**
- * Registry of supported mint methods and payload shapes.
- * Extend via declaration merging to support additional methods.
- */
-export interface MintMethodDefinitions {
+export type BuiltInMintMethod = 'bolt11' | 'onchain' | 'bolt12';
+
+export type GenericMintMethod<M extends string = string> = M extends BuiltInMintMethod ? never : M;
+
+export interface GenericMintQuoteSnapshot {
+  quote: string;
+  request: string;
+  unit: string;
+  expiry?: number | null;
+  pubkey: string;
+  amount_paid: Amount;
+  amount_issued: Amount;
+  [key: string]: unknown;
+}
+
+export interface GenericMintQuoteData {
+  pubkey: string;
+  amountPaid: Amount;
+  amountIssued: Amount;
+}
+
+export type GenericMintQuoteCreatePayload = Record<string, unknown> & {
+  amount?: never;
+  unit?: never;
+  pubkey?: never;
+};
+
+export interface GenericMintQuoteCreateData {
+  amount: UnitAmount;
+  payload?: GenericMintQuoteCreatePayload;
+}
+
+type BuiltInMintMethodDefinitions = {
   bolt11: {
     methodData: Record<string, never>;
     createQuoteData: { amount: UnitAmount };
@@ -66,19 +94,34 @@ export interface MintMethodDefinitions {
     remoteState: never;
     quote: MintQuoteBolt12Response;
   };
-}
+};
 
-export type MintMethod = keyof MintMethodDefinitions;
-export type MintMethodData<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['methodData'];
-export type MintMethodCreateQuoteData<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['createQuoteData'];
-export type MintMethodQuoteData<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['quoteData'];
-export type MintMethodRemoteState<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['remoteState'];
-export type MintMethodQuoteSnapshot<M extends MintMethod = MintMethod> =
-  MintMethodDefinitions[M]['quote'];
+export type MintMethod = BuiltInMintMethod;
+export type MintMethodData<M extends string = MintMethod> = M extends BuiltInMintMethod
+  ? BuiltInMintMethodDefinitions[M]['methodData']
+  : GenericMintMethod<M> extends never
+    ? never
+    : Record<string, unknown>;
+export type MintMethodCreateQuoteData<M extends string = MintMethod> = M extends BuiltInMintMethod
+  ? BuiltInMintMethodDefinitions[M]['createQuoteData']
+  : GenericMintMethod<M> extends never
+    ? never
+    : GenericMintQuoteCreateData;
+export type MintMethodQuoteData<M extends string = MintMethod> = M extends BuiltInMintMethod
+  ? BuiltInMintMethodDefinitions[M]['quoteData']
+  : GenericMintMethod<M> extends never
+    ? never
+    : GenericMintQuoteData;
+export type MintMethodRemoteState<M extends string = MintMethod> = M extends BuiltInMintMethod
+  ? BuiltInMintMethodDefinitions[M]['remoteState']
+  : GenericMintMethod<M> extends never
+    ? never
+    : never;
+export type MintMethodQuoteSnapshot<M extends string = MintMethod> = M extends BuiltInMintMethod
+  ? BuiltInMintMethodDefinitions[M]['quote']
+  : GenericMintMethod<M> extends never
+    ? never
+    : GenericMintQuoteSnapshot;
 
 export interface MintMethodMeta<M extends MintMethod = MintMethod> {
   method: M;

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -559,8 +559,8 @@ export class MintOperationService {
     }
   }
 
-  async recoverExecutingOperation(
-    op: ExecutingMintOperation,
+  async recoverExecutingOperation<M extends MintMethod>(
+    op: ExecutingMintOperation<M>,
     options?: { skipLock?: boolean },
   ): Promise<void> {
     const releaseLock = options?.skipLock ? undefined : await this.acquireOperationLock(op.id);

--- a/packages/core/test/unit/PaymentMethodRouting.test.ts
+++ b/packages/core/test/unit/PaymentMethodRouting.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { assertGenericMeltMethod, isBuiltInMeltMethod } from '../../infra/handlers/melt';
+import { assertGenericMintMethod, isBuiltInMintMethod } from '../../infra/handlers/mint';
+
+describe('payment method routing guards', () => {
+  it('identifies built-in mint and melt methods', () => {
+    expect(isBuiltInMintMethod('bolt11')).toBe(true);
+    expect(isBuiltInMintMethod('bolt12')).toBe(true);
+    expect(isBuiltInMintMethod('onchain')).toBe(true);
+    expect(isBuiltInMintMethod('nostr-zap')).toBe(false);
+
+    expect(isBuiltInMeltMethod('bolt11')).toBe(true);
+    expect(isBuiltInMeltMethod('bolt12')).toBe(true);
+    expect(isBuiltInMeltMethod('onchain')).toBe(true);
+    expect(isBuiltInMeltMethod('lnurl-pay')).toBe(false);
+  });
+
+  it('rejects built-in methods from generic routing paths', () => {
+    expect(() => assertGenericMintMethod('bolt11')).toThrow(
+      'Built-in mint method bolt11 must use its built-in handler path',
+    );
+    expect(() => assertGenericMeltMethod('onchain')).toThrow(
+      'Built-in melt method onchain must use its built-in handler path',
+    );
+
+    expect(() => assertGenericMintMethod('nostr-zap')).not.toThrow();
+    expect(() => assertGenericMeltMethod('lnurl-pay')).not.toThrow();
+  });
+});

--- a/packages/core/test/unit/PaymentMethodRouting.test.ts
+++ b/packages/core/test/unit/PaymentMethodRouting.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'bun:test';
-import { assertGenericMeltMethod, isBuiltInMeltMethod } from '../../infra/handlers/melt';
-import { assertGenericMintMethod, isBuiltInMintMethod } from '../../infra/handlers/mint';
+import {
+  assertGenericMeltMethod,
+  isBuiltInMeltMethod,
+  toGenericMeltMethod,
+} from '../../infra/handlers/melt';
+import {
+  assertGenericMintMethod,
+  isBuiltInMintMethod,
+  toGenericMintMethod,
+} from '../../infra/handlers/mint';
 
 describe('payment method routing guards', () => {
   it('identifies built-in mint and melt methods', () => {
@@ -25,5 +33,17 @@ describe('payment method routing guards', () => {
 
     expect(() => assertGenericMintMethod('nostr-zap')).not.toThrow();
     expect(() => assertGenericMeltMethod('lnurl-pay')).not.toThrow();
+  });
+
+  it('converts non-built-in method strings into validated generic methods', () => {
+    expect(toGenericMintMethod('nostr-zap') as string).toBe('nostr-zap');
+    expect(toGenericMeltMethod('lnurl-pay') as string).toBe('lnurl-pay');
+
+    expect(() => toGenericMintMethod('bolt12')).toThrow(
+      'Built-in mint method bolt12 must use its built-in handler path',
+    );
+    expect(() => toGenericMeltMethod('bolt11')).toThrow(
+      'Built-in melt method bolt11 must use its built-in handler path',
+    );
   });
 });

--- a/packages/core/test/unit/QuoteApi.test.ts
+++ b/packages/core/test/unit/QuoteApi.test.ts
@@ -8,10 +8,19 @@ import {
   type CreateMintQuoteInput,
   type GenericMeltQuoteCreateResult,
   type GenericMintQuoteCreateResult,
+  type GenericQuoteApiShapes,
 } from '../../api/QuoteApi.ts';
 import type { MeltOpsApi } from '../../api/MeltOpsApi.ts';
 import type { MeltQuote } from '../../models/MeltQuote.ts';
 import type { MintQuote } from '../../models/MintQuote.ts';
+import type {
+  GenericMeltMethod,
+  ValidatedGenericMeltMethod,
+} from '../../operations/melt/MeltMethodHandler.ts';
+import type {
+  GenericMintMethod,
+  ValidatedGenericMintMethod,
+} from '../../operations/mint/MintMethodHandler.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 
 const mintUrl = 'https://mint.test';
@@ -58,6 +67,18 @@ type _AssertBuiltInMintRejectedFromGenericShape = Assert<
 type _AssertBuiltInMeltRejectedFromGenericShape = Assert<
   CreateGenericMeltQuoteInput<'onchain'>['method'] extends never ? true : false
 >;
+type _AssertBroadMintStringRejectedAsGenericMethod = Assert<
+  GenericMintMethod<string> extends never ? true : false
+>;
+type _AssertBroadMeltStringRejectedAsGenericMethod = Assert<
+  GenericMeltMethod<string> extends never ? true : false
+>;
+type _AssertBroadMintInputRequiresValidatedMethod = Assert<
+  CreateGenericMintQuoteInput<string>['method'] extends ValidatedGenericMintMethod ? true : false
+>;
+type _AssertBroadMeltInputRequiresValidatedMethod = Assert<
+  CreateGenericMeltQuoteInput<string>['method'] extends ValidatedGenericMeltMethod ? true : false
+>;
 
 const genericMintInput: CreateGenericMintQuoteInput<'nostr-zap'> = {
   mintUrl,
@@ -68,6 +89,18 @@ const genericMintInput: CreateGenericMintQuoteInput<'nostr-zap'> = {
 const genericMeltInput: CreateGenericMeltQuoteInput<'lnurl-pay'> = {
   mintUrl,
   method: 'lnurl-pay',
+  methodData: { request: 'lnurl1test', callback: 'https://example.test/pay' },
+};
+const validatedMintMethod = 'nostr-zap' as ValidatedGenericMintMethod;
+const validatedMeltMethod = 'lnurl-pay' as ValidatedGenericMeltMethod;
+const validatedGenericMintInput: CreateGenericMintQuoteInput<string> = {
+  mintUrl,
+  method: validatedMintMethod,
+  amount: Amount.from(21),
+};
+const validatedGenericMeltInput: CreateGenericMeltQuoteInput<string> = {
+  mintUrl,
+  method: validatedMeltMethod,
   methodData: { request: 'lnurl1test', callback: 'https://example.test/pay' },
 };
 // @ts-expect-error Generic mint inputs require a concrete non-built-in method literal.
@@ -82,7 +115,58 @@ const untypedGenericMeltInput: CreateGenericMeltQuoteInput = {
   method: 'onchain',
   methodData: { request: 'lnurl1test' },
 };
-void [genericMintInput, genericMeltInput, untypedGenericMintInput, untypedGenericMeltInput];
+const runtimeMintMethod: string = 'nostr-zap';
+const runtimeMeltMethod: string = 'lnurl-pay';
+const broadStringGenericMintInput: CreateGenericMintQuoteInput<string> = {
+  mintUrl,
+  // @ts-expect-error Broad runtime strings must be validated before generic mint quote use.
+  method: runtimeMintMethod,
+  amount: Amount.from(21),
+};
+const broadStringGenericMeltInput: CreateGenericMeltQuoteInput<string> = {
+  mintUrl,
+  // @ts-expect-error Broad runtime strings must be validated before generic melt quote use.
+  method: runtimeMeltMethod,
+  methodData: { request: 'lnurl1test' },
+};
+
+function assertGenericQuoteApiShapes(
+  api: GenericQuoteApiShapes,
+  rawMethod: string,
+  validatedMint: ValidatedGenericMintMethod,
+  validatedMelt: ValidatedGenericMeltMethod,
+): void {
+  void api.createMint({ mintUrl, method: 'nostr-zap', amount: Amount.from(21) });
+  void api.createMelt({
+    mintUrl,
+    method: 'lnurl-pay',
+    methodData: { request: 'lnurl1test' },
+  });
+  void api.createMint({ mintUrl, method: validatedMint, amount: Amount.from(21) });
+  void api.createMelt({
+    mintUrl,
+    method: validatedMelt,
+    methodData: { request: 'lnurl1test' },
+  });
+  // @ts-expect-error Broad runtime strings must be validated before generic quote use.
+  void api.createMint({ mintUrl, method: rawMethod, amount: Amount.from(21) });
+  // @ts-expect-error Built-in methods must use the built-in quote API.
+  void api.createMint({ mintUrl, method: 'bolt11', amount: Amount.from(21) });
+  // @ts-expect-error Built-in methods must use the built-in quote API.
+  void api.createMelt({ mintUrl, method: 'onchain', methodData: { request: 'bc1test' } });
+}
+
+void [
+  genericMintInput,
+  genericMeltInput,
+  validatedGenericMintInput,
+  validatedGenericMeltInput,
+  untypedGenericMintInput,
+  untypedGenericMeltInput,
+  broadStringGenericMintInput,
+  broadStringGenericMeltInput,
+  assertGenericQuoteApiShapes,
+];
 
 function assertMethodRequirementsRemain(): void {
   // @ts-expect-error Mint quote creation still requires method.

--- a/packages/core/test/unit/QuoteApi.test.ts
+++ b/packages/core/test/unit/QuoteApi.test.ts
@@ -70,7 +70,19 @@ const genericMeltInput: CreateGenericMeltQuoteInput<'lnurl-pay'> = {
   method: 'lnurl-pay',
   methodData: { request: 'lnurl1test', callback: 'https://example.test/pay' },
 };
-void [genericMintInput, genericMeltInput];
+// @ts-expect-error Generic mint inputs require a concrete non-built-in method literal.
+const untypedGenericMintInput: CreateGenericMintQuoteInput = {
+  mintUrl,
+  method: 'bolt11',
+  amount: Amount.from(21),
+};
+// @ts-expect-error Generic melt inputs require a concrete non-built-in method literal.
+const untypedGenericMeltInput: CreateGenericMeltQuoteInput = {
+  mintUrl,
+  method: 'onchain',
+  methodData: { request: 'lnurl1test' },
+};
+void [genericMintInput, genericMeltInput, untypedGenericMintInput, untypedGenericMeltInput];
 
 function assertMethodRequirementsRemain(): void {
   // @ts-expect-error Mint quote creation still requires method.

--- a/packages/core/test/unit/QuoteApi.test.ts
+++ b/packages/core/test/unit/QuoteApi.test.ts
@@ -1,6 +1,14 @@
 import { Amount } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
-import { QuoteApi } from '../../api/QuoteApi.ts';
+import {
+  QuoteApi,
+  type CreateGenericMeltQuoteInput,
+  type CreateGenericMintQuoteInput,
+  type CreateMeltQuoteInput,
+  type CreateMintQuoteInput,
+  type GenericMeltQuoteCreateResult,
+  type GenericMintQuoteCreateResult,
+} from '../../api/QuoteApi.ts';
 import type { MeltOpsApi } from '../../api/MeltOpsApi.ts';
 import type { MeltQuote } from '../../models/MeltQuote.ts';
 import type { MintQuote } from '../../models/MintQuote.ts';
@@ -9,9 +17,60 @@ import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 const mintUrl = 'https://mint.test';
 const quoteId = 'quote-1';
 
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type IsNever<T> = [T] extends [never] ? true : false;
+
 type MintCreateInput = Parameters<QuoteApi['mint']['create']>[0];
 type MintImportInput = Parameters<QuoteApi['mint']['import']>[0];
 type MeltCreateInput = Parameters<QuoteApi['melt']['create']>[0];
+type _AssertBuiltInMintInputKeepsBolt11Narrowing = Assert<
+  CreateMintQuoteInput<'bolt11'> extends {
+    method: 'bolt11';
+    amount: unknown;
+  }
+    ? true
+    : false
+>;
+type _AssertBuiltInMeltInputKeepsBolt12Narrowing = Assert<
+  CreateMeltQuoteInput<'bolt12'> extends {
+    method: 'bolt12';
+    methodData: { offer: string; invoice?: never };
+  }
+    ? true
+    : false
+>;
+type _AssertArbitraryGenericMintIsNotNever = Assert<
+  IsNever<GenericMintQuoteCreateResult<'nostr-zap'>> extends false ? true : false
+>;
+type _AssertArbitraryGenericMintIsNotAny = Assert<
+  IsAny<GenericMintQuoteCreateResult<'nostr-zap'>> extends false ? true : false
+>;
+type _AssertArbitraryGenericMeltIsNotNever = Assert<
+  IsNever<GenericMeltQuoteCreateResult<'lnurl-pay'>> extends false ? true : false
+>;
+type _AssertArbitraryGenericMeltIsNotAny = Assert<
+  IsAny<GenericMeltQuoteCreateResult<'lnurl-pay'>> extends false ? true : false
+>;
+type _AssertBuiltInMintRejectedFromGenericShape = Assert<
+  CreateGenericMintQuoteInput<'bolt11'>['method'] extends never ? true : false
+>;
+type _AssertBuiltInMeltRejectedFromGenericShape = Assert<
+  CreateGenericMeltQuoteInput<'onchain'>['method'] extends never ? true : false
+>;
+
+const genericMintInput: CreateGenericMintQuoteInput<'nostr-zap'> = {
+  mintUrl,
+  method: 'nostr-zap',
+  amount: Amount.from(21),
+  payload: { recipient: 'npub1test' },
+};
+const genericMeltInput: CreateGenericMeltQuoteInput<'lnurl-pay'> = {
+  mintUrl,
+  method: 'lnurl-pay',
+  methodData: { request: 'lnurl1test', callback: 'https://example.test/pay' },
+};
+void [genericMintInput, genericMeltInput];
 
 function assertMethodRequirementsRemain(): void {
   // @ts-expect-error Mint quote creation still requires method.


### PR DESCRIPTION
## Description

This pull request resolves #234 and adds explicit built-in and generic payment method type surfaces for core quote and operation APIs.

## Problem

Payment method extension needed a public type model that distinguishes built-in methods from arbitrary generic method strings. Without that split, generic quote and operation inputs were hard to type safely, and built-in method names could leak into generic routing paths.

## Summary

- Adds built-in and generic mint/melt method types across `QuoteApi`, mint/melt quote models, and operation inputs.
- Validates generic method strings through mint and melt handler providers so built-in method names are rejected from generic paths.
- Adds runtime and type-focused unit coverage for generic quote inputs and payment method routing.
- Compatibility note: this changes released public API types for `@cashu/coco-core` and is marked as a major changeset.

## Verification

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test:unit`

## Changeset

- Added `.changeset/payment-method-types.md` with a major bump for `@cashu/coco-core`.