### PR TITLE
docs(core): document public import surfaces

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,6 +19,35 @@ For a real application you will usually install a storage adapter alongside the
 core package, for example `@cashu/coco-sqlite`, `@cashu/coco-indexeddb`, or
 `@cashu/coco-expo-sqlite`. Bun applications can use `@cashu/coco-sqlite-bun`.
 
+## Entry points
+
+`@cashu/coco-core` publishes three stable import surfaces. Pick the narrowest
+one that matches what you are building:
+
+```ts
+// App and React usage
+import { initializeCoco, Amount, type Manager } from '@cashu/coco-core';
+
+// Storage adapter implementations and adapter contract tests
+import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
+
+// Plugin authors
+import type { Plugin, PluginExtensions } from '@cashu/coco-core/plugin';
+```
+
+- Use the package root for app-facing wallet setup, manager APIs, public models,
+  errors, amount helpers, events, logging, and config boundary types.
+- Use `@cashu/coco-core/adapter` when you are writing persistence adapters or
+  adapter contract tests. Repository contracts, persisted operation/domain
+  shapes, and serialization helpers live there.
+- Use `@cashu/coco-core/plugin` when you are writing extensions. Plugin
+  lifecycle types, extension augmentation types, plugin service keys, and plugin
+  errors live there.
+
+Concrete services, operation service classes, handler providers, transport
+internals, `PluginHost`, and individual memory repository classes are
+implementation details. They are not app-facing root API.
+
 ## Protocol Support
 
 - [x] NUT-00
@@ -142,21 +171,26 @@ If you prefer manual wiring, construct `Manager` directly and call `initPlugins(
 
 ## Architecture
 
-- `Manager`: Facade wiring services together; exposes `mint`, `wallet`, `ops`,
-  `quotes`, `paymentRequests`, and `subscription` APIs plus watcher helpers.
-- `MintService`: Fetches `mintInfo`, keysets and persists via repositories.
-- `WalletService`: Caches and constructs `Wallet` from stored keysets.
-- `ProofService`: Manages proofs, selection, states, and counters.
-- Legacy mint quote orchestration has been replaced by `MintOperationService`,
-  `manager.ops.mint`, and canonical quote resurfacing through `manager.quotes.mint`.
-- Legacy melt quote orchestration has been replaced by `MeltOperationService`,
-  `manager.ops.melt`, and canonical quote resurfacing through `manager.quotes.melt`.
-- `CounterService`: Simple per-(mint,keyset) numeric counter with events.
-- `EventBus<CoreEvents>`: Lightweight typed pub/sub used internally (includes `subscriptions:paused` and `subscriptions:resumed`).
+- `Manager` is the app-facing facade. It exposes `mint`, `wallet`, `auth`,
+  `quotes`, `paymentRequests`, `ops`, `subscription`, `history`, and `keyring`
+  APIs plus watcher and processor helpers.
+- `initializeCoco` wires the manager from a `CocoConfig`, including
+  repositories, seed access, logging, subscriptions, plugins, watchers, and
+  processors.
+- `manager.ops.*` is the supported surface for recoverable send, receive, mint,
+  and melt lifecycles.
+- `manager.quotes.mint` and `manager.quotes.melt` expose canonical quote lookup,
+  creation, and refresh workflows.
+- `manager.on(...)` exposes typed `CoreEvents`, including subscription,
+  operation, proof, quote, history, mint, and auth-session events.
 
 ### Repositories
 
 Repository contracts for storage adapters are exported from `@cashu/coco-core/adapter`:
+
+```ts
+import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
+```
 
 - `MintRepository`
 - `KeysetRepository`
@@ -179,14 +213,14 @@ The package root exports `MemoryRepositories` as an in-memory test/example repos
 
 - `mint`, `wallet`, `auth`, `quotes`, `paymentRequests`, `ops`,
   `subscription`, `history`, and `keyring`
-- `ext: PluginExtensions`
+- `ext: PluginExtensions` from `@cashu/coco-core/plugin`
 - `on/once/off` for `CoreEvents`
 - `enableMintOperationWatcher()`, `disableMintOperationWatcher()`
 - `enableMintOperationProcessor()`, `disableMintOperationProcessor()`,
   `waitForMintOperationProcessor()`
 - `enableProofStateWatcher()`, `disableProofStateWatcher()`
 - `pauseSubscriptions()`, `resumeSubscriptions()`
-- `use(plugin: Plugin): void`
+- `use(plugin: Plugin): void` with `Plugin` from `@cashu/coco-core/plugin`
 - `initPlugins(): Promise<void>`
 - `dispose(): Promise<void>`
 
@@ -295,7 +329,10 @@ those details are derived from canonical quote storage.
 
 ### Subscriptions in Node vs browser
 
-`Manager` will auto-detect a global `WebSocket` if available (e.g., browsers). In non-browser environments, provide a `webSocketFactory` to the `Manager` constructor or use the exposed `SubscriptionManager`/`WsConnectionManager` utilities.
+`Manager` will auto-detect a global `WebSocket` if available (e.g., browsers).
+In non-browser environments, provide a `webSocketFactory` through
+`initializeCoco` or `Manager` construction. App code should not need transport
+internals.
 
 ## Core events
 
@@ -384,7 +421,7 @@ await manager.dispose();
 
 ## Exports
 
-From the package root:
+From the package root (`@cashu/coco-core`), for app and React usage:
 
 - `Manager`, `initializeCoco`, `CocoConfig`
 - `MemoryRepositories`
@@ -399,12 +436,13 @@ From the package root:
 - Amount/unit helpers and intentional `@cashu/cashu-ts` re-exports such as `Amount`
 - Config boundary types: `WebSocketLike`, `WebSocketFactory`
 
-From the adapter subpath (`@cashu/coco-core/adapter`):
+From the adapter subpath (`@cashu/coco-core/adapter`), for storage adapter
+implementations and adapter contract tests:
 
 - Repository contracts, transaction scope types, persisted operation/domain types, and
   adapter serialization helpers for storage implementations
 
-From the plugin subpath (`@cashu/coco-core/plugin`):
+From the plugin subpath (`@cashu/coco-core/plugin`), for extension authors:
 
 - Plugin author types: `Plugin`, `PluginContext`, `PluginExtensions`, `PluginEventBus`,
   `ServiceKey`, `ServiceMap`, `Cleanup`, `CleanupFn`

--- a/packages/docs/pages/coco-config.md
+++ b/packages/docs/pages/coco-config.md
@@ -3,6 +3,10 @@
 Coco can be configured using a configuration object `CocoConfig`
 
 ```ts
