### PR TITLE
fix(core): canonicalize P2PK keys with legacy aliases

### DIFF
--- a/.changeset/canonical-p2pk-keys.md
+++ b/.changeset/canonical-p2pk-keys.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Derive P2PK public keys in canonical SEC1 compressed format while treating legacy and canonical
+public key encodings as aliases across P2PK keyring operations.

--- a/.changeset/canonical-p2pk-keys.md
+++ b/.changeset/canonical-p2pk-keys.md
@@ -2,5 +2,5 @@
 '@cashu/coco-core': patch
 ---
 
-Derive P2PK public keys in canonical SEC1 compressed format while retaining proof-signing
-compatibility with legacy public key aliases.
+Derive P2PK public keys in canonical SEC1 compressed format while treating legacy and canonical
+public key encodings as aliases across P2PK keyring operations.

--- a/.changeset/canonical-p2pk-keys.md
+++ b/.changeset/canonical-p2pk-keys.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Derive P2PK public keys in canonical SEC1 compressed format while retaining proof-signing
+compatibility with legacy public key aliases.

--- a/TRANSACTION_DESIGN.md
+++ b/TRANSACTION_DESIGN.md
@@ -315,6 +315,13 @@ The first slice implements this separation without changing the user-facing KeyR
   implementation; repositories provide persistence primitives without deriving keys or opening
   allocation transactions.
 
+P2PK imports and deletions resolve canonical SEC1 and legacy always-`02` identities through
+the scoped repository before mutating it. Import returns the persisted `Keypair`, including an
+existing row's identity and derivation metadata; `KeyRingTransactions.importP2pkKey` exposes that
+result only after commit. These commands do not alter allocation high-water marks. Read-only
+keyring lookup and signing reuse the same bounded alias lookup with narrow `KeypairQueries`
+access. The helper owns no transaction and never enumerates the keyring or rewrites rows.
+
 No keypair dependency exception remains. Other legacy key-management consumers, including mint
 quote handlers, migrate with their owning workflows; a narrow signing interface must never be a
 disguise for `getOrCreateKey()` or other hidden persistence.

