### PR TITLE
docs: remove postponed generic payment ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,17 +34,9 @@ A payment method that coco models with method-specific behavior and validation. 
 methods are `bolt11`, `bolt12`, and `onchain`.
 _Avoid_: Default method, native method
 
-**Generic Payment Method**:
-A base quote struct compatible payment method that a mint advertises but coco does not model as a
-Built-in Payment Method. Generic Payment Methods preserve the mint's method string; their mint
-quotes are reusable, locked to a wallet-controlled quote key, and claimable according to the paid
-amount that has not yet been issued.
-_Avoid_: Runtime payment method, custom payment method
-
 **Payment Method Handler**:
-A method-specific or generic implementation of coco's quote-backed payment lifecycle. Built-in
-payment methods use dedicated handlers; Generic Payment Methods use generic mint and melt handlers
-while preserving the advertised method string.
+A method-specific implementation of coco's quote-backed payment lifecycle. Built-in payment
+methods use dedicated handlers.
 _Avoid_: Payment plugin, method switch
 
 **Quote-backed Operation**:

--- a/docs/adr/0001-generic-mint-quotes-are-reusable-and-key-locked.md
+++ b/docs/adr/0001-generic-mint-quotes-are-reusable-and-key-locked.md
@@ -1,7 +1,0 @@
-# Generic mint quotes are reusable and key locked
-
-Generic Payment Method mint quotes are accepted only when they provide reusable quote accounting:
-the paid amount and the issued amount. Coco generates the wallet-controlled quote key for these
-quotes and rejects generic mint quote responses that omit the reusable accounting fields, because
-operation recovery and safe claim calculation depend on coco owning the quote key and knowing the
-unissued paid value.

--- a/docs/adr/0002-keep-built-in-methods-first-class-while-allowing-generic-method-strings.md
+++ b/docs/adr/0002-keep-built-in-methods-first-class-while-allowing-generic-method-strings.md
@@ -1,7 +1,0 @@
-# Keep built-in methods first-class while allowing generic method strings
-
-Coco keeps `bolt11`, `bolt12`, and `onchain` as Built-in Payment Methods with narrow typed inputs
-and return types, while adding Generic Payment Method entry points that accept arbitrary method
-strings through an explicit generic payload shape. This is a breaking public API change, so coco
-will use clear built-in/generic method type names rather than preserving compatibility aliases that
-obscure the distinction.

--- a/docs/adr/0003-preserve-raw-generic-quote-responses.md
+++ b/docs/adr/0003-preserve-raw-generic-quote-responses.md
@@ -1,6 +1,0 @@
-# Preserve raw generic quote responses
-
-Generic Payment Method quotes expose `rawQuoteData` as the JSON object returned by the mint before
-coco converts lifecycle fields into domain values. Generic quote adapter calls therefore need
-access to the raw mint response as well as parsed lifecycle fields, because callers use Generic
-Payment Methods precisely when method-specific response fields are not known to coco.


### PR DESCRIPTION
## Description

This pull request updates the repo domain documentation by removing stale generic payment-method ADRs and pruning the matching glossary language from `CONTEXT.md`.

## Problem

The current ADRs described decisions for a feature that is now postponed. Leaving them in place risks future agents and reviewers treating planned generic payment-method behavior as current architecture.

## Summary

- Delete the three generic payment-method ADRs under `docs/adr/`.
- Remove the `Generic Payment Method` glossary entry and narrow `Payment Method Handler` to the current method-specific model.
- No compatibility risk; this is documentation-only cleanup.

## Verification

- `rg -n "Generic Payment Method|generic payment|rawQuoteData|generic method|generic mint quote|docs/adr/000|0001-generic|0002-keep-built|0003-preserve" CONTEXT.md docs packages --glob '!dist/**'`
- `git diff --check`

## Changeset

- No changeset added; this only changes repo domain docs and ADR files, not a published package or public package docs.