### PR TITLE
docs: remove stale release candidate messaging

### DIFF
--- a/.changeset/clean-readme-release-state.md
+++ b/.changeset/clean-readme-release-state.md
@@ -1,0 +1,11 @@
+---
+'@cashu/coco-core': patch
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-adapter-tests': patch
+'@cashu/coco-react': patch
+---
+
+Remove outdated prerelease warning text from the published package READMEs.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A modular, TypeScript-first toolkit for building Cashu wallets and applications.
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 coco provides a complete foundation for Cashu development with a storage-agnostic
 core that handles proof management, mint synchronization, quote lifecycle,
 counter tracking, and state updates through a typed event bus. Published

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -1,8 +1,5 @@
 # @cashu/coco-adapter-tests
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 This package exports reusable test helpers that verify whether a storage adapter
 conforms to the `Repositories` contract from `@cashu/coco-core`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,9 +2,6 @@
 
 Modular, storage-agnostic core for working with Cashu mints and wallets.
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 - **Storage-agnostic**: Repositories are interfaces; bring your own persistence.
 - **Typed Event Bus**: Subscribe to mint, proof, quote, and counter events with strong types.
 - **High-level APIs**: `MintApi`, `WalletApi`, `AuthApi`, `PaymentRequestsApi`,

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -1,8 +1,5 @@
 # @cashu/coco-expo-sqlite
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 Expo SQLite storage adapter for Coco in React Native and Expo applications.
 
 The public entry point is `SqliteRepositories`. Open the `expo-sqlite` database

--- a/packages/indexeddb/README.md
+++ b/packages/indexeddb/README.md
@@ -1,8 +1,5 @@
 # @cashu/coco-indexeddb
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 IndexedDB storage adapter for Coco in browser and worker environments.
 
 ## Install

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,8 +1,5 @@
 # @cashu/coco-react
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 React hooks and providers for integrating a Coco `Manager` into React
 applications.
 

--- a/packages/sqlite-bun/README.md
+++ b/packages/sqlite-bun/README.md
@@ -1,8 +1,5 @@
 # @cashu/coco-sqlite-bun
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 SQLite adapter for Coco using Bun's built-in `bun:sqlite` module.
 
 The public entry point is `SqliteRepositories`. Open the `bun:sqlite` database

--- a/packages/sqlite3/README.md
+++ b/packages/sqlite3/README.md
@@ -1,8 +1,5 @@
 # @cashu/coco-sqlite
 
-> ⚠️ Release candidate: Coco is stabilizing for v1, but breaking changes may
-> still land before the final 1.0 release. Pin versions in production.
-
 Node storage adapter for Coco built on `better-sqlite3`.
 
 The public entry point is `SqliteRepositories`. Open the `better-sqlite3`


### PR DESCRIPTION
This pull request updates the public Coco README files so they no longer describe the project as a release candidate or pre-1.0.

This pull request resolves #243.

## Problem

The published READMEs still contained RC-era copy about stabilizing for v1, possible breakage before final 1.0, and production pinning guidance that no longer matches the current v2 release state.

## Summary

- Removed the stale release warning block from the root README and published package READMEs.
- Added a patch changeset for the fixed public package group so package READMEs can be republished.

## Verification

- `rg -n "release candidate|release-candidate|pre-1\\.0|stabiliz|final 1\\.0|1\\.0 release|RC-era|Pin versions in production" README.md packages -g 'README.md'`
- `git grep -n -E "release candidate|release-candidate|pre-1\\.0|stabilizing for v1|final 1\\.0|1\\.0 release|RC-era|Pin versions in production" HEAD -- README.md packages/core/README.md packages/react/README.md packages/adapter-tests/README.md packages/indexeddb/README.md packages/expo-sqlite/README.md packages/sqlite3/README.md packages/sqlite-bun/README.md`
- `git diff --check origin/master...HEAD`

## Changeset

- Added `.changeset/clean-readme-release-state.md`