### PR TITLE
feat(core): wire melt settlement into manager lifecycle

### DIFF
--- a/.changeset/melt-manager-lifecycle.md
+++ b/.changeset/melt-manager-lifecycle.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Start melt quote watching and melt settlement processing from the manager lifecycle by default,
+including pause, resume, disposal, and startup scans for pending melt quote and operation state.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -505,7 +505,10 @@ export class Manager {
     watchExistingPendingQuotesOnStart?: boolean;
   }): Promise<void> {
     if (this.disposed) return;
-    if (this.meltQuoteWatcher?.isRunning()) return;
+    if (this.meltQuoteWatcher?.isRunning()) {
+      await this.meltSettlementProcessor?.setInterestRegistrar(this.meltQuoteWatcher);
+      return;
+    }
     const watcherLogger = this.logger.child
       ? this.logger.child({ module: 'MeltQuoteWatcherService' })
       : this.logger;
@@ -520,10 +523,12 @@ export class Manager {
       },
     );
     await this.meltQuoteWatcher.start();
+    await this.meltSettlementProcessor?.setInterestRegistrar(this.meltQuoteWatcher);
   }
 
   async disableMeltQuoteWatcher(): Promise<void> {
     if (!this.meltQuoteWatcher) return;
+    await this.meltSettlementProcessor?.setInterestRegistrar(undefined);
     await this.meltQuoteWatcher.stop();
     this.meltQuoteWatcher = undefined;
   }

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -13,6 +13,8 @@ import {
   MintService,
   MintOperationWatcherService,
   MintOperationProcessor,
+  MeltQuoteWatcherService,
+  MeltSettlementProcessor,
   ProofService,
   WalletService,
   SeedService,
@@ -110,6 +112,11 @@ export interface CocoConfig {
       /** When enabled, scan existing inflight proofs on start (default: true) */
       watchExistingInflightOnStart?: boolean;
     };
+    /** Melt quote watcher (enabled by default) */
+    meltQuoteWatcher?: {
+      disabled?: boolean;
+      watchExistingPendingQuotesOnStart?: boolean;
+    };
   };
   /**
    * Processor configuration (all enabled by default)
@@ -126,6 +133,11 @@ export interface CocoConfig {
       baseRetryDelayMs?: number;
       initialEnqueueDelayMs?: number;
       autoClaimMintQuotes?: boolean;
+    };
+    /** Melt settlement processor (enabled by default) */
+    meltSettlementProcessor?: {
+      disabled?: boolean;
+      initializeExistingPendingOperationsOnStart?: boolean;
     };
   };
   /**
@@ -184,10 +196,20 @@ export async function initializeCoco(config: CocoConfig): Promise<Manager> {
     await coco.enableProofStateWatcher(proofStateWatcherConfig);
   }
 
+  const meltQuoteWatcherConfig = config.watchers?.meltQuoteWatcher;
+  if (!meltQuoteWatcherConfig?.disabled) {
+    await coco.enableMeltQuoteWatcher(meltQuoteWatcherConfig);
+  }
+
   // Enable processors (default: all enabled unless explicitly disabled)
   const mintOperationProcessorConfig = config.processors?.mintOperationProcessor;
   if (!mintOperationProcessorConfig?.disabled) {
     await coco.enableMintOperationProcessor(mintOperationProcessorConfig);
+  }
+
+  const meltSettlementProcessorConfig = config.processors?.meltSettlementProcessor;
+  if (!meltSettlementProcessorConfig?.disabled) {
+    await coco.enableMeltSettlementProcessor(meltSettlementProcessorConfig);
   }
 
   // Recover any pending send operations from previous session
@@ -226,6 +248,8 @@ export class Manager {
   readonly subscriptions: SubscriptionManager;
   private mintOperationWatcher?: MintOperationWatcherService;
   private mintOperationProcessor?: MintOperationProcessor;
+  private meltQuoteWatcher?: MeltQuoteWatcherService;
+  private meltSettlementProcessor?: MeltSettlementProcessor;
   private legacyMintQuoteRepository: LegacyMintQuoteRepository;
   private quoteLifecycle: QuoteLifecycle;
   private proofStateWatcher?: ProofStateWatcherService;
@@ -404,6 +428,8 @@ export class Manager {
 
     await this.disableMintOperationWatcher();
     await this.disableProofStateWatcher();
+    await this.disableMeltSettlementProcessor();
+    await this.disableMeltQuoteWatcher();
     await this.disableMintOperationProcessor();
     await this.pluginHost.dispose();
     this.subscriptions.closeAll();
@@ -473,6 +499,61 @@ export class Manager {
     if (!this.mintOperationProcessor) return;
     await this.mintOperationProcessor.stop();
     this.mintOperationProcessor = undefined;
+  }
+
+  async enableMeltQuoteWatcher(options?: {
+    watchExistingPendingQuotesOnStart?: boolean;
+  }): Promise<void> {
+    if (this.disposed) return;
+    if (this.meltQuoteWatcher?.isRunning()) return;
+    const watcherLogger = this.logger.child
+      ? this.logger.child({ module: 'MeltQuoteWatcherService' })
+      : this.logger;
+    this.meltQuoteWatcher = new MeltQuoteWatcherService(
+      this.subscriptions,
+      this.mintService,
+      this.quoteLifecycle,
+      this.eventBus,
+      watcherLogger,
+      {
+        watchExistingPendingQuotesOnStart: options?.watchExistingPendingQuotesOnStart ?? true,
+      },
+    );
+    await this.meltQuoteWatcher.start();
+  }
+
+  async disableMeltQuoteWatcher(): Promise<void> {
+    if (!this.meltQuoteWatcher) return;
+    await this.meltQuoteWatcher.stop();
+    this.meltQuoteWatcher = undefined;
+  }
+
+  async enableMeltSettlementProcessor(options?: {
+    initializeExistingPendingOperationsOnStart?: boolean;
+  }): Promise<boolean> {
+    if (this.disposed) return false;
+    if (this.meltSettlementProcessor?.isRunning()) return false;
+    const processorLogger = this.logger.child
+      ? this.logger.child({ module: 'MeltSettlementProcessor' })
+      : this.logger;
+    this.meltSettlementProcessor = new MeltSettlementProcessor(
+      this.meltOperationService,
+      this.eventBus,
+      processorLogger,
+      {
+        initializeExistingPendingOperationsOnStart:
+          options?.initializeExistingPendingOperationsOnStart ?? true,
+        interestRegistrar: this.meltQuoteWatcher,
+      },
+    );
+    await this.meltSettlementProcessor.start();
+    return true;
+  }
+
+  async disableMeltSettlementProcessor(): Promise<void> {
+    if (!this.meltSettlementProcessor) return;
+    await this.meltSettlementProcessor.stop();
+    this.meltSettlementProcessor = undefined;
   }
 
   async waitForMintOperationProcessor(): Promise<void> {
@@ -599,6 +680,8 @@ export class Manager {
     // Disable watchers
     await this.disableMintOperationWatcher();
     await this.disableProofStateWatcher();
+    await this.disableMeltSettlementProcessor();
+    await this.disableMeltQuoteWatcher();
 
     // Disable processor
     await this.disableMintOperationProcessor();
@@ -630,10 +713,20 @@ export class Manager {
       await this.enableProofStateWatcher(proofStateWatcherConfig);
     }
 
+    const meltQuoteWatcherConfig = this.originalWatcherConfig?.meltQuoteWatcher;
+    if (!meltQuoteWatcherConfig?.disabled) {
+      await this.enableMeltQuoteWatcher(meltQuoteWatcherConfig);
+    }
+
     // Re-enable processor based on original configuration (idempotent)
     const mintOperationProcessorConfig = this.originalProcessorConfig?.mintOperationProcessor;
     if (!mintOperationProcessorConfig?.disabled) {
       await this.enableMintOperationProcessor(mintOperationProcessorConfig);
+    }
+
+    const meltSettlementProcessorConfig = this.originalProcessorConfig?.meltSettlementProcessor;
+    if (!meltSettlementProcessorConfig?.disabled) {
+      await this.enableMeltSettlementProcessor(meltSettlementProcessorConfig);
     }
 
     await this.recoverPendingMintOperations();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -145,12 +145,18 @@ await manager.enableMintOperationWatcher({ watchExistingPendingOnStart: true });
 // Process queued mint operations from live events (auto-enabled by initializeCoco)
 await manager.enableMintOperationProcessor({ processIntervalMs: 3000 });
 
+// Watch canonical melt quote updates and settle pending melt operations
+await manager.enableMeltQuoteWatcher();
+await manager.enableMeltSettlementProcessor();
+
 // Watch proof state updates (e.g., to move inflight proofs to spent)
 await manager.enableProofStateWatcher();
 
 // Later, you can stop them
 await manager.disableMintOperationWatcher();
 await manager.disableMintOperationProcessor();
+await manager.disableMeltQuoteWatcher();
+await manager.disableMeltSettlementProcessor();
 await manager.disableProofStateWatcher();
 ```
 
@@ -163,8 +169,10 @@ await manager.disableProofStateWatcher();
 - `logger`: optional logger (defaults to `NullLogger`)
 - `webSocketFactory`: optional WebSocket factory
 - `plugins`: optional plugin list
-- `watchers`: enable/disable watcher services (`mintOperationWatcher`, `proofStateWatcher`)
-- `processors`: enable/disable processors (`mintOperationProcessor`) and tune intervals
+- `watchers`: enable/disable watcher services (`mintOperationWatcher`, `meltQuoteWatcher`,
+  `proofStateWatcher`)
+- `processors`: enable/disable processors (`mintOperationProcessor`, `meltSettlementProcessor`)
+  and tune intervals
 - `subscriptions`: polling intervals for hybrid WebSocket + polling (`slowPollingIntervalMs`, `fastPollingIntervalMs`)
 
 If you prefer manual wiring, construct `Manager` directly and call `initPlugins()` before enabling watchers/processors.
@@ -218,6 +226,8 @@ The package root exports `MemoryRepositories` as an in-memory test/example repos
 - `enableMintOperationWatcher()`, `disableMintOperationWatcher()`
 - `enableMintOperationProcessor()`, `disableMintOperationProcessor()`,
   `waitForMintOperationProcessor()`
+- `enableMeltQuoteWatcher()`, `disableMeltQuoteWatcher()`
+- `enableMeltSettlementProcessor()`, `disableMeltSettlementProcessor()`
 - `enableProofStateWatcher()`, `disableProofStateWatcher()`
 - `pauseSubscriptions()`, `resumeSubscriptions()`
 - `use(plugin: Plugin): void` with `Plugin` from `@cashu/coco-core/plugin`

--- a/packages/core/services/watchers/MeltSettlementProcessor.ts
+++ b/packages/core/services/watchers/MeltSettlementProcessor.ts
@@ -42,11 +42,13 @@ function isPendingMeltOperation(operation: MeltOperation): operation is PendingM
 class MeltSettlementInterestRegistry {
   private readonly operationIdsByQuoteKey = new Map<QuoteKey, Set<string>>();
   private readonly quoteKeyByOperationId = new Map<string, QuoteKey>();
+  private readonly operationById = new Map<string, OperationQuoteInterest>();
 
   add(operation: OperationQuoteInterest): boolean {
     const key = toKey(operation.mintUrl, operation.method, operation.quoteId);
     const existingKey = this.quoteKeyByOperationId.get(operation.id);
     if (existingKey === key) {
+      this.operationById.set(operation.id, operation);
       return false;
     }
 
@@ -62,6 +64,7 @@ class MeltSettlementInterestRegistry {
 
     operationIds.add(operation.id);
     this.quoteKeyByOperationId.set(operation.id, key);
+    this.operationById.set(operation.id, operation);
     return true;
   }
 
@@ -72,6 +75,7 @@ class MeltSettlementInterestRegistry {
     }
 
     this.quoteKeyByOperationId.delete(operationId);
+    this.operationById.delete(operationId);
     const operationIds = this.operationIdsByQuoteKey.get(key);
     operationIds?.delete(operationId);
     if (operationIds?.size === 0) {
@@ -91,6 +95,10 @@ class MeltSettlementInterestRegistry {
   getAllOperationIds(): string[] {
     return Array.from(this.quoteKeyByOperationId.keys());
   }
+
+  getAllOperations(): OperationQuoteInterest[] {
+    return Array.from(this.operationById.values());
+  }
 }
 
 export class MeltSettlementProcessor {
@@ -98,7 +106,7 @@ export class MeltSettlementProcessor {
   private readonly bus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
   private readonly options: Required<Omit<MeltSettlementProcessorOptions, 'interestRegistrar'>>;
-  private readonly interestRegistrar?: OperationInterestRegistrar;
+  private interestRegistrar?: OperationInterestRegistrar;
 
   private running = false;
   private offPending?: () => void;
@@ -130,6 +138,31 @@ export class MeltSettlementProcessor {
 
   isRunning(): boolean {
     return this.running;
+  }
+
+  /** @internal Rebinds the watcher that owns operation quote subscriptions. */
+  async setInterestRegistrar(interestRegistrar?: OperationInterestRegistrar): Promise<void> {
+    if (this.interestRegistrar === interestRegistrar) {
+      if (this.running && interestRegistrar) {
+        await this.registerTrackedOperationInterests();
+      }
+      return;
+    }
+
+    const previousRegistrar = this.interestRegistrar;
+    const registeredOperationIds = Array.from(this.registeredOperationInterestIds);
+    this.interestRegistrar = interestRegistrar;
+    this.registeredOperationInterestIds.clear();
+
+    if (previousRegistrar) {
+      for (const operationId of registeredOperationIds) {
+        await this.removeOperationWatchInterest(previousRegistrar, operationId);
+      }
+    }
+
+    if (this.running && this.interestRegistrar) {
+      await this.registerTrackedOperationInterests();
+    }
   }
 
   async start(): Promise<void> {
@@ -237,18 +270,13 @@ export class MeltSettlementProcessor {
     }
 
     const mintUrl = normalizeMintUrl(operation.mintUrl);
-    const interest = {
-      operationId: operation.id,
-      mintUrl,
-      method: operation.method,
-      quoteId: operation.quoteId,
-    };
-    const added = this.interests.add({
+    const operationInterest = {
       id: operation.id,
       mintUrl,
       method: operation.method,
       quoteId: operation.quoteId,
-    });
+    };
+    const added = this.interests.add(operationInterest);
     if (!added && !this.interestRegistrar) {
       return;
     }
@@ -262,23 +290,14 @@ export class MeltSettlementProcessor {
       });
     }
 
