### PR TITLE
feat(core): narrow root public surface

### DIFF
--- a/.changeset/narrow-core-root-surface.md
+++ b/.changeset/narrow-core-root-surface.md
@@ -1,0 +1,12 @@
+---
+'@cashu/coco-core': major
+---
+
+Narrow the root public entry point to app-facing wallet APIs, domain types, amount helpers,
+logging, events, and `MemoryRepositories`.
+
+Concrete services, operation service classes, repository contracts, individual memory
+repositories, infra transports, handler providers, plugin internals, and adapter
+serialization helpers are no longer exported from the package root. Storage adapter
+authors should import persistence contracts from `@cashu/coco-core/adapter`, and plugin
+authors should import extension contracts from `@cashu/coco-core/plugin`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -156,7 +156,7 @@ If you prefer manual wiring, construct `Manager` directly and call `initPlugins(
 
 ### Repositories
 
-Interfaces in `packages/core/repositories/index.ts`:
+Repository contracts for storage adapters are exported from `@cashu/coco-core/adapter`:
 
 - `MintRepository`
 - `KeysetRepository`
@@ -171,7 +171,7 @@ Interfaces in `packages/core/repositories/index.ts`:
 - `MintOperationRepository`
 - `ReceiveOperationRepository`
 
-In-memory reference implementations are provided under `repositories/memory/` for testing.
+The package root exports `MemoryRepositories` as an in-memory test/example repository bundle.
 
 ## Public API surface
 
@@ -387,17 +387,22 @@ await manager.dispose();
 From the package root:
 
 - `Manager`, `initializeCoco`, `CocoConfig`
-- Repository interfaces and memory implementations
+- `MemoryRepositories`
 - Public APIs including `MintApi`, `WalletApi`, `AuthApi`, `PaymentRequestsApi`,
   `SubscriptionApi`, and the operation-oriented APIs
-- Models, services, and operations
-- Events: `CoreEvents`, `EventBus`, `EventBusOptions`, `EventHandler`
+- Public models, errors, API inputs/results, and operation result types
+- Events: `CoreEvents`, `EventBus`, `EventHandler`
 - Types: `CoreProof`, `ProofState`, `BalanceQuery`, `BalanceSnapshot`,
   `BalancesByMint`, `BalanceBreakdown`, `BalancesBreakdownByMint`
 - Logging: `ConsoleLogger`, `Logger`
 - Helpers: `getEncodedToken`, `getDecodedToken`, `normalizeMintUrl`
-- Infrastructure helpers: `SubscriptionManager`, `WsConnectionManager`,
-  `WebSocketLike`, `WebSocketFactory`
+- Amount/unit helpers and intentional `@cashu/cashu-ts` re-exports such as `Amount`
+- Config boundary types: `WebSocketLike`, `WebSocketFactory`
+
+From the adapter subpath (`@cashu/coco-core/adapter`):
+
+- Repository contracts, transaction scope types, persisted operation/domain types, and
+  adapter serialization helpers for storage implementations
 
 From the plugin subpath (`@cashu/coco-core/plugin`):
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -391,7 +391,7 @@ From the package root:
 - Public APIs including `MintApi`, `WalletApi`, `AuthApi`, `PaymentRequestsApi`,
   `SubscriptionApi`, and the operation-oriented APIs
 - Public models, errors, API inputs/results, and operation result types
-- Events: `CoreEvents`, `EventBus`, `EventHandler`
+- Events: `CoreEvents`, `EventHandler`
 - Types: `CoreProof`, `ProofState`, `BalanceQuery`, `BalanceSnapshot`,
   `BalancesByMint`, `BalanceBreakdown`, `BalancesBreakdownByMint`
 - Logging: `ConsoleLogger`, `Logger`
@@ -406,8 +406,8 @@ From the adapter subpath (`@cashu/coco-core/adapter`):
 
 From the plugin subpath (`@cashu/coco-core/plugin`):
 
-- Plugin author types: `Plugin`, `PluginContext`, `PluginExtensions`, `ServiceKey`,
-  `ServiceMap`, `Cleanup`, `CleanupFn`
+- Plugin author types: `Plugin`, `PluginContext`, `PluginExtensions`, `PluginEventBus`,
+  `ServiceKey`, `ServiceMap`, `Cleanup`, `CleanupFn`
 - Plugin errors: `DuplicatePluginRegistrationError`, `ExtensionRegistrationError`
 
 The package root (`@cashu/coco-core`) is the supported public import path unless

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -14,7 +14,7 @@ export type {
   BalancesBreakdownByMint,
 } from './types.ts';
 export type { CoreEvents } from './events/types.ts';
-export type { EventBus, EventHandler } from './events/EventBus.ts';
+export type { EventHandler } from './events/EventBus.ts';
 export { type Logger, ConsoleLogger } from './logging/index.ts';
 export { MemoryRepositories } from './repositories/memory/MemoryRepositories.ts';
 export type {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,11 +1,7 @@
 export * from './Manager.ts';
 export * from './amounts.ts';
-export * from './repositories/index.ts';
 export * from './models/index.ts';
 export * from './api/index.ts';
-export * from './services/index.ts';
-export * from './operations/index.ts';
-export * from './events/index.ts';
 export type {
   CoreProof,
   ProofState,
@@ -17,7 +13,86 @@ export type {
   BalanceBreakdown,
   BalancesBreakdownByMint,
 } from './types.ts';
+export type { CoreEvents } from './events/types.ts';
+export type { EventBus, EventHandler } from './events/EventBus.ts';
 export { type Logger, ConsoleLogger } from './logging/index.ts';
+export { MemoryRepositories } from './repositories/memory/MemoryRepositories.ts';
+export type {
+  SendMethod,
+  SendMethodData,
+} from './operations/send/SendMethodHandler.ts';
+export type {
+  InitSendOperation,
+  PreparedSendOperation,
+  ExecutingSendOperation,
+  PendingSendOperation,
+  FinalizedSendOperation,
+  RollingBackSendOperation,
+  RolledBackSendOperation,
+  SendOperation,
+  SendOperationState,
+  TerminalSendOperation,
+} from './operations/send/SendOperation.ts';
+export type {
+  MintMethod,
+  MintMethodData,
+  MintMethodCreateQuoteData,
+  MintMethodQuoteData,
+  MintMethodRemoteState,
+  MintMethodQuoteSnapshot,
+} from './operations/mint/MintMethodHandler.ts';
+export type {
+  InitMintOperation,
+  PendingMintOperation,
+  ExecutingMintOperation,
+  FinalizedMintOperation,
+  FailedMintOperation,
+  MintOperation,
+  MintOperationFailure,
+  MintOperationState,
+  TerminalMintOperation,
+} from './operations/mint/MintOperation.ts';
+export type {
+  MeltMethod,
+  MeltMethodData,
+  MeltMethodInputData,
+  MeltMethodRemoteState,
+  MeltMethodQuoteSnapshot,
+} from './operations/melt/MeltMethodHandler.ts';
+export type {
+  InitMeltOperation,
+  PreparedMeltOperation,
+  ExecutingMeltOperation,
+  PendingMeltOperation,
+  FailedMeltOperation,
+  FinalizedMeltOperation,
+  RollingBackMeltOperation,
+  RolledBackMeltOperation,
+  MeltOperation,
+  MeltOperationState,
+  MeltMethodFinalizedData,
+  TerminalMeltOperation,
+} from './operations/melt/MeltOperation.ts';
+export type {
+  ReceiveOperationSource,
+  InitReceiveOperation,
+  PreparedReceiveOperation,
+  ExecutingReceiveOperation,
+  FinalizedReceiveOperation,
+  RolledBackReceiveOperation,
+  ReceiveOperation,
+  ReceiveOperationState,
+  TerminalReceiveOperation,
+} from './operations/receive/ReceiveOperation.ts';
+export type {
+  PaymentRequestReceiveAttempt,
+  PaymentRequestReceiveAttemptState,
+  PaymentRequestReceiveOperation,
+  PaymentRequestReceiveSource,
+  PaymentRequestReceiveState,
+  PaymentRequestReceiveTransport,
+  ParsedPaymentRequestPayload,
+} from './operations/paymentRequestReceive/PaymentRequestReceiveOperation.ts';
 export {
   Amount,
   getEncodedToken,
@@ -25,17 +100,9 @@ export {
   getTokenMetadata,
   type AmountLike,
 } from '@cashu/cashu-ts';
-export { SubscriptionManager } from './infra/SubscriptionManager.ts';
-export { WsConnectionManager } from './infra/WsConnectionManager.ts';
 export type { WebSocketLike, WebSocketFactory } from './infra/WsConnectionManager.ts';
-export { PaymentRequestReceiveTransportHandlerProvider } from './infra/handlers/paymentRequestReceive';
-export * from './plugins/index.ts';
 export {
   normalizeMintUrl,
   toAmount,
   sumAmounts,
-  serializeAmount,
-  stringifyJson,
-  deserializeAmount,
-  deserializeToken,
 } from './utils.ts';

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,10 +17,7 @@ export type { CoreEvents } from './events/types.ts';
 export type { EventHandler } from './events/EventBus.ts';
 export { type Logger, ConsoleLogger } from './logging/index.ts';
 export { MemoryRepositories } from './repositories/memory/MemoryRepositories.ts';
-export type {
-  SendMethod,
-  SendMethodData,
-} from './operations/send/SendMethodHandler.ts';
+export type { SendMethod, SendMethodData } from './operations/send/SendMethodHandler.ts';
 export type {
   InitSendOperation,
   PreparedSendOperation,
@@ -101,8 +98,4 @@ export {
   type AmountLike,
 } from '@cashu/cashu-ts';
 export type { WebSocketLike, WebSocketFactory } from './infra/WsConnectionManager.ts';
-export {
-  normalizeMintUrl,
-  toAmount,
-  sumAmounts,
-} from './utils.ts';
+export { normalizeMintUrl, toAmount, sumAmounts } from './utils.ts';

--- a/packages/core/plugin.ts
+++ b/packages/core/plugin.ts
@@ -1,3 +1,5 @@
+import type { ServiceMap } from './plugins/types.ts';
+
 export type {
   Cleanup,
   CleanupFn,
@@ -7,4 +9,5 @@ export type {
   ServiceKey,
   ServiceMap,
 } from './plugins/types.ts';
+export type PluginEventBus = ServiceMap['eventBus'];
 export { DuplicatePluginRegistrationError, ExtensionRegistrationError } from './plugins/types.ts';

--- a/packages/docs/pages/plugins.md
+++ b/packages/docs/pages/plugins.md
@@ -93,11 +93,10 @@ Plugins can register custom APIs that become accessible via `manager.ext`. This 
 Use `ctx.registerExtension(key, api)` in your plugin's `onInit` or `onReady` hook:
 
 ```ts
