### PR TITLE
fix(core): publish documented event types

### DIFF
--- a/.changeset/public-core-events.md
+++ b/.changeset/public-core-events.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Export documented core event types and event bus APIs from the package root.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -391,9 +391,15 @@ From the package root:
 - Public APIs including `MintApi`, `WalletApi`, `AuthApi`, `PaymentRequestsApi`,
   `SubscriptionApi`, and the operation-oriented APIs
 - Models, services, operations, and plugin types
+- Events: `CoreEvents`, `EventBus`, `EventBusOptions`, `EventHandler`
 - Types: `CoreProof`, `ProofState`, `BalanceQuery`, `BalanceSnapshot`,
   `BalancesByMint`, `BalanceBreakdown`, `BalancesBreakdownByMint`
 - Logging: `ConsoleLogger`, `Logger`
 - Helpers: `getEncodedToken`, `getDecodedToken`, `normalizeMintUrl`
 - Infrastructure helpers: `SubscriptionManager`, `WsConnectionManager`,
   `WebSocketLike`, `WebSocketFactory`
+
+The package root (`@cashu/coco-core`) is the supported public import path unless
+`package.json` explicitly lists a subpath export. Documented public symbols must be
+reachable from the root or from a listed subpath. Internal barrels such as source
+folder indexes are private unless the export map and docs explicitly make them public.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,6 +5,7 @@ export * from './models/index.ts';
 export * from './api/index.ts';
 export * from './services/index.ts';
 export * from './operations/index.ts';
+export * from './events/index.ts';
 export type {
   CoreProof,
   ProofState,

--- a/packages/core/plugins/types.ts
+++ b/packages/core/plugins/types.ts
@@ -71,7 +71,7 @@ export interface Plugin<Req extends readonly ServiceKey[] = readonly ServiceKey[
  * Plugin authors should augment this interface via module augmentation:
  *
  * @example
- * declare module '@coco/core' {
+ * declare module '@cashu/coco-core' {
  *   interface PluginExtensions {
  *     myPlugin: MyPluginApi;
  *   }

--- a/packages/docs/pages/plugins.md
+++ b/packages/docs/pages/plugins.md
@@ -87,11 +87,13 @@ Plugins can register custom APIs that become accessible via `manager.ext`. This 
 Use `ctx.registerExtension(key, api)` in your plugin's `onInit` or `onReady` hook:
 
 ```ts
-class MyPluginApi {
-  constructor(private eventBus: EventBus) {}
+import type { CoreEvents, EventBus, Plugin } from '@cashu/coco-core';
 
-  doSomething() {
-    this.eventBus.emit('my-plugin:action', { foo: 'bar' });
+class MyPluginApi {
+  constructor(private eventBus: EventBus<CoreEvents>) {}
+
+  onSubscriptionsResumed(handler: () => void): () => void {
+    return this.eventBus.on('subscriptions:resumed', handler);
   }
 
   async fetchData() {
@@ -122,7 +124,7 @@ const manager = await initializeCoco({
 });
 
 // Access the plugin's API
-manager.ext.myPlugin.doSomething();
+const unsubscribe = manager.ext.myPlugin.onSubscriptionsResumed(() => {});
 const result = await manager.ext.myPlugin.fetchData();
 ```
 
@@ -132,13 +134,13 @@ For full TypeScript autocomplete and type safety, plugin authors should augment 
 
 ```ts
 // my-plugin/index.ts
-import type { Plugin, PluginExtensions } from '@cashu/coco-core';
+import type { CoreEvents, EventBus, Plugin, PluginExtensions } from '@cashu/coco-core';
 
 // Define your API class
 export class MyPluginApi {
-  constructor(private eventBus: EventBus) {}
-  doSomething(): void {
-    /* ... */
+  constructor(private eventBus: EventBus<CoreEvents>) {}
+  onSubscriptionsResumed(handler: () => void): () => void {
+    return this.eventBus.on('subscriptions:resumed', handler);
   }
   async fetchData(): Promise<{ data: string }> {
     /* ... */


### PR DESCRIPTION
## Description

This pull request fixes the documented core event surface so consumers can import event-related types from the supported `@cashu/coco-core` root path. This pull request resolves #245.

## Problem

Core docs and plugin examples referenced typed events and the event bus, but `CoreEvents` and `EventBus` were not public named exports from the package root.

## Summary

- Re-export `CoreEvents`, `EventBus`, and related event bus types from `@cashu/coco-core`.
- Document the root export policy for public core symbols.
- Update plugin examples to import and type the event bus from the package root.
- Add a patch changeset.

## Verification

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run format:check`

Earlier before removing the package export check, these also passed on the same branch: `bun run build`, `bun run --filter='@cashu/coco-core' test:unit`, `bun run docs:build`, and `bun run typecheck`.

Note: `bun run --filter='@cashu/coco-core' test` was also attempted. It failed only when it reached integration tests requiring `MINT_URL` and reachable test mints; unit tests in that run passed.

## Changeset

- Added `.changeset/public-core-events.md`