### PR TITLE
fix(core): align cashu-ts error types

### DIFF
--- a/.changeset/align-cashu-error-types.md
+++ b/.changeset/align-cashu-error-types.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Re-export cashu-ts transport and mint operation errors from core so protocol
+errors thrown by Coco share constructor identity with cashu-ts.

--- a/packages/core/models/Error.ts
+++ b/packages/core/models/Error.ts
@@ -1,3 +1,5 @@
+export { HttpResponseError, MintOperationError, NetworkError } from '@cashu/cashu-ts';
+
 export class UnknownMintError extends Error {
   constructor(message: string) {
     super(message);
@@ -69,43 +71,6 @@ export class ProofOperationError extends Error {
     this.mintUrl = mintUrl;
     this.keysetId = keysetId;
     (this as unknown as { cause?: unknown }).cause = cause;
-  }
-}
-
-/**
- * This error is thrown when a HTTP response is not 2XX nor a protocol error.
- */
-export class HttpResponseError extends Error {
-  status: number;
-  constructor(message: string, status: number) {
-    super(message);
-    this.status = status;
-    this.name = 'HttpResponseError';
-    Object.setPrototypeOf(this, HttpResponseError.prototype);
-  }
-}
-
-/**
- * This error is thrown when a network request fails.
- */
-export class NetworkError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'NetworkError';
-    Object.setPrototypeOf(this, NetworkError.prototype);
-  }
-}
-
-/**
- * This error is thrown when a protocol error occurs per Cashu NUT-00 error codes.
- */
-export class MintOperationError extends HttpResponseError {
-  code: number;
-  constructor(code: number, detail: string) {
-    super(detail || 'Unknown mint operation error', 400);
-    this.code = code;
-    this.name = 'MintOperationError';
-    Object.setPrototypeOf(this, MintOperationError.prototype);
   }
 }
 

--- a/packages/core/test/unit/RequestRateLimiter.test.ts
+++ b/packages/core/test/unit/RequestRateLimiter.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, beforeEach, afterEach, expect } from 'bun:test';
+import { MintOperationError as CashuMintOperationError } from '@cashu/cashu-ts';
+import type { HeadersInit } from 'bun';
+
 import { RequestRateLimiter } from '../../infra/RequestRateLimiter.ts';
 import { HttpResponseError, NetworkError, MintOperationError } from '../../models/Error.ts';
-import type { HeadersInit } from 'bun';
 
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
@@ -111,6 +113,8 @@ describe('RequestRateLimiter', () => {
   });
 
   it('throws MintOperationError for 400 with protocol error shape', async () => {
+    expect(MintOperationError).toBe(CashuMintOperationError);
+
     // @ts-ignore
     globalThis.fetch = async () => {
       return new Response(JSON.stringify({ code: 4200, detail: 'proof already spent' }), {
@@ -125,6 +129,7 @@ describe('RequestRateLimiter', () => {
       throw new Error('Expected MintOperationError');
     } catch (err) {
       expect(err).toBeInstanceOf(MintOperationError);
+      expect(err).toBeInstanceOf(CashuMintOperationError);
       const e = err as MintOperationError;
       expect(e.status).toBe(400);
       expect(e.code).toBe(4200);


### PR DESCRIPTION
## Summary

- re-export cashu-ts `HttpResponseError`, `NetworkError`, and `MintOperationError` from core
- assert Coco mint protocol errors share constructor identity with cashu-ts errors
- add a patch changeset for `@cashu/coco-core`

## Problem

Coco defined local copies of cashu-ts transport and mint operation errors. Those classes had the same names and shape, but a different constructor identity, so `instanceof MintOperationError` checks inside cashu-ts could miss protocol errors thrown by Coco's custom request layer.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/RequestRateLimiter.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-core' build`