### PR TITLE
fix(core): remove legacy send created event

### DIFF
--- a/.changeset/remove-send-created-event.md
+++ b/.changeset/remove-send-created-event.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': major
+---
+
+Remove the undocumented `send:created` event from the public `CoreEvents` type. Consumers should use
+`send:pending`, which is the emitted token-created send lifecycle event.

--- a/packages/core/events/types.ts
+++ b/packages/core/events/types.ts
@@ -36,8 +36,6 @@ export interface CoreEvents {
   'send:prepared': { mintUrl: string; operationId: string; operation: SendOperation };
   /** Emitted when send operation is executed (token created) */
   'send:pending': { mintUrl: string; operationId: string; operation: SendOperation; token: Token };
-  /** Emitted when send operation is executed (token created) this one should be cleaned up in the future */
-  'send:created': { mintUrl: string; token: Token };
   /** Emitted when send operation is finalized (proofs confirmed spent) */
   'send:finalized': { mintUrl: string; operationId: string; operation: SendOperation };
   /** Emitted when send operation is rolled back */


### PR DESCRIPTION
## Summary

- Remove the undocumented `send:created` event from the public `CoreEvents` type.
- Keep `send:pending` as the canonical emitted token-created send lifecycle event.
- Add a major changeset for `@cashu/coco-core` because this removes an exported TypeScript API key.

## Problem

`send:created` was exposed in the public event type, but runtime code does not emit it and event docs do not document it. This made the v2 event API surface inconsistent.

## Verification

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test -- test/unit/SendOperationService.test.ts test/unit/SendOperationService.recovery.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`

Full `bun run --filter='@cashu/coco-core' test` was also attempted, but integration tests failed due to local/live mint setup: missing `MINT_URL` and unreachable live/local mints.