### PR TITLE
fix(core): make manager disposal complete

### DIFF
--- a/.changeset/complete-manager-disposal.md
+++ b/.changeset/complete-manager-disposal.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': patch
+'@cashu/coco-react': patch
+---
+
+Make `Manager.dispose()` stop manager-owned watchers, processors, subscriptions, and plugin
+resources, and let the React provider rely on core disposal directly.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -254,6 +254,8 @@ export class Manager {
   private originalProcessorConfig: CocoConfig['processors'];
   private readonly mintRequestProvider: MintRequestProvider;
   private readonly mintAdapter: MintAdapter;
+  private disposed = false;
+  private disposePromise?: Promise<void>;
   constructor(
     repositories: Repositories,
     seedGetter: () => Promise<Uint8Array>,
@@ -386,7 +388,25 @@ export class Manager {
   }
 
   async dispose(): Promise<void> {
+    if (this.disposePromise) {
+      await this.disposePromise;
+      return;
+    }
+    if (this.disposed) return;
+
+    this.disposePromise = this.disposeOwnedResources();
+    await this.disposePromise;
+  }
+
+  private async disposeOwnedResources(): Promise<void> {
+    this.disposed = true;
+    this.subscriptionsPaused = true;
+
+    await this.disableMintOperationWatcher();
+    await this.disableProofStateWatcher();
+    await this.disableMintOperationProcessor();
     await this.pluginHost.dispose();
+    this.subscriptions.closeAll();
   }
 
   off<E extends keyof CoreEvents>(
@@ -400,6 +420,7 @@ export class Manager {
     watchExistingPendingOnStart?: boolean;
     watchExistingPendingQuotesOnStart?: boolean;
   }): Promise<void> {
+    if (this.disposed) return;
     if (this.mintOperationWatcher?.isRunning()) return;
     const watcherLogger = this.logger.child
       ? this.logger.child({ module: 'MintOperationWatcherService' })
@@ -432,6 +453,7 @@ export class Manager {
     initialEnqueueDelayMs?: number;
     autoClaimMintQuotes?: boolean;
   }): Promise<boolean> {
+    if (this.disposed) return false;
     if (this.mintOperationProcessor?.isRunning()) return false;
     const processorLogger = this.logger.child
       ? this.logger.child({ module: 'MintOperationProcessor' })
@@ -461,6 +483,7 @@ export class Manager {
   async enableProofStateWatcher(options?: {
     watchExistingInflightOnStart?: boolean;
   }): Promise<void> {
+    if (this.disposed) return;
     if (this.proofStateWatcher?.isRunning()) return;
     const watcherLogger = this.logger.child
       ? this.logger.child({ module: 'ProofStateWatcherService' })
@@ -585,6 +608,10 @@ export class Manager {
   }
 
   async resumeSubscriptions(): Promise<void> {
+    if (this.disposed) {
+      this.logger.debug('Cannot resume subscriptions after manager disposal');
+      return;
+    }
     this.subscriptionsPaused = false;
     this.logger.info('Resuming subscriptions');
     await this.eventBus.emit('subscriptions:resumed', undefined);

--- a/packages/core/infra/SubscriptionManager.ts
+++ b/packages/core/infra/SubscriptionManager.ts
@@ -396,6 +396,14 @@ export class SubscriptionManager {
     this.subscriptions.clear();
     this.activeByMint.clear();
     this.pendingSubscribeByMint.clear();
+    const injectedTransport = this.transportByMint.get('*');
+    this.transportByMint.clear();
+    if (injectedTransport) {
+      this.transportByMint.set('*', injectedTransport);
+    }
+    this.nextIdByMint.clear();
+    this.messageHandlerByMint.clear();
+    this.openHandlerByMint.clear();
     this.hasOpenedByMint.clear();
   }
 

--- a/packages/core/plugins/PluginHost.ts
+++ b/packages/core/plugins/PluginHost.ts
@@ -10,11 +10,18 @@ export class PluginHost {
   private readonly readyPlugins = new WeakSet<Plugin>();
   private readonly initPromises = new WeakMap<Plugin, Promise<void>>();
   private readonly readyPromises = new WeakMap<Plugin, Promise<void>>();
+  private readonly lifecyclePromises = new Set<Promise<void>>();
   private services?: ServiceMap;
   private initialized = false;
   private readyPhase = false;
+  private disposed = false;
+  private disposePromise?: Promise<void>;
 
   use(plugin: Plugin): void {
+    if (this.disposePromise || this.disposed) {
+      throw new Error('Cannot register plugin after disposal has started');
+    }
+
     if (this.registeredPlugins.has(plugin)) {
       throw new DuplicatePluginRegistrationError(plugin.name);
     }
@@ -23,14 +30,15 @@ export class PluginHost {
     this.plugins.push(plugin);
     if (this.initialized && this.services) {
       const services = this.services;
-      const initPromise = this.ensureInitialized(plugin, services);
-      if (this.readyPhase) {
-        void initPromise.then(() => this.ensureReady(plugin, services));
-      }
+      void this.trackLifecycle(this.initializeRuntimePlugin(plugin, services));
     }
   }
 
   async init(services: ServiceMap): Promise<void> {
+    if (this.disposePromise || this.disposed) {
+      throw new Error('Cannot initialize plugins after disposal has started');
+    }
+
     this.services = services;
     this.initialized = true;
     for (const p of this.plugins) {
@@ -39,6 +47,10 @@ export class PluginHost {
   }
 
   async ready(): Promise<void> {
+    if (this.disposePromise || this.disposed) {
+      throw new Error('Cannot mark plugins ready after disposal has started');
+    }
+
     if (!this.services) return;
     this.readyPhase = true;
     for (const p of this.plugins) {
@@ -47,6 +59,19 @@ export class PluginHost {
   }
 
   async dispose(): Promise<void> {
+    if (this.disposePromise) {
+      await this.disposePromise;
+      return;
+    }
+    if (this.disposed) return;
+
+    this.disposePromise = this.runDispose();
+    await this.disposePromise;
+  }
+
+  private async runDispose(): Promise<void> {
+    await this.waitForLifecycle();
+
     const errors: unknown[] = [];
     for (const p of this.plugins) {
       try {
@@ -69,6 +94,33 @@ export class PluginHost {
       // eslint-disable-next-line no-console
       console.error('One or more plugin dispose/cleanup handlers failed');
     }
+    this.disposed = true;
+  }
+
+  private async initializeRuntimePlugin(plugin: Plugin, services: ServiceMap): Promise<void> {
+    await this.ensureInitialized(plugin, services);
+    if (this.readyPhase) {
+      await this.ensureReady(plugin, services);
+    }
+  }
+
+  private trackLifecycle(promise: Promise<void>): Promise<void> {
+    this.lifecyclePromises.add(promise);
+    void promise.then(
+      () => {
+        this.lifecyclePromises.delete(promise);
+      },
+      () => {
+        this.lifecyclePromises.delete(promise);
+      },
+    );
+    return promise;
+  }
+
+  private async waitForLifecycle(): Promise<void> {
+    while (this.lifecyclePromises.size > 0) {
+      await Promise.allSettled([...this.lifecyclePromises]);
+    }
   }
 
   /**
@@ -87,13 +139,15 @@ export class PluginHost {
       return;
     }
 
-    const promise = this.runInit(plugin, services)
-      .then(() => {
-        this.initializedPlugins.add(plugin);
-      })
-      .finally(() => {
-        this.initPromises.delete(plugin);
-      });
+    const promise = this.trackLifecycle(
+      this.runInit(plugin, services)
+        .then(() => {
+          this.initializedPlugins.add(plugin);
+        })
+        .finally(() => {
+          this.initPromises.delete(plugin);
+        }),
+    );
 
     this.initPromises.set(plugin, promise);
     await promise;
@@ -109,13 +163,15 @@ export class PluginHost {
       return;
     }
 
-    const promise = this.runReady(plugin, services)
-      .then(() => {
-        this.readyPlugins.add(plugin);
-      })
-      .finally(() => {
-        this.readyPromises.delete(plugin);
-      });
+    const promise = this.trackLifecycle(
+      this.runReady(plugin, services)
+        .then(() => {
+          this.readyPlugins.add(plugin);
+        })
+        .finally(() => {
+          this.readyPromises.delete(plugin);
+        }),
+    );
 
     this.readyPromises.set(plugin, promise);
     await promise;

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -590,6 +590,109 @@ describe('initializeCoco', () => {
     });
   });
 
+  describe('dispose', () => {
+    it('should stop owned watchers, processors, and active subscriptions', async () => {
+      const manager = await initializeCoco(baseConfig);
+      const subscriptionInternals = manager.subscriptions as unknown as {
+        subscriptions: Map<string, unknown>;
+        activeByMint: Map<string, Set<string>>;
+        transportByMint: Map<string, unknown>;
+      };
+
+      manager.subscriptions.pause();
+      await manager.subscriptions.subscribe('https://mint.test', 'bolt11_mint_quote', ['quote-1']);
+
+      expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
+      expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(subscriptionInternals.subscriptions.size).toBe(1);
+      expect(subscriptionInternals.activeByMint.size).toBe(1);
+      expect(subscriptionInternals.transportByMint.size).toBe(1);
+
+      await manager.dispose();
+
+      expect(manager['mintOperationWatcher']).toBeUndefined();
+      expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(subscriptionInternals.subscriptions.size).toBe(0);
+      expect(subscriptionInternals.activeByMint.size).toBe(0);
+      expect(subscriptionInternals.transportByMint.size).toBe(0);
+    });
+
+    it('should run plugin disposal and cleanup only once', async () => {
+      const onDispose = mock(() => {});
+      const cleanup = mock(() => {});
+
+      const manager = await initializeCoco({
+        ...baseConfig,
+        plugins: [
+          {
+            name: 'dispose-plugin',
+            required: [] as const,
+            onInit: () => cleanup,
+            onDispose,
+          },
+        ],
+      });
+
+      await manager.dispose();
+      await manager.dispose();
+
+      expect(onDispose).toHaveBeenCalledTimes(1);
+      expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not recreate subscription transports during plugin cleanup', async () => {
+      const manager = await initializeCoco({
+        ...baseConfig,
+        plugins: [
+          {
+            name: 'subscription-cleanup-plugin',
+            required: ['subscriptions'] as const,
+            onInit: async ({ services }) => {
+              services.subscriptions.pause();
+              const subscription = await services.subscriptions.subscribe(
+                'https://mint.test',
+                'bolt11_mint_quote',
+                ['quote-plugin'],
+              );
+              return () => subscription.unsubscribe();
+            },
+          },
+        ],
+      });
+      const subscriptionInternals = manager.subscriptions as unknown as {
+        subscriptions: Map<string, unknown>;
+        activeByMint: Map<string, Set<string>>;
+        transportByMint: Map<string, unknown>;
+      };
+
+      expect(subscriptionInternals.subscriptions.size).toBe(1);
+      expect(subscriptionInternals.activeByMint.size).toBe(1);
+      expect(subscriptionInternals.transportByMint.size).toBe(1);
+
+      await manager.dispose();
+
+      expect(subscriptionInternals.subscriptions.size).toBe(0);
+      expect(subscriptionInternals.activeByMint.size).toBe(0);
+      expect(subscriptionInternals.transportByMint.size).toBe(0);
+    });
+
+    it('should not restart background work after disposal', async () => {
+      const manager = await initializeCoco(baseConfig);
+
+      await manager.dispose();
+      await manager.resumeSubscriptions();
+      await manager.enableMintOperationWatcher();
+      await manager.enableProofStateWatcher();
+      await manager.enableMintOperationProcessor();
+
+      expect(manager['mintOperationWatcher']).toBeUndefined();
+      expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['mintOperationProcessor']).toBeUndefined();
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle empty watchers config object', async () => {
       const manager = await initializeCoco({

--- a/packages/core/test/unit/PluginHost.test.ts
+++ b/packages/core/test/unit/PluginHost.test.ts
@@ -221,6 +221,70 @@ describe('PluginHost', () => {
     expect(order).toEqual(['init', 'ready']);
   });
 
+  it('waits for runtime plugin lifecycle before draining cleanups during disposal', async () => {
+    const calls: string[] = [];
+    let resolveInit!: () => void;
+    let markInitStarted: () => void = () => {};
+    const initStarted = new Promise<void>((resolve) => {
+      markInitStarted = resolve;
+    });
+    const initGate = new Promise<void>((resolve) => {
+      resolveInit = resolve;
+    });
+
+    await host.init(services);
+    await host.ready();
+
+    const plugin: Plugin<['logger']> = {
+      name: 'runtime-async-cleanup',
+      required: ['logger'],
+      onInit: async () => {
+        markInitStarted();
+        await initGate;
+        return () => {
+          calls.push('init-cleanup');
+        };
+      },
+      onReady: () => {
+        calls.push('ready');
+        return () => {
+          calls.push('ready-cleanup');
+        };
+      },
+      onDispose: () => {
+        calls.push('dispose');
+      },
+    };
+
+    host.use(plugin);
+    await initStarted;
+
+    const disposePromise = host.dispose();
+    resolveInit();
+    await disposePromise;
+
+    expect(calls).toContain('ready');
+    expect(calls).toContain('dispose');
+    expect(calls).toContain('init-cleanup');
+    expect(calls).toContain('ready-cleanup');
+  });
+
+  it('rejects runtime plugin registration once disposal starts', async () => {
+    await host.init(services);
+    await host.ready();
+
+    const disposePromise = host.dispose();
+
+    expect(() =>
+      host.use({
+        name: 'too-late',
+        required: [] as const,
+      }),
+    ).toThrow('Cannot register plugin after disposal has started');
+
+    await disposePromise;
+  });
+
   it('calls onDispose and continues running all cleanups', async () => {
     const calls: string[] = [];
     const pluginA: Plugin<['logger']> = {

--- a/packages/core/test/unit/SubscriptionManager.test.ts
+++ b/packages/core/test/unit/SubscriptionManager.test.ts
@@ -304,9 +304,7 @@ describe('SubscriptionManager pause/resume', () => {
     const mintUrl = 'https://mint.example.com';
 
     await subManager.subscribe(mintUrl, 'bolt11_mint_quote', ['quote1']);
-    expect(mockTransport.sentMessages.some((message) => message.method === 'subscribe')).toBe(
-      true,
-    );
+    expect(mockTransport.sentMessages.some((message) => message.method === 'subscribe')).toBe(true);
 
     subManager.closeAll();
     const messageCountAfterClose = mockTransport.sentMessages.length;

--- a/packages/core/test/unit/SubscriptionManager.test.ts
+++ b/packages/core/test/unit/SubscriptionManager.test.ts
@@ -299,4 +299,21 @@ describe('SubscriptionManager pause/resume', () => {
     // Should not error
     expect(mockTransport.resumed).toBe(true);
   });
+
+  it('preserves an injected transport after closeAll', async () => {
+    const mintUrl = 'https://mint.example.com';
+
+    await subManager.subscribe(mintUrl, 'bolt11_mint_quote', ['quote1']);
+    expect(mockTransport.sentMessages.some((message) => message.method === 'subscribe')).toBe(
+      true,
+    );
+
+    subManager.closeAll();
+    const messageCountAfterClose = mockTransport.sentMessages.length;
+
+    await subManager.subscribe(mintUrl, 'bolt11_mint_quote', ['quote2']);
+
+    const messagesAfterClose = mockTransport.sentMessages.slice(messageCountAfterClose);
+    expect(messagesAfterClose.some((message) => message.method === 'subscribe')).toBe(true);
+  });
 });

--- a/packages/react/src/lib/providers/root.test.tsx
+++ b/packages/react/src/lib/providers/root.test.tsx
@@ -149,9 +149,9 @@ describe('CocoCashuProvider', () => {
     unmount();
 
     await waitForAssertion(() => {
-      expect(manager.pauseSubscriptions).toHaveBeenCalledTimes(1);
       expect(manager.dispose).toHaveBeenCalledTimes(1);
     });
+    expect(manager.pauseSubscriptions).not.toHaveBeenCalled();
   });
 
   it('tears down an owned manager that resolves after unmount', async () => {
@@ -177,8 +177,8 @@ describe('CocoCashuProvider', () => {
     });
 
     await waitForAssertion(() => {
-      expect(manager.pauseSubscriptions).toHaveBeenCalledTimes(1);
       expect(manager.dispose).toHaveBeenCalledTimes(1);
     });
+    expect(manager.pauseSubscriptions).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/lib/providers/root.tsx
+++ b/packages/react/src/lib/providers/root.tsx
@@ -45,13 +45,7 @@ const normalizeError = (error: unknown): Error =>
   error instanceof Error ? error : new Error(String(error));
 
 const teardownOwnedManager = async (manager: Manager): Promise<void> => {
-  // TODO: Replace this bandaid with manager.dispose() once core disposal tears down
-  // watchers, processors, and subscriptions.
-  try {
-    await manager.pauseSubscriptions();
-  } finally {
-    await manager.dispose();
-  }
+  await manager.dispose();
 };
 
 const InitializingCocoCashuProvider = ({


### PR DESCRIPTION
This pull request resolves #255 and resolves #256.

## Description

This pull request fixes `Manager.dispose()` so it is the complete teardown path for manager-owned background work, then lets the React provider rely on that core disposal path directly.

## Problem

`Manager.dispose()` only disposed plugins, while React had to call `pauseSubscriptions()` first as a workaround. This left disposal semantics incomplete for watchers, processors, subscriptions, plugin cleanup idempotence, and React owned-manager teardown tests.

## Summary

- Stop mint-operation watchers, proof-state watchers, mint-operation processors, and active subscriptions during manager disposal.
- Make manager and plugin disposal idempotent so repeated calls do not re-run cleanup.
- Dispose plugin resources before final subscription close so plugin subscription cleanup cannot recreate transports after teardown.
- Preserve injected subscription transports across `SubscriptionManager.closeAll()` resets.
- Wait for in-flight runtime plugin init/ready hooks before draining plugin cleanups, and reject plugin registration once disposal starts.
- Remove the React provider's manual `pauseSubscriptions()` workaround and update provider tests to assert direct disposal.
- Add disposal tests and a patch changeset for core/react.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/Manager.test.ts`
- `bun run --filter='@cashu/coco-core' test -- test/unit/PluginHost.test.ts`
- `bun run --filter='@cashu/coco-core' test -- test/unit/SubscriptionManager.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-react' typecheck`
- `bun run --filter='@cashu/coco-react' lint`
- `bun run test -- src/lib/providers/root.test.tsx` from `packages/react`
- `bun run test` from `packages/react`
- `bun run build` from `packages/react`

Attempted `bun run --filter='@cashu/coco-core' test`; integration tests require `MINT_URL`/auth env and external mint access, so that command failed for environment/network reasons.

## Changeset

- Added `.changeset/complete-manager-disposal.md`.