### PR TITLE
Bug: make polling fallback to poll every quoteId

### DIFF
--- a/.changeset/poll-all-quote-filters.md
+++ b/.changeset/poll-all-quote-filters.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Poll every quote ID in multi-filter quote subscriptions when using the polling fallback.

--- a/packages/core/infra/PollingTransport.ts
+++ b/packages/core/infra/PollingTransport.ts
@@ -176,12 +176,14 @@ export class PollingTransport implements RealTimeTransport {
           scheduler.hasProofBatchTask = true;
         }
       } else {
-        const filter = params.filters[0];
-        if (!filter) {
+        const filters = params.filters ?? [];
+        if (filters.length === 0) {
           this.logger?.error('PollingTransport: subscribe with no filter', { mintUrl, req });
           return;
         }
-        scheduler.queue.push({ subId, kind: params.kind, filter });
+        for (const filter of filters) {
+          scheduler.queue.push({ subId, kind: params.kind, filter });
+        }
       }
 
       // Acknowledge subscribe immediately

--- a/packages/core/test/unit/PollingTransport.test.ts
+++ b/packages/core/test/unit/PollingTransport.test.ts
@@ -175,6 +175,57 @@ describe('PollingTransport subscription kinds', () => {
     transport.closeAll();
   });
 
+  it('polls every filter in a multi-filter quote subscription', async () => {
+    const quoteIds = ['quote1', 'quote2', 'quote3'];
+    const checkMintQuote = mock((_: string, __: string, quoteId: string) =>
+      Promise.resolve({
+        quote: quoteId,
+        request: `${quoteId}-request`,
+        amount: 10,
+        unit: 'sat',
+        expiry: null,
+        state: 'UNPAID',
+      }),
+    );
+    const adapter = {
+      checkMintQuote,
+      checkMeltQuoteState: mock(() => Promise.resolve({})),
+      checkProofStates: mock(() => Promise.resolve([])),
+    } as unknown as MintAdapter;
+    const transport = new PollingTransport(adapter, { intervalMs: 1 }, new NullLogger());
+    const messages: any[] = [];
+
+    transport.on(mintUrl, 'message', (evt) => {
+      messages.push(JSON.parse(evt.data));
+    });
+    transport.send(mintUrl, {
+      jsonrpc: '2.0',
+      method: 'subscribe',
+      params: { kind: 'bolt11_mint_quote', subId: 'multi-filter-sub-1', filters: quoteIds },
+      id: 1,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const polledQuoteIds = checkMintQuote.mock.calls.map((call) => call[2]);
+    for (const quoteId of quoteIds) {
+      expect(polledQuoteIds).toContain(quoteId);
+    }
+
+    const updateMessages = messages.filter((message) => message.method === 'subscribe');
+    expect(updateMessages.length).toBeGreaterThanOrEqual(quoteIds.length);
+    expect(updateMessages.every((message) => message.params?.subId === 'multi-filter-sub-1')).toBe(
+      true,
+    );
+
+    const payloadQuoteIds = updateMessages.map((message) => message.params?.payload?.quote);
+    for (const quoteId of quoteIds) {
+      expect(payloadQuoteIds).toContain(quoteId);
+    }
+
+    transport.closeAll();
+  });
+
   it('emits an error and does not enqueue unsupported subscription kinds', async () => {
     const adapter = createMockMintAdapter();
     const transport = new PollingTransport(adapter, { intervalMs: 5000 }, new NullLogger());


### PR DESCRIPTION
## Description

This pull request fixes polling fallback coverage for multi-filter quote subscriptions #266 .

## Problem

Polling fallback accepted a quote subscription with multiple filters but only enqueued the first quote ID, so batched mint quote watches could leave later quotes stale when WebSocket updates were unavailable.

## Summary

- Enqueue one polling task per non-proof subscription filter.
- Add a regression test proving all quote filters are polled and emitted under the same subscription ID.
- Add a patch changeset for `@cashu/coco-core`.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/PollingTransport.test.ts`
- `git diff --check`
- Local `bun --eval` repro now shows `q1,q2,q3` rotation.
- `bun run --filter='@cashu/coco-core' typecheck` fails due unrelated existing errors.

## Changeset

- Added `.changeset/poll-all-quote-filters.md`