### PR TITLE
feat(core): persist melt quote observations

### DIFF
--- a/.changeset/melt-quote-observations.md
+++ b/.changeset/melt-quote-observations.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Persist meaningful melt quote observations and emit `melt-quote:updated` after canonical quote
+state changes.

--- a/packages/core/events/types.ts
+++ b/packages/core/events/types.ts
@@ -1,6 +1,7 @@
 import type { Token } from '@cashu/cashu-ts';
-import type { MeltOperation } from '@core/operations/melt';
+import type { MeltMethod, MeltOperation } from '@core/operations/melt';
 import type { MintOperation, MintMethod } from '@core/operations/mint';
+import type { MeltQuote } from '../models/MeltQuote';
 import type { MintQuote } from '../models/MintQuote';
 import type { UnitAmount } from '../amounts.ts';
 import type { Counter } from '../models/Counter';
@@ -69,6 +70,12 @@ export interface CoreEvents {
     method: MintMethod;
     quoteId: string;
     quote: MintQuote;
+  };
+  'melt-quote:updated': {
+    mintUrl: string;
+    method: MeltMethod;
+    quoteId: string;
+    quote: MeltQuote;
   };
   'mint-op:requeue': { mintUrl: string; operationId: string; operation: MintOperation };
   'mint-op:executing': { mintUrl: string; operationId: string; operation: MintOperation };

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -109,6 +109,52 @@ function getRemoteStateChange(
   return false;
 }
 
+function serializeMeltChange(change: MeltQuote['change']): unknown {
+  return change ?? [];
+}
+
+function getMeaningfulMeltQuoteFields(quote: MeltQuote): unknown {
+  const base = {
+    method: quote.method,
+    quoteId: quote.quoteId,
+    request: quote.request,
+    amount: quote.amount.toString(),
+    unit: quote.unit,
+    expiry: quote.expiry,
+    state: quote.state,
+    change: serializeMeltChange(quote.change),
+  };
+
+  if (quote.method === 'onchain') {
+    return {
+      ...base,
+      fee_options: quote.fee_options.map((option) => ({
+        fee_index: option.fee_index,
+        fee_reserve: option.fee_reserve.toString(),
+        estimated_blocks: option.estimated_blocks,
+      })),
+      outpoint: quote.outpoint ?? null,
+    };
+  }
+
+  return {
+    ...base,
+    fee_reserve: quote.fee_reserve.toString(),
+    payment_preimage: quote.payment_preimage ?? null,
+  };
+}
+
+function getMeltQuoteChange(existing: MeltQuote | null, incoming: MeltQuote): boolean {
+  if (!existing) {
+    return true;
+  }
+
+  return (
+    JSON.stringify(getMeaningfulMeltQuoteFields(existing)) !==
+    JSON.stringify(getMeaningfulMeltQuoteFields(incoming))
+  );
+}
+
 export interface QuoteLifecycleDeps {
   mintHandlerProvider: MintHandlerProvider;
   meltHandlerProvider: MeltHandlerProvider;
@@ -182,17 +228,7 @@ export class QuoteLifecycle {
       quote: existingQuote,
     });
 
-    await this.meltQuoteRepository.upsertMeltQuote(refreshed);
-    const quote = await this.meltQuoteRepository.getMeltQuote(
-      existingQuote.mintUrl,
-      existingQuote.method,
-      existingQuote.quoteId,
-    );
-    if (!quote) {
-      throw new Error(
-        `Cannot refresh quote: melt quote ${existingQuote.quoteId} was not found after persistence`,
-      );
-    }
+    const quote = await this.recordMeltQuoteObservation(refreshed);
     return quote;
   }
 
@@ -561,10 +597,7 @@ export class QuoteLifecycle {
       );
     }
 