--- a/packages/core/api/KeyRingApi.ts
+++ b/packages/core/api/KeyRingApi.ts
@@ -22,7 +22,8 @@ export class KeyRingApi {
   }
 
   /**
-   * Adds an existing keypair to the keyring using a secret key.
+   * Adds an existing keypair using its canonical compressed public key. If the same secret is
+   * already stored under coco's legacy public key encoding, returns that existing keypair.
    * @param secretKey - The 32-byte secret key as Uint8Array
    */
   async addKeyPair(secretKey: Uint8Array): Promise<Keypair> {
@@ -30,17 +31,17 @@ export class KeyRingApi {
   }
 
   /**
-   * Removes a keypair from the keyring.
-   * @param publicKey - The public key (hex string) of the keypair to remove
+   * Removes a keypair from the keyring using its canonical or legacy public key encoding.
+   * @param publicKey - A canonical or legacy public key hex string for the keypair to remove
    */
   async removeKeyPair(publicKey: string): Promise<void> {
     return this.keyRingService.removeKeyPair(publicKey);
   }
 
   /**
-   * Retrieves a specific keypair by its public key.
-   * @param publicKey - The public key (hex string) to look up
-   * @returns The keypair if found, null otherwise
+   * Retrieves a specific keypair using its canonical or legacy public key encoding.
+   * @param publicKey - A canonical or legacy public key hex string to look up
+   * @returns The persisted keypair if found, preserving its stored public key encoding
    */
   async getKeyPair(publicKey: string): Promise<Keypair | null> {
     return this.keyRingService.getKeyPair(publicKey);

--- a/packages/core/docs/adr/0011-use-domain-transaction-gateways.md
+++ b/packages/core/docs/adr/0011-use-domain-transaction-gateways.md
@@ -20,6 +20,11 @@ Method-specific argument objects use `*Input` types and the parameter name `inpu
 runner callbacks are named `work`. These names distinguish actions from their inputs and the work
 that composes them.
 
+P2PK import and deletion resolve legacy public-key aliases inside their owning transaction.
+Import returns the persisted keypair after commit, preserving an existing row's identity and
+derivation metadata. Read-only lookup and signing share the alias algorithm through narrow key
+access; the algorithm cannot open transactions or mutate storage.
+
 ## Considered Options
 
 Broad Service dependencies and transaction-scoped Service clones obscure effects and transaction

--- a/packages/core/keypairs/KeypairDerivation.ts
+++ b/packages/core/keypairs/KeypairDerivation.ts
@@ -1,4 +1,4 @@
-import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { HDKey } from '@scure/bip32';
 import type { KeypairPurpose } from '../models/Keypair.ts';
@@ -23,10 +23,7 @@ export class KeypairDerivation {
           `m/129373'/${derivationPurpose}'/0'/0'/${derivationIndex}`,
         );
         if (!secretKey) throw new Error('Failed to derive secret key');
-        const publicKeyHex =
-          purpose === 'nut20_mint_quote'
-            ? bytesToHex(secp256k1.getPublicKey(secretKey, true))
-            : '02' + bytesToHex(schnorr.getPublicKey(secretKey));
+        const publicKeyHex = bytesToHex(secp256k1.getPublicKey(secretKey, true));
         return { publicKeyHex, secretKey };
       },
     };

--- a/packages/core/keypairs/P2pkKeyLookup.ts
+++ b/packages/core/keypairs/P2pkKeyLookup.ts
@@ -1,0 +1,26 @@
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { bytesToHex } from '@noble/curves/utils.js';
+import type { Keypair } from '../models/Keypair.ts';
+import type { KeypairQueries } from './KeypairQueries.ts';
+
+/**
+ * Resolves canonical SEC1 and legacy always-02 P2PK identities without changing stored rows.
+ * Uses at most two reads. Mutation callers must supply their transaction's scoped key access.
+ */
+export async function findP2pkKeyPair(
+  keys: Pick<KeypairQueries, 'getPersistedKeyPair'>,
+  publicKey: string,
+): Promise<Keypair | null> {
+  const directMatch = await keys.getPersistedKeyPair(publicKey, 'p2pk');
+  if (directMatch) return directMatch;
+  if (!/^0[23][0-9a-f]{64}$/.test(publicKey)) return null;
+
+  const alternateKey = (publicKey.startsWith('02') ? '03' : '02') + publicKey.slice(2);
+  const candidate = await keys.getPersistedKeyPair(alternateKey, 'p2pk');
+  if (!candidate) return null;
+
+  // Flipping parity alone is insufficient: an even-Y key has no distinct legacy alias.
+  const canonicalKey = bytesToHex(secp256k1.getPublicKey(candidate.secretKey, true));
+  const legacyKey = '02' + canonicalKey.slice(2);
+  return publicKey === canonicalKey || publicKey === legacyKey ? candidate : null;
+}

--- a/packages/core/keypairs/P2pkSigner.ts
+++ b/packages/core/keypairs/P2pkSigner.ts
@@ -3,6 +3,7 @@ import { schnorr } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { KeypairQueries } from './KeypairQueries.ts';
+import { findP2pkKeyPair } from './P2pkKeyLookup.ts';
 
 /** Signs with existing keys. Never allocates a key or writes Wallet state. */
 export interface P2pkSigner {
@@ -16,7 +17,7 @@ export class KeypairP2pkSigner implements P2pkSigner {
     if (!proof.secret || typeof proof.secret !== 'string') {
       throw new Error('Proof secret is required and must be a string');
     }
-    const keyPair = await this.keys.getPersistedKeyPair(publicKey, 'p2pk');
+    const keyPair = await findP2pkKeyPair(this.keys, publicKey);
     if (!keyPair) {
       throw new Error(`Key pair not found for public key: ${publicKey.substring(0, 8)}...`);
     }

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -120,7 +120,7 @@ export class KeyRingService {
     if (!proof.secret || typeof proof.secret !== 'string') {
       throw new Error('Proof secret is required and must be a string');
     }
-    const keyPair = await this.keyRingRepository.getPersistedKeyPair(publicKey, 'p2pk');
+    const keyPair = await this.findSigningKeyPair(publicKey);
     if (!keyPair) {
       const publicKeyPreview = publicKey.substring(0, 8);
       this.logger?.error('Key pair not found', { publicKey });
@@ -146,5 +146,25 @@ export class KeyRingService {
 
   private getCompressedPublicKeyHex(secretKey: Uint8Array): string {
     return bytesToHex(secp256k1.getPublicKey(secretKey, true));
+  }
+
+  private getLegacyPublicKeyHex(secretKey: Uint8Array): string {
+    return '02' + bytesToHex(schnorr.getPublicKey(secretKey));
+  }
+
+  private async findSigningKeyPair(publicKey: string): Promise<Keypair | null> {
+    const directMatch = await this.keyRingRepository.getPersistedKeyPair(publicKey, 'p2pk');
+    if (directMatch) {
+      return directMatch;
+    }
+
+    const persistedKeyPairs = await this.keyRingRepository.getAllPersistedKeyPairs('p2pk');
+    for (const keyPair of persistedKeyPairs) {
+      if (this.getLegacyPublicKeyHex(keyPair.secretKey) === publicKey) {
+        return keyPair;
+      }
+    }
+
+    return null;
   }
 }

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -78,6 +78,10 @@ export class KeyRingService {
       throw new Error('Secret key must be exactly 32 bytes');
     }
     const publicKeyHex = this.getPublicKeyHex(secretKey);
+    const existingKeyPair = await this.findP2pkKeyPairByAlias(publicKeyHex);
+    if (existingKeyPair) {
+      return existingKeyPair;
+    }
     await this.keyRingRepository.setPersistedKeyPair({
       publicKeyHex,
       secretKey,
@@ -89,7 +93,11 @@ export class KeyRingService {
 
   async removeKeyPair(publicKey: string): Promise<void> {
     this.logger?.debug('Removing key pair', { publicKey });
-    await this.keyRingRepository.deletePersistedKeyPair(publicKey, 'p2pk');
+    const keyPair = await this.findP2pkKeyPairByAlias(publicKey);
+    if (!keyPair) {
+      return;
+    }
+    await this.keyRingRepository.deletePersistedKeyPair(keyPair.publicKeyHex, 'p2pk');
     this.logger?.debug('Key pair removed', { publicKey });
   }
 
@@ -97,7 +105,7 @@ export class KeyRingService {
     if (!publicKey || typeof publicKey !== 'string') {
       throw new Error('Public key is required and must be a string');
     }
-    return this.keyRingRepository.getPersistedKeyPair(publicKey, 'p2pk');
+    return this.findP2pkKeyPairByAlias(publicKey);
   }
 
   async getMintQuoteKeyPair(publicKey: string): Promise<Keypair | null> {
@@ -120,7 +128,7 @@ export class KeyRingService {
     if (!proof.secret || typeof proof.secret !== 'string') {
       throw new Error('Proof secret is required and must be a string');
     }
-    const keyPair = await this.findSigningKeyPair(publicKey);
+    const keyPair = await this.findP2pkKeyPairByAlias(publicKey);
     if (!keyPair) {
       const publicKeyPreview = publicKey.substring(0, 8);
       this.logger?.error('Key pair not found', { publicKey });
@@ -152,7 +160,12 @@ export class KeyRingService {
     return '02' + bytesToHex(schnorr.getPublicKey(secretKey));
   }
 
-  private async findSigningKeyPair(publicKey: string): Promise<Keypair | null> {
+  /**
+   * Resolves the canonical SEC1 encoding and coco's legacy even-Y encoding as aliases.
+   * Existing rows keep their stored identity; the fallback scans only P2PK keys so NUT-20 keys
+   * cannot satisfy a P2PK lookup.
+   */
+  private async findP2pkKeyPairByAlias(publicKey: string): Promise<Keypair | null> {
     const directMatch = await this.keyRingRepository.getPersistedKeyPair(publicKey, 'p2pk');
     if (directMatch) {
       return directMatch;
@@ -160,7 +173,10 @@ export class KeyRingService {
 
     const persistedKeyPairs = await this.keyRingRepository.getAllPersistedKeyPairs('p2pk');
     for (const keyPair of persistedKeyPairs) {
-      if (this.getLegacyPublicKeyHex(keyPair.secretKey) === publicKey) {
+      if (
+        this.getPublicKeyHex(keyPair.secretKey) === publicKey ||
+        this.getLegacyPublicKeyHex(keyPair.secretKey) === publicKey
+      ) {
         return keyPair;
       }
     }

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -138,12 +138,10 @@ export class KeyRingService {
 
   /**
    * Converts a secret key to its corresponding public key in SEC1 compressed format.
-   * Note: schnorr.getPublicKey() returns a 32-byte x-only public key (BIP340).
-   * We prepend '02' to create a 33-byte SEC1 compressed format as expected by Cashu.
    */
   private getPublicKeyHex(secretKey: Uint8Array): string {
-    const publicKey = schnorr.getPublicKey(secretKey);
-    return '02' + bytesToHex(publicKey);
+    const publicKey = secp256k1.getPublicKey(secretKey, true);
+    return bytesToHex(publicKey);
   }
 
   private getCompressedPublicKeyHex(secretKey: Uint8Array): string {

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -2,11 +2,12 @@ import type { Proof } from '@cashu/cashu-ts';
 import type { Logger } from '@core/logging';
 import type { Keypair, KeypairPurpose } from '@core/models/Keypair';
 import type { KeyRingTransactions } from '@core/transactions/keypairs/KeyRingTransactions.ts';
-import { schnorr } from '@noble/curves/secp256k1.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
 import type { KeypairQueries } from '../keypairs/KeypairQueries.ts';
 import type { KeypairDerivation } from '../keypairs/KeypairDerivation.ts';
 import type { P2pkSigner } from '../keypairs/P2pkSigner.ts';
+import { findP2pkKeyPair } from '../keypairs/P2pkKeyLookup.ts';
 
 export class KeyRingService {
   constructor(
@@ -52,13 +53,13 @@ export class KeyRingService {
       throw new Error('Secret key must be exactly 32 bytes');
     }
     const publicKeyHex = this.getPublicKeyHex(secretKey);
-    await this.transactions.importP2pkKey({
+    const keyPair = await this.transactions.importP2pkKey({
       publicKeyHex,
       secretKey,
       purpose: 'p2pk',
     });
-    this.logger?.debug('Key pair added', { publicKeyHex });
-    return { publicKeyHex, secretKey, purpose: 'p2pk' };
+    this.logger?.debug('Key pair added', { publicKeyHex: keyPair.publicKeyHex });
+    return keyPair;
   }
 
   async removeKeyPair(publicKey: string): Promise<void> {
@@ -71,7 +72,7 @@ export class KeyRingService {
     if (!publicKey || typeof publicKey !== 'string') {
       throw new Error('Public key is required and must be a string');
     }
-    return this.keypairQueries.getPersistedKeyPair(publicKey, 'p2pk');
+    return findP2pkKeyPair(this.keypairQueries, publicKey);
   }
 
   async getMintQuoteKeyPair(publicKey: string): Promise<Keypair | null> {
@@ -97,11 +98,8 @@ export class KeyRingService {
 
   /**
    * Converts a secret key to its corresponding public key in SEC1 compressed format.
-   * Note: schnorr.getPublicKey() returns a 32-byte x-only public key (BIP340).
-   * We prepend '02' to create a 33-byte SEC1 compressed format as expected by Cashu.
    */
   private getPublicKeyHex(secretKey: Uint8Array): string {
-    const publicKey = schnorr.getPublicKey(secretKey);
-    return '02' + bytesToHex(publicKey);
+    return bytesToHex(secp256k1.getPublicKey(secretKey, true));
   }
 }

--- a/packages/core/test/unit/CoreTransaction.test.ts
+++ b/packages/core/test/unit/CoreTransaction.test.ts
@@ -257,6 +257,7 @@ describe('RepositoryCoreTransactionRunner', () => {
             scope.keyRingRepository.setPersistedKeyPair(keypair),
             scope.counterRepository.setCounter('https://mint.test', 'keyset', 7),
           ]);
+          return keypair;
         };
         return { keypairs };
       });

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -13,6 +13,25 @@ for (let i = 0; i < 64; i++) {
   MOCK_SEED[i] = i;
 }
 
+async function mnemonicToSeedNormalized(mnemonic: string, passphrase: string): Promise<Uint8Array> {
+  const encoder = new TextEncoder();
+  const password = encoder.encode(mnemonic.normalize('NFKD'));
+  const salt = encoder.encode(`mnemonic${passphrase.normalize('NFKD')}`);
+  const key = await crypto.subtle.importKey('raw', password, 'PBKDF2', false, ['deriveBits']);
+  const seed = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-512',
+      salt,
+      iterations: 2048,
+    },
+    key,
+    512,
+  );
+
+  return new Uint8Array(seed);
+}
+
 describe('KeyRingService', () => {
   let repo: MemoryKeyRingRepository;
   let seedService: SeedService;
@@ -29,8 +48,8 @@ describe('KeyRingService', () => {
       const result = await service.generateNewKeyPair();
 
       expect(result.publicKeyHex).toBeDefined();
-      expect(result.publicKeyHex.length).toBe(66); // 32 bytes * 2 for hex + '02' prefix
-      expect(result.publicKeyHex.startsWith('02')).toBe(true);
+      expect(result.publicKeyHex.length).toBe(66);
+      expect(['02', '03']).toContain(result.publicKeyHex.slice(0, 2));
       expect('secretKey' in result).toBe(false);
 
       // Verify it was stored in the repository
@@ -96,6 +115,50 @@ describe('KeyRingService', () => {
       // Should derive the same key for the same derivation index (0)
       expect(kp1.publicKeyHex).toBe(kp2.publicKeyHex);
       expect(bytesToHex(kp1.secretKey)).toBe(bytesToHex(kp2.secretKey));
+    });
+
+    it('P2PK derivation test vectors', async () => {
+      const seed = await mnemonicToSeedNormalized(
+        'half depart obvious quality work element tank gorilla view sugar picture humble',
+        '',
+      );
+      const vectorRepo = new MemoryKeyRingRepository();
+      const vectorSeedService = new SeedService(async () => seed);
+      const vectorService = new KeyRingService(vectorRepo, vectorSeedService);
+
+      const kp0 = await vectorService.generateNewKeyPair();
+      const kp1 = await vectorService.generateNewKeyPair();
+      const kp2 = await vectorService.generateNewKeyPair();
+      const kp3 = await vectorService.generateNewKeyPair();
+      const kp4 = await vectorService.generateNewKeyPair();
+
+      expect(kp0.publicKeyHex).toBe(
+        '021693d45f4fdf610ae641fedb0944fb460fbb8264f21c19d2626c3da755fcbbcb',
+      );
+      expect(kp1.publicKeyHex).toBe(
+        '0395461ab678058c0ed6aa39f38dda490eaa163e9ad27070b23ec3d06b41e07535',
+      );
+      expect(kp2.publicKeyHex).toBe(
+        '02a05e4e593a633e9b4405f01c9632c8afde24cb613017a1aee56fd76291ad26d1',
+      );
+      expect(kp3.publicKeyHex).toBe(
+        '033addea25c3873b93d67d536c61c9d9c993f6efd8b9dfa657951b66b5001e51dd',
+      );
+      expect(kp4.publicKeyHex).toBe(
+        '03c964bdf42fc82b6c574615746eeca37527a24f1fdfc1b34a732c53843b5744a5',
+      );
+
+      const stored0 = await vectorRepo.getPersistedKeyPair(kp0.publicKeyHex);
+      const stored1 = await vectorRepo.getPersistedKeyPair(kp1.publicKeyHex);
+      const stored2 = await vectorRepo.getPersistedKeyPair(kp2.publicKeyHex);
+      const stored3 = await vectorRepo.getPersistedKeyPair(kp3.publicKeyHex);
+      const stored4 = await vectorRepo.getPersistedKeyPair(kp4.publicKeyHex);
+
+      expect(stored0?.derivationIndex).toBe(0);
+      expect(stored1?.derivationIndex).toBe(1);
+      expect(stored2?.derivationIndex).toBe(2);
+      expect(stored3?.derivationIndex).toBe(3);
+      expect(stored4?.derivationIndex).toBe(4);
     });
 
     it('continues derivation index after imported keys', async () => {
@@ -192,8 +255,7 @@ describe('KeyRingService', () => {
       const secretKey = schnorr.utils.randomSecretKey();
       const result = await service.addKeyPair(secretKey);
 
-      // The public key should have '02' prefix for compressed format
-      const publicKeyHex = '02' + bytesToHex(schnorr.getPublicKey(secretKey));
+      const publicKeyHex = bytesToHex(secp256k1.getPublicKey(secretKey, true));
       const stored = await repo.getPersistedKeyPair(publicKeyHex);
 
       expect(stored).not.toBeNull();

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -36,6 +36,12 @@ function getLegacyPublicKeyHex(secretKey: Uint8Array): string {
   return '02' + bytesToHex(schnorr.getPublicKey(secretKey));
 }
 
+const ODD_Y_SECRET_KEY = Uint8Array.from([...new Uint8Array(31), 6]);
+const ODD_Y_CANONICAL_PUBLIC_KEY =
+  '03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556';
+const ODD_Y_LEGACY_PUBLIC_KEY =
+  '02fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556';
+
 describe('KeyRingService', () => {
   let repo: MemoryKeyRingRepository;
   let seedService: SeedService;
@@ -276,6 +282,21 @@ describe('KeyRingService', () => {
       expect(stored?.derivationIndex).toBeUndefined();
     });
 
+    it('does not duplicate a persisted legacy odd-Y keypair when importing its secret', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        derivationIndex: 7,
+        purpose: 'p2pk',
+      });
+
+      const imported = await service.addKeyPair(ODD_Y_SECRET_KEY);
+
+      expect(imported.publicKeyHex).toBe(ODD_Y_LEGACY_PUBLIC_KEY);
+      expect(imported.derivationIndex).toBe(7);
+      expect(await service.getAllKeyPairs()).toHaveLength(1);
+    });
+
     it('rejects secret key that is not 32 bytes', async () => {
       const invalidKey = new Uint8Array(31); // Wrong length
 
@@ -309,6 +330,26 @@ describe('KeyRingService', () => {
       expect(stored).toBeNull();
     });
 
+    it('removes a canonical odd-Y keypair by its legacy public key alias', async () => {
+      await service.addKeyPair(ODD_Y_SECRET_KEY);
+
+      await service.removeKeyPair(ODD_Y_LEGACY_PUBLIC_KEY);
+
+      expect(await service.getKeyPair(ODD_Y_CANONICAL_PUBLIC_KEY)).toBeNull();
+    });
+
+    it('removes a persisted legacy odd-Y keypair by its canonical public key alias', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        purpose: 'p2pk',
+      });
+
+      await service.removeKeyPair(ODD_Y_CANONICAL_PUBLIC_KEY);
+
+      expect(await repo.getPersistedKeyPair(ODD_Y_LEGACY_PUBLIC_KEY, 'p2pk')).toBeNull();
+    });
+
     it('does not throw when removing non-existent key', async () => {
       // Should complete without throwing
       await service.removeKeyPair(
@@ -327,6 +368,26 @@ describe('KeyRingService', () => {
       expect(retrieved).not.toBeNull();
       expect(retrieved?.publicKeyHex).toBe(generated.publicKeyHex);
       expect(bytesToHex(retrieved!.secretKey)).toBe(bytesToHex(generated.secretKey));
+    });
+
+    it('retrieves a canonical odd-Y keypair by its legacy public key alias', async () => {
+      await service.addKeyPair(ODD_Y_SECRET_KEY);
+
+      const retrieved = await service.getKeyPair(ODD_Y_LEGACY_PUBLIC_KEY);
+
+      expect(retrieved?.publicKeyHex).toBe(ODD_Y_CANONICAL_PUBLIC_KEY);
+    });
+
+    it('retrieves a persisted legacy odd-Y keypair by its canonical public key alias', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        purpose: 'p2pk',
+      });
+
+      const retrieved = await service.getKeyPair(ODD_Y_CANONICAL_PUBLIC_KEY);
+
+      expect(retrieved?.publicKeyHex).toBe(ODD_Y_LEGACY_PUBLIC_KEY);
     });
 
     it('returns null for non-existent key', async () => {
@@ -538,6 +599,25 @@ describe('KeyRingService', () => {
         proof,
         getLegacyPublicKeyHex(oddYKeyPair.secretKey),
       );
+      const witness = JSON.parse(signed.witness as string);
+
+      expect(witness.signatures).toHaveLength(1);
+    });
+
+    it('signs a canonical alias using a persisted legacy odd-Y keypair', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        purpose: 'p2pk',
+      });
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'canonical-alias-secret',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const signed = await service.signProof(proof, ODD_Y_CANONICAL_PUBLIC_KEY);
       const witness = JSON.parse(signed.witness as string);
 
       expect(witness.signatures).toHaveLength(1);

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -32,6 +32,10 @@ async function mnemonicToSeedNormalized(mnemonic: string, passphrase: string): P
   return new Uint8Array(seed);
 }
 
+function getLegacyPublicKeyHex(secretKey: Uint8Array): string {
+  return '02' + bytesToHex(schnorr.getPublicKey(secretKey));
+}
+
 describe('KeyRingService', () => {
   let repo: MemoryKeyRingRepository;
   let seedService: SeedService;
@@ -493,6 +497,52 @@ describe('KeyRingService', () => {
       expect(signatureBytes.length).toBe(64);
     });
 
+    it('signs proofs locked to the legacy public key alias', async () => {
+      const kp = await service.generateNewKeyPair({ dumpSecretKey: true });
+      const legacyPublicKeyHex = getLegacyPublicKeyHex(kp.secretKey);
+
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'legacy-secret',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const signed = await service.signProof(proof, legacyPublicKeyHex);
+      const witness = JSON.parse(signed.witness as string);
+
+      expect(witness.signatures).toHaveLength(1);
+    });
+
+    it('signs legacy aliases for keys with odd-Y compressed public keys', async () => {
+      const seed = await mnemonicToSeedNormalized(
+        'half depart obvious quality work element tank gorilla view sugar picture humble',
+        '',
+      );
+      const vectorRepo = new MemoryKeyRingRepository();
+      const vectorSeedService = new SeedService(async () => seed);
+      const vectorService = new KeyRingService(vectorRepo, vectorSeedService);
+
+      await vectorService.generateNewKeyPair();
+      const oddYKeyPair = await vectorService.generateNewKeyPair({ dumpSecretKey: true });
+      expect(oddYKeyPair.publicKeyHex.startsWith('03')).toBe(true);
+
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'odd-y-legacy-secret',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const signed = await vectorService.signProof(
+        proof,
+        getLegacyPublicKeyHex(oddYKeyPair.secretKey),
+      );
+      const witness = JSON.parse(signed.witness as string);
+
+      expect(witness.signatures).toHaveLength(1);
+    });
+
     it('throws when keypair not found', async () => {
       const proof: Proof = {
         id: 'keyset123',
@@ -520,6 +570,23 @@ describe('KeyRingService', () => {
 
       await expect(service.signProof(proof, fakePublicKey)).rejects.toThrow(
         'Key pair not found for public key: abcdef12...',
+      );
+    });
+
+    it('does not match unrelated legacy public keys', async () => {
+      await service.generateNewKeyPair({ dumpSecretKey: true });
+
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'my-secret-string',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const fakeLegacyPublicKey = '02' + '11'.repeat(32);
+
+      await expect(service.signProof(proof, fakeLegacyPublicKey)).rejects.toThrow(
+        /Key pair not found for public key/,
       );
     });
 

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -24,6 +24,35 @@ for (let i = 0; i < 64; i++) {
   MOCK_SEED[i] = i;
 }
 
+async function mnemonicToSeedNormalized(mnemonic: string, passphrase: string): Promise<Uint8Array> {
+  const encoder = new TextEncoder();
+  const password = encoder.encode(mnemonic.normalize('NFKD'));
+  const salt = encoder.encode(`mnemonic${passphrase.normalize('NFKD')}`);
+  const key = await crypto.subtle.importKey('raw', password, 'PBKDF2', false, ['deriveBits']);
+  const seed = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-512',
+      salt,
+      iterations: 2048,
+    },
+    key,
+    512,
+  );
+
+  return new Uint8Array(seed);
+}
+
+function getLegacyPublicKeyHex(secretKey: Uint8Array): string {
+  return '02' + bytesToHex(schnorr.getPublicKey(secretKey));
+}
+
+const ODD_Y_SECRET_KEY = Uint8Array.from([...new Uint8Array(31), 6]);
+const ODD_Y_CANONICAL_PUBLIC_KEY =
+  '03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556';
+const ODD_Y_LEGACY_PUBLIC_KEY =
+  '02fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556';
+
 describe('KeyRingService', () => {
   let repositories: MemoryRepositories;
   let repo: KeyRingRepository;
@@ -54,8 +83,8 @@ describe('KeyRingService', () => {
       const result = await service.generateNewKeyPair();
 
       expect(result.publicKeyHex).toBeDefined();
-      expect(result.publicKeyHex.length).toBe(66); // 32 bytes * 2 for hex + '02' prefix
-      expect(result.publicKeyHex.startsWith('02')).toBe(true);
+      expect(result.publicKeyHex.length).toBe(66);
+      expect(['02', '03']).toContain(result.publicKeyHex.slice(0, 2));
       expect('secretKey' in result).toBe(false);
 
       // Verify it was stored in the repository
@@ -121,6 +150,51 @@ describe('KeyRingService', () => {
       // Should derive the same key for the same derivation index (0)
       expect(kp1.publicKeyHex).toBe(kp2.publicKeyHex);
       expect(bytesToHex(kp1.secretKey)).toBe(bytesToHex(kp2.secretKey));
+    });
+
+    it('P2PK derivation test vectors', async () => {
+      const seed = await mnemonicToSeedNormalized(
+        'half depart obvious quality work element tank gorilla view sugar picture humble',
+        '',
+      );
+      const vectorRepositories = new MemoryRepositories();
+      const vectorRepo = vectorRepositories.keyRingRepository;
+      const vectorSeedService = new SeedService(async () => seed);
+      const vectorService = createService(vectorRepositories, vectorSeedService);
+
+      const kp0 = await vectorService.generateNewKeyPair();
+      const kp1 = await vectorService.generateNewKeyPair();
+      const kp2 = await vectorService.generateNewKeyPair();
+      const kp3 = await vectorService.generateNewKeyPair();
+      const kp4 = await vectorService.generateNewKeyPair();
+
+      expect(kp0.publicKeyHex).toBe(
+        '021693d45f4fdf610ae641fedb0944fb460fbb8264f21c19d2626c3da755fcbbcb',
+      );
+      expect(kp1.publicKeyHex).toBe(
+        '0395461ab678058c0ed6aa39f38dda490eaa163e9ad27070b23ec3d06b41e07535',
+      );
+      expect(kp2.publicKeyHex).toBe(
+        '02a05e4e593a633e9b4405f01c9632c8afde24cb613017a1aee56fd76291ad26d1',
+      );
+      expect(kp3.publicKeyHex).toBe(
+        '033addea25c3873b93d67d536c61c9d9c993f6efd8b9dfa657951b66b5001e51dd',
+      );
+      expect(kp4.publicKeyHex).toBe(
+        '03c964bdf42fc82b6c574615746eeca37527a24f1fdfc1b34a732c53843b5744a5',
+      );
+
+      const stored0 = await vectorRepo.getPersistedKeyPair(kp0.publicKeyHex);
+      const stored1 = await vectorRepo.getPersistedKeyPair(kp1.publicKeyHex);
+      const stored2 = await vectorRepo.getPersistedKeyPair(kp2.publicKeyHex);
+      const stored3 = await vectorRepo.getPersistedKeyPair(kp3.publicKeyHex);
+      const stored4 = await vectorRepo.getPersistedKeyPair(kp4.publicKeyHex);
+
+      expect(stored0?.derivationIndex).toBe(0);
+      expect(stored1?.derivationIndex).toBe(1);
+      expect(stored2?.derivationIndex).toBe(2);
+      expect(stored3?.derivationIndex).toBe(3);
+      expect(stored4?.derivationIndex).toBe(4);
     });
 
     it('continues derivation index after imported keys', async () => {
@@ -367,8 +441,7 @@ describe('KeyRingService', () => {
       const secretKey = schnorr.utils.randomSecretKey();
       const result = await service.addKeyPair(secretKey);
 
-      // The public key should have '02' prefix for compressed format
-      const publicKeyHex = '02' + bytesToHex(schnorr.getPublicKey(secretKey));
+      const publicKeyHex = bytesToHex(secp256k1.getPublicKey(secretKey, true));
       const stored = await repo.getPersistedKeyPair(publicKeyHex);
 
       expect(stored).not.toBeNull();
@@ -383,6 +456,21 @@ describe('KeyRingService', () => {
 
       const stored = await repo.getPersistedKeyPair(result.publicKeyHex);
       expect(stored?.derivationIndex).toBeUndefined();
+    });
+
+    it('does not duplicate a persisted legacy odd-Y keypair when importing its secret', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        derivationIndex: 7,
+        purpose: 'p2pk',
+      });
+
+      const imported = await service.addKeyPair(ODD_Y_SECRET_KEY);
+
+      expect(imported.publicKeyHex).toBe(ODD_Y_LEGACY_PUBLIC_KEY);
+      expect(imported.derivationIndex).toBe(7);
+      expect(await service.getAllKeyPairs()).toHaveLength(1);
     });
 
     it('rejects secret key that is not 32 bytes', async () => {
@@ -418,6 +506,26 @@ describe('KeyRingService', () => {
       expect(stored).toBeNull();
     });
 
+    it('removes a canonical odd-Y keypair by its legacy public key alias', async () => {
+      await service.addKeyPair(ODD_Y_SECRET_KEY);
+
+      await service.removeKeyPair(ODD_Y_LEGACY_PUBLIC_KEY);
+
+      expect(await service.getKeyPair(ODD_Y_CANONICAL_PUBLIC_KEY)).toBeNull();
+    });
+
+    it('removes a persisted legacy odd-Y keypair by its canonical public key alias', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        purpose: 'p2pk',
+      });
+
+      await service.removeKeyPair(ODD_Y_CANONICAL_PUBLIC_KEY);
+
+      expect(await repo.getPersistedKeyPair(ODD_Y_LEGACY_PUBLIC_KEY, 'p2pk')).toBeNull();
+    });
+
     it('does not throw when removing non-existent key', async () => {
       // Should complete without throwing
       await service.removeKeyPair(
@@ -436,6 +544,26 @@ describe('KeyRingService', () => {
       expect(retrieved).not.toBeNull();
       expect(retrieved?.publicKeyHex).toBe(generated.publicKeyHex);
       expect(bytesToHex(retrieved!.secretKey)).toBe(bytesToHex(generated.secretKey));
+    });
+
+    it('retrieves a canonical odd-Y keypair by its legacy public key alias', async () => {
+      await service.addKeyPair(ODD_Y_SECRET_KEY);
+
+      const retrieved = await service.getKeyPair(ODD_Y_LEGACY_PUBLIC_KEY);
+
+      expect(retrieved?.publicKeyHex).toBe(ODD_Y_CANONICAL_PUBLIC_KEY);
+    });
+
+    it('retrieves a persisted legacy odd-Y keypair by its canonical public key alias', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        purpose: 'p2pk',
+      });
+
+      const retrieved = await service.getKeyPair(ODD_Y_CANONICAL_PUBLIC_KEY);
+
+      expect(retrieved?.publicKeyHex).toBe(ODD_Y_LEGACY_PUBLIC_KEY);
     });
 
     it('returns null for non-existent key', async () => {
@@ -609,6 +737,72 @@ describe('KeyRingService', () => {
       expect(signatureBytes.length).toBe(64);
     });
 
+    it('signs proofs locked to the legacy public key alias', async () => {
+      const kp = await service.generateNewKeyPair({ dumpSecretKey: true });
+      const legacyPublicKeyHex = getLegacyPublicKeyHex(kp.secretKey);
+
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'legacy-secret',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const signed = await service.signProof(proof, legacyPublicKeyHex);
+      const witness = JSON.parse(signed.witness as string);
+
+      expect(witness.signatures).toHaveLength(1);
+    });
+
+    it('signs legacy aliases for keys with odd-Y compressed public keys', async () => {
+      const seed = await mnemonicToSeedNormalized(
+        'half depart obvious quality work element tank gorilla view sugar picture humble',
+        '',
+      );
+      const vectorRepositories = new MemoryRepositories();
+      const vectorRepo = vectorRepositories.keyRingRepository;
+      const vectorSeedService = new SeedService(async () => seed);
+      const vectorService = createService(vectorRepositories, vectorSeedService);
+
+      await vectorService.generateNewKeyPair();
+      const oddYKeyPair = await vectorService.generateNewKeyPair({ dumpSecretKey: true });
+      expect(oddYKeyPair.publicKeyHex.startsWith('03')).toBe(true);
+
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'odd-y-legacy-secret',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const signed = await vectorService.signProof(
+        proof,
+        getLegacyPublicKeyHex(oddYKeyPair.secretKey),
+      );
+      const witness = JSON.parse(signed.witness as string);
+
+      expect(witness.signatures).toHaveLength(1);
+    });
+
+    it('signs a canonical alias using a persisted legacy odd-Y keypair', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: ODD_Y_LEGACY_PUBLIC_KEY,
+        secretKey: ODD_Y_SECRET_KEY,
+        purpose: 'p2pk',
+      });
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'canonical-alias-secret',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const signed = await service.signProof(proof, ODD_Y_CANONICAL_PUBLIC_KEY);
+      const witness = JSON.parse(signed.witness as string);
+
+      expect(witness.signatures).toHaveLength(1);
+    });
+
     it('throws when keypair not found', async () => {
       const proof: Proof = {
         id: 'keyset123',
@@ -636,6 +830,23 @@ describe('KeyRingService', () => {
 
       await expect(service.signProof(proof, fakePublicKey)).rejects.toThrow(
         'Key pair not found for public key: abcdef12...',
+      );
+    });
+
+    it('does not match unrelated legacy public keys', async () => {
+      await service.generateNewKeyPair({ dumpSecretKey: true });
+
+      const proof: Proof = {
+        id: 'keyset123',
+        amount: Amount.from(64),
+        secret: 'my-secret-string',
+        C: '0000000000000000000000000000000000000000000000000000000000000000',
+      };
+
+      const fakeLegacyPublicKey = '02' + '11'.repeat(32);
+
+      await expect(service.signProof(proof, fakeLegacyPublicKey)).rejects.toThrow(
+        /Key pair not found for public key/,
       );
     });
 

--- a/packages/core/test/unit/KeypairCapabilities.test.ts
+++ b/packages/core/test/unit/KeypairCapabilities.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'bun:test';
-import { schnorr } from '@noble/curves/secp256k1.js';
+import { describe, expect, it, mock } from 'bun:test';
+import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type { Proof } from '@cashu/cashu-ts';
 import { KeypairDerivation } from '../../keypairs/KeypairDerivation.ts';
 import { KeypairP2pkSigner } from '../../keypairs/P2pkSigner.ts';
+import { findP2pkKeyPair } from '../../keypairs/P2pkKeyLookup.ts';
+import { MemoryKeyRingRepository } from '../../repositories/memory/MemoryKeyRingRepository.ts';
 
 describe('shared keypair capabilities', () => {
   it('prepares derivation once and reuses it synchronously without loading the seed again', async () => {
@@ -45,5 +47,77 @@ describe('shared keypair capabilities', () => {
     expect(proof.witness).toBeUndefined();
     await expect(signer.signProof(proof, 'missing')).rejects.toThrow('Key pair not found');
     expect(lookups).toEqual([publicKeyHex, 'missing']);
+  });
+});
+
+describe('P2PK alias lookup and signing', () => {
+  const secretKey = Uint8Array.from([...new Uint8Array(31), 6]);
+  const canonicalKey = '03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556';
+  const legacyKey = '02' + canonicalKey.slice(2);
+
+  it.each([
+    [canonicalKey, legacyKey],
+    [legacyKey, canonicalKey],
+  ])('signs using stored %s through alias %s with two reads', async (storedKey, alias) => {
+    const repository = new MemoryKeyRingRepository();
+    await repository.setPersistedKeyPair({ publicKeyHex: storedKey, secretKey, purpose: 'p2pk' });
+    const getPersistedKeyPair = mock(repository.getPersistedKeyPair.bind(repository));
+    const signer = new KeypairP2pkSigner({ getPersistedKeyPair });
+    const proof = { secret: 'proof-secret' } as Proof;
+    const signed = await signer.signProof(proof, alias);
+    const witness = JSON.parse(signed.witness as string) as { signatures: string[] };
+
+    expect(
+      schnorr.verify(
+        hexToBytes(witness.signatures[0]!),
+        sha256(new TextEncoder().encode(proof.secret)),
+        hexToBytes(alias.slice(2)),
+      ),
+    ).toBe(true);
+    expect(getPersistedKeyPair).toHaveBeenCalledTimes(2);
+    expect(getPersistedKeyPair).toHaveBeenNthCalledWith(1, alias, 'p2pk');
+    expect(getPersistedKeyPair).toHaveBeenNthCalledWith(2, storedKey, 'p2pk');
+    expect(proof.witness).toBeUndefined();
+  });
+
+  it('does not treat the opposite parity of an even-Y key as a legacy alias', async () => {
+    const repository = new MemoryKeyRingRepository();
+    const evenSecret = Uint8Array.from([...new Uint8Array(31), 1]);
+    const publicKeyHex = bytesToHex(secp256k1.getPublicKey(evenSecret, true));
+    expect(publicKeyHex.startsWith('02')).toBe(true);
+    await repository.setPersistedKeyPair({ publicKeyHex, secretKey: evenSecret, purpose: 'p2pk' });
+
+    expect(await findP2pkKeyPair(repository, '03' + publicKeyHex.slice(2))).toBeNull();
+  });
+
+  it('keeps mint quote keys out of both direct and alias signing', async () => {
+    const repository = new MemoryKeyRingRepository();
+    await repository.setPersistedKeyPair({
+      publicKeyHex: canonicalKey,
+      secretKey,
+      purpose: 'nut20_mint_quote',
+    });
+    const signer = new KeypairP2pkSigner(repository);
+    for (const publicKey of [canonicalKey, legacyKey]) {
+      expect(await findP2pkKeyPair(repository, publicKey)).toBeNull();
+      await expect(
+        signer.signProof({ secret: 'proof-secret' } as Proof, publicKey),
+      ).rejects.toThrow('Key pair not found');
+    }
+  });
+
+  it('bounds absent-key lookups and does not derive from unrelated stored secrets', async () => {
+    const repository = new MemoryKeyRingRepository();
+    await repository.setPersistedKeyPair({
+      publicKeyHex: canonicalKey,
+      secretKey: new Uint8Array(32),
+      purpose: 'p2pk',
+    });
+    const getPersistedKeyPair = mock(repository.getPersistedKeyPair.bind(repository));
+    expect(await findP2pkKeyPair({ getPersistedKeyPair }, '02' + '11'.repeat(32))).toBeNull();
+    expect(getPersistedKeyPair).toHaveBeenCalledTimes(2);
+    getPersistedKeyPair.mockClear();
+    expect(await findP2pkKeyPair({ getPersistedKeyPair }, 'missing')).toBeNull();
+    expect(getPersistedKeyPair).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/test/unit/P2pkTransactions.test.ts
+++ b/packages/core/test/unit/P2pkTransactions.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type { Keypair } from '../../models/Keypair.ts';
+import type { Repositories } from '../../repositories/index.ts';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { RepositoryCoreTransactionRunner } from '../../transactions/CoreTransaction.ts';
+import { CoreKeyRingTransactions } from '../../transactions/keypairs/KeyRingTransactions.ts';
+import { SqlStorageRepositories } from '../../../sql-storage/src/repositories.ts';
+import { SqliteDb } from '../../../sqlite-bun/src/db.ts';
+import { overrideTransactions } from '../overrideTransactions.ts';
+
+const canonicalKey = '03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556';
+const legacyKey = '02' + canonicalKey.slice(2);
+const importedKey: Keypair = {
+  publicKeyHex: canonicalKey,
+  secretKey: Uint8Array.from([...new Uint8Array(31), 6]),
+  purpose: 'p2pk',
+};
+const legacyKeypair: Keypair = { ...importedKey, publicKeyHex: legacyKey, derivationIndex: 7 };
+
+describe.each(['memory', 'sqlite'] as const)('P2PK transactions with %s', (adapter) => {
+  let database: Database | undefined;
+  let repositories: Repositories;
+  let runner: RepositoryCoreTransactionRunner;
+  let transactions: CoreKeyRingTransactions;
+
+  beforeEach(async () => {
+    if (adapter === 'sqlite') {
+      database = new Database(':memory:');
+      repositories = new SqlStorageRepositories({ database: new SqliteDb({ database }) });
+    } else {
+      repositories = new MemoryRepositories();
+    }
+    await repositories.init();
+    runner = new RepositoryCoreTransactionRunner(repositories);
+    transactions = new CoreKeyRingTransactions(runner);
+  });
+
+  afterEach(() => database?.close());
+
+  it('preserves a legacy identity and metadata across concurrent reimports', async () => {
+    await repositories.keyRingRepository.setPersistedKeyPair(legacyKeypair);
+    await repositories.keyRingRepository.setLastAllocatedIndex('p2pk', 12);
+
+    const results = await Promise.all([
+      transactions.importP2pkKey(importedKey),
+      transactions.importP2pkKey(importedKey),
+    ]);
+
+    expect(results).toEqual([legacyKeypair, legacyKeypair]);
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([
+      legacyKeypair,
+    ]);
+    expect(await repositories.keyRingRepository.getLastAllocatedIndex('p2pk')).toBe(12);
+  });
+
+  it('deduplicates concurrent imports into an empty keyring', async () => {
+    await Promise.all([
+      transactions.importP2pkKey(importedKey),
+      transactions.importP2pkKey(importedKey),
+    ]);
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toHaveLength(1);
+    expect(await repositories.keyRingRepository.getLastAllocatedIndex('p2pk')).toBeNull();
+  });
+
+  it('resolves import and deletion against preceding writes in the same scope', async () => {
+    await runner.run(async (scope) => {
+      await scope.keypairs.importP2pk(legacyKeypair);
+      expect(await scope.keypairs.importP2pk(importedKey)).toEqual(legacyKeypair);
+      await scope.keypairs.deleteP2pk(canonicalKey);
+    });
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([]);
+  });
+
+  it('uses one transaction for alias reads and deletion without changing allocation state', async () => {
+    await repositories.keyRingRepository.setPersistedKeyPair(legacyKeypair);
+    await repositories.keyRingRepository.setLastAllocatedIndex('p2pk', 12);
+    const transactionStarted = mock(() => {});
+    const gateway = new CoreKeyRingTransactions(
+      new RepositoryCoreTransactionRunner(
+        overrideTransactions(repositories, (work) => {
+          transactionStarted();
+          return repositories.withTransaction(work);
+        }),
+      ),
+    );
+    await gateway.deleteP2pkKey(canonicalKey);
+
+    expect(transactionStarted).toHaveBeenCalledTimes(1);
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([]);
+    expect(await repositories.keyRingRepository.getLastAllocatedIndex('p2pk')).toBe(12);
+  });
+
+  it('returns import results only after commit and preserves them on a repeated import', async () => {
+    const transactionStarted = mock(() => {});
+    const gateway = new CoreKeyRingTransactions(
+      new RepositoryCoreTransactionRunner(
+        overrideTransactions(repositories, (work) => {
+          transactionStarted();
+          return repositories.withTransaction(work);
+        }),
+      ),
+    );
+    const first = await gateway.importP2pkKey(importedKey);
+    expect(await repositories.keyRingRepository.getPersistedKeyPair(canonicalKey, 'p2pk')).toEqual(
+      expect.objectContaining(first),
+    );
+    const second = await gateway.importP2pkKey(importedKey);
+    expect(second).toEqual(expect.objectContaining(first));
+    expect(transactionStarted).toHaveBeenCalledTimes(2);
+  });
+
+  it('rolls alias deletion back with the owning transaction', async () => {
+    await repositories.keyRingRepository.setPersistedKeyPair(legacyKeypair);
+    await expect(
+      runner.run(async (scope) => {
+        await scope.keypairs.deleteP2pk(canonicalKey);
+        throw new Error('abort');
+      }),
+    ).rejects.toThrow('abort');
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([
+      legacyKeypair,
+    ]);
+  });
+
+  it('rolls import back with the owning transaction', async () => {
+    await expect(
+      runner.run(async (scope) => {
+        await scope.keypairs.importP2pk(importedKey);
+        throw new Error('abort');
+      }),
+    ).rejects.toThrow('abort');
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([]);
+  });
+
+  it('does not delete a mint quote key through either P2PK encoding', async () => {
+    const quoteKey: Keypair = { ...importedKey, purpose: 'nut20_mint_quote' };
+    await repositories.keyRingRepository.setPersistedKeyPair(quoteKey);
+    await transactions.deleteP2pkKey(legacyKey);
+    await transactions.deleteP2pkKey(canonicalKey);
+    expect(
+      await repositories.keyRingRepository.getPersistedKeyPair(canonicalKey, 'nut20_mint_quote'),
+    ).toEqual(expect.objectContaining(quoteKey));
+  });
+});

--- a/packages/core/transactions/keypairs/KeyRingTransactions.ts
+++ b/packages/core/transactions/keypairs/KeyRingTransactions.ts
@@ -5,7 +5,8 @@ import type { CoreTransactionRunner } from '../CoreTransaction.ts';
 /** Each key-management command owns one transaction and resolves after commit. */
 export interface KeyRingTransactions {
   allocate(input: AllocateKeypairInput): Promise<Keypair>;
-  importP2pkKey(keypair: Keypair): Promise<void>;
+  /** Returns the persisted keypair, retaining an existing canonical or legacy identity. */
+  importP2pkKey(keypair: Keypair): Promise<Keypair>;
   deleteP2pkKey(publicKey: string): Promise<void>;
 }
 
@@ -16,7 +17,7 @@ export class CoreKeyRingTransactions implements KeyRingTransactions {
     return this.runner.run((transaction) => transaction.keypairs.allocate(input));
   }
 
-  importP2pkKey(keypair: Keypair): Promise<void> {
+  importP2pkKey(keypair: Keypair): Promise<Keypair> {
     return this.runner.run((transaction) => transaction.keypairs.importP2pk(keypair));
   }
 

--- a/packages/core/transactions/scoped/keypairs/ScopedKeypairCommands.ts
+++ b/packages/core/transactions/scoped/keypairs/ScopedKeypairCommands.ts
@@ -2,6 +2,7 @@ import type { Keypair } from '@core/models/Keypair';
 import { DerivationIndexExhaustedError } from '@core/models/Error';
 import type { KeyRingRepository } from '@core/repositories';
 import type { AllocateKeypairInput } from '../../../keypairs/types.ts';
+import { findP2pkKeyPair } from '../../../keypairs/P2pkKeyLookup.ts';
 
 const MAX_DERIVATION_INDEX = 0x7fffffff;
 
@@ -9,7 +10,8 @@ const MAX_DERIVATION_INDEX = 0x7fffffff;
 export interface ScopedKeypairCommands {
   /** Await each allocation before starting another for the same purpose within this scope. */
   allocate(input: AllocateKeypairInput): Promise<Keypair>;
-  importP2pk(keypair: Keypair): Promise<void>;
+  /** Resolves aliases inside this scope and returns the persisted identity and metadata. */
+  importP2pk(keypair: Keypair): Promise<Keypair>;
   deleteP2pk(publicKey: string): Promise<void>;
 }
 
@@ -35,11 +37,15 @@ export class RepositoryKeypairCommands implements ScopedKeypairCommands {
     return keypair;
   }
 
-  importP2pk(keypair: Keypair): Promise<void> {
-    return this.repository.setPersistedKeyPair(keypair);
+  async importP2pk(keypair: Keypair): Promise<Keypair> {
+    const existing = await findP2pkKeyPair(this.repository, keypair.publicKeyHex);
+    if (existing) return existing;
+    await this.repository.setPersistedKeyPair(keypair);
+    return keypair;
   }
 
-  deleteP2pk(publicKey: string): Promise<void> {
-    return this.repository.deletePersistedKeyPair(publicKey, 'p2pk');
+  async deleteP2pk(publicKey: string): Promise<void> {
+    const existing = await findP2pkKeyPair(this.repository, publicKey);
+    if (existing) await this.repository.deletePersistedKeyPair(existing.publicKeyHex, 'p2pk');
   }
 }

--- a/packages/docs/pages/keyring.md
+++ b/packages/docs/pages/keyring.md
@@ -30,6 +30,9 @@ console.log('Public key:', keypair.publicKeyHex);
 console.log('Secret key:', keypair.secretKey); // Uint8Array(32)
 ```
 
+Generated P2PK public keys use canonical SEC1 compressed encoding, including the key's actual
+`02` or `03` parity prefix. This matches CDK and the deterministic P2PK derivation vectors.
+
 ::: warning
 The secret key is sensitive cryptographic material. When setting `dumpSecretKey: true`, ensure you handle the key securely and clear it from memory when no longer needed.
 :::
@@ -45,10 +48,15 @@ const keypair = await coco.keyring.addKeyPair(secretKey);
 console.log('Imported public key:', keypair.publicKeyHex);
 ```
 
+For compatibility with earlier coco versions, the keyring treats the legacy always-`02` encoding
+and the canonical compressed encoding as aliases for the same P2PK key. Existing persisted keys
+keep their stored public key encoding and derivation metadata; imports do not create a duplicate
+row for the other alias.
+
 ### Retrieving Keypairs
 
 ```ts
-// Get a specific keypair by public key
+// Get a specific keypair by its canonical or legacy public key encoding
 const keypair = await coco.keyring.getKeyPair(publicKeyHex);
 if (keypair) {
   console.log('Found keypair:', keypair.publicKeyHex);
@@ -65,7 +73,7 @@ console.log(`You have ${allKeypairs.length} keypairs`);
 ### Removing Keypairs
 
 ```ts
-// Remove a keypair by public key
+// Remove a keypair by its canonical or legacy public key encoding
 await coco.keyring.removeKeyPair(publicKeyHex);
 ```
 

--- a/packages/docs/pages/keyring.md
+++ b/packages/docs/pages/keyring.md
@@ -30,6 +30,9 @@ console.log('Public key:', keypair.publicKeyHex);
 console.log('Secret key:', keypair.secretKey); // Uint8Array(32)
 ```
 
+Generated P2PK public keys use canonical SEC1 compressed encoding, including the key's actual
+`02` or `03` parity prefix. This matches CDK and the deterministic P2PK derivation vectors.
+
 ::: warning
 The secret key is sensitive cryptographic material. When setting `dumpSecretKey: true`, ensure you handle the key securely and clear it from memory when no longer needed.
 :::
@@ -57,10 +60,15 @@ const keypair = await coco.keyring.addKeyPair(secretKey);
 console.log('Imported public key:', keypair.publicKeyHex);
 ```
 
+For compatibility with earlier coco versions, the keyring treats the legacy always-`02` encoding
+and the canonical compressed encoding as aliases for the same P2PK key. Existing persisted keys
+keep their stored public key encoding and derivation metadata; imports do not create a duplicate
+row for the other alias.
+
 ### Retrieving Keypairs
 
 ```ts
-// Get a specific keypair by public key
+// Get a specific keypair by its canonical or legacy public key encoding
 const keypair = await coco.keyring.getKeyPair(publicKeyHex);
 if (keypair) {
   console.log('Found keypair:', keypair.publicKeyHex);
@@ -77,7 +85,7 @@ console.log(`You have ${allKeypairs.length} keypairs`);
 ### Removing Keypairs
 
 ```ts
-// Remove a keypair by public key
+// Remove a keypair by its canonical or legacy public key encoding
 await coco.keyring.removeKeyPair(publicKeyHex);
 ```
 


### PR DESCRIPTION
Replaces #121 with the original two commits rebased onto current `master`. Their author metadata remains attributed to `lescuer97`.

## Problem

Older coco versions serialized every P2PK key as `02 + x-only key`. That remains valid for BIP340 verification, but odd-Y keys do not match the canonical compressed SEC1 identity emitted by CDK and required by the deterministic derivation vectors.

Changing the serialized identity without an alias layer would strand existing persisted keys and proofs after an upgrade or seed-based keyring restore.

## Summary

- derive new P2PK keys with their canonical `02` or `03` SEC1 prefix, matching CDK and the deterministic vectors
- resolve canonical and legacy encodings bidirectionally for P2PK lookup, removal, and proof signing
- preserve existing persisted row identities and derivation metadata instead of rewriting the database
- avoid duplicate rows when an existing legacy key is imported again
- scope alias matching to P2PK keys so NUT-20 mint quote keys remain isolated
- document the compatibility behavior and add a patch changeset for `@cashu/coco-core`

Existing legacy rows remain unchanged. The upgraded keyring accepts either encoding and returns the persisted keypair with its stored identity.

References:

- CDK implementation: https://github.com/cashubtc/cdk/blob/dd74c9ac3e53e1b764daec60deae41b4348e707e/crates/cdk/src/wallet/p2pk.rs
- Specification work: https://github.com/cashubtc/nuts/pull/331

## Verification

- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test:unit` (1,011 passed)
- `bun run --filter='@cashu/coco-core' test -- test/unit/KeyRingService.test.ts` (46 passed)
- `bun run docs:build`
- `bunx prettier --check packages/core/services/KeyRingService.ts packages/core/api/KeyRingApi.ts packages/core/test/unit/KeyRingService.test.ts packages/docs/pages/keyring.md .changeset/canonical-p2pk-keys.md`
