### PR TITLE
docs(core): codify methodless quote identity contract

### DIFF
--- a/packages/core/models/QuoteIdentity.ts
+++ b/packages/core/models/QuoteIdentity.ts
@@ -3,13 +3,30 @@ import type { MeltQuote } from './MeltQuote';
 import type { MintMethod } from '../operations/mint/MintMethodHandler';
 import type { MintQuote } from './MintQuote';
 
+/**
+ * Public quote identity shared by mint and melt quote APIs.
+ *
+ * The identity intentionally omits `method`: callers identify a quote by `{ mintUrl, quoteId }`,
+ * and repositories compare the identity after normalizing `mintUrl`. Within each quote kind
+ * (mint quotes separately from melt quotes), a quote ID must be unique for a normalized mint URL
+ * across all methods. Mint quote identities and melt quote identities are separate namespaces, so
+ * the same `{ mintUrl, quoteId }` can identify one mint quote and one melt quote.
+ */
 export type QuoteIdentity = {
   mintUrl: string;
   quoteId: string;
 };
 
+/**
+ * Method-scoped mint quote reference used after the quote method is known. The `method` narrows the
+ * public `QuoteIdentity` to the concrete repository row; it is not part of public quote identity.
+ */
 export type MintQuoteRef<M extends MintMethod = MintMethod> = QuoteIdentity &
   Pick<MintQuote<M>, 'method'>;
 
+/**
+ * Method-scoped melt quote reference used after the quote method is known. The `method` narrows the
+ * public `QuoteIdentity` to the concrete repository row; it is not part of public quote identity.
+ */
 export type MeltQuoteRef<M extends MeltMethod = MeltMethod> = QuoteIdentity &
   Pick<MeltQuote<M>, 'method'>;

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -114,10 +114,41 @@ export interface ProofRepository {
   getReservedProofs(): Promise<CoreProof[]>;
 }
 
+/**
+ * Stores canonical mint quotes.
+ *
+ * Public mint quote identity is methodless: `{ mintUrl, quoteId }` after mint URL normalization.
+ * Method-scoped APIs address the concrete storage row once the quote method is known. Adapters must
+ * reject upserts that would create two mint quotes with the same `{ mintUrl, quoteId }` for
+ * different methods at the same normalized mint URL. Melt quotes use a separate identity namespace.
+ */
 export interface MintQuoteRepository {
+  /**
+   * Look up a mint quote by its public methodless identity, normalizing `identity.mintUrl` first.
+   *
+   * Implementations should return the single matching mint quote, return `null` when none exists,
+   * and report a quote identity conflict if stored data contains multiple methods for the same
+   * normalized `{ mintUrl, quoteId }`.
+   */
   getMintQuoteById(identity: QuoteIdentity): Promise<MintQuote | null>;
+
+  /**
+   * Look up the exact method-scoped mint quote row, normalizing `mintUrl` before comparison.
+   */
   getMintQuote(mintUrl: string, method: string, quoteId: string): Promise<MintQuote | null>;
+
+  /**
+   * Insert or update the exact method-scoped mint quote row after normalizing `quote.mintUrl`.
+   *
+   * Upserting the same normalized `{ mintUrl, method, quoteId }` updates that quote. Upserting a
+   * different method with the same normalized `{ mintUrl, quoteId }` must fail with a quote
+   * identity conflict instead of creating an ambiguous methodless public identity.
+   */
   upsertMintQuote(quote: MintQuote): Promise<void>;
+
+  /**
+   * Update state for the exact method-scoped mint quote row.
+   */
   setMintQuoteState(
     mintUrl: string,
     method: string,
@@ -132,9 +163,36 @@ export interface LegacyMintQuoteRepository {
   getPendingLegacyMintQuotes(mintUrl?: string): Promise<MintQuote[]>;
 }
 
+/**
+ * Stores canonical melt quotes.
+ *
+ * Public melt quote identity is methodless: `{ mintUrl, quoteId }` after mint URL normalization.
+ * Method-scoped APIs address the concrete storage row once the quote method is known. Adapters must
+ * reject upserts that would create two melt quotes with the same `{ mintUrl, quoteId }` for
+ * different methods at the same normalized mint URL. Mint quotes use a separate identity namespace.
+ */
 export interface MeltQuoteRepository {
+  /**
+   * Look up a melt quote by its public methodless identity, normalizing `identity.mintUrl` first.
+   *
+   * Implementations should return the single matching melt quote, return `null` when none exists,
+   * and report a quote identity conflict if stored data contains multiple methods for the same
+   * normalized `{ mintUrl, quoteId }`.
+   */
   getMeltQuoteById(identity: QuoteIdentity): Promise<MeltQuote | null>;
+
+  /**
+   * Look up the exact method-scoped melt quote row, normalizing `mintUrl` before comparison.
+   */
   getMeltQuote(mintUrl: string, method: string, quoteId: string): Promise<MeltQuote | null>;
+
+  /**
+   * Insert or update the exact method-scoped melt quote row after normalizing `quote.mintUrl`.
+   *
+   * Upserting the same normalized `{ mintUrl, method, quoteId }` updates that quote. Upserting a
+   * different method with the same normalized `{ mintUrl, quoteId }` must fail with a quote
+   * identity conflict instead of creating an ambiguous methodless public identity.
+   */
   upsertMeltQuote(quote: MeltQuote): Promise<void>;
   getPendingMeltQuotes(method?: string): Promise<MeltQuote[]>;
 }


### PR DESCRIPTION
## Summary

- Documents that public `QuoteIdentity` intentionally remains methodless: `{ mintUrl, quoteId }`.
- Codifies normalized mint URL canonical identity, per-kind cross-method quote ID uniqueness, and separate mint/melt quote namespaces.
- Adds repository interface docs for methodless lookup, method-scoped lookup, and upsert collision behavior.

Parent PRD: `issues/006-settle-quote-identity-semantics.md`
Closes #259

## Validation

- `bun run --filter='@cashu/coco-core' test -- test/unit/MemoryQuoteRepository.test.ts`
- `bun run --filter='@cashu/coco-sql-storage' test -- src/test/schema.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bunx prettier --check packages/core/models/QuoteIdentity.ts packages/core/repositories/index.ts`
- `git diff --check origin/master...HEAD`

Additional worker validation reported:
- `bun run --filter='@cashu/coco-indexeddb' test:browser -- src/test/contract.test.ts`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run --filter='@cashu/coco-core' test:unit`

Note: `bun run --filter='@cashu/coco-core' test` includes integration tests that require `MINT_URL` or live mint access, so targeted unit/schema checks were used for this slice.