-import type { CoreEvents, EventBus } from '@cashu/coco-core';
-import type { Plugin } from '@cashu/coco-core/plugin';
+import type { Plugin, PluginEventBus } from '@cashu/coco-core/plugin';
 
 class MyPluginApi {
-  constructor(private eventBus: EventBus<CoreEvents>) {}
+  constructor(private eventBus: PluginEventBus) {}
 
   onSubscriptionsResumed(handler: () => void): () => void {
     return this.eventBus.on('subscriptions:resumed', handler);
@@ -141,12 +140,11 @@ For full TypeScript autocomplete and type safety, plugin authors should augment 
 
 ```ts
 // my-plugin/index.ts
-import type { CoreEvents, EventBus } from '@cashu/coco-core';
-import type { Plugin, PluginExtensions } from '@cashu/coco-core/plugin';
+import type { Plugin, PluginEventBus, PluginExtensions } from '@cashu/coco-core/plugin';
 
 // Define your API class
 export class MyPluginApi {
-  constructor(private eventBus: EventBus<CoreEvents>) {}
+  constructor(private eventBus: PluginEventBus) {}
   onSubscriptionsResumed(handler: () => void): () => void {
     return this.eventBus.on('subscriptions:resumed', handler);
   }


### PR DESCRIPTION
This pull request narrows the root `@cashu/coco-core` entry point to the stable app-facing wallet surface for v2.

This pull request resolves #249.

## Problem

The package root was exposing concrete services, operation service classes, repository internals, infra transports, handler providers, plugin internals, and adapter serialization helpers as semver API.

## Summary

- Replaces broad root barrels with explicit app-facing exports.
- Keeps storage contracts under `@cashu/coco-core/adapter` and plugin contracts under `@cashu/coco-core/plugin`.
- Updates core README export docs.
- Adds a major changeset for the public export surface change.

## Verification

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-react' typecheck`
- `bun run --filter='@cashu/coco-adapter-tests' typecheck`
- `bun run --filter='@cashu/coco-indexeddb' typecheck`
- `bun run --filter='@cashu/coco-expo-sqlite' typecheck`
- `bun run --filter='@cashu/coco-sqlite' typecheck`
- `bun run --filter='@cashu/coco-sql-storage' typecheck`
- `bun run --filter='@cashu/coco-sqlite-bun' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-react' build`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run --filter='@cashu/coco-indexeddb' build`
- `bun run --filter='@cashu/coco-expo-sqlite' build`
- `bun run --filter='@cashu/coco-sqlite' build`
- `bun run --filter='@cashu/coco-sql-storage' build`
- `bun run --filter='@cashu/coco-sqlite-bun' build`
- `bun run --filter='@cashu/coco-core' test:unit`

Full `bun run --filter='@cashu/coco-core' test` was attempted, but integration tests require `MINT_URL`/auth env or reachable mint services in this environment.