### PR TITLE
feat(core): add melt settlement processor

### DIFF
--- a/.changeset/melt-settlement-processor.md
+++ b/.changeset/melt-settlement-processor.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': patch
+---
+
+Add a melt settlement processor that tracks exact pending melt operation interest, reacts to
+canonical melt quote updates, and advances interested operations through the existing melt saga
+without introducing a retry queue.

--- a/packages/core/services/watchers/MeltSettlementProcessor.ts
+++ b/packages/core/services/watchers/MeltSettlementProcessor.ts
@@ -109,6 +109,7 @@ export class MeltSettlementProcessor {
   private readonly inFlightOperationIds = new Set<string>();
   private readonly followUpCheckByOperationId = new Map<string, OperationCheckContext>();
   private readonly registeredOperationInterestIds = new Set<string>();
+  private readonly scheduledInitialCheckOperationIds = new Set<string>();
   private readonly inFlightChecks = new Set<Promise<void>>();
 
   constructor(
@@ -206,6 +207,7 @@ export class MeltSettlementProcessor {
     this.inFlightOperationIds.clear();
     this.followUpCheckByOperationId.clear();
     this.registeredOperationInterestIds.clear();
+    this.scheduledInitialCheckOperationIds.clear();
     this.logger?.info('MeltSettlementProcessor stopped');
   }
 
@@ -247,16 +249,18 @@ export class MeltSettlementProcessor {
       method: operation.method,
       quoteId: operation.quoteId,
     });
-    if (!added) {
+    if (!added && !this.interestRegistrar) {
       return;
     }
 
-    this.logger?.debug('Registered melt settlement interest', {
-      operationId: operation.id,
-      mintUrl,
-      method: operation.method,
-      quoteId: operation.quoteId,
-    });
+    if (added) {
+      this.logger?.debug('Registered melt settlement interest', {
+        operationId: operation.id,
+        mintUrl,
+        method: operation.method,
+        quoteId: operation.quoteId,
+      });
+    }
 
     try {
       await this.interestRegistrar?.registerOperationInterest(interest);
@@ -264,7 +268,9 @@ export class MeltSettlementProcessor {
         this.registeredOperationInterestIds.add(operation.id);
       }
     } catch (err) {
-      this.interests.remove(operation.id);
+      if (added) {
+        this.interests.remove(operation.id);
+      }
       this.logger?.warn('Failed to register melt quote operation watch interest', {
         operationId: operation.id,
         mintUrl,
@@ -280,7 +286,7 @@ export class MeltSettlementProcessor {
       return;
     }
 
-    await this.checkInterestedOperation(operation.id, {
+    this.scheduleInitialOperationCheck(operation.id, {
       mintUrl,
       method: operation.method,
       quoteId: operation.quoteId,
@@ -294,9 +300,28 @@ export class MeltSettlementProcessor {
     }
 
     this.followUpCheckByOperationId.delete(operationId);
+    this.scheduledInitialCheckOperationIds.delete(operationId);
     this.logger?.debug('Removed melt settlement interest', { operationId });
 
     await this.removeRegisteredOperationInterest(operationId);
+  }
+
+  private scheduleInitialOperationCheck(operationId: string, context: OperationCheckContext): void {
+    if (this.scheduledInitialCheckOperationIds.has(operationId)) {
+      return;
+    }
+
+    this.scheduledInitialCheckOperationIds.add(operationId);
+    setTimeout(() => {
+      this.scheduledInitialCheckOperationIds.delete(operationId);
+
+      if (!this.running || !this.interests.has(operationId)) {
+        return;
+      }
+
+      // Pending events are emitted before MeltOperationService releases its per-operation lock.
+      void this.checkInterestedOperation(operationId, context);
+    }, 0);
   }
 
   private async removeRegisteredOperationInterest(operationId: string): Promise<void> {

--- a/packages/core/services/watchers/MeltSettlementProcessor.ts
+++ b/packages/core/services/watchers/MeltSettlementProcessor.ts
@@ -1,0 +1,290 @@
+import type { EventBus, CoreEvents } from '@core/events';
+import type { MeltQuoteOperationInterest } from '@core/services/watchers/MeltQuoteWatcherService.ts';
+import type { Logger } from '../../logging/Logger.ts';
+import type { MeltOperationService } from '../../operations/melt/MeltOperationService.ts';
+import type { MeltOperation, PendingMeltOperation } from '../../operations/melt/MeltOperation.ts';
+import type { MeltMethod } from '../../operations/melt/MeltMethodHandler.ts';
+import { normalizeMintUrl } from '../../utils.ts';
+
+type QuoteKey = string; // `${mintUrl}::${method}::${quoteId}`
+
+interface OperationInterestRegistrar {
+  registerOperationInterest(interest: MeltQuoteOperationInterest): Promise<void>;
+  removeOperationInterest(operationId: string): Promise<void>;
+}
+
+export interface MeltSettlementProcessorOptions {
+  initializeExistingPendingOperationsOnStart?: boolean;
+  interestRegistrar?: OperationInterestRegistrar;
+}
+
+function toKey(mintUrl: string, method: MeltMethod, quoteId: string): QuoteKey {
+  return `${normalizeMintUrl(mintUrl)}::${method}::${quoteId}`;
+}
+
+function isPendingMeltOperation(operation: MeltOperation): operation is PendingMeltOperation {
+  return operation.state === 'pending';
+}
+
+class MeltSettlementInterestRegistry {
+  private readonly operationIdsByQuoteKey = new Map<QuoteKey, Set<string>>();
+  private readonly quoteKeyByOperationId = new Map<string, QuoteKey>();
+
+  add(operation: PendingMeltOperation): boolean {
+    const key = toKey(operation.mintUrl, operation.method, operation.quoteId);
+    const existingKey = this.quoteKeyByOperationId.get(operation.id);
+    if (existingKey === key) {
+      return false;
+    }
+
+    if (existingKey) {
+      this.remove(operation.id);
+    }
+
+    let operationIds = this.operationIdsByQuoteKey.get(key);
+    if (!operationIds) {
+      operationIds = new Set<string>();
+      this.operationIdsByQuoteKey.set(key, operationIds);
+    }
+
+    operationIds.add(operation.id);
+    this.quoteKeyByOperationId.set(operation.id, key);
+    return true;
+  }
+
+  remove(operationId: string): boolean {
+    const key = this.quoteKeyByOperationId.get(operationId);
+    if (!key) {
+      return false;
+    }
+
+    this.quoteKeyByOperationId.delete(operationId);
+    const operationIds = this.operationIdsByQuoteKey.get(key);
+    operationIds?.delete(operationId);
+    if (operationIds?.size === 0) {
+      this.operationIdsByQuoteKey.delete(key);
+    }
+    return true;
+  }
+
+  getOperationIds(mintUrl: string, method: MeltMethod, quoteId: string): string[] {
+    return Array.from(this.operationIdsByQuoteKey.get(toKey(mintUrl, method, quoteId)) ?? []);
+  }
+
+  getAllOperationIds(): string[] {
+    return Array.from(this.quoteKeyByOperationId.keys());
+  }
+}
+
+export class MeltSettlementProcessor {
+  private readonly meltOperations: MeltOperationService;
+  private readonly bus: EventBus<CoreEvents>;
+  private readonly logger?: Logger;
+  private readonly options: Required<Omit<MeltSettlementProcessorOptions, 'interestRegistrar'>>;
+  private readonly interestRegistrar?: OperationInterestRegistrar;
+
+  private running = false;
+  private offPending?: () => void;
+  private offQuoteUpdated?: () => void;
+  private offFinalized?: () => void;
+  private offRolledBack?: () => void;
+  private readonly interests = new MeltSettlementInterestRegistry();
+  private readonly inFlightOperationIds = new Set<string>();
+  private readonly inFlightChecks = new Set<Promise<void>>();
+
+  constructor(
+    meltOperations: MeltOperationService,
+    bus: EventBus<CoreEvents>,
+    logger?: Logger,
+    options: MeltSettlementProcessorOptions = {},
+  ) {
+    this.meltOperations = meltOperations;
+    this.bus = bus;
+    this.logger = logger;
+    this.options = {
+      initializeExistingPendingOperationsOnStart:
+        options.initializeExistingPendingOperationsOnStart ?? true,
+    };
+    this.interestRegistrar = options.interestRegistrar;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    this.logger?.info('MeltSettlementProcessor started');
+
+    this.offPending = this.bus.on('melt-op:pending', async ({ operation }) => {
+      if (isPendingMeltOperation(operation)) {
+        await this.registerOperationInterest(operation);
+      }
+    });
+
+    this.offQuoteUpdated = this.bus.on(
+      'melt-quote:updated',
+      async ({ mintUrl, method, quoteId, quote }) => {
+        const operationIds = this.interests.getOperationIds(mintUrl, method, quoteId);
+        if (operationIds.length === 0) {
+          return;
+        }
+
+        await Promise.all(
+          operationIds.map((operationId) =>
+            this.checkInterestedOperation(operationId, {
+              mintUrl: quote.mintUrl,
+              method: quote.method,
+              quoteId: quote.quoteId,
+            }),
+          ),
+        );
+      },
+    );
+
+    this.offFinalized = this.bus.on('melt-op:finalized', async ({ operationId }) => {
+      await this.removeOperationInterest(operationId);
+    });
+
+    this.offRolledBack = this.bus.on('melt-op:rolled-back', async ({ operationId }) => {
+      await this.removeOperationInterest(operationId);
+    });
+
+    if (this.options.initializeExistingPendingOperationsOnStart) {
+      await this.initializeExistingPendingOperations();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+
+    const unsubscribe = (off: (() => void) | undefined) => {
+      try {
+        off?.();
+      } catch {
+        // ignore unsubscribe failures
+      }
+    };
+    unsubscribe(this.offPending);
+    unsubscribe(this.offQuoteUpdated);
+    unsubscribe(this.offFinalized);
+    unsubscribe(this.offRolledBack);
+    this.offPending = undefined;
+    this.offQuoteUpdated = undefined;
+    this.offFinalized = undefined;
+    this.offRolledBack = undefined;
+
+    while (this.inFlightChecks.size > 0) {
+      await Promise.allSettled(Array.from(this.inFlightChecks));
+    }
+
+    const operationIds = this.interests.getAllOperationIds();
+    for (const operationId of operationIds) {
+      await this.removeOperationInterest(operationId);
+    }
+    this.inFlightOperationIds.clear();
+    this.logger?.info('MeltSettlementProcessor stopped');
+  }
+
+  private async initializeExistingPendingOperations(): Promise<void> {
+    try {
+      const operations = await this.meltOperations.getPendingOperations();
+      for (const operation of operations) {
+        if (isPendingMeltOperation(operation)) {
+          await this.registerOperationInterest(operation);
+        }
+      }
+    } catch (err) {
+      this.logger?.warn('Failed to initialize pending melt settlement interest', { err });
+    }
+  }
+
+  private async registerOperationInterest(operation: PendingMeltOperation): Promise<void> {
+    const added = this.interests.add(operation);
+    if (!added) {
+      return;
+    }
+
+    this.logger?.debug('Registered melt settlement interest', {
+      operationId: operation.id,
+      mintUrl: operation.mintUrl,
+      method: operation.method,
+      quoteId: operation.quoteId,
+    });
+
+    try {
+      await this.interestRegistrar?.registerOperationInterest({
+        operationId: operation.id,
+        mintUrl: operation.mintUrl,
+        method: operation.method,
+        quoteId: operation.quoteId,
+      });
+    } catch (err) {
+      this.logger?.warn('Failed to register melt quote operation watch interest', {
+        operationId: operation.id,
+        mintUrl: operation.mintUrl,
+        method: operation.method,
+        quoteId: operation.quoteId,
+        err,
+      });
+    }
+  }
+
+  private async removeOperationInterest(operationId: string): Promise<void> {
+    const removed = this.interests.remove(operationId);
+    if (!removed) {
+      return;
+    }
+
+    this.logger?.debug('Removed melt settlement interest', { operationId });
+
+    try {
+      await this.interestRegistrar?.removeOperationInterest(operationId);
+    } catch (err) {
+      this.logger?.warn('Failed to remove melt quote operation watch interest', {
+        operationId,
+        err,
+      });
+    }
+  }
+
+  private checkInterestedOperation(
+    operationId: string,
+    quote: { mintUrl: string; method: MeltMethod; quoteId: string },
+  ): Promise<void> {
+    if (this.inFlightOperationIds.has(operationId)) {
+      this.logger?.debug('Melt settlement check already in flight', {
+        operationId,
+        mintUrl: quote.mintUrl,
+        method: quote.method,
+        quoteId: quote.quoteId,
+      });
+      return Promise.resolve();
+    }
+
+    this.inFlightOperationIds.add(operationId);
+    const check = (async () => {
+      try {
+        await this.meltOperations.checkPendingOperation(operationId);
+      } catch (err) {
+        this.logger?.warn('Failed to settle pending melt operation', {
+          operationId,
+          mintUrl: quote.mintUrl,
+          method: quote.method,
+          quoteId: quote.quoteId,
+          err,
+        });
+      } finally {
+        this.inFlightOperationIds.delete(operationId);
+      }
+    })();
+
+    this.inFlightChecks.add(check);
+    check.finally(() => {
+      this.inFlightChecks.delete(check);
+    });
+    return check;
+  }
+}

--- a/packages/core/services/watchers/MeltSettlementProcessor.ts
+++ b/packages/core/services/watchers/MeltSettlementProcessor.ts
@@ -8,6 +8,19 @@ import { normalizeMintUrl } from '../../utils.ts';
 
 type QuoteKey = string; // `${mintUrl}::${method}::${quoteId}`
 
+interface OperationQuoteInterest {
+  id: string;
+  mintUrl: string;
+  method: MeltMethod;
+  quoteId: string;
+}
+
+interface OperationCheckContext {
+  mintUrl: string;
+  method: MeltMethod;
+  quoteId: string;
+}
+
 interface OperationInterestRegistrar {
   registerOperationInterest(interest: MeltQuoteOperationInterest): Promise<void>;
   removeOperationInterest(operationId: string): Promise<void>;
@@ -30,7 +43,7 @@ class MeltSettlementInterestRegistry {
   private readonly operationIdsByQuoteKey = new Map<QuoteKey, Set<string>>();
   private readonly quoteKeyByOperationId = new Map<string, QuoteKey>();
 
-  add(operation: PendingMeltOperation): boolean {
+  add(operation: OperationQuoteInterest): boolean {
     const key = toKey(operation.mintUrl, operation.method, operation.quoteId);
     const existingKey = this.quoteKeyByOperationId.get(operation.id);
     if (existingKey === key) {
@@ -67,6 +80,10 @@ class MeltSettlementInterestRegistry {
     return true;
   }
 
+  has(operationId: string): boolean {
+    return this.quoteKeyByOperationId.has(operationId);
+  }
+
   getOperationIds(mintUrl: string, method: MeltMethod, quoteId: string): string[] {
     return Array.from(this.operationIdsByQuoteKey.get(toKey(mintUrl, method, quoteId)) ?? []);
   }
@@ -90,6 +107,8 @@ export class MeltSettlementProcessor {
   private offRolledBack?: () => void;
   private readonly interests = new MeltSettlementInterestRegistry();
   private readonly inFlightOperationIds = new Set<string>();
+  private readonly followUpCheckByOperationId = new Map<string, OperationCheckContext>();
+  private readonly registeredOperationInterestIds = new Set<string>();
   private readonly inFlightChecks = new Set<Promise<void>>();
 
   constructor(
@@ -185,13 +204,22 @@ export class MeltSettlementProcessor {
       await this.removeOperationInterest(operationId);
     }
     this.inFlightOperationIds.clear();
+    this.followUpCheckByOperationId.clear();
+    this.registeredOperationInterestIds.clear();
     this.logger?.info('MeltSettlementProcessor stopped');
   }
 
   private async initializeExistingPendingOperations(): Promise<void> {
     try {
       const operations = await this.meltOperations.getPendingOperations();
+      if (!this.running) {
+        return;
+      }
+
       for (const operation of operations) {
+        if (!this.running) {
+          return;
+        }
         if (isPendingMeltOperation(operation)) {
           await this.registerOperationInterest(operation);
         }
@@ -202,34 +230,61 @@ export class MeltSettlementProcessor {
   }
 
   private async registerOperationInterest(operation: PendingMeltOperation): Promise<void> {
-    const added = this.interests.add(operation);
+    if (!this.running) {
+      return;
+    }
+
+    const mintUrl = normalizeMintUrl(operation.mintUrl);
+    const interest = {
+      operationId: operation.id,
+      mintUrl,
+      method: operation.method,
+      quoteId: operation.quoteId,
+    };
+    const added = this.interests.add({
+      id: operation.id,
+      mintUrl,
+      method: operation.method,
+      quoteId: operation.quoteId,
+    });
     if (!added) {
       return;
     }
 
     this.logger?.debug('Registered melt settlement interest', {
       operationId: operation.id,
-      mintUrl: operation.mintUrl,
+      mintUrl,
       method: operation.method,
       quoteId: operation.quoteId,
     });
 
     try {
-      await this.interestRegistrar?.registerOperationInterest({
-        operationId: operation.id,
-        mintUrl: operation.mintUrl,
-        method: operation.method,
-        quoteId: operation.quoteId,
-      });
+      await this.interestRegistrar?.registerOperationInterest(interest);
+      if (this.interestRegistrar) {
+        this.registeredOperationInterestIds.add(operation.id);
+      }
     } catch (err) {
+      this.interests.remove(operation.id);
       this.logger?.warn('Failed to register melt quote operation watch interest', {
         operationId: operation.id,
-        mintUrl: operation.mintUrl,
+        mintUrl,
         method: operation.method,
         quoteId: operation.quoteId,
         err,
       });
+      return;
     }
+
+    if (!this.running || !this.interests.has(operation.id)) {
+      await this.removeRegisteredOperationInterest(operation.id);
+      return;
+    }
+
+    await this.checkInterestedOperation(operation.id, {
+      mintUrl,
+      method: operation.method,
+      quoteId: operation.quoteId,
+    });
   }
 
   private async removeOperationInterest(operationId: string): Promise<void> {
@@ -238,7 +293,17 @@ export class MeltSettlementProcessor {
       return;
     }
 
+    this.followUpCheckByOperationId.delete(operationId);
     this.logger?.debug('Removed melt settlement interest', { operationId });
+
+    await this.removeRegisteredOperationInterest(operationId);
+  }
+
+  private async removeRegisteredOperationInterest(operationId: string): Promise<void> {
+    const wasRegistered = this.registeredOperationInterestIds.delete(operationId);
+    if (!wasRegistered) {
+      return;
+    }
 
     try {
       await this.interestRegistrar?.removeOperationInterest(operationId);
@@ -254,37 +319,65 @@ export class MeltSettlementProcessor {
     operationId: string,
     quote: { mintUrl: string; method: MeltMethod; quoteId: string },
   ): Promise<void> {
+    const context = {
+      mintUrl: normalizeMintUrl(quote.mintUrl),
+      method: quote.method,
+      quoteId: quote.quoteId,
+    };
+
     if (this.inFlightOperationIds.has(operationId)) {
+      this.followUpCheckByOperationId.set(operationId, context);
       this.logger?.debug('Melt settlement check already in flight', {
         operationId,
-        mintUrl: quote.mintUrl,
-        method: quote.method,
-        quoteId: quote.quoteId,
+        mintUrl: context.mintUrl,
+        method: context.method,
+        quoteId: context.quoteId,
       });
       return Promise.resolve();
     }
 
-    this.inFlightOperationIds.add(operationId);
-    const check = (async () => {
-      try {
-        await this.meltOperations.checkPendingOperation(operationId);
-      } catch (err) {
-        this.logger?.warn('Failed to settle pending melt operation', {
-          operationId,
-          mintUrl: quote.mintUrl,
-          method: quote.method,
-          quoteId: quote.quoteId,
-          err,
-        });
-      } finally {
-        this.inFlightOperationIds.delete(operationId);
-      }
-    })();
+    const check = this.runOperationCheckLoop(operationId, context);
 
     this.inFlightChecks.add(check);
     check.finally(() => {
       this.inFlightChecks.delete(check);
     });
     return check;
+  }
+
+  private async runOperationCheckLoop(
+    operationId: string,
+    initialContext: OperationCheckContext,
+  ): Promise<void> {
+    this.inFlightOperationIds.add(operationId);
+    let nextContext: OperationCheckContext | undefined = initialContext;
+
+    try {
+      while (nextContext) {
+        const context = nextContext;
+        nextContext = undefined;
+
+        try {
+          await this.meltOperations.checkPendingOperation(operationId);
+        } catch (err) {
+          this.logger?.warn('Failed to settle pending melt operation', {
+            operationId,
+            mintUrl: context.mintUrl,
+            method: context.method,
+            quoteId: context.quoteId,
+            err,
+          });
+        }
+
+        const followUpContext = this.followUpCheckByOperationId.get(operationId);
+        if (followUpContext) {
+          this.followUpCheckByOperationId.delete(operationId);
+          nextContext = followUpContext;
+        }
+      }
+    } finally {
+      this.inFlightOperationIds.delete(operationId);
+      this.followUpCheckByOperationId.delete(operationId);
+    }
   }
 }

--- a/packages/core/services/watchers/index.ts
+++ b/packages/core/services/watchers/index.ts
@@ -1,4 +1,5 @@
 export * from './MintOperationWatcherService';
 export * from './MintOperationProcessor';
 export * from './MeltQuoteWatcherService';
+export * from './MeltSettlementProcessor';
 export * from './ProofStateWatcherService';

--- a/packages/core/test/unit/MeltSettlementProcessor.test.ts
+++ b/packages/core/test/unit/MeltSettlementProcessor.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
 import { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { Logger } from '../../logging/Logger.ts';
+import { OperationInProgressError } from '../../models/Error.ts';
 import type { MeltQuote } from '../../models/MeltQuote.ts';
 import type {
   FinalizedMeltOperation,
@@ -91,8 +92,15 @@ describe('MeltSettlementProcessor', () => {
       quote,
     });
 
+  const flushDeferredInitialChecks = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  };
+
   const registerPendingAndClearInitialCheck = async (operation = makePendingOperation()) => {
     await emitPending(operation);
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+    await flushDeferredInitialChecks();
     expect(checkPendingOperation).toHaveBeenCalledWith(operation.id);
     checkPendingOperation.mockClear();
   };
@@ -126,60 +134,99 @@ describe('MeltSettlementProcessor', () => {
     );
   });
 
-  it('registers operation interest and checks immediately when a melt operation enters pending', async () => {
+  it(
+    'registers operation interest and defers the initial check when a melt operation enters pending',
+    async () => {
+      await processor.start();
+
+      await emitPending();
+
+      expect(registerOperationInterest).toHaveBeenCalledWith({
+        operationId: 'melt-op-1',
+        mintUrl,
+        method: 'bolt11',
+        quoteId,
+      });
+      expect(checkPendingOperation).not.toHaveBeenCalled();
+
+      await flushDeferredInitialChecks();
+
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+      expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+
+      checkPendingOperation.mockClear();
+
+      await emitQuoteUpdated();
+
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+      expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+    },
+  );
+
+  it('does not run the initial pending-event check before the event handler returns', async () => {
+    let pendingEventReturned = false;
+    checkPendingOperation.mockImplementation(async () => {
+      if (!pendingEventReturned) {
+        throw new OperationInProgressError('melt-op-1');
+      }
+      return 'stay_pending';
+    });
     await processor.start();
 
     await emitPending();
 
-    expect(registerOperationInterest).toHaveBeenCalledWith({
-      operationId: 'melt-op-1',
-      mintUrl,
-      method: 'bolt11',
-      quoteId,
-    });
-    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
 
-    checkPendingOperation.mockClear();
-
-    await emitQuoteUpdated();
+    pendingEventReturned = true;
+    await flushDeferredInitialChecks();
 
     expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it('initializes operation interest and checks existing pending melt operations on startup', async () => {
-    const pending = makePendingOperation({ id: 'existing-pending' });
-    getPendingOperations.mockResolvedValueOnce([
-      pending,
-      { ...pending, id: 'existing-executing', state: 'executing' },
-    ]);
+  it(
+    'initializes operation interest and checks existing pending melt operations on startup',
+    async () => {
+      const pending = makePendingOperation({ id: 'existing-pending' });
+      getPendingOperations.mockResolvedValueOnce([
+        pending,
+        { ...pending, id: 'existing-executing', state: 'executing' },
+      ]);
 
-    await processor.start();
+      await processor.start();
 
-    expect(registerOperationInterest).toHaveBeenCalledTimes(1);
-    expect(registerOperationInterest).toHaveBeenCalledWith({
-      operationId: 'existing-pending',
-      mintUrl,
-      method: 'bolt11',
-      quoteId,
-    });
-    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-    expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
+      expect(registerOperationInterest).toHaveBeenCalledTimes(1);
+      expect(registerOperationInterest).toHaveBeenCalledWith({
+        operationId: 'existing-pending',
+        mintUrl,
+        method: 'bolt11',
+        quoteId,
+      });
+      expect(checkPendingOperation).not.toHaveBeenCalled();
 
-    checkPendingOperation.mockClear();
+      await flushDeferredInitialChecks();
 
-    await emitQuoteUpdated();
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+      expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
 
-    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-    expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
-  });
+      checkPendingOperation.mockClear();
+
+      await emitQuoteUpdated();
+
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+      expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
+    },
+  );
 
   it('checks only operation ids with exact interest in the updated quote', async () => {
     await processor.start();
-    await emitPending(makePendingOperation({ id: 'interested-a', quoteId: 'quote-a' }));
-    await emitPending(makePendingOperation({ id: 'interested-b', quoteId: 'quote-b' }));
-    checkPendingOperation.mockClear();
+    await registerPendingAndClearInitialCheck(
+      makePendingOperation({ id: 'interested-a', quoteId: 'quote-a' }),
+    );
+    await registerPendingAndClearInitialCheck(
+      makePendingOperation({ id: 'interested-b', quoteId: 'quote-b' }),
+    );
 
     await emitQuoteUpdated(makeQuote({ quoteId: 'quote-a', quote: 'quote-a' }));
 
@@ -231,6 +278,48 @@ describe('MeltSettlementProcessor', () => {
     await first;
     expect(checkPendingOperation).toHaveBeenCalledTimes(2);
   });
+
+  it(
+    'reattempts watcher registration for duplicate pending interest without concurrent checks',
+    async () => {
+      await processor.start();
+      await registerPendingAndClearInitialCheck();
+      registerOperationInterest.mockClear();
+
+      let resolveCheck: ((value: 'stay_pending') => void) | undefined;
+      checkPendingOperation.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCheck = resolve;
+          }),
+      );
+
+      const inFlightNotification = emitQuoteUpdated();
+      await Promise.resolve();
+
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+
+      await emitPending();
+
+      expect(registerOperationInterest).toHaveBeenCalledTimes(1);
+      expect(registerOperationInterest).toHaveBeenCalledWith({
+        operationId: 'melt-op-1',
+        mintUrl,
+        method: 'bolt11',
+        quoteId,
+      });
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+
+      await flushDeferredInitialChecks();
+
+      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+
+      resolveCheck?.('stay_pending');
+      await inFlightNotification;
+
+      expect(checkPendingOperation).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it('logs processor failures without retrying until a future notification arrives', async () => {
     await processor.start();
@@ -353,6 +442,10 @@ describe('MeltSettlementProcessor', () => {
 
     expect(registerOperationInterest).toHaveBeenCalledTimes(2);
     expect(removeOperationInterest).not.toHaveBeenCalled();
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+
+    await flushDeferredInitialChecks();
+
     expect(checkPendingOperation).toHaveBeenCalledTimes(1);
     expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
   });
@@ -389,5 +482,7 @@ describe('MeltSettlementProcessor', () => {
       method: 'bolt11',
       quoteId,
     });
+
+    await flushDeferredInitialChecks();
   });
 });

--- a/packages/core/test/unit/MeltSettlementProcessor.test.ts
+++ b/packages/core/test/unit/MeltSettlementProcessor.test.ts
@@ -91,6 +91,12 @@ describe('MeltSettlementProcessor', () => {
       quote,
     });
 
+  const registerPendingAndClearInitialCheck = async (operation = makePendingOperation()) => {
+    await emitPending(operation);
+    expect(checkPendingOperation).toHaveBeenCalledWith(operation.id);
+    checkPendingOperation.mockClear();
+  };
+
   beforeEach(() => {
     bus = new EventBus<CoreEvents>();
     checkPendingOperation = mock(async () => 'stay_pending');
@@ -120,7 +126,7 @@ describe('MeltSettlementProcessor', () => {
     );
   });
 
-  it('registers operation interest when a melt operation enters pending', async () => {
+  it('registers operation interest and checks immediately when a melt operation enters pending', async () => {
     await processor.start();
 
     await emitPending();
@@ -131,13 +137,18 @@ describe('MeltSettlementProcessor', () => {
       method: 'bolt11',
       quoteId,
     });
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+
+    checkPendingOperation.mockClear();
 
     await emitQuoteUpdated();
 
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
     expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
   });
 
-  it('initializes operation interest for existing pending melt operations on startup', async () => {
+  it('initializes operation interest and checks existing pending melt operations on startup', async () => {
     const pending = makePendingOperation({ id: 'existing-pending' });
     getPendingOperations.mockResolvedValueOnce([
       pending,
@@ -153,9 +164,14 @@ describe('MeltSettlementProcessor', () => {
       method: 'bolt11',
       quoteId,
     });
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
+
+    checkPendingOperation.mockClear();
 
     await emitQuoteUpdated();
 
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
     expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
   });
 
@@ -163,6 +179,7 @@ describe('MeltSettlementProcessor', () => {
     await processor.start();
     await emitPending(makePendingOperation({ id: 'interested-a', quoteId: 'quote-a' }));
     await emitPending(makePendingOperation({ id: 'interested-b', quoteId: 'quote-b' }));
+    checkPendingOperation.mockClear();
 
     await emitQuoteUpdated(makeQuote({ quoteId: 'quote-a', quote: 'quote-a' }));
 
@@ -173,7 +190,7 @@ describe('MeltSettlementProcessor', () => {
     'checks interested operations when the observed quote state is %s',
     async (state) => {
       await processor.start();
-      await emitPending();
+      await registerPendingAndClearInitialCheck();
 
       await emitQuoteUpdated(makeQuote({ state }));
 
@@ -189,7 +206,10 @@ describe('MeltSettlementProcessor', () => {
     expect(checkPendingOperation).not.toHaveBeenCalled();
   });
 
-  it('suppresses concurrent checks for the same operation', async () => {
+  it('collapses in-flight duplicate checks into one follow-up for the same operation', async () => {
+    await processor.start();
+    await registerPendingAndClearInitialCheck();
+
     let resolveCheck: ((value: 'stay_pending') => void) | undefined;
     checkPendingOperation.mockImplementationOnce(
       () =>
@@ -197,23 +217,26 @@ describe('MeltSettlementProcessor', () => {
           resolveCheck = resolve;
         }),
     );
-    await processor.start();
-    await emitPending();
 
     const first = emitQuoteUpdated();
     await Promise.resolve();
-    await emitQuoteUpdated();
+    await Promise.all([emitQuoteUpdated(), emitQuoteUpdated()]);
 
     expect(checkPendingOperation).toHaveBeenCalledTimes(1);
 
     resolveCheck?.('stay_pending');
+    await Promise.resolve();
+
+    expect(checkPendingOperation).toHaveBeenCalledTimes(2);
     await first;
+    expect(checkPendingOperation).toHaveBeenCalledTimes(2);
   });
 
   it('logs processor failures without retrying until a future notification arrives', async () => {
-    checkPendingOperation.mockRejectedValueOnce(new Error('mint unavailable'));
     await processor.start();
-    await emitPending();
+    await registerPendingAndClearInitialCheck();
+
+    checkPendingOperation.mockRejectedValueOnce(new Error('mint unavailable'));
 
     await emitQuoteUpdated();
     await Promise.resolve();
@@ -234,7 +257,7 @@ describe('MeltSettlementProcessor', () => {
 
   it('removes operation interest when an operation finalizes', async () => {
     await processor.start();
-    await emitPending();
+    await registerPendingAndClearInitialCheck();
 
     await bus.emit('melt-op:finalized', {
       mintUrl,
@@ -249,7 +272,7 @@ describe('MeltSettlementProcessor', () => {
 
   it('removes operation interest when an operation rolls back', async () => {
     await processor.start();
-    await emitPending();
+    await registerPendingAndClearInitialCheck();
 
     await bus.emit('melt-op:rolled-back', {
       mintUrl,
@@ -266,7 +289,7 @@ describe('MeltSettlementProcessor', () => {
     expect(processor.isRunning()).toBe(false);
 
     await processor.start();
-    await emitPending();
+    await registerPendingAndClearInitialCheck();
 
     expect(processor.isRunning()).toBe(true);
 
@@ -281,6 +304,9 @@ describe('MeltSettlementProcessor', () => {
   });
 
   it('waits for in-flight checks before removing interests on stop', async () => {
+    await processor.start();
+    await registerPendingAndClearInitialCheck();
+
     let resolveCheck: ((value: 'stay_pending') => void) | undefined;
     checkPendingOperation.mockImplementationOnce(
       () =>
@@ -288,8 +314,6 @@ describe('MeltSettlementProcessor', () => {
           resolveCheck = resolve;
         }),
     );
-    await processor.start();
-    await emitPending();
 
     const notification = emitQuoteUpdated();
     await Promise.resolve();
@@ -305,5 +329,65 @@ describe('MeltSettlementProcessor', () => {
 
     expect(removeOperationInterest).toHaveBeenCalledWith('melt-op-1');
     expect(processor.isRunning()).toBe(false);
+  });
+
+  it('retries registration after registrar registration fails', async () => {
+    const err = new Error('watch unavailable');
+    registerOperationInterest.mockRejectedValueOnce(err);
+    await processor.start();
+
+    await emitPending();
+
+    expect(registerOperationInterest).toHaveBeenCalledTimes(1);
+    expect(removeOperationInterest).not.toHaveBeenCalled();
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith('Failed to register melt quote operation watch interest', {
+      operationId: 'melt-op-1',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+      err,
+    });
+
+    await emitPending();
+
+    expect(registerOperationInterest).toHaveBeenCalledTimes(2);
+    expect(removeOperationInterest).not.toHaveBeenCalled();
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+  });
+
+  it('does not register startup pending operations after stop', async () => {
+    let resolvePendingOperations: ((operations: PendingMeltOperation[]) => void) | undefined;
+    getPendingOperations.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePendingOperations = resolve;
+        }),
+    );
+
+    const starting = processor.start();
+    await Promise.resolve();
+
+    await processor.stop();
+
+    resolvePendingOperations?.([makePendingOperation({ id: 'late-startup-pending' })]);
+    await starting;
+
+    expect(registerOperationInterest).not.toHaveBeenCalled();
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+  });
+
+  it('normalizes mint URLs before registering watcher interest', async () => {
+    await processor.start();
+
+    await emitPending(makePendingOperation({ mintUrl: `${mintUrl}/` }));
+
+    expect(registerOperationInterest).toHaveBeenCalledWith({
+      operationId: 'melt-op-1',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+    });
   });
 });

--- a/packages/core/test/unit/MeltSettlementProcessor.test.ts
+++ b/packages/core/test/unit/MeltSettlementProcessor.test.ts
@@ -134,34 +134,31 @@ describe('MeltSettlementProcessor', () => {
     );
   });
 
-  it(
-    'registers operation interest and defers the initial check when a melt operation enters pending',
-    async () => {
-      await processor.start();
+  it('registers operation interest and defers the initial check when a melt operation enters pending', async () => {
+    await processor.start();
 
-      await emitPending();
+    await emitPending();
 
-      expect(registerOperationInterest).toHaveBeenCalledWith({
-        operationId: 'melt-op-1',
-        mintUrl,
-        method: 'bolt11',
-        quoteId,
-      });
-      expect(checkPendingOperation).not.toHaveBeenCalled();
+    expect(registerOperationInterest).toHaveBeenCalledWith({
+      operationId: 'melt-op-1',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+    });
+    expect(checkPendingOperation).not.toHaveBeenCalled();
 
-      await flushDeferredInitialChecks();
+    await flushDeferredInitialChecks();
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-      expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
 
-      checkPendingOperation.mockClear();
+    checkPendingOperation.mockClear();
 
-      await emitQuoteUpdated();
+    await emitQuoteUpdated();
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-      expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
-    },
-  );
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+  });
 
   it('does not run the initial pending-event check before the event handler returns', async () => {
     let pendingEventReturned = false;
@@ -185,39 +182,36 @@ describe('MeltSettlementProcessor', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it(
-    'initializes operation interest and checks existing pending melt operations on startup',
-    async () => {
-      const pending = makePendingOperation({ id: 'existing-pending' });
-      getPendingOperations.mockResolvedValueOnce([
-        pending,
-        { ...pending, id: 'existing-executing', state: 'executing' },
-      ]);
+  it('initializes operation interest and checks existing pending melt operations on startup', async () => {
+    const pending = makePendingOperation({ id: 'existing-pending' });
+    getPendingOperations.mockResolvedValueOnce([
+      pending,
+      { ...pending, id: 'existing-executing', state: 'executing' },
+    ]);
 
-      await processor.start();
+    await processor.start();
 
-      expect(registerOperationInterest).toHaveBeenCalledTimes(1);
-      expect(registerOperationInterest).toHaveBeenCalledWith({
-        operationId: 'existing-pending',
-        mintUrl,
-        method: 'bolt11',
-        quoteId,
-      });
-      expect(checkPendingOperation).not.toHaveBeenCalled();
+    expect(registerOperationInterest).toHaveBeenCalledTimes(1);
+    expect(registerOperationInterest).toHaveBeenCalledWith({
+      operationId: 'existing-pending',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+    });
+    expect(checkPendingOperation).not.toHaveBeenCalled();
 
-      await flushDeferredInitialChecks();
+    await flushDeferredInitialChecks();
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-      expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
 
-      checkPendingOperation.mockClear();
+    checkPendingOperation.mockClear();
 
-      await emitQuoteUpdated();
+    await emitQuoteUpdated();
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
-      expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
-    },
-  );
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
+  });
 
   it('checks only operation ids with exact interest in the updated quote', async () => {
     await processor.start();
@@ -279,47 +273,44 @@ describe('MeltSettlementProcessor', () => {
     expect(checkPendingOperation).toHaveBeenCalledTimes(2);
   });
 
-  it(
-    'reattempts watcher registration for duplicate pending interest without concurrent checks',
-    async () => {
-      await processor.start();
-      await registerPendingAndClearInitialCheck();
-      registerOperationInterest.mockClear();
+  it('reattempts watcher registration for duplicate pending interest without concurrent checks', async () => {
+    await processor.start();
+    await registerPendingAndClearInitialCheck();
+    registerOperationInterest.mockClear();
 
-      let resolveCheck: ((value: 'stay_pending') => void) | undefined;
-      checkPendingOperation.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveCheck = resolve;
-          }),
-      );
+    let resolveCheck: ((value: 'stay_pending') => void) | undefined;
+    checkPendingOperation.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCheck = resolve;
+        }),
+    );
 
-      const inFlightNotification = emitQuoteUpdated();
-      await Promise.resolve();
+    const inFlightNotification = emitQuoteUpdated();
+    await Promise.resolve();
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
 
-      await emitPending();
+    await emitPending();
 
-      expect(registerOperationInterest).toHaveBeenCalledTimes(1);
-      expect(registerOperationInterest).toHaveBeenCalledWith({
-        operationId: 'melt-op-1',
-        mintUrl,
-        method: 'bolt11',
-        quoteId,
-      });
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(registerOperationInterest).toHaveBeenCalledTimes(1);
+    expect(registerOperationInterest).toHaveBeenCalledWith({
+      operationId: 'melt-op-1',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+    });
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
 
-      await flushDeferredInitialChecks();
+    await flushDeferredInitialChecks();
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
 
-      resolveCheck?.('stay_pending');
-      await inFlightNotification;
+    resolveCheck?.('stay_pending');
+    await inFlightNotification;
 
-      expect(checkPendingOperation).toHaveBeenCalledTimes(2);
-    },
-  );
+    expect(checkPendingOperation).toHaveBeenCalledTimes(2);
+  });
 
   it('logs processor failures without retrying until a future notification arrives', async () => {
     await processor.start();

--- a/packages/core/test/unit/MeltSettlementProcessor.test.ts
+++ b/packages/core/test/unit/MeltSettlementProcessor.test.ts
@@ -1,0 +1,309 @@
+import { Amount } from '@cashu/cashu-ts';
+import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
+import { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+import type { Logger } from '../../logging/Logger.ts';
+import type { MeltQuote } from '../../models/MeltQuote.ts';
+import type {
+  FinalizedMeltOperation,
+  PendingMeltOperation,
+  RolledBackMeltOperation,
+} from '../../operations/melt/MeltOperation.ts';
+import type { MeltOperationService } from '../../operations/melt/MeltOperationService.ts';
+import type { MeltQuoteWatcherService } from '../../services/watchers/MeltQuoteWatcherService.ts';
+import { MeltSettlementProcessor } from '../../services/watchers/MeltSettlementProcessor.ts';
+
+describe('MeltSettlementProcessor', () => {
+  const mintUrl = 'https://mint.test';
+  const quoteId = 'melt-quote-1';
+
+  let bus: EventBus<CoreEvents>;
+  let checkPendingOperation: Mock<any>;
+  let getPendingOperations: Mock<any>;
+  let registerOperationInterest: Mock<any>;
+  let removeOperationInterest: Mock<any>;
+  let logger: Logger;
+  let warn: Mock<any>;
+  let processor: MeltSettlementProcessor;
+
+  const makePendingOperation = (
+    overrides: Partial<PendingMeltOperation> = {},
+  ): PendingMeltOperation => ({
+    id: 'melt-op-1',
+    mintUrl,
+    method: 'bolt11',
+    methodData: { invoice: 'lnbc1test' },
+    unit: 'sat',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    state: 'pending',
+    needsSwap: false,
+    amount: Amount.from(10),
+    fee_reserve: Amount.from(1),
+    quoteId,
+    swap_fee: Amount.zero(),
+    inputAmount: Amount.from(11),
+    inputProofSecrets: ['input-secret'],
+    changeOutputData: { keep: [], send: [] },
+    ...overrides,
+  });
+
+  const makeQuote = (overrides: Partial<MeltQuote<'bolt11'>> = {}): MeltQuote<'bolt11'> => ({
+    mintUrl,
+    method: 'bolt11',
+    quoteId,
+    quote: quoteId,
+    request: 'lnbc1test',
+    amount: Amount.from(10),
+    unit: 'sat',
+    fee_reserve: Amount.from(1),
+    expiry: Math.floor(Date.now() / 1000) + 3600,
+    state: 'PENDING',
+    payment_preimage: null,
+    change: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  });
+
+  const makeFinalizedOperation = (): FinalizedMeltOperation => ({
+    ...makePendingOperation(),
+    state: 'finalized',
+  });
+
+  const makeRolledBackOperation = (): RolledBackMeltOperation => ({
+    ...makePendingOperation(),
+    state: 'rolled_back',
+  });
+
+  const emitPending = (operation = makePendingOperation()) =>
+    bus.emit('melt-op:pending', {
+      mintUrl: operation.mintUrl,
+      operationId: operation.id,
+      operation,
+    });
+
+  const emitQuoteUpdated = (quote = makeQuote()) =>
+    bus.emit('melt-quote:updated', {
+      mintUrl: quote.mintUrl,
+      method: quote.method,
+      quoteId: quote.quoteId,
+      quote,
+    });
+
+  beforeEach(() => {
+    bus = new EventBus<CoreEvents>();
+    checkPendingOperation = mock(async () => 'stay_pending');
+    getPendingOperations = mock(async () => []);
+    registerOperationInterest = mock(async () => {});
+    removeOperationInterest = mock(async () => {});
+    warn = mock(() => {});
+    logger = {
+      debug: mock(() => {}),
+      info: mock(() => {}),
+      warn,
+      error: mock(() => {}),
+    };
+    processor = new MeltSettlementProcessor(
+      {
+        checkPendingOperation,
+        getPendingOperations,
+      } as unknown as MeltOperationService,
+      bus,
+      logger,
+      {
+        interestRegistrar: {
+          registerOperationInterest,
+          removeOperationInterest,
+        } as unknown as MeltQuoteWatcherService,
+      },
+    );
+  });
+
+  it('registers operation interest when a melt operation enters pending', async () => {
+    await processor.start();
+
+    await emitPending();
+
+    expect(registerOperationInterest).toHaveBeenCalledWith({
+      operationId: 'melt-op-1',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+    });
+
+    await emitQuoteUpdated();
+
+    expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+  });
+
+  it('initializes operation interest for existing pending melt operations on startup', async () => {
+    const pending = makePendingOperation({ id: 'existing-pending' });
+    getPendingOperations.mockResolvedValueOnce([
+      pending,
+      { ...pending, id: 'existing-executing', state: 'executing' },
+    ]);
+
+    await processor.start();
+
+    expect(registerOperationInterest).toHaveBeenCalledTimes(1);
+    expect(registerOperationInterest).toHaveBeenCalledWith({
+      operationId: 'existing-pending',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+    });
+
+    await emitQuoteUpdated();
+
+    expect(checkPendingOperation).toHaveBeenCalledWith('existing-pending');
+  });
+
+  it('checks only operation ids with exact interest in the updated quote', async () => {
+    await processor.start();
+    await emitPending(makePendingOperation({ id: 'interested-a', quoteId: 'quote-a' }));
+    await emitPending(makePendingOperation({ id: 'interested-b', quoteId: 'quote-b' }));
+
+    await emitQuoteUpdated(makeQuote({ quoteId: 'quote-a', quote: 'quote-a' }));
+
+    expect(checkPendingOperation.mock.calls.map((call) => call[0])).toEqual(['interested-a']);
+  });
+
+  it.each(['PAID', 'PENDING', 'UNPAID'] as const)(
+    'checks interested operations when the observed quote state is %s',
+    async (state) => {
+      await processor.start();
+      await emitPending();
+
+      await emitQuoteUpdated(makeQuote({ state }));
+
+      expect(checkPendingOperation).toHaveBeenCalledWith('melt-op-1');
+    },
+  );
+
+  it('does nothing for quote updates without operation interest', async () => {
+    await processor.start();
+
+    await emitQuoteUpdated();
+
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+  });
+
+  it('suppresses concurrent checks for the same operation', async () => {
+    let resolveCheck: ((value: 'stay_pending') => void) | undefined;
+    checkPendingOperation.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCheck = resolve;
+        }),
+    );
+    await processor.start();
+    await emitPending();
+
+    const first = emitQuoteUpdated();
+    await Promise.resolve();
+    await emitQuoteUpdated();
+
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+
+    resolveCheck?.('stay_pending');
+    await first;
+  });
+
+  it('logs processor failures without retrying until a future notification arrives', async () => {
+    checkPendingOperation.mockRejectedValueOnce(new Error('mint unavailable'));
+    await processor.start();
+    await emitPending();
+
+    await emitQuoteUpdated();
+    await Promise.resolve();
+
+    expect(checkPendingOperation).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('Failed to settle pending melt operation', {
+      operationId: 'melt-op-1',
+      mintUrl,
+      method: 'bolt11',
+      quoteId,
+      err: expect.any(Error),
+    });
+
+    await emitQuoteUpdated();
+
+    expect(checkPendingOperation).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes operation interest when an operation finalizes', async () => {
+    await processor.start();
+    await emitPending();
+
+    await bus.emit('melt-op:finalized', {
+      mintUrl,
+      operationId: 'melt-op-1',
+      operation: makeFinalizedOperation(),
+    });
+    await emitQuoteUpdated();
+
+    expect(removeOperationInterest).toHaveBeenCalledWith('melt-op-1');
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+  });
+
+  it('removes operation interest when an operation rolls back', async () => {
+    await processor.start();
+    await emitPending();
+
+    await bus.emit('melt-op:rolled-back', {
+      mintUrl,
+      operationId: 'melt-op-1',
+      operation: makeRolledBackOperation(),
+    });
+    await emitQuoteUpdated();
+
+    expect(removeOperationInterest).toHaveBeenCalledWith('melt-op-1');
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+  });
+
+  it('reports running state and removes registered interests on stop', async () => {
+    expect(processor.isRunning()).toBe(false);
+
+    await processor.start();
+    await emitPending();
+
+    expect(processor.isRunning()).toBe(true);
+
+    await processor.stop();
+
+    expect(processor.isRunning()).toBe(false);
+    expect(removeOperationInterest).toHaveBeenCalledWith('melt-op-1');
+
+    await emitQuoteUpdated();
+
+    expect(checkPendingOperation).not.toHaveBeenCalled();
+  });
+
+  it('waits for in-flight checks before removing interests on stop', async () => {
+    let resolveCheck: ((value: 'stay_pending') => void) | undefined;
+    checkPendingOperation.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCheck = resolve;
+        }),
+    );
+    await processor.start();
+    await emitPending();
+
+    const notification = emitQuoteUpdated();
+    await Promise.resolve();
+
+    const stopped = processor.stop();
+    await Promise.resolve();
+
+    expect(removeOperationInterest).not.toHaveBeenCalled();
+
+    resolveCheck?.('stay_pending');
+    await notification;
+    await stopped;
+
+    expect(removeOperationInterest).toHaveBeenCalledWith('melt-op-1');
+    expect(processor.isRunning()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add MeltSettlementProcessor for issue #271.
- Track exact pending melt operation interest by mint/method/quote id and operation id.
- React to canonical melt-quote:updated events by calling the existing pending melt operation saga.
- Remove operation interest on finalized/rolled-back melt operations and suppress duplicate in-flight checks.
- Add focused unit coverage and a core changeset.

## Scope

Closes #271.
Parent PRD: #267.

This PR intentionally does not wire the processor into Manager lifecycle; that remains #272.

## Validation

- bun run --filter='@cashu/coco-core' test -- test/unit/MeltSettlementProcessor.test.ts
- bun run --filter='@cashu/coco-core' typecheck
- bun run --filter='@cashu/coco-core' test -- test/unit/MeltSettlementProcessor.test.ts test/unit/MeltQuoteWatcherService.test.ts test/unit/MeltOperationService.test.ts
- bun run --filter='@cashu/coco-core' build
- git diff --check origin/master...HEAD
- bun run --filter='@cashu/coco-core' test:unit

Note: the worker also attempted the full core test suite; unit tests passed, but integration tests require live mint/test environment setup in this checkout.