### PR TITLE
[codex] docs: record quote observation decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,6 +53,11 @@ quote parameters and endpoint fields, but quote-backed minting and melting share
 saga shape for outputs, inputs, proof state, and recovery.
 _Avoid_: Method flow, payment workflow
 
+**Quote Observation**:
+A mint response that reports the current remote state of a quote and is recorded into Coco's
+canonical quote row before any Quote-backed Operation is advanced from it.
+_Avoid_: Quote refresh, subscription update
+
 **Payment Method Capability**:
 A mint-advertised statement that a payment method supports a unit for minting or melting. Coco
 derives payment method capabilities from NUT-04 and NUT-05 mint metadata.
@@ -60,7 +65,8 @@ _Avoid_: Payment option, method support flag
 
 **Melt Quote State**:
 The mint's settlement state for a melt quote. `PAID` is terminal, while `PENDING` can return to
-`UNPAID` when settlement fails.
+`UNPAID` when settlement fails; a newer `UNPAID` observation can therefore be more accurate than an
+older `PENDING` observation.
 _Avoid_: Payment status, melt lifecycle
 
 **Restore**:

--- a/docs/adr/0004-quote-observations-precede-operation-advancement.md
+++ b/docs/adr/0004-quote-observations-precede-operation-advancement.md
@@ -1,0 +1,7 @@
+# Quote observations precede operation advancement
+
+Coco records a Quote Observation into the canonical quote row before advancing any Quote-backed
+Operation from that observation. Watchers therefore observe and persist quote state, while separate
+operation processors react to quote update events and call the operation saga; this keeps remote
+quote observation separate from proof mutation and prevents future maintainers from folding
+subscription handling directly into operation finalization.


### PR DESCRIPTION
## Summary

- Adds `Quote Observation` to the domain glossary.
- Clarifies that newer `UNPAID` melt quote observations can supersede older `PENDING` observations.
- Adds ADR-0004 recording that quote observations are persisted before quote-backed operations advance.

## Why

The melt quote observation slice has landed via #273, and the active melt watcher/settlement issues already refer to this vocabulary and ADR. This keeps the repository context aligned with the implementation and with PRD #267.

## Impact

Documentation-only change. No runtime behavior, API surface, schema, or package release metadata changes.

## Validation

- `git diff --cached --check` before commit
