### PR TITLE
fix(core): serialize receive prepare per mint to prevent NUT-13 counter collisions

### DIFF
--- a/.changeset/serialize-receive-prepare.md
+++ b/.changeset/serialize-receive-prepare.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Serialize concurrent receive `prepare()` per mint with the shared `MintScopedLock`. Receive was left out of the mint-level lock added for proof selection, but it shares the same non-atomic NUT-13 counter derivation, so two concurrent receives on one mint could read the same counter and derive colliding deterministic outputs, failing with "Failed to persist proofs".

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -890,6 +890,9 @@ export class Manager {
       walletRestoreLogger,
     );
 
+    // One shared instance across every counter-consuming operation service so that
+    // send, receive, melt, and mint serialize their per-mint deterministic-output
+    // derivation against each other. Passing separate instances would break that.
     const mintScopedLock = new MintScopedLock();
 
     const sendOperationLogger = this.getChildLogger('SendOperationService');
@@ -923,6 +926,7 @@ export class Manager {
       tokenService,
       this.eventBus,
       receiveOperationLogger,
+      mintScopedLock,
     );
     const receiveOperationRepository = repositories.receiveOperationRepository;
     const paymentRequestReceiveOperationRepository =

--- a/packages/core/operations/receive/ReceiveOperationService.ts
+++ b/packages/core/operations/receive/ReceiveOperationService.ts
@@ -42,6 +42,7 @@ import type { WalletService } from '../../services/WalletService';
 import { createReceiveOperation, getOutputProofSecrets } from './ReceiveOperation';
 import type { ReceiveOperationRepository, ProofRepository } from '../../repositories';
 import { OperationIdLock } from '../OperationIdLock';