+import type { Logger, WebSocketFactory } from '@cashu/coco-core';
+import type { Repositories } from '@cashu/coco-core/adapter';
+import type { Plugin } from '@cashu/coco-core/plugin';
+
 export interface CocoConfig {
   repo: Repositories;
   seedGetter: () => Promise<Uint8Array>;

--- a/packages/docs/pages/plugins.md
+++ b/packages/docs/pages/plugins.md
@@ -2,6 +2,11 @@
 
 Coco's plugin system allows you to extend the wallet's functionality by hooking into its lifecycle and registering custom APIs.
 
+Plugin authors should import plugin lifecycle types, extension augmentation
+types, service keys, and plugin errors from `@cashu/coco-core/plugin`.
+Applications still import `initializeCoco` and manager-facing symbols from the
+package root.
+
 ## Basic Plugin Structure
 
 A plugin is an object that implements the `Plugin` interface:
@@ -56,7 +61,7 @@ manager.use(myPlugin);
 
 ## Available Services
 
-Plugins can request access to internal services by declaring them in the `required` array. The following services are available:
+Plugins can request supported service capabilities by declaring them in the `required` array. The following service keys are available:
 
 These service keys are the supported plugin service surface. Plugins should import
 `ServiceKey`, `ServiceMap`, `Plugin`, `PluginContext`, and `PluginExtensions` from

--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -3,6 +3,9 @@
 Coco is built in a platform agnostic way. As we can not assume anything about the presence of a certain storage API (e.g. IndexedDB), coco exposes a storage interface that needs to be satisfied when instantiating.
 
 ```ts
+import { initializeCoco } from '@cashu/coco-core';
+import { SqliteRepositories } from '@cashu/coco-sqlite';
+
 const repo = new SqliteRepositories({ database: db }); // Implements the Repositories interface
 await repo.init(); // Ensures schema and applies migrations
 const coco = await initializeCoco({
@@ -13,6 +16,19 @@ const coco = await initializeCoco({
 ```
 
 Some storage implementations are maintained as part of the cashubtc/coco repository, but technically you can use any class that implements the `Repositories` interface.
+
+App code imports `initializeCoco` and other wallet-facing symbols from
+`@cashu/coco-core`. Adapter implementations and adapter contract tests should
+import repository contracts and serialization helpers from the adapter subpath:
+
+```ts
+import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
+```
+
+The adapter subpath is the stable public surface for persistence authors.
+Concrete core services, operation service classes, handler providers, transport
+internals, and individual memory repository classes are not part of the
+app-facing root API.
 
 ## SQLite adapter public API
 

--- a/packages/docs/starting/migrating-from-alpha.md
+++ b/packages/docs/starting/migrating-from-alpha.md
@@ -75,6 +75,42 @@ import { CocoCashuProvider } from 'coco-cashu-react';
 import { CocoCashuProvider } from '@cashu/coco-react';
 ```
 
+### Public core entry points
+
+The current `@cashu/coco-core` package has a narrower root API than the alpha
+packages. Use the package root for application and React code:
+
+```ts
+import { initializeCoco, Amount, type Manager } from '@cashu/coco-core';
+```
+
+If you maintain a storage adapter or adapter contract tests, move repository
+contracts, persisted operation/domain types, and serialization helpers to the
+adapter subpath:
+
+```ts
+// before
+import { type Repositories, serializeAmount } from '@cashu/coco-core';
+
+// after
+import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
+```
+
+If you author plugins, move plugin lifecycle types, extension augmentation
+types, service keys, and plugin errors to the plugin subpath:
+
+```ts
+// before
+import type { Plugin, PluginExtensions, ServiceKey } from '@cashu/coco-core';
+
+// after
+import type { Plugin, PluginExtensions, ServiceKey } from '@cashu/coco-core/plugin';
+```
+
+Concrete services, operation service classes, handler providers, transport
+internals, `PluginHost`, and individual memory repository classes are not
+app-facing root API in the current release line.
+
 ## Node users: move from `sqlite3` to `better-sqlite3`
 
 The old `coco-cashu-sqlite3` package has been replaced by
@@ -357,6 +393,8 @@ version strings.
 
 - Replace all `coco-cashu-*` dependencies with `@cashu/*`
 - Rewrite imports to the new namespace
+- Move adapter-facing imports to `@cashu/coco-core/adapter`
+- Move plugin-facing imports to `@cashu/coco-core/plugin`
 - For Node, switch from `sqlite3` to `better-sqlite3`
 - Reinstall dependencies and regenerate the lockfile
 - Replace removed alpha-era manager and `WalletApi` wrappers with

--- a/packages/docs/starting/start-here.md
+++ b/packages/docs/starting/start-here.md
@@ -23,6 +23,27 @@ const total = await coco.wallet.balances.total();
 For lifecycle-oriented operation flows, use `coco.ops.send`, `coco.ops.receive`,
 and `coco.ops.melt`.
 
+## Core import paths
+
+Most applications only need the package root:
+
+```ts
+import { initializeCoco, Amount, type Manager } from '@cashu/coco-core';
+```
+
+Use dedicated subpaths when you build lower-level extensions:
+
+```ts
+// Storage adapter implementations and adapter contract tests
+import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
+
+// Plugin authors
+import type { Plugin, PluginExtensions } from '@cashu/coco-core/plugin';
+```
+
+The root API is the stable app-facing surface. The adapter subpath is for
+persistence authors, and the plugin subpath is for extension authors.
+
 ## BIP-39 Seed
 
 In order to work properly coco requires you to supply a BIP39 conforming seed. Coco will never persist that seed, so you need to supply it via a `seedGetter` function. This function is expected to be passed when instantiating coco and will be called automatically when coco needs the key to derive new secrets from it


### PR DESCRIPTION
This pull request updates the published Coco docs so users can distinguish the root app-facing API from the adapter and plugin subpath APIs.

This pull request resolves #250.

## Problem

After narrowing the core root export surface, docs needed to stop presenting adapter/plugin/internal symbols as general app-facing root API.

## Summary

- Documents `@cashu/coco-core`, `@cashu/coco-core/adapter`, and `@cashu/coco-core/plugin` usage.
- Updates VitePress examples and migration notes for adapter/plugin import moves.
- No changeset added because this is documentation-only and does not change package exports or runtime behavior.

## Verification

- `git diff --check`
- `bun run docs:build`

## Changeset

- No changeset added; docs-only guidance for existing public surfaces.