-    try {
-      await this.interestRegistrar?.registerOperationInterest(interest);
-      if (this.interestRegistrar) {
-        this.registeredOperationInterestIds.add(operation.id);
+    if (this.interestRegistrar) {
+      const registered = await this.registerOperationWatchInterest(operationInterest);
+      if (!registered) {
+        if (added) {
+          this.interests.remove(operation.id);
+        }
+        return;
       }
-    } catch (err) {
-      if (added) {
-        this.interests.remove(operation.id);
-      }
-      this.logger?.warn('Failed to register melt quote operation watch interest', {
-        operationId: operation.id,
-        mintUrl,
-        method: operation.method,
-        quoteId: operation.quoteId,
-        err,
-      });
-      return;
     }
 
     if (!this.running || !this.interests.has(operation.id)) {
@@ -306,6 +325,46 @@ export class MeltSettlementProcessor {
     await this.removeRegisteredOperationInterest(operationId);
   }
 
+  private async registerTrackedOperationInterests(): Promise<void> {
+    for (const operation of this.interests.getAllOperations()) {
+      if (!this.running) {
+        return;
+      }
+      if (this.registeredOperationInterestIds.has(operation.id)) {
+        continue;
+      }
+      await this.registerOperationWatchInterest(operation);
+    }
+  }
+
+  private async registerOperationWatchInterest(
+    operation: OperationQuoteInterest,
+  ): Promise<boolean> {
+    if (!this.interestRegistrar) {
+      return true;
+    }
+
+    try {
+      await this.interestRegistrar.registerOperationInterest({
+        operationId: operation.id,
+        mintUrl: operation.mintUrl,
+        method: operation.method,
+        quoteId: operation.quoteId,
+      });
+      this.registeredOperationInterestIds.add(operation.id);
+      return true;
+    } catch (err) {
+      this.logger?.warn('Failed to register melt quote operation watch interest', {
+        operationId: operation.id,
+        mintUrl: operation.mintUrl,
+        method: operation.method,
+        quoteId: operation.quoteId,
+        err,
+      });
+      return false;
+    }
+  }
+
   private scheduleInitialOperationCheck(operationId: string, context: OperationCheckContext): void {
     if (this.scheduledInitialCheckOperationIds.has(operationId)) {
       return;
@@ -329,9 +388,19 @@ export class MeltSettlementProcessor {
     if (!wasRegistered) {
       return;
     }
+    if (!this.interestRegistrar) {
+      return;
+    }
 
+    await this.removeOperationWatchInterest(this.interestRegistrar, operationId);
+  }
+
+  private async removeOperationWatchInterest(
+    registrar: OperationInterestRegistrar,
+    operationId: string,
+  ): Promise<void> {
     try {
-      await this.interestRegistrar?.removeOperationInterest(operationId);
+      await registrar.removeOperationInterest(operationId);
     } catch (err) {
       this.logger?.warn('Failed to remove melt quote operation watch interest', {
         operationId,

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -1,15 +1,18 @@
-import { Amount } from '@cashu/cashu-ts';
+import { Amount, type SerializedBlindedSignature } from '@cashu/cashu-ts';
 import { describe, it, beforeEach, expect, mock } from 'bun:test';
 
 import { initializeCoco, type CocoConfig, Manager } from '../../Manager';
 import { PaymentRequestsApi } from '../../api/PaymentRequestsApi';
 import { QuoteApi } from '../../api/QuoteApi';
 import type { CoreEvents } from '../../events/types';
+import { meltQuoteFromBolt11Response } from '../../models/MeltQuote';
 import { mintQuoteFromBolt11Response } from '../../models/MintQuote';
+import type { PendingMeltOperation } from '../../operations/melt';
 import type { PendingMintOperation } from '../../operations/mint';
 import { MemoryRepositories } from '../../repositories/memory';
 import { NullLogger } from '../../logging';
 import type { FinalizedReceiveOperation } from '../../operations/receive/ReceiveOperation';
+import type { CoreProof } from '../../types';
 
 describe('initializeCoco', () => {
   let repositories: MemoryRepositories;
@@ -35,13 +38,17 @@ describe('initializeCoco', () => {
       // Verify watchers are running (they have isRunning methods)
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
 
-      // Verify processor is running
+      // Verify processors are running
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
       await manager.disableMintOperationWatcher();
       await manager.disableProofStateWatcher();
+      await manager.disableMeltQuoteWatcher();
       await manager.disableMintOperationProcessor();
+      await manager.disableMeltSettlementProcessor();
     });
 
     it('should initialize repositories', async () => {
@@ -358,6 +365,179 @@ describe('initializeCoco', () => {
     };
   }
 
+  function makePendingMeltOperation(
+    id: string,
+    quoteId: string,
+    overrides: Partial<PendingMeltOperation> = {},
+  ): PendingMeltOperation {
+    return {
+      id,
+      state: 'pending',
+      mintUrl: 'https://mint.test',
+      method: 'bolt11',
+      methodData: { invoice: 'lnbc100' },
+      amount: Amount.from(100),
+      quoteId,
+      fee_reserve: Amount.from(1),
+      swap_fee: Amount.from(0),
+      needsSwap: false,
+      inputAmount: Amount.from(101),
+      inputProofSecrets: [`input-${id}`],
+      changeOutputData: { keep: [], send: [] },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      ...overrides,
+      unit: overrides.unit ?? 'sat',
+    };
+  }
+
+  function makeInputProof(secret: string, operationId: string): CoreProof {
+    return {
+      amount: Amount.from(101),
+      C: `C_${secret}`,
+      id: 'keyset-1',
+      secret,
+      mintUrl: 'https://mint.test',
+      unit: 'sat',
+      state: 'ready',
+      usedByOperationId: operationId,
+    };
+  }
+
+  function makeMeltQuote(
+    quoteId: string,
+    state: 'UNPAID' | 'PENDING' | 'PAID',
+    options: { expired?: boolean; change?: SerializedBlindedSignature[] } = {},
+  ) {
+    return meltQuoteFromBolt11Response('https://mint.test', {
+      quote: quoteId,
+      request: 'lnbc100',
+      amount: Amount.from(100),
+      unit: 'sat',
+      fee_reserve: Amount.from(1),
+      expiry: Math.floor(Date.now() / 1000) + (options.expired ? -60 : 3600),
+      state,
+      payment_preimage: state === 'PAID' ? 'preimage-123' : null,
+      change: options.change,
+    });
+  }
+
+  const flushDeferredInitialChecks = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  };
+
+  describe('melt watcher and settlement lifecycle', () => {
+    it('starts melt quote watching and settlement processing by default', async () => {
+      const manager = await initializeCoco(baseConfig);
+
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
+
+      await manager.dispose();
+    });
+
+    it('resumes pending canonical melt quote watches and pending operation interest on startup', async () => {
+      await repositories.init();
+      const canonicalQuote = makeMeltQuote('melt-canonical-startup', 'PENDING');
+      const expiredOperationQuote = makeMeltQuote('melt-expired-operation-startup', 'PENDING', {
+        expired: true,
+      });
+      const expiredOperation = makePendingMeltOperation(
+        'melt-op-expired-startup',
+        expiredOperationQuote.quoteId,
+      );
+
+      await repositories.meltQuoteRepository.upsertMeltQuote(canonicalQuote);
+      await repositories.meltQuoteRepository.upsertMeltQuote(expiredOperationQuote);
+      await repositories.meltOperationRepository.create(expiredOperation);
+
+      const manager = new Manager(repositories, seedGetter, new NullLogger());
+      await manager.initPlugins();
+      manager.subscriptions.pause();
+      manager['mintService'].isTrustedMint = mock(async () => true);
+      const checkPendingOperation = mock(async () => 'stay_pending' as const);
+      manager['meltOperationService'].checkPendingOperation = checkPendingOperation;
+
+      await manager.enableMeltQuoteWatcher();
+      await manager.enableMeltSettlementProcessor();
+      await flushDeferredInitialChecks();
+
+      const subscriptionInternals = manager.subscriptions as unknown as {
+        subscriptions: Map<string, { kind: string; filters: string[] }>;
+      };
+      const subscriptions = Array.from(subscriptionInternals.subscriptions.values());
+
+      expect(subscriptions).toHaveLength(2);
+      expect(subscriptions.map((subscription) => subscription.kind).sort()).toEqual([
+        'bolt11_melt_quote',
+        'bolt11_melt_quote',
+      ]);
+      expect(subscriptions.map((subscription) => subscription.filters[0]).sort()).toEqual([
+        'melt-canonical-startup',
+        'melt-expired-operation-startup',
+      ]);
+      expect(checkPendingOperation).toHaveBeenCalledWith(expiredOperation.id);
+
+      await manager.dispose();
+    });
+
+    it('settles a pending melt operation from a canonical melt quote update', async () => {
+      const manager = await initializeCoco({
+        ...baseConfig,
+        watchers: {
+          mintOperationWatcher: { disabled: true },
+          proofStateWatcher: { disabled: true },
+        },
+        processors: {
+          mintOperationProcessor: { disabled: true },
+        },
+      });
+      manager.subscriptions.pause();
+      manager['mintService'].isTrustedMint = mock(async () => true);
+
+      const operation = makePendingMeltOperation('melt-op-settle', 'melt-quote-settle');
+      await repositories.proofRepository.saveProofs('https://mint.test', [
+        makeInputProof(operation.inputProofSecrets[0]!, operation.id),
+      ]);
+      await repositories.meltOperationRepository.create(operation);
+      await repositories.meltQuoteRepository.upsertMeltQuote(
+        makeMeltQuote(operation.quoteId, 'PENDING'),
+      );
+
+      await manager['eventBus'].emit('melt-op:pending', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation,
+      });
+
+      const paidQuote = makeMeltQuote(operation.quoteId, 'PAID', { change: [] });
+      await repositories.meltQuoteRepository.upsertMeltQuote(paidQuote);
+      await manager['eventBus'].emit('melt-quote:updated', {
+        mintUrl: paidQuote.mintUrl,
+        method: paidQuote.method,
+        quoteId: paidQuote.quoteId,
+        quote: paidQuote,
+      });
+      await flushDeferredInitialChecks();
+
+      await expect(
+        repositories.meltOperationRepository.getById(operation.id),
+      ).resolves.toMatchObject({
+        state: 'finalized',
+        finalizedData: { preimage: 'preimage-123' },
+      });
+      await expect(
+        repositories.proofRepository.getProofBySecret(
+          operation.mintUrl,
+          operation.inputProofSecrets[0]!,
+        ),
+      ).resolves.toMatchObject({ state: 'spent' });
+
+      await manager.dispose();
+    });
+  });
+
   describe('watchers configuration', () => {
     it('should disable mintOperationWatcher when explicitly disabled', async () => {
       const manager = await initializeCoco({
@@ -369,10 +549,11 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should disable proofStateWatcher when explicitly disabled', async () => {
@@ -391,20 +572,40 @@ describe('initializeCoco', () => {
       await manager.disableMintOperationProcessor();
     });
 
+    it('should disable meltQuoteWatcher when explicitly disabled', async () => {
+      const manager = await initializeCoco({
+        ...baseConfig,
+        watchers: {
+          meltQuoteWatcher: { disabled: true },
+        },
+      });
+
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
+      expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
+      expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
+
+      await manager.dispose();
+    });
+
     it('should disable all watchers when all are explicitly disabled', async () => {
       const manager = await initializeCoco({
         ...baseConfig,
         watchers: {
           mintOperationWatcher: { disabled: true },
           proofStateWatcher: { disabled: true },
+          meltQuoteWatcher: { disabled: true },
         },
       });
 
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should pass options to mintOperationWatcher when not disabled', async () => {
@@ -419,9 +620,7 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should enable with options even when disabled is explicitly false', async () => {
@@ -437,9 +636,22 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
+    });
+
+    it('should pass options to meltQuoteWatcher when not disabled', async () => {
+      const manager = await initializeCoco({
+        ...baseConfig,
+        watchers: {
+          meltQuoteWatcher: {
+            watchExistingPendingQuotesOnStart: false,
+          },
+        },
+      });
+
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
+
+      await manager.dispose();
     });
   });
 
@@ -460,6 +672,23 @@ describe('initializeCoco', () => {
       await manager.disableProofStateWatcher();
     });
 
+    it('should disable meltSettlementProcessor when explicitly disabled', async () => {
+      const manager = await initializeCoco({
+        ...baseConfig,
+        processors: {
+          meltSettlementProcessor: { disabled: true },
+        },
+      });
+
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
+      expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
+      expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
+
+      await manager.dispose();
+    });
+
     it('should pass options to mintOperationProcessor when not disabled', async () => {
       const manager = await initializeCoco({
         ...baseConfig,
@@ -473,9 +702,7 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should enable with options even when disabled is explicitly false', async () => {
@@ -491,9 +718,22 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
+    });
+
+    it('should pass options to meltSettlementProcessor when not disabled', async () => {
+      const manager = await initializeCoco({
+        ...baseConfig,
+        processors: {
+          meltSettlementProcessor: {
+            initializeExistingPendingOperationsOnStart: false,
+          },
+        },
+      });
+
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
+
+      await manager.dispose();
     });
   });
 
@@ -537,10 +777,11 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
   });
 
@@ -563,9 +804,7 @@ describe('initializeCoco', () => {
 
       expect(pluginInitMock).toHaveBeenCalled();
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should reject duplicate plugin instance registration', async () => {
@@ -604,7 +843,9 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
       expect(subscriptionInternals.subscriptions.size).toBe(1);
       expect(subscriptionInternals.activeByMint.size).toBe(1);
       expect(subscriptionInternals.transportByMint.size).toBe(1);
@@ -613,7 +854,9 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
       expect(subscriptionInternals.subscriptions.size).toBe(0);
       expect(subscriptionInternals.activeByMint.size).toBe(0);
       expect(subscriptionInternals.transportByMint.size).toBe(0);
@@ -686,10 +929,14 @@ describe('initializeCoco', () => {
       await manager.enableMintOperationWatcher();
       await manager.enableProofStateWatcher();
       await manager.enableMintOperationProcessor();
+      await manager.enableMeltQuoteWatcher();
+      await manager.enableMeltSettlementProcessor();
 
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
     });
   });
 
@@ -702,10 +949,9 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should handle empty processors config object', async () => {
@@ -715,10 +961,9 @@ describe('initializeCoco', () => {
       });
 
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should handle empty config objects for both watchers and processors', async () => {
@@ -730,11 +975,11 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should handle all features disabled', async () => {
@@ -743,15 +988,19 @@ describe('initializeCoco', () => {
         watchers: {
           mintOperationWatcher: { disabled: true },
           proofStateWatcher: { disabled: true },
+          meltQuoteWatcher: { disabled: true },
         },
         processors: {
           mintOperationProcessor: { disabled: true },
+          meltSettlementProcessor: { disabled: true },
         },
       });
 
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
 
       // Should still have API access
       expect(manager.mint).toBeDefined();
@@ -766,9 +1015,11 @@ describe('initializeCoco', () => {
         watchers: {
           mintOperationWatcher: { disabled: true },
           proofStateWatcher: { disabled: true },
+          meltQuoteWatcher: { disabled: true },
         },
         processors: {
           mintOperationProcessor: { disabled: true },
+          meltSettlementProcessor: { disabled: true },
         },
       });
 
@@ -786,14 +1037,18 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
       await manager.pauseSubscriptions();
 
       // After pause, watchers and processor are disabled (set to undefined)
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
     });
 
     it('should resume and restart all watchers and processors', async () => {
@@ -804,11 +1059,11 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should be idempotent - multiple pause calls should not error', async () => {
@@ -821,7 +1076,9 @@ describe('initializeCoco', () => {
       // After pause, watchers and processor are disabled (set to undefined)
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
     });
 
     it('should be idempotent - multiple resume calls should not error', async () => {
@@ -834,11 +1091,11 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should handle resume without prior pause (OS connection teardown scenario)', async () => {
@@ -849,11 +1106,11 @@ describe('initializeCoco', () => {
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should respect original configuration - disabled watchers stay disabled', async () => {
@@ -862,15 +1119,19 @@ describe('initializeCoco', () => {
         watchers: {
           mintOperationWatcher: { disabled: true },
           proofStateWatcher: { disabled: false },
+          meltQuoteWatcher: { disabled: false },
         },
         processors: {
           mintOperationProcessor: { disabled: false },
+          meltSettlementProcessor: { disabled: false },
         },
       });
 
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
       await manager.pauseSubscriptions();
       await manager.resumeSubscriptions();
@@ -879,10 +1140,11 @@ describe('initializeCoco', () => {
       expect(manager['mintOperationWatcher']).toBeUndefined();
       // Others should be running again
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']?.isRunning()).toBe(true);
+      expect(manager['meltSettlementProcessor']?.isRunning()).toBe(true);
 
-      await manager.disableProofStateWatcher();
-      await manager.disableMintOperationProcessor();
+      await manager.dispose();
     });
 
     it('should respect original configuration - disabled processor stays disabled', async () => {
@@ -891,15 +1153,19 @@ describe('initializeCoco', () => {
         watchers: {
           mintOperationWatcher: { disabled: false },
           proofStateWatcher: { disabled: false },
+          meltQuoteWatcher: { disabled: false },
         },
         processors: {
           mintOperationProcessor: { disabled: true },
+          meltSettlementProcessor: { disabled: true },
         },
       });
 
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
 
       await manager.pauseSubscriptions();
       await manager.resumeSubscriptions();
@@ -907,11 +1173,12 @@ describe('initializeCoco', () => {
       // Watchers should be running again
       expect(manager['mintOperationWatcher']?.isRunning()).toBe(true);
       expect(manager['proofStateWatcher']?.isRunning()).toBe(true);
+      expect(manager['meltQuoteWatcher']?.isRunning()).toBe(true);
       // Processor should remain undefined (was disabled)
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
 
-      await manager.disableMintOperationWatcher();
-      await manager.disableProofStateWatcher();
+      await manager.dispose();
     });
 
     it('should handle all features disabled', async () => {
@@ -920,9 +1187,11 @@ describe('initializeCoco', () => {
         watchers: {
           mintOperationWatcher: { disabled: true },
           proofStateWatcher: { disabled: true },
+          meltQuoteWatcher: { disabled: true },
         },
         processors: {
           mintOperationProcessor: { disabled: true },
+          meltSettlementProcessor: { disabled: true },
         },
       });
 
@@ -932,7 +1201,9 @@ describe('initializeCoco', () => {
       // All should remain undefined
       expect(manager['mintOperationWatcher']).toBeUndefined();
       expect(manager['proofStateWatcher']).toBeUndefined();
+      expect(manager['meltQuoteWatcher']).toBeUndefined();
       expect(manager['mintOperationProcessor']).toBeUndefined();
+      expect(manager['meltSettlementProcessor']).toBeUndefined();
     });
   });
 });

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -482,6 +482,47 @@ describe('initializeCoco', () => {
       await manager.dispose();
     });
 
+    it('attaches melt quote watching when settlement processing starts first', async () => {
+      await repositories.init();
+      const expiredOperationQuote = makeMeltQuote('melt-expired-operation-first', 'PENDING', {
+        expired: true,
+      });
+      const expiredOperation = makePendingMeltOperation(
+        'melt-op-expired-first',
+        expiredOperationQuote.quoteId,
+      );
+
+      await repositories.meltQuoteRepository.upsertMeltQuote(expiredOperationQuote);
+      await repositories.meltOperationRepository.create(expiredOperation);
+
+      const manager = new Manager(repositories, seedGetter, new NullLogger());
+      await manager.initPlugins();
+      manager.subscriptions.pause();
+      manager['mintService'].isTrustedMint = mock(async () => true);
+      const checkPendingOperation = mock(async () => 'stay_pending' as const);
+      manager['meltOperationService'].checkPendingOperation = checkPendingOperation;
+
+      await manager.enableMeltSettlementProcessor();
+      await manager.enableMeltQuoteWatcher();
+      await flushDeferredInitialChecks();
+
+      const subscriptionInternals = manager.subscriptions as unknown as {
+        subscriptions: Map<string, { kind: string; filters: string[] }>;
+      };
+      const subscriptions = Array.from(subscriptionInternals.subscriptions.values());
+
+      expect(subscriptions).toHaveLength(1);
+      expect(subscriptions.map((subscription) => subscription.kind)).toEqual([
+        'bolt11_melt_quote',
+      ]);
+      expect(subscriptions.map((subscription) => subscription.filters[0])).toEqual([
+        'melt-expired-operation-first',
+      ]);
+      expect(checkPendingOperation).toHaveBeenCalledWith(expiredOperation.id);
+
+      await manager.dispose();
+    });
+
     it('settles a pending melt operation from a canonical melt quote update', async () => {
       const manager = await initializeCoco({
         ...baseConfig,

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -512,9 +512,7 @@ describe('initializeCoco', () => {
       const subscriptions = Array.from(subscriptionInternals.subscriptions.values());
 
       expect(subscriptions).toHaveLength(1);
-      expect(subscriptions.map((subscription) => subscription.kind)).toEqual([
-        'bolt11_melt_quote',
-      ]);
+      expect(subscriptions.map((subscription) => subscription.kind)).toEqual(['bolt11_melt_quote']);
       expect(subscriptions.map((subscription) => subscription.filters[0])).toEqual([
         'melt-expired-operation-first',
       ]);

--- a/packages/docs/pages/coco-config.md
+++ b/packages/docs/pages/coco-config.md
@@ -17,9 +17,15 @@ export interface CocoConfig {
     mintOperationWatcher?: {
       disabled?: boolean;
       watchExistingPendingOnStart?: boolean;
+      watchExistingPendingQuotesOnStart?: boolean;
     };
     proofStateWatcher?: {
       disabled?: boolean;
+      watchExistingInflightOnStart?: boolean;
+    };
+    meltQuoteWatcher?: {
+      disabled?: boolean;
+      watchExistingPendingQuotesOnStart?: boolean;
     };
   };
   processors?: {
@@ -29,6 +35,11 @@ export interface CocoConfig {
       maxRetries?: number;
       baseRetryDelayMs?: number;
       initialEnqueueDelayMs?: number;
+      autoClaimMintQuotes?: boolean;
+    };
+    meltSettlementProcessor?: {
+      disabled?: boolean;
+      initializeExistingPendingOperationsOnStart?: boolean;
     };
   };
 }

--- a/packages/docs/pages/watchers-processors.md
+++ b/packages/docs/pages/watchers-processors.md
@@ -4,8 +4,10 @@ By default, when using `initializeCoco()`, all watchers and processors are autom
 
 ```ts
 await coco.enableMintOperationProcessor();
+await coco.enableMeltSettlementProcessor();
 await coco.enableProofStateWatcher();
 await coco.enableMintOperationWatcher();
+await coco.enableMeltQuoteWatcher();
 ```
 
 `initializeCoco()` also recovers pending `coco.ops.send`, `coco.ops.receive`, and `coco.ops.melt`
@@ -20,9 +22,11 @@ const coco = await initializeCoco({
   watchers: {
     mintOperationWatcher: { disabled: true },
     proofStateWatcher: { disabled: true },
+    meltQuoteWatcher: { disabled: true },
   },
   processors: {
     mintOperationProcessor: { disabled: true },
+    meltSettlementProcessor: { disabled: true },
   },
 });
 ```
@@ -38,6 +42,20 @@ it claims locally available balance when quote updates show newly claimable fund
 This module watches pending mint operations via WebSockets and polling, observes remote quote
 state changes, and emits operation-based mint events. It supports BOLT11 mint quotes and reusable
 onchain mint quotes. It does not finalize operations itself.
+
+## MeltQuoteWatcher
+
+This module watches canonical pending melt quotes via WebSockets and polling, records remote quote
+observations, and emits canonical `melt-quote:updated` events. It also keeps operation-owned quote
+interest active for pending melt operations, including expired quotes, until settlement finalizes or
+rolls back.
+
+## MeltSettlementProcessor
+
+This module reacts to canonical melt quote update events for interested pending melt operations and
+advances them through the existing melt operation saga. It starts with existing pending melt
+operations by default, suppresses concurrent checks for the same operation, and relies on later
+quote notifications or manual refresh after transient failures.
 
 ## ProofStateWatcher
 
@@ -61,8 +79,8 @@ When `pauseSubscriptions()` is called:
 
 - All WebSocket connections are closed immediately
 - Reconnection attempts are disabled to save battery
-- All watchers (`MintOperationWatcher`, `ProofStateWatcher`) are stopped
-- The `MintOperationProcessor` is stopped
+- All watchers (`MintOperationWatcher`, `MeltQuoteWatcher`, `ProofStateWatcher`) are stopped
+- The `MintOperationProcessor` and `MeltSettlementProcessor` are stopped
 
 ### What happens during resume?
 
@@ -70,8 +88,8 @@ When `resumeSubscriptions()` is called:
 
 - All subscriptions are re-established (WebSockets or polling)
 - Watchers are restarted based on their original configuration
-- The `MintOperationProcessor` is restarted if enabled
-- Startup and resume backlog reconciliation are handled by mint operation recovery
+- Processors are restarted based on their original configuration
+- Startup and resume backlog reconciliation are handled by operation recovery and watcher scans
 - Everything returns to its previous state before pausing
 
 ### Use Cases


### PR DESCRIPTION
## Parent PRD

- #267

## Slice

- Closes #272
- Blocked by #270 and #271, now merged via #276 and #279

## Summary

- Starts melt quote watching and melt settlement processing by default from `initializeCoco`, unless disabled through watcher/processor config.
- Wires both services into `Manager` pause, resume, and disposal alongside existing watcher/processor lifecycle.
- Adds config options for melt quote watcher startup scans and melt settlement processor pending-operation initialization.
- Adds manager-level coverage for default startup, disabled config, pause/resume, disposal, startup scans, expired quote operation interest, and pending melt settlement.
- Updates core/docs watcher and config documentation and adds a patch changeset.

## Validation

- `bun run --filter='@cashu/coco-core' test -- test/unit/Manager.test.ts test/unit/MeltQuoteWatcherService.test.ts test/unit/MeltSettlementProcessor.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run docs:build`
- `git diff --check origin/master...HEAD`

## Notes

Full `@cashu/coco-core` test was attempted by the implementation worker but local integration prerequisites were unavailable. This PR is intentionally limited to manager lifecycle wiring for the melt watcher and settlement processor.