-    await this.meltQuoteRepository.upsertMeltQuote(quote);
-    const persistedQuote =
-      (await this.meltQuoteRepository.getMeltQuote(mintUrl, method, quote.quoteId)) ?? quote;
-    return persistedQuote as MeltQuote<M>;
+    return (await this.recordMeltQuoteObservation(quote)) as MeltQuote<M>;
   }
 
   getMeltQuote(mintUrl: string, method: MeltMethod, quoteId: string): Promise<MeltQuote | null> {
@@ -664,6 +697,45 @@ export class QuoteLifecycle {
     return meltQuoteToMethodSnapshot(quote);
   }
 
+  /**
+   * Records a canonical melt quote observation and emits `melt-quote:updated` only when storage
+   * changed meaningfully.
+   */
+  async recordMeltQuoteObservation(canonicalQuote: MeltQuote): Promise<MeltQuote> {
+    const { quote, remoteQuoteChanged } =
+      await this.resolveAndPersistMeltQuoteObservation(canonicalQuote);
+    await this.emitMeltQuoteUpdatedIfNeeded(quote, remoteQuoteChanged);
+    return quote;
+  }
+
+  private async resolveAndPersistMeltQuoteObservation(
+    canonicalQuote: MeltQuote,
+  ): Promise<{ quote: MeltQuote; remoteQuoteChanged: boolean }> {
+    const existing = await this.meltQuoteRepository.getMeltQuote(
+      canonicalQuote.mintUrl,
+      canonicalQuote.method,
+      canonicalQuote.quoteId,
+    );
+
+    if (existing?.state === 'PAID' && canonicalQuote.state !== 'PAID') {
+      return {
+        quote: existing,
+        remoteQuoteChanged: false,
+      };
+    }
+
+    const remoteQuoteChanged = getMeltQuoteChange(existing, canonicalQuote);
+    if (!remoteQuoteChanged && existing) {
+      return {
+        quote: existing,
+        remoteQuoteChanged: false,
+      };
+    }
+
+    const persisted = await this.persistCanonicalMeltQuote(canonicalQuote);
+    return { quote: persisted, remoteQuoteChanged };
+  }
+
   private async persistCanonicalMintQuote(canonicalQuote: MintQuote): Promise<MintQuote> {
     await this.mintQuoteRepository.upsertMintQuote(canonicalQuote);
     return (
@@ -684,6 +756,37 @@ export class QuoteLifecycle {
     }
 
     await this.eventBus.emit('mint-quote:updated', {
+      mintUrl: quote.mintUrl,
+      method: quote.method,
+      quoteId: quote.quoteId,
+      quote,
+    });
+  }
+
+  private async persistCanonicalMeltQuote(canonicalQuote: MeltQuote): Promise<MeltQuote> {
+    await this.meltQuoteRepository.upsertMeltQuote(canonicalQuote);
+    const quote = await this.meltQuoteRepository.getMeltQuote(
+      canonicalQuote.mintUrl,
+      canonicalQuote.method,
+      canonicalQuote.quoteId,
+    );
+    if (!quote) {
+      throw new Error(
+        `Cannot persist quote observation: melt quote ${canonicalQuote.quoteId} for ${canonicalQuote.method} at ${canonicalQuote.mintUrl} was not found after persistence`,
+      );
+    }
+    return quote;
+  }
+
+  private async emitMeltQuoteUpdatedIfNeeded(
+    quote: MeltQuote,
+    remoteQuoteChanged: boolean,
+  ): Promise<void> {
+    if (!remoteQuoteChanged) {
+      return;
+    }
+
+    await this.eventBus.emit('melt-quote:updated', {
       mintUrl: quote.mintUrl,
       method: quote.method,
       quoteId: quote.quoteId,

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -109,7 +109,7 @@ function getRemoteStateChange(
   return false;
 }
 
-function serializeMeltChange(change: MeltQuote['change']): unknown {
+function serializeMeltChange(change: MeltQuote['change']): NonNullable<MeltQuote['change']> {
   return change ?? [];
 }
 

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -717,7 +717,7 @@ export class QuoteLifecycle {
       canonicalQuote.quoteId,
     );
 
-    if (existing?.state === 'PAID' && canonicalQuote.state !== 'PAID') {
+    if (existing?.state === 'PAID') {
       return {
         quote: existing,
         remoteQuoteChanged: false,

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -28,7 +28,7 @@ import type {
   PendingCheckResult,
   FinalizeResult,
 } from '../../operations/melt/MeltMethodHandler.ts';
-import { meltQuoteFromBolt11Response } from '../../models/MeltQuote.ts';
+import { meltQuoteFromBolt11Response, type MeltQuote } from '../../models/MeltQuote.ts';
 import {
   UnknownMintError,
   ProofValidationError,
@@ -419,6 +419,126 @@ describe('MeltOperationService', () => {
       expect(handler.fetchRemoteQuote).toHaveBeenCalled();
       expect(quote.state).toBe('PENDING');
       expect(await quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-1')).toEqual(quote);
+    });
+
+    it('refreshMeltQuote persists the canonical quote before emitting melt-quote:updated', async () => {
+      (handler.fetchRemoteQuote as Mock<any>).mockImplementationOnce(
+        async ({ quote }: { quote: MeltQuote<'bolt11'> }) =>
+          meltQuoteFromBolt11Response(quote.mintUrl, {
+            quote: quote.quoteId,
+            request: quote.request,
+            amount: quote.amount,
+            unit: quote.unit,
+            fee_reserve: quote.fee_reserve,
+            expiry: quote.expiry,
+            state: 'PAID',
+            payment_preimage: 'preimage-paid',
+          }),
+      );
+
+      const events: Array<CoreEvents['melt-quote:updated']> = [];
+      const persistedDuringEvent: Array<string | undefined> = [];
+      eventBus.on('melt-quote:updated', async (event) => {
+        events.push(event);
+        const storedQuote = await meltQuoteRepository.getMeltQuote(
+          event.mintUrl,
+          event.method,
+          event.quoteId,
+        );
+        persistedDuringEvent.push(storedQuote?.state);
+      });
+
+      const refreshed = await quoteLifecycle.refreshMeltQuoteById({ mintUrl, quoteId: 'quote-1' });
+
+      expect(refreshed.state).toBe('PAID');
+      if (refreshed.method === 'onchain') throw new Error('Expected BOLT melt quote');
+      expect(refreshed.payment_preimage).toBe('preimage-paid');
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        mintUrl,
+        method: 'bolt11',
+        quoteId: 'quote-1',
+        quote: refreshed,
+      });
+      expect(persistedDuringEvent).toEqual(['PAID']);
+    });
+
+    it('suppresses duplicate melt quote observations without meaningful stored changes', async () => {
+      const events: Array<CoreEvents['melt-quote:updated']> = [];
+      eventBus.on('melt-quote:updated', (event) => {
+        events.push(event);
+      });
+
+      await quoteLifecycle.refreshMeltQuoteById({ mintUrl, quoteId: 'quote-1' });
+      await quoteLifecycle.refreshMeltQuoteById({ mintUrl, quoteId: 'quote-1' });
+
+      expect(events.map((event) => event.quote.state)).toEqual(['PENDING']);
+    });
+
+    it('persists PENDING to UNPAID melt quote observations', async () => {
+      await persistMeltQuote('quote-pending-to-unpaid', 'PENDING');
+      (handler.fetchRemoteQuote as Mock<any>).mockImplementationOnce(
+        async ({ quote }: { quote: MeltQuote<'bolt11'> }) =>
+          meltQuoteFromBolt11Response(quote.mintUrl, {
+            quote: quote.quoteId,
+            request: quote.request,
+            amount: quote.amount,
+            unit: quote.unit,
+            fee_reserve: quote.fee_reserve,
+            expiry: quote.expiry,
+            state: 'UNPAID',
+            payment_preimage: null,
+          }),
+      );
+
+      const events: Array<CoreEvents['melt-quote:updated']> = [];
+      eventBus.on('melt-quote:updated', (event) => {
+        events.push(event);
+      });
+
+      const refreshed = await quoteLifecycle.refreshMeltQuoteById({
+        mintUrl,
+        quoteId: 'quote-pending-to-unpaid',
+      });
+
+      expect(refreshed.state).toBe('UNPAID');
+      expect(events.map((event) => event.quote.state)).toEqual(['UNPAID']);
+      await expect(
+        quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-pending-to-unpaid'),
+      ).resolves.toMatchObject({ state: 'UNPAID' });
+    });
+
+    it('does not downgrade terminal PAID melt quotes from stale observations', async () => {
+      await persistMeltQuote('quote-terminal-paid', 'PAID');
+      (handler.fetchRemoteQuote as Mock<any>).mockImplementationOnce(
+        async ({ quote }: { quote: MeltQuote<'bolt11'> }) =>
+          meltQuoteFromBolt11Response(quote.mintUrl, {
+            quote: quote.quoteId,
+            request: quote.request,
+            amount: quote.amount,
+            unit: quote.unit,
+            fee_reserve: quote.fee_reserve,
+            expiry: quote.expiry,
+            state: 'UNPAID',
+            payment_preimage: null,
+          }),
+      );
+
+      const events: Array<CoreEvents['melt-quote:updated']> = [];
+      eventBus.on('melt-quote:updated', (event) => {
+        events.push(event);
+      });
+
+      const refreshed = await quoteLifecycle.refreshMeltQuoteById({
+        mintUrl,
+        quoteId: 'quote-terminal-paid',
+      });
+
+      expect(refreshed.state).toBe('PAID');
+      expect(events).toHaveLength(0);
+      await expect(
+        quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-terminal-paid'),
+      ).resolves.toMatchObject({ state: 'PAID', payment_preimage: 'preimage-123' });
     });
   });
 

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -368,11 +368,32 @@ describe('MeltOperationService', () => {
 
   describe('quotes', () => {
     it('creates and persists a canonical melt quote without creating an operation', async () => {
+      const events: Array<CoreEvents['melt-quote:updated']> = [];
+      const persistedDuringEvent: Array<string | undefined> = [];
+      eventBus.on('melt-quote:updated', async (event) => {
+        events.push(event);
+        const storedQuote = await meltQuoteRepository.getMeltQuote(
+          event.mintUrl,
+          event.method,
+          event.quoteId,
+        );
+        persistedDuringEvent.push(storedQuote?.quoteId);
+      });
+
       const quote = await quoteLifecycle.createMeltQuote(mintUrl, 'bolt11', { invoice });
 
       expect(quote.quoteId).toBe('quote-created');
       expect(handler.createQuote).toHaveBeenCalled();
       expect(await quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-created')).toBeDefined();
+      expect(events).toEqual([
+        {
+          mintUrl,
+          method: 'bolt11',
+          quoteId: 'quote-created',
+          quote,
+        },
+      ]);
+      expect(persistedDuringEvent).toEqual(['quote-created']);
       expect(await meltOperationRepository.getAll()).toHaveLength(0);
     });
 

--- a/packages/core/test/unit/MeltOperationService.test.ts
+++ b/packages/core/test/unit/MeltOperationService.test.ts
@@ -561,6 +561,41 @@ describe('MeltOperationService', () => {
         quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-terminal-paid'),
       ).resolves.toMatchObject({ state: 'PAID', payment_preimage: 'preimage-123' });
     });
+
+    it('ignores later PAID melt quote observations after terminal settlement', async () => {
+      await persistMeltQuote('quote-terminal-paid-repeat', 'PAID');
+      (handler.fetchRemoteQuote as Mock<any>).mockImplementationOnce(
+        async ({ quote }: { quote: MeltQuote<'bolt11'> }) =>
+          meltQuoteFromBolt11Response(quote.mintUrl, {
+            quote: quote.quoteId,
+            request: quote.request,
+            amount: quote.amount,
+            unit: quote.unit,
+            fee_reserve: quote.fee_reserve,
+            expiry: quote.expiry,
+            state: 'PAID',
+            payment_preimage: null,
+          }),
+      );
+
+      const events: Array<CoreEvents['melt-quote:updated']> = [];
+      eventBus.on('melt-quote:updated', (event) => {
+        events.push(event);
+      });
+
+      const refreshed = await quoteLifecycle.refreshMeltQuoteById({
+        mintUrl,
+        quoteId: 'quote-terminal-paid-repeat',
+      });
+
+      expect(refreshed.state).toBe('PAID');
+      if (refreshed.method === 'onchain') throw new Error('Expected BOLT melt quote');
+      expect(refreshed.payment_preimage).toBe('preimage-123');
+      expect(events).toHaveLength(0);
+      await expect(
+        quoteLifecycle.getMeltQuote(mintUrl, 'bolt11', 'quote-terminal-paid-repeat'),
+      ).resolves.toMatchObject({ state: 'PAID', payment_preimage: 'preimage-123' });
+    });
   });
 
   describe('prepare', () => {


### PR DESCRIPTION
## Parent PRD

- #267

## Slice

- Closes #268

## Summary

- Add typed canonical `melt-quote:updated` events for persisted melt quote changes.
- Route manual melt quote creation and refresh through a single quote observation path.
- Suppress duplicate observations without meaningful stored changes.
- Preserve melt-specific state rules: `PENDING -> UNPAID` is persisted and terminal `PAID` is not downgraded by stale observations.
- Add focused core tests and a patch changeset.

## Validation

- `bun run --filter='@cashu/coco-core' test -- test/unit/MeltOperationService.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-core' test:unit`

## Notes

Full `@cashu/coco-core` test was attempted by the implementation worker; unit tests passed, but live integration checks need the repo's mint/auth environment. This PR intentionally does not add melt quote watching, settlement processing, or manager lifecycle wiring; those remain in dependent slices.