### PR TITLE
feat(core): expose quotes to plugins

### DIFF
--- a/.changeset/plugin-quote-service.md
+++ b/.changeset/plugin-quote-service.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': minor
+---
+
+Expose the canonical quote API through the plugin service map so plugins can import mint quotes.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -395,6 +395,7 @@ export class Manager {
       counterService: this.counterService,
       meltOperationService: this.meltOperationService,
       mintOperationService: this.mintOperationService,
+      quotes: this.quotes,
       historyService: this.historyService,
       sendOperationService: this.sendOperationService,
       receiveOperationService: this.receiveOperationService,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -433,6 +433,23 @@ const myPlugin: Plugin<['eventBus', 'logger']> = {
 };
 ```
 
+Plugins that ingest externally created mint quotes can request the canonical
+quote API:
+
+```ts
+const quotePlugin: Plugin<['quotes']> = {
+  name: 'quote-plugin',
+  required: ['quotes'] as const,
+  onReady: async ({ services }) => {
+    await services.quotes.mint.import({
+      mintUrl,
+      method: 'bolt11',
+      quote,
+    });
+  },
+};
+```
+
 ### Using plugins
 
 ```ts

--- a/packages/core/plugins/types.ts
+++ b/packages/core/plugins/types.ts
@@ -2,6 +2,7 @@ import type { SubscriptionManager } from '../infra/SubscriptionManager.ts';
 import type { EventBus } from '../events/EventBus.ts';
 import type { CoreEvents } from '../events/types.ts';
 import type { Logger } from '../logging/Logger.ts';
+import type { QuoteApi } from '../api/QuoteApi.ts';
 import type {
   CounterService,
   HistoryService,
@@ -42,6 +43,7 @@ export interface ServiceMap {
   receiveOperationService: ReceiveOperationService;
   meltOperationService: MeltOperationService;
   mintOperationService: MintOperationService;
+  quotes: QuoteApi;
   paymentRequestService: PaymentRequestService;
   paymentRequestReceiveService: PaymentRequestReceiveService;
   subscriptions: SubscriptionManager;

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -5,6 +5,7 @@ import { initializeCoco, type CocoConfig, Manager } from '../../Manager';
 import { PaymentRequestsApi } from '../../api/PaymentRequestsApi';
 import { QuoteApi } from '../../api/QuoteApi';
 import type { CoreEvents } from '../../events/types';
+import type { Mint } from '../../models/Mint';
 import { meltQuoteFromBolt11Response } from '../../models/MeltQuote';
 import { mintQuoteFromBolt11Response } from '../../models/MintQuote';
 import type { PendingMeltOperation } from '../../operations/melt';
@@ -12,7 +13,8 @@ import type { PendingMintOperation } from '../../operations/mint';
 import { MemoryRepositories } from '../../repositories/memory';
 import { NullLogger } from '../../logging';
 import type { FinalizedReceiveOperation } from '../../operations/receive/ReceiveOperation';
-import type { CoreProof } from '../../types';
+import type { Plugin } from '../../plugin';
+import type { CoreProof, MintInfo } from '../../types';
 
 describe('initializeCoco', () => {
   let repositories: MemoryRepositories;
@@ -83,6 +85,95 @@ describe('initializeCoco', () => {
       await manager.disableMintOperationWatcher();
       await manager.disableProofStateWatcher();
       await manager.disableMintOperationProcessor();
+    });
+
+    it('should expose the quote api to plugins', async () => {
+      let pluginQuotes: QuoteApi | undefined;
+      const plugin: Plugin<['quotes']> = {
+        name: 'quotes-plugin',
+        required: ['quotes'],
+        onReady: ({ services }) => {
+          pluginQuotes = services.quotes;
+        },
+      };
+
+      const manager = await initializeCoco({
+        ...baseConfig,
+        plugins: [plugin],
+        watchers: {
+          mintOperationWatcher: { disabled: true },
+          proofStateWatcher: { disabled: true },
+        },
+        processors: {
+          mintOperationProcessor: { disabled: true },
+        },
+      });
+
+      expect(pluginQuotes).toBe(manager.quotes);
+      expect(pluginQuotes).toBeInstanceOf(QuoteApi);
+
+      await manager.dispose();
+    });
+
+    it('should let plugins import canonical mint quotes through the quote api', async () => {
+      const mintUrl = 'https://mint.test';
+      const quoteId = 'plugin-import-quote';
+      const now = Math.floor(Date.now() / 1000);
+      await repositories.mintRepository.addNewMint({
+        mintUrl,
+        name: mintUrl,
+        mintInfo: {
+          nuts: {
+            '4': { methods: [{ method: 'bolt11', unit: 'sat' }] },
+          },
+        } as MintInfo,
+        trusted: true,
+        createdAt: now,
+        updatedAt: now,
+      } satisfies Mint);
+
+      let importedQuoteId: string | undefined;
+      const plugin: Plugin<['quotes']> = {
+        name: 'quotes-import-plugin',
+        required: ['quotes'],
+        onReady: async ({ services }) => {
+          const quote = await services.quotes.mint.import({
+            mintUrl,
+            method: 'bolt11',
+            quote: {
+              quote: quoteId,
+              request: 'lnbc1pluginimportquote',
+              amount: Amount.from(21),
+              unit: 'sat',
+              expiry: 4_102_444_800,
+              state: 'PAID',
+            },
+          });
+          importedQuoteId = quote.quoteId;
+        },
+      };
+
+      const manager = await initializeCoco({
+        ...baseConfig,
+        plugins: [plugin],
+        watchers: {
+          mintOperationWatcher: { disabled: true },
+          proofStateWatcher: { disabled: true },
+        },
+        processors: {
+          mintOperationProcessor: { disabled: true },
+        },
+      });
+
+      expect(importedQuoteId).toBe(quoteId);
+      await expect(manager.quotes.mint.get({ mintUrl, quoteId })).resolves.toMatchObject({
+        mintUrl,
+        quoteId,
+        method: 'bolt11',
+        state: 'PAID',
+      });
+
+      await manager.dispose();
     });
 
     it('does not reconcile canonical quote-only rows into mint operations on startup', async () => {

--- a/packages/docs/pages/plugins.md
+++ b/packages/docs/pages/plugins.md
@@ -83,11 +83,31 @@ implementation wiring and is not needed to author extensions.
 | `receiveOperationService`      | Receive operation lifecycle                 |
 | `meltOperationService`         | Melt operation lifecycle                    |
 | `mintOperationService`         | Mint operation lifecycle                    |
+| `quotes`                       | Canonical quote create/import/lookup API    |
 | `paymentRequestService`        | Payment request helpers                     |
 | `paymentRequestReceiveService` | Payment request receive operation lifecycle |
 | `subscriptions`                | WebSocket subscription manager              |
 | `eventBus`                     | Event pub/sub system                        |
 | `logger`                       | Logging interface                           |
+
+Plugins that sync externally created mint quotes can request `quotes` and use
+the same canonical quote API available on the manager:
+
+```ts
+import type { Plugin } from '@cashu/coco-core/plugin';
+
+const externalQuotePlugin: Plugin<['quotes']> = {
+  name: 'external-quote-plugin',
+  required: ['quotes'],
+  onReady: async ({ services }) => {
+    await services.quotes.mint.import({
+      mintUrl,
+      method: 'bolt11',
+      quote,
+    });
+  },
+};
+```
 
 ## Plugin Extensions
 


### PR DESCRIPTION
This pull request adds the manager quote API to the public plugin service surface so plugins can import canonical mint quotes without internal service casts.

## Problem

Plugin authors could call `manager.quotes.mint.import(...)` from app code, but `PluginContext.services` did not expose an equivalent stable service. This blocked plugins that ingest externally created paid mint quotes.

This pull request resolves #305.

## Summary

- Adds `quotes: QuoteApi` to `ServiceMap` and passes `manager.quotes` into plugin initialization.
- Covers plugin quote access and BOLT11 canonical quote import in `Manager.test.ts`.
- Documents the `quotes` service and external quote import path.
- Adds `.changeset/plugin-quote-service.md` for the public core API addition.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/QuoteApi.test.ts test/unit/Manager.test.ts test/unit/PluginHost.test.ts`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run docs:build`
- `bun run --filter='@cashu/coco-core' test:unit`

Full `@cashu/coco-core` test was attempted. With network access, remaining failures require missing `MINT_URL`/auth env and a local mint at `localhost:3338`.

## Changeset

- Added `.changeset/plugin-quote-service.md`