### PR TITLE
test(core): cover proof and send mutation frontier

### DIFF
--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -989,6 +989,109 @@ describe('ProofService', () => {
     });
   });
 
+  describe('prepareProofsForReceiving', () => {
+    const createService = () =>
+      new ProofService(
+        counterService,
+        proofRepo,
+        walletService as any,
+        mintService as any,
+        keyRingService as any,
+        seedService,
+        undefined,
+        bus,
+      );
+
+    const makeLockedSecret = (scriptType: string, recipientPublicKey: string, tags?: string[][]) =>
+      JSON.stringify([
+        scriptType,
+        {
+          nonce: 'nonce-1',
+          data: recipientPublicKey,
+          ...(tags ? { tags } : {}),
+        },
+      ]);
+
+    const expectProofValidationFailure = async (promise: Promise<unknown>, message: string) => {
+      try {
+        await promise;
+        throw new Error('Expected proof validation to fail');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ProofValidationError);
+        expect((error as Error).message).toBe(message);
+      }
+    };
+
+    it('returns regular non-JSON proof secrets unchanged and does not sign them', async () => {
+      const signProof = mock(async (proof: any, publicKey: string) => ({
+        ...proof,
+        witness: `signature-for-${publicKey}`,
+      }));
+      keyRingService = { signProof };
+      const service = createService();
+      const regularProof = makeProof({ secret: 'regular-secret' });
+
+      const result = await service.prepareProofsForReceiving([regularProof]);
+
+      expect(result).toEqual([regularProof]);
+      expect(result[0]).toBe(regularProof);
+      expect(signProof).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-P2PK JSON locked proofs before signing', async () => {
+      const signProof = mock(async (proof: any, publicKey: string) => ({
+        ...proof,
+        witness: `signature-for-${publicKey}`,
+      }));
+      keyRingService = { signProof };
+      const service = createService();
+      const lockedProof = makeProof({
+        secret: makeLockedSecret('HTLC', 'recipient-pubkey'),
+      });
+
+      await expectProofValidationFailure(
+        service.prepareProofsForReceiving([lockedProof]),
+        'Only P2PK locking scripts are supported',
+      );
+      expect(signProof).not.toHaveBeenCalled();
+    });
+
+    it('rejects P2PK proofs with additional pubkeys before signing', async () => {
+      const signProof = mock(async (proof: any, publicKey: string) => ({
+        ...proof,
+        witness: `signature-for-${publicKey}`,
+      }));
+      keyRingService = { signProof };
+      const service = createService();
+      const multisigProof = makeProof({
+        secret: makeLockedSecret('P2PK', 'recipient-pubkey', [['pubkeys', 'other-pubkey']]),
+      });
+
+      await expectProofValidationFailure(
+        service.prepareProofsForReceiving([multisigProof]),
+        'Multisig is not supported',
+      );
+      expect(signProof).not.toHaveBeenCalled();
+    });
+
+    it('signs a valid P2PK proof with the recipient public key and returns the replacement', async () => {
+      const recipientPublicKey = 'recipient-pubkey';
+      const p2pkProof = makeProof({
+        secret: makeLockedSecret('P2PK', recipientPublicKey),
+      });
+      const signedProof = { ...p2pkProof, witness: 'signed-witness' };
+      const signProof = mock(async () => signedProof);
+      keyRingService = { signProof };
+      const service = createService();
+
+      const result = await service.prepareProofsForReceiving([p2pkProof]);
+
+      expect(signProof).toHaveBeenCalledWith(p2pkProof, recipientPublicKey);
+      expect(result).toEqual([signedProof]);
+      expect(result[0]).toBe(signedProof);
+    });
+  });
+
   describe('reserveProofs', () => {
     it('emits the reserved input amount without counting operation output proofs', async () => {
       const service = new ProofService(

--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -474,6 +474,100 @@ describe('ProofService', () => {
   });
 
   describe('state changes and deletions', () => {
+    it('releaseProofs clears reservations and emits event', async () => {
+      const service = new ProofService(
+        counterService,
+        proofRepo,
+        walletService as any,
+        mintService as any,
+        keyRingService as any,
+        seedService,
+        undefined,
+        bus,
+      );
+
+      await proofRepo.saveProofs(mintUrl, [
+        makeProof({ secret: 'reserved-a', id: 'k1' }),
+        makeProof({ secret: 'reserved-b', id: 'k1' }),
+      ]);
+      await proofRepo.reserveProofs(mintUrl, ['reserved-a', 'reserved-b'], 'operation-1');
+
+      const releasedEvents: Array<{ mintUrl: string; secrets: string[] }> = [];
+      bus.on('proofs:released', (payload) => {
+        releasedEvents.push(payload);
+      });
+
+      await service.releaseProofs(mintUrl, ['reserved-a', 'reserved-b']);
+
+      const releasedProofA = await proofRepo.getProofBySecret(mintUrl, 'reserved-a');
+      const releasedProofB = await proofRepo.getProofBySecret(mintUrl, 'reserved-b');
+      expect(releasedProofA).toMatchObject({ secret: 'reserved-a', state: 'ready' });
+      expect(releasedProofB).toMatchObject({ secret: 'reserved-b', state: 'ready' });
+      expect(releasedProofA?.usedByOperationId).toBeUndefined();
+      expect(releasedProofB?.usedByOperationId).toBeUndefined();
+      expect(releasedEvents).toEqual([{ mintUrl, secrets: ['reserved-a', 'reserved-b'] }]);
+    });
+
+    it('restoreProofsToReady marks proofs ready, clears reservations, and emits events', async () => {
+      const service = new ProofService(
+        counterService,
+        proofRepo,
+        walletService as any,
+        mintService as any,
+        keyRingService as any,
+        seedService,
+        undefined,
+        bus,
+      );
+
+      await proofRepo.saveProofs(mintUrl, [
+        makeProof({
+          secret: 'inflight-proof',
+          id: 'k1',
+          state: 'inflight',
+          usedByOperationId: 'operation-1',
+        }),
+        makeProof({
+          secret: 'reserved-proof',
+          id: 'k1',
+          state: 'ready',
+          usedByOperationId: 'operation-1',
+        }),
+      ]);
+
+      const stateChangedEvents: Array<{
+        mintUrl: string;
+        secrets: string[];
+        state: 'inflight' | 'ready' | 'spent';
+      }> = [];
+      const releasedEvents: Array<{ mintUrl: string; secrets: string[] }> = [];
+      bus.on('proofs:state-changed', (payload) => {
+        stateChangedEvents.push(payload);
+      });
+      bus.on('proofs:released', (payload) => {
+        releasedEvents.push(payload);
+      });
+
+      await service.restoreProofsToReady(mintUrl, ['inflight-proof', 'reserved-proof']);
+
+      const restoredInflightProof = await proofRepo.getProofBySecret(mintUrl, 'inflight-proof');
+      const restoredReservedProof = await proofRepo.getProofBySecret(mintUrl, 'reserved-proof');
+      expect(restoredInflightProof).toMatchObject({ secret: 'inflight-proof', state: 'ready' });
+      expect(restoredReservedProof).toMatchObject({ secret: 'reserved-proof', state: 'ready' });
+      expect(restoredInflightProof?.usedByOperationId).toBeUndefined();
+      expect(restoredReservedProof?.usedByOperationId).toBeUndefined();
+      expect(stateChangedEvents).toEqual([
+        {
+          mintUrl,
+          secrets: ['inflight-proof', 'reserved-proof'],
+          state: 'ready',
+        },
+      ]);
+      expect(releasedEvents).toEqual([
+        { mintUrl, secrets: ['inflight-proof', 'reserved-proof'] },
+      ]);
+    });
+
     it('setProofState updates repository and emits event', async () => {
       const service = new ProofService(
         counterService,

--- a/packages/core/test/unit/SendOperationService.test.ts
+++ b/packages/core/test/unit/SendOperationService.test.ts
@@ -14,9 +14,13 @@ import type { WalletService } from '../../services/WalletService';
 import type { Logger } from '../../logging/Logger';
 import type { CoreProof } from '../../types';
 import type {
+  ExecutingSendOperation,
+  FinalizedSendOperation,
+  InitSendOperation,
   PreparedSendOperation,
   PendingSendOperation,
   RolledBackSendOperation,
+  RollingBackSendOperation,
 } from '../../operations/send/SendOperation';
 import type { SendMethodHandler } from '../../operations/send/SendMethodHandler';
 
@@ -48,6 +52,67 @@ describe('SendOperationService', () => {
   const unitAmount = (amount: number, unit = 'sat') => ({
     amount: Amount.from(amount),
     unit,
+  });
+
+  const makeInitOperation = (id: string): InitSendOperation => ({
+    id,
+    state: 'init',
+    mintUrl,
+    amount: Amount.from(100),
+    unit: 'sat',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    method: 'default',
+    methodData: {},
+  });
+
+  const makePreparedOperation = (
+    id: string,
+    overrides: Partial<PreparedSendOperation> = {},
+  ): PreparedSendOperation => ({
+    id,
+    state: 'prepared',
+    mintUrl,
+    amount: Amount.from(100),
+    unit: 'sat',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    needsSwap: false,
+    fee: Amount.from(0),
+    inputAmount: Amount.from(100),
+    inputProofSecrets: ['proof-1'],
+    method: 'default',
+    methodData: {},
+    ...overrides,
+  });
+
+  const makeExecutingOperation = (id: string): ExecutingSendOperation => ({
+    ...makePreparedOperation(id),
+    state: 'executing',
+  });
+
+  const makePendingOperation = (
+    id: string,
+    overrides: Partial<PendingSendOperation> = {},
+  ): PendingSendOperation => ({
+    ...makePreparedOperation(id),
+    state: 'pending',
+    ...overrides,
+  });
+
+  const makeFinalizedOperation = (id: string): FinalizedSendOperation => ({
+    ...makePendingOperation(id),
+    state: 'finalized',
+  });
+
+  const makeRollingBackOperation = (id: string): RollingBackSendOperation => ({
+    ...makePendingOperation(id),
+    state: 'rolling_back',
+  });
+
+  const makeRolledBackOperation = (id: string): RolledBackSendOperation => ({
+    ...makePendingOperation(id),
+    state: 'rolled_back',
   });
 
   beforeEach(() => {
@@ -326,6 +391,114 @@ describe('SendOperationService', () => {
     const persisted = await sendOpRepo.getById(preparedOp.id);
     expect(persisted?.state).toBe('rolled_back');
     expect(persisted?.error).toBe('Explicit handler failure');
+  });
+
+  it('rejects rollback for a missing operation and releases the operation lock', async () => {
+    const operationId = 'missing-send-op';
+
+    await expect(service.rollback(operationId)).rejects.toThrow(
+      `Operation ${operationId} not found`,
+    );
+
+    expect(service.isOperationLocked(operationId)).toBe(false);
+    expect(walletService.getWalletWithActiveKeysetId).not.toHaveBeenCalled();
+  });
+
+  it('rejects rollback for non-rollbackable states before handler or wallet side effects', async () => {
+    const rollback = mock(async () => {});
+    const guardedHandler: SendMethodHandler<'default'> = {
+      prepare: mock(async () => {
+        throw new Error('not used');
+      }),
+      execute: mock(async () => {
+        throw new Error('not used');
+      }),
+      rollback,
+      recoverExecuting: mock(async () => {
+        throw new Error('not used');
+      }),
+    };
+
+    handlerProvider = new SendHandlerProvider({
+      default: guardedHandler,
+      p2pk: new P2pkSendHandler(),
+    });
+    service = new SendOperationService(
+      sendOpRepo,
+      proofRepo,
+      proofService,
+      mintService,
+      walletService,
+      eventBus,
+      handlerProvider,
+      logger,
+    );
+
+    const operations = [
+      makeFinalizedOperation('send-op-finalized'),
+      makeRolledBackOperation('send-op-rolled-back'),
+      makeRollingBackOperation('send-op-rolling-back'),
+      makeInitOperation('send-op-init'),
+      makeExecutingOperation('send-op-executing'),
+    ];
+
+    for (const operation of operations) {
+      await sendOpRepo.create(operation);
+
+      await expect(service.rollback(operation.id)).rejects.toThrow(
+        `Cannot rollback operation in state ${operation.state}`,
+      );
+
+      expect(service.isOperationLocked(operation.id)).toBe(false);
+    }
+
+    expect(rollback).not.toHaveBeenCalled();
+    expect(walletService.getWalletWithActiveKeysetId).not.toHaveBeenCalled();
+  });
+
+  it('rejects pending P2PK rollback before handler rollback or wallet side effects', async () => {
+    const rollback = mock(async () => {});
+    const p2pkHandler: SendMethodHandler<'p2pk'> = {
+      prepare: mock(async () => {
+        throw new Error('not used');
+      }),
+      execute: mock(async () => {
+        throw new Error('not used');
+      }),
+      rollback,
+      recoverExecuting: mock(async () => {
+        throw new Error('not used');
+      }),
+    };
+    handlerProvider = new SendHandlerProvider({
+      default: new DefaultSendHandler(),
+      p2pk: p2pkHandler,
+    });
+    service = new SendOperationService(
+      sendOpRepo,
+      proofRepo,
+      proofService,
+      mintService,
+      walletService,
+      eventBus,
+      handlerProvider,
+      logger,
+    );
+
+    const pendingP2pkOp = makePendingOperation('send-op-pending-p2pk', {
+      method: 'p2pk',
+      methodData: { pubkey: 'receiver-pubkey' },
+    });
+    await sendOpRepo.create(pendingP2pkOp);
+
+    await expect(service.rollback(pendingP2pkOp.id)).rejects.toThrow(
+      'Cannot rollback pending P2PK send operation',
+    );
+
+    expect(rollback).not.toHaveBeenCalled();
+    expect(walletService.getWalletWithActiveKeysetId).not.toHaveBeenCalled();
+    expect(service.isOperationLocked(pendingP2pkOp.id)).toBe(false);
+    expect((await sendOpRepo.getById(pendingP2pkOp.id))?.state).toBe('pending');
   });
 
   it('waits for an in-progress finalization to finish before returning', async () => {


### PR DESCRIPTION
## Description

This pull request adds focused core unit coverage for the current Stryker frontier from `reports/mutation/core-unit/mutation.json`.

## Problem

The mutation report showed missing coverage around proof release/restore events, send rollback guards, and P2PK receive proof validation.

## Summary

- Adds `ProofService` tests for release/restore event behavior.
- Adds `SendOperationService.rollback` tests for non-rollbackable states.
- Adds `ProofService.prepareProofsForReceiving` tests for regular and P2PK proof handling.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/ProofService.test.ts test/unit/SendOperationService.test.ts`
- `git diff --check`

## Changeset

- No changeset added; test-only changes with no public API or package behavior change.