### PR TITLE
fix(sqlite): declare better-sqlite3 types dependency

### DIFF
--- a/.changeset/sqlite-types-dependency.md
+++ b/.changeset/sqlite-types-dependency.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-sqlite': patch
+---
+
+Declare `@types/better-sqlite3` as a package dependency so downstream TypeScript
+consumers can resolve public SQLite adapter declarations without installing the
+type package manually.

--- a/bun.lock
+++ b/bun.lock
@@ -138,12 +138,12 @@
       "name": "@cashu/coco-sqlite",
       "version": "1.0.0",
       "dependencies": {
+        "@types/better-sqlite3": "^7.6.12",
         "better-sqlite3": "^12.6.2",
       },
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0",
         "@cashu/coco-sql-storage": "1.0.0",
-        "@types/better-sqlite3": "^7.6.12",
         "vitest": "^2.1.9",
       },
       "peerDependencies": {

--- a/packages/sqlite3/package.json
+++ b/packages/sqlite3/package.json
@@ -15,7 +15,6 @@
     "README.md"
   ],
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.12",
     "@cashu/coco-adapter-tests": "1.0.0",
     "@cashu/coco-sql-storage": "1.0.0",
     "vitest": "^2.1.9"
@@ -27,6 +26,7 @@
     }
   },
   "dependencies": {
+    "@types/better-sqlite3": "^7.6.12",
     "better-sqlite3": "^12.6.2"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Moves `@types/better-sqlite3` into `@cashu/coco-sqlite` dependencies because the public declarations expose `better-sqlite3`'s `Database` type.
- Refreshes `bun.lock`.
- Adds a patch changeset for `@cashu/coco-sqlite`.

## Parent PRD

- `issues/008-fix-sqlite-types-dependency.md`

## Validation

- `bun run --filter='@cashu/coco-sqlite' build`
- `bun run --filter='@cashu/coco-sqlite' typecheck`
- `bun run --filter='@cashu/coco-sqlite' test -- src/test/contract.test.ts`
- `git diff --check origin/master...HEAD`
- Packed downstream consumer check: `bun run typecheck` in `/tmp/coco-issue-261-consumer-pack`, without declaring `@types/better-sqlite3`

Full `@cashu/coco-sqlite` test coverage still requires `MINT_URL` for `src/test/integration.test.ts`; the contract test was run locally.

Resolves #261