+import { MintScopedLock } from '../MintScopedLock';
 import { DEFAULT_UNIT, normalizeUnit } from '../../amounts.ts';
 
 const NON_TERMINAL_RECEIVE_MINT_ERROR_CODES = new Set([
@@ -77,6 +78,8 @@ export class ReceiveOperationService {
   private readonly operationIdLock = new OperationIdLock();
   /** Lock for the global recovery process */
   private recoveryLock: Promise<void> | null = null;
+  /** In-memory lock to serialize deterministic-output derivation (counter) per mint */
+  private readonly mintScopedLock: MintScopedLock;
 
   constructor(
     receiveOperationRepository: ReceiveOperationRepository,
@@ -88,6 +91,7 @@ export class ReceiveOperationService {
     tokenService: TokenService,
     eventBus: EventBus<CoreEvents>,
     logger?: Logger,
+    mintScopedLock?: MintScopedLock,
   ) {
     this.receiveOperationRepository = receiveOperationRepository;
     this.proofRepository = proofRepository;
@@ -98,6 +102,7 @@ export class ReceiveOperationService {
     this.tokenService = tokenService;
     this.eventBus = eventBus;
     this.logger = logger;
+    this.mintScopedLock = mintScopedLock ?? new MintScopedLock();
   }
 
   /**
@@ -170,22 +175,41 @@ export class ReceiveOperationService {
   async prepare(operation: InitReceiveOperation): Promise<PreparedReceiveOperation> {
     const releaseLock = await this.acquireOperationLock(operation.id);
     try {
-      const current = await this.receiveOperationRepository.getById(operation.id);
-      if (!current) {
-        throw new Error(`Operation ${operation.id} not found`);
-      }
-      if (current.state !== 'init') {
-        throw new Error(`Cannot prepare operation in state '${current.state}'. Expected 'init'.`);
+      // Serialize per-mint so concurrent receives on the same keyset cannot read the
+      // same NUT-13 counter and derive colliding deterministic outputs. Mirrors the
+      // send/melt/mint services, which already hold this lock across counter usage.
+      const releaseMintLock = await this.mintScopedLock.acquire(operation.mintUrl);
+      let prepared: PreparedReceiveOperation;
+      try {
+        const current = await this.receiveOperationRepository.getById(operation.id);
+        if (!current) {
+          throw new Error(`Operation ${operation.id} not found`);
+        }
+        if (current.state !== 'init') {
+          throw new Error(`Cannot prepare operation in state '${current.state}'. Expected 'init'.`);
+        }
+
+        try {
+          prepared = await this.prepareInternal(current as InitReceiveOperation);
+        } catch (e) {
+          if (current.state === 'init') {
+            await this.tryRecoverInitOperation(current as InitReceiveOperation);
+          }
+          throw e;
+        }
+      } finally {
+        releaseMintLock();
       }
 
-      try {
-        return await this.prepareInternal(current as InitReceiveOperation);
-      } catch (e) {
-        if (current.state === 'init') {
-          await this.tryRecoverInitOperation(current as InitReceiveOperation);
-        }
-        throw e;
-      }
+      // Emit outside the mint lock so a listener cannot extend or re-enter the
+      // per-mint critical section. Mirrors the send service.
+      await this.eventBus.emit('receive-op:prepared', {
+        mintUrl: prepared.mintUrl,
+        operationId: prepared.id,
+        operation: prepared,
+      });
+
+      return prepared;
     } finally {
       releaseLock();
     }
@@ -236,11 +260,6 @@ export class ReceiveOperationService {
     };
 
     await this.receiveOperationRepository.update(prepared);
-    await this.eventBus.emit('receive-op:prepared', {
-      mintUrl,
-      operationId: prepared.id,
-      operation: prepared,
-    });
 
     this.logger?.info('Receive operation prepared', {
       operationId: operation.id,

--- a/packages/core/test/unit/ReceiveOperationService.test.ts
+++ b/packages/core/test/unit/ReceiveOperationService.test.ts
@@ -26,6 +26,7 @@ import { getOutputProofSecrets } from '../../operations/receive/ReceiveOperation
 import { MemoryHistoryRepository } from '../../repositories/memory/MemoryHistoryRepository';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
 import { ReceiveOperationService } from '../../operations/receive/ReceiveOperationService';
+import { MintScopedLock } from '../../operations/MintScopedLock';
 import { MemoryReceiveOperationRepository } from '../../repositories/memory/MemoryReceiveOperationRepository';
 
 describe('ReceiveOperationService', () => {
@@ -163,6 +164,56 @@ describe('ReceiveOperationService', () => {
     expect(prepared.state).toBe('prepared');
     expect(prepared.fee).toEqual(Amount.from(0));
     expect(prepared.outputData).toBeDefined();
+  });
+
+  it('serializes concurrent prepare() on the same mint so deterministic outputs cannot collide', async () => {
+    // Two independent tokens received on the same mint at the same time (for example the
+    // same gift-wrapped token delivered more than once, or two tokens arriving together)
+    // must not derive blinded outputs from the same NUT-13 counter value. The per-mint
+    // lock has to serialize the counter-consuming section across operations, the same way
+    // the send/melt/mint services already do. Without it both prepares read the same
+    // counter and produce colliding secrets, which the store then rejects as duplicate
+    // proofs.
+    let inside = 0;
+    let maxInside = 0;
+    const racingProofService = {
+      prepareProofsForReceiving: mock(async (proofs: Proof[]) => proofs),
+      createOutputsAndIncrementCounters: mock(async () => {
+        inside += 1;
+        maxInside = Math.max(maxInside, inside);
+        // Hold the counter-consuming section open long enough for a racing prepare to
+        // overlap here if it is not serialized.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        inside -= 1;
+        return { keep: makeOutputData(['out-1']), send: [] };
+      }),
+      setProofState: mock(async () => {}),
+      saveProofs: mock(async () => {}),
+    } as unknown as ProofService;
+
+    const mintScopedLock = new MintScopedLock();
+    service = new ReceiveOperationService(
+      receiveOpRepo,
+      proofRepo,
+      racingProofService,
+      mintService,
+      walletService,
+      mintAdapter,
+      tokenService,
+      eventBus,
+      undefined,
+      mintScopedLock,
+    );
+
+    const opA = await service.init({ mint: mintUrl, proofs: [makeProof('a')] } as Token);
+    const opB = await service.init({ mint: mintUrl, proofs: [makeProof('b')] } as Token);
+
+    const [preparedA, preparedB] = await Promise.all([service.prepare(opA), service.prepare(opB)]);
+
+    expect(maxInside).toBe(1);
+    expect(preparedA.state).toBe('prepared');
+    expect(preparedB.state).toBe('prepared');
+    expect(racingProofService.createOutputsAndIncrementCounters).toHaveBeenCalledTimes(2);
   });
 
   it('emits receive-op:prepared after the prepared state is persisted', async () => {


### PR DESCRIPTION
## Problem

Receiving ecash intermittently fails with:

```
Failed to persist proofs for 1 keyset group(s) [<keysetId>]
```

The per-mint `MintScopedLock` was introduced for **proof selection**: the send and melt services select wallet-owned input proofs, so they acquire it to avoid selecting the same proofs concurrently. Receive has no proof selection — it swaps the proofs carried in the incoming token — so it was excluded.

However, the lock is held across the whole `prepare()`, which also performs the shared, **non-atomic** NUT-13 counter `read → derive → increment` in `createOutputsAndIncrementCounters`. Receive consumes that same per-keyset counter. With no lock, two receive operations on the same mint — e.g. the same gift-wrapped token delivered more than once, or two tokens arriving at the same time — read the same counter value, derive identical blinded outputs, and the second write collides on the unique proof key, producing the error above.

`MintOperationService`, which also has no proof selection, was later given the same lock; receive is the one counter-consuming operation still missing it.

## Fix

- `ReceiveOperationService` now takes the shared `MintScopedLock` and acquires it in `prepare()` around the counter-consuming section, mirroring `SendOperationService`.
- `Manager` wires the same shared lock instance it already passes to the send/melt/mint services.

The lock is an optional last constructor parameter (defaults to a fresh instance), so the change is backward compatible.

## Test

Adds a regression test that runs two concurrent `prepare()` calls for two different tokens on the same mint and asserts the counter-consuming section is never entered concurrently. It fails without the lock (the two prepares overlap) and passes with it.

## Verification

- `bun test packages/core/test/unit` — 1000 passing
- `bun run typecheck` — no new errors introduced by this change

> Note: like the existing lock, this is an in-memory (single-runtime) guard and does not coordinate across processes.
