### PR TITLE
Fix(core): separate failed mint events from finalization

### DIFF
--- a/.changeset/mint-failure-events.md
+++ b/.changeset/mint-failure-events.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': major
+---
+
+Emit terminal failed mint operations through `mint-op:failed` instead of
+`mint-op:finalized`, so `mint-op:finalized` now only reports successful
+issuance.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,16 +113,28 @@ const pendingMint = await manager.ops.mint.prepare({
   amount: 100,
 });
 
-const finalized = new Promise<void>((resolve) => {
-  const off = manager.on('mint-op:finalized', ({ operationId }) => {
+const completed = new Promise<void>((resolve, reject) => {
+  let offFinalized = () => {};
+  let offFailed = () => {};
+  const cleanup = () => {
+    offFinalized();
+    offFailed();
+  };
+
+  offFinalized = manager.on('mint-op:finalized', ({ operationId }) => {
     if (operationId !== pendingMint.id) return;
-    off();
+    cleanup();
     resolve();
+  });
+  offFailed = manager.on('mint-op:failed', ({ operationId, operation }) => {
+    if (operationId !== pendingMint.id) return;
+    cleanup();
+    reject(new Error(operation.terminalFailure?.reason ?? operation.error ?? 'Mint failed'));
   });
 });
 
 // pay pendingMint.request externally; default processors finalize after payment
-await finalized;
+await completed;
 
 // Check balances
 const balances = await manager.wallet.balances.byMint();
@@ -373,6 +385,7 @@ include:
 - `mint-op:requeue` → `{ mintUrl, operationId, operation }`
 - `mint-op:executing` → `{ mintUrl, operationId, operation }`
 - `mint-op:finalized` → `{ mintUrl, operationId, operation }`
+- `mint-op:failed` → `{ mintUrl, operationId, operation }`
 - `send:prepared` → `{ mintUrl, operationId, operation }`
 - `send:pending` → `{ mintUrl, operationId, operation, token }`
 - `send:finalized` → `{ mintUrl, operationId, operation }`

--- a/packages/core/events/types.ts
+++ b/packages/core/events/types.ts
@@ -1,6 +1,11 @@
 import type { Token } from '@cashu/cashu-ts';
 import type { MeltMethod, MeltOperation } from '@core/operations/melt';
-import type { MintOperation, MintMethod } from '@core/operations/mint';
+import type {
+  FailedMintOperation,
+  FinalizedMintOperation,
+  MintMethod,
+  MintOperation,
+} from '@core/operations/mint';
 import type { MeltQuote } from '../models/MeltQuote';
 import type { MintQuote } from '../models/MintQuote';
 import type { UnitAmount } from '../amounts.ts';
@@ -79,7 +84,8 @@ export interface CoreEvents {
   };
   'mint-op:requeue': { mintUrl: string; operationId: string; operation: MintOperation };
   'mint-op:executing': { mintUrl: string; operationId: string; operation: MintOperation };
-  'mint-op:finalized': { mintUrl: string; operationId: string; operation: MintOperation };
+  'mint-op:finalized': { mintUrl: string; operationId: string; operation: FinalizedMintOperation };
+  'mint-op:failed': { mintUrl: string; operationId: string; operation: FailedMintOperation };
   'subscriptions:paused': void;
   'subscriptions:resumed': void;
   'auth-session:updated': { mintUrl: string };

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1075,7 +1075,7 @@ export class MintOperationService {
 
     await this.mintOperationRepository.update(failed);
 
-    await this.eventBus.emit('mint-op:finalized', {
+    await this.eventBus.emit('mint-op:failed', {
       mintUrl: failed.mintUrl,
       operationId: failed.id,
       operation: failed,
@@ -1205,7 +1205,7 @@ export class MintOperationService {
 
     await this.mintOperationRepository.update(failed);
 
-    await this.eventBus.emit('mint-op:finalized', {
+    await this.eventBus.emit('mint-op:failed', {
       mintUrl: failed.mintUrl,
       operationId: failed.id,
       operation: failed,

--- a/packages/core/services/HistoryService.ts
+++ b/packages/core/services/HistoryService.ts
@@ -64,6 +64,9 @@ export class HistoryService {
     this.eventBus.on('mint-op:finalized', ({ mintUrl, operation }) => {
       return this.emitProjectedMint(mintUrl, operation);
     });
+    this.eventBus.on('mint-op:failed', ({ mintUrl, operation }) => {
+      return this.emitProjectedMint(mintUrl, operation);
+    });
 
     this.eventBus.on('receive-op:finalized', ({ mintUrl, operation }) => {
       return this.emitProjectedReceive(mintUrl, operation);

--- a/packages/core/services/watchers/MintOperationWatcherService.ts
+++ b/packages/core/services/watchers/MintOperationWatcherService.ts
@@ -107,6 +107,7 @@ export class MintOperationWatcherService {
   private offPending?: () => void;
   private offExecuting?: () => void;
   private offFinalized?: () => void;
+  private offFailed?: () => void;
   private offUntrusted?: () => void;
 
   constructor(
@@ -193,6 +194,17 @@ export class MintOperationWatcherService {
         await this.stopWatchingOperation(operationId);
       } catch (err) {
         this.logger?.error('Failed to stop watching finalized mint operation', {
+          operationId,
+          err,
+        });
+      }
+    });
+
+    this.offFailed = this.bus.on('mint-op:failed', async ({ operationId }) => {
+      try {
+        await this.stopWatchingOperation(operationId);
+      } catch (err) {
+        this.logger?.error('Failed to stop watching failed mint operation', {
           operationId,
           err,
         });
@@ -306,6 +318,16 @@ export class MintOperationWatcherService {
         // ignore
       } finally {
         this.offFinalized = undefined;
+      }
+    }
+
+    if (this.offFailed) {
+      try {
+        this.offFailed();
+      } catch {
+        // ignore
+      } finally {
+        this.offFailed = undefined;
       }
     }
 

--- a/packages/core/test/unit/HistoryService.test.ts
+++ b/packages/core/test/unit/HistoryService.test.ts
@@ -160,10 +160,10 @@ describe('HistoryService', () => {
     expect(historyUpdateEvents).toHaveLength(0);
   });
 
-  it('emits mint operation state without operation-level remote quote state', async () => {
+  it('projects failed mint operation state from mint failure events', async () => {
     const failed = makeFailedMintOperation('mint-op-1', 'quote-1');
 
-    await eventBus.emit('mint-op:finalized', {
+    await eventBus.emit('mint-op:failed', {
       mintUrl,
       operationId: failed.id,
       operation: failed,

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -922,11 +922,15 @@ describe('MintOperationService', () => {
   it('prepare + finalize runs pending -> execute for an existing canonical quote', async () => {
     const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
     const finalizedEvents: Array<CoreEvents['mint-op:finalized']> = [];
+    const failedEvents: Array<CoreEvents['mint-op:failed']> = [];
     eventBus.on('mint-quote:updated', (event) => {
       quoteUpdatedEvents.push(event);
     });
     eventBus.on('mint-op:finalized', (event) => {
       finalizedEvents.push(event);
+    });
+    eventBus.on('mint-op:failed', (event) => {
+      failedEvents.push(event);
     });
 
     await persistQuote();
@@ -951,6 +955,7 @@ describe('MintOperationService', () => {
     expect(finalizedEvents.length).toBe(1);
     expect(finalizedEvents[0]?.operationId).toBe(finalized?.id);
     expect(finalizedEvents[0]?.operation.state).toBe('finalized');
+    expect(failedEvents).toHaveLength(0);
   });
 
   it('finalize is idempotent after finalize', async () => {
@@ -1458,7 +1463,15 @@ describe('MintOperationService', () => {
 
   it('recoverExecutingOperation finalizes expired quotes as terminal failures', async () => {
     const op = makeExecutingOp('exec-expired');
+    const finalizedEvents: Array<CoreEvents['mint-op:finalized']> = [];
+    const failedEvents: Array<CoreEvents['mint-op:failed']> = [];
     await operationRepo.create(op);
+    eventBus.on('mint-op:finalized', (event) => {
+      finalizedEvents.push(event);
+    });
+    eventBus.on('mint-op:failed', (event) => {
+      failedEvents.push(event);
+    });
 
     (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({
       status: 'TERMINAL',
@@ -1471,6 +1484,13 @@ describe('MintOperationService', () => {
 
     expect(stored?.state).toBe('failed');
     expect(stored?.error).toBe(`Recovered: quote ${quoteId} expired while executing mint`);
+    expect(finalizedEvents).toHaveLength(0);
+    expect(failedEvents).toHaveLength(1);
+    expect(failedEvents[0]?.operationId).toBe(op.id);
+    expect(failedEvents[0]?.operation.state).toBe('failed');
+    expect(failedEvents[0]?.operation.terminalFailure?.reason).toBe(
+      `Recovered: quote ${quoteId} expired while executing mint`,
+    );
   });
 
   it('finalize returns a failed operation when recovery finds an expired quote', async () => {
@@ -1559,6 +1579,53 @@ describe('MintOperationService', () => {
     if (!stored || stored.state !== 'pending') {
       throw new Error('Expected pending operation to remain pending after unpaid check');
     }
+  });
+
+  it('checkPendingOperation emits mint-op:failed for terminal pending failures', async () => {
+    const pendingOp = makePendingOp('pending-terminal');
+    const observedAt = Date.now();
+    const finalizedEvents: Array<CoreEvents['mint-op:finalized']> = [];
+    const failedEvents: Array<CoreEvents['mint-op:failed']> = [];
+
+    await operationRepo.create(pendingOp);
+    eventBus.on('mint-op:finalized', (event) => {
+      finalizedEvents.push(event);
+    });
+    eventBus.on('mint-op:failed', (event) => {
+      failedEvents.push(event);
+    });
+
+    (handler.checkPending as Mock<any>).mockResolvedValueOnce({
+      observedRemoteState: 'UNPAID',
+      observedRemoteStateAt: observedAt,
+      category: 'terminal',
+      terminalFailure: {
+        reason: 'Quote expired before issuance',
+        code: 'quote_expired',
+        retryable: false,
+        observedAt,
+      },
+    });
+
+    const result = await service.checkPendingOperation(pendingOp.id);
+    const stored = await operationRepo.getById(pendingOp.id);
+
+    expect(result.category).toBe('terminal');
+    expect(stored?.state).toBe('failed');
+    expect(stored?.error).toBe('Quote expired before issuance');
+    expect(stored?.terminalFailure).toMatchObject({
+      reason: 'Quote expired before issuance',
+      code: 'quote_expired',
+      retryable: false,
+      observedAt,
+    });
+    expect(finalizedEvents).toHaveLength(0);
+    expect(failedEvents).toHaveLength(1);
+    expect(failedEvents[0]?.operationId).toBe(pendingOp.id);
+    expect(failedEvents[0]?.operation.state).toBe('failed');
+    expect(failedEvents[0]?.operation.terminalFailure?.reason).toBe(
+      'Quote expired before issuance',
+    );
   });
 
   it('checkPendingOperation records onchain quote snapshots without protocol state', async () => {

--- a/packages/core/test/unit/MintOperationWatcherService.test.ts
+++ b/packages/core/test/unit/MintOperationWatcherService.test.ts
@@ -13,7 +13,10 @@ import {
 import type { SubscriptionManager } from '../../infra/SubscriptionManager.ts';
 import type { MintService } from '../../services/MintService.ts';
 import type { MintOperationService } from '../../operations/mint/MintOperationService.ts';
-import type { PendingMintOperation } from '../../operations/mint/MintOperation.ts';
+import type {
+  FailedMintOperation,
+  PendingMintOperation,
+} from '../../operations/mint/MintOperation.ts';
 import type { MintQuote } from '../../models/MintQuote.ts';
 import { NullLogger } from '../../logging/NullLogger.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
@@ -43,6 +46,19 @@ describe('MintOperationWatcherService', () => {
     outputData: '{"keep":[],"send":[]}' as unknown as PendingMintOperation['outputData'],
     createdAt: Date.now(),
     updatedAt: Date.now(),
+  });
+
+  const makeFailedOperation = (operation = makePendingOperation()): FailedMintOperation => ({
+    ...operation,
+    state: 'failed',
+    updatedAt: Date.now(),
+    error: 'Quote expired before issuance',
+    terminalFailure: {
+      reason: 'Quote expired before issuance',
+      code: 'quote_expired',
+      retryable: false,
+      observedAt: Date.now(),
+    },
   });
 
   const makeOnchainOperation = (): PendingMintOperation<'onchain'> =>
@@ -697,6 +713,31 @@ describe('MintOperationWatcherService', () => {
       operationId: second.id,
       operation: { ...second, state: 'finalized' },
     });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+    await watcher.stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops operation-specific watch interest when an operation fails', async () => {
+    const operation = makePendingOperation();
+
+    const watcher = makeWatcher({
+      mintOperations: {
+        getPendingOperations: mock(async () => [operation]),
+      } as unknown as MintOperationService,
+      options: { watchExistingPendingQuotesOnStart: false },
+    });
+
+    await watcher.start();
+    expect(subscribe).toHaveBeenCalledTimes(1);
+
+    await bus.emit('mint-op:failed', {
+      mintUrl,
+      operationId: operation.id,
+      operation: makeFailedOperation(operation),
+    });
+
     expect(unsubscribe).toHaveBeenCalledTimes(1);
 
     await watcher.stop();

--- a/packages/docs/pages/mint-operations.md
+++ b/packages/docs/pages/mint-operations.md
@@ -86,8 +86,8 @@ settlement state changes. Stable metadata-only updates do not emit. Importing a
 quote can therefore start watcher interest, but it does not create history or a
 mint operation; call `coco.ops.mint.prepare(...)` when you want to redeem it.
 Use `coco.on('mint-quote:updated', ...)` for live application quote state, and
-use `mint-op:finalized` or `coco.ops.mint.finalize(...)` for issuance
-completion.
+use `mint-op:finalized`, `mint-op:failed`, or `coco.ops.mint.finalize(...)` for
+issuance completion.
 
 For BOLT11 quotes, the invoice is available at `quote.request`. For reusable
 onchain quotes, the address/payment request is also available at `quote.request`
@@ -258,6 +258,31 @@ coco.on('mint-op:executing', ({ operationId }) => {
 });
 
 coco.on('mint-op:finalized', ({ operationId, operation }) => {
-  console.log('Mint terminal', operationId, operation.state);
+  console.log('Mint finalized', operationId, operation.state);
 });
+
+coco.on('mint-op:failed', ({ operationId, operation }) => {
+  console.log('Mint failed', operationId, operation.terminalFailure?.reason ?? operation.error);
+});
+
+const waitForMintCompletion = (operationId: string) =>
+  new Promise<void>((resolve, reject) => {
+    let offFinalized = () => {};
+    let offFailed = () => {};
+    const cleanup = () => {
+      offFinalized();
+      offFailed();
+    };
+
+    offFinalized = coco.on('mint-op:finalized', (payload) => {
+      if (payload.operationId !== operationId) return;
+      cleanup();
+      resolve();
+    });
+    offFailed = coco.on('mint-op:failed', ({ operationId: failedId, operation }) => {
+      if (failedId !== operationId) return;
+      cleanup();
+      reject(new Error(operation.terminalFailure?.reason ?? operation.error ?? 'Mint failed'));
+    });
+  });
 ```

--- a/packages/docs/starting/migrating-from-v1.md
+++ b/packages/docs/starting/migrating-from-v1.md
@@ -114,9 +114,15 @@ const offMelt = manager.on('melt-quote:updated', ({ mintUrl, quoteId, quote }) =
 
 Use `manager.quotes.*.refresh({ mintUrl, quoteId })` when resuming or when your
 app wants to explicitly check remote quote state. Use operation APIs and
-operation events such as `mint-op:finalized`, `melt-op:finalized`, or
-`melt-op:rolled-back` when the app needs to wait for value movement to reach a
-terminal state.
+operation events such as `mint-op:finalized`, `mint-op:failed`,
+`melt-op:finalized`, or `melt-op:rolled-back` when the app needs to wait for
+value movement to reach a terminal state.
+
+Mint completion waits should subscribe to both `mint-op:finalized` and
+`mint-op:failed`. `mint-op:finalized` now means successful issuance only; use
+`mint-op:failed` to reject or surface
+`operation.terminalFailure?.reason ?? operation.error` for terminal mint
+failures.
 
 ## Melt quote migration
 
@@ -159,7 +165,8 @@ manager.on('mint-quote:updated', ({ mintUrl, method, quoteId, quote }) => {
 ```
 
 Use `mint-quote:updated` only for quote state. Operation consumers should follow
-`mint-op:pending`, `mint-op:executing`, and `mint-op:finalized`.
+`mint-op:pending`, `mint-op:executing`, `mint-op:finalized`, and
+`mint-op:failed`.
 
 Because quote-only updates are separate from operation updates, `history:updated`
 is not emitted for bare quote creation or quote refresh. When a quote update

--- a/packages/docs/starting/minting.md
+++ b/packages/docs/starting/minting.md
@@ -60,15 +60,27 @@ const pendingMint = await coco.ops.mint.prepare({
 console.log('pay this: ', pendingMint.request);
 console.log('this is the quote id: ', pendingMint.quoteId);
 
-const finalized = new Promise<void>((resolve) => {
-  const off = coco.on('mint-op:finalized', (payload) => {
+const completed = new Promise<void>((resolve, reject) => {
+  let offFinalized = () => {};
+  let offFailed = () => {};
+  const cleanup = () => {
+    offFinalized();
+    offFailed();
+  };
+
+  offFinalized = coco.on('mint-op:finalized', (payload) => {
     if (payload.operationId !== pendingMint.id) return;
-    off();
+    cleanup();
     resolve();
+  });
+  offFailed = coco.on('mint-op:failed', ({ operationId, operation }) => {
+    if (operationId !== pendingMint.id) return;
+    cleanup();
+    reject(new Error(operation.terminalFailure?.reason ?? operation.error ?? 'Mint failed'));
   });
 });
 
-await finalized;
+await completed;
 ```
 
 If you disable the default mint processor and want to finalize manually, listen

--- a/packages/react/src/lib/hooks/operationHooks.test.tsx
+++ b/packages/react/src/lib/hooks/operationHooks.test.tsx
@@ -355,6 +355,24 @@ function createFinalizedMintOperation(
   } as MintExecuteResult;
 }
 
+function createFailedMintOperation(
+  overrides: Partial<MintOperationRecord> = {},
+): MintOperationRecord {
+  return {
+    ...createPendingMintOperation(),
+    state: 'failed',
+    updatedAt: 1_700_000_020_000,
+    error: 'Quote expired before issuance',
+    terminalFailure: {
+      reason: 'Quote expired before issuance',
+      code: 'quote_expired',
+      retryable: false,
+      observedAt: 1_700_000_020_000,
+    },
+    ...overrides,
+  } as MintOperationRecord;
+}
+
 function createMintCheckPaymentResult(
   overrides: Partial<MintCheckPaymentResult> = {},
 ): MintCheckPaymentResult {
@@ -1278,6 +1296,33 @@ describe('useMintOperation', () => {
 
     await waitForAssertion(() => {
       expect(result.current.currentOperation).toEqual(finalized);
+    });
+    expect(mint.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('reacts to background failed events for the bound mint operation id', async () => {
+    const { manager, mint, emit } = createMintManagerMock();
+    const pending = createPendingMintOperation();
+    const failed = createFailedMintOperation({ id: pending.id });
+
+    mint.get.mockResolvedValueOnce(pending);
+
+    const { result } = renderHook(() => useMintOperation(pending.id), {
+      wrapper: createHookWrapper(manager),
+    });
+
+    await waitForAssertion(() => {
+      expect(result.current.currentOperation).toEqual(pending);
+    });
+
+    await emit('mint-op:failed', {
+      mintUrl: pending.mintUrl,
+      operationId: pending.id,
+      operation: failed,
+    });
+
+    await waitForAssertion(() => {
+      expect(result.current.currentOperation).toEqual(failed);
     });
     expect(mint.get).toHaveBeenCalledTimes(1);
   });

--- a/packages/react/src/lib/hooks/useMintOperation.ts
+++ b/packages/react/src/lib/hooks/useMintOperation.ts
@@ -128,11 +128,15 @@ export function useMintOperation(
     const unsubscribeFinalized = manager.on('mint-op:finalized', ({ operation }) => {
       handleObservedOperation(operation);
     });
+    const unsubscribeFailed = manager.on('mint-op:failed', ({ operation }) => {
+      handleObservedOperation(operation);
+    });
 
     return () => {
       unsubscribePending();
       unsubscribeExecuting();
       unsubscribeFinalized();
+      unsubscribeFailed();
     };
   }, [handleObservedOperation, manager]);
 


### PR DESCRIPTION
## Description

This pull request fixes #283  mint operation terminal event semantics so successful issuance emits `mint-op:finalized`, while terminal failures emit `mint-op:failed`.

## Problem

Failed mint operations were being reported through the successful finalization event, forcing callers to inspect payload state and making completion waits misleading.

## Summary

- Narrows `mint-op:finalized` to `FinalizedMintOperation` and adds typed `mint-op:failed`.
- Routes failed mint service paths, history projection, watcher cleanup, and React hook updates through `mint-op:failed`.
- Updates mint completion docs/examples and v1 migration guidance to wait on both success and failure events.
- Adds `.changeset/mint-failure-events.md` for the public core event behavior change.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MintOperationService.test.ts test/unit/HistoryService.test.ts test/unit/MintOperationWatcherService.test.ts`
- `bun run --filter='@cashu/coco-react' test -- src/lib/hooks/operationHooks.test.tsx`
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-react' typecheck`


## Changeset

- Added `.changeset/mint-failure-events.md`