### PR TITLE
feat(core): Support P2PK payment request sends

### DIFF
--- a/.changeset/p2pk-payment-requests.md
+++ b/.changeset/p2pk-payment-requests.md
@@ -1,0 +1,17 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-adapter-tests': major
+'@cashu/coco-indexeddb': major
+'@cashu/coco-expo-sqlite': major
+'@cashu/coco-sql-storage': major
+'@cashu/coco-sqlite': major
+'@cashu/coco-sqlite-bun': major
+---
+
+Add payer-side NUT-18 P2PK payment request support.
+
+Core now exposes normalized P2PK payment request requirements, filters payable
+mints to those advertising NUT-11, and prepares payment request sends through
+the general P2PK send handler with structured NUT-11 options from cashu-ts.
+Adapter packages now require cashu-ts 4.6.1, and adapter contract coverage
+checks that structured send method data remains persisted.

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@cashu/coco-core": "1.0.0",
       },
       "peerDependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@cashu/coco-core": "^1.0.0",
         "typescript": "^5",
       },
@@ -34,7 +34,7 @@
       "name": "@cashu/coco-core",
       "version": "1.0.0",
       "dependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@scure/bip32": "^2.0.1",
@@ -61,7 +61,7 @@
         "@cashu/coco-sql-storage": "1.0.0",
       },
       "peerDependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@cashu/coco-core": "1.0.0",
         "expo-sqlite": "*",
         "typescript": "^5",
@@ -80,7 +80,7 @@
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@cashu/coco-core": "1.0.0",
         "typescript": "^5",
       },
@@ -116,7 +116,7 @@
       "name": "@cashu/coco-sql-storage",
       "version": "1.0.0",
       "peerDependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@cashu/coco-core": "1.0.0",
         "typescript": "^5",
       },
@@ -129,7 +129,7 @@
         "@cashu/coco-sql-storage": "1.0.0",
       },
       "peerDependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@cashu/coco-core": "1.0.0",
         "typescript": "^5",
       },
@@ -147,7 +147,7 @@
         "vitest": "^2.1.9",
       },
       "peerDependencies": {
-        "@cashu/cashu-ts": "4.5",
+        "@cashu/cashu-ts": "4.6.1",
         "@cashu/coco-core": "1.0.0",
         "typescript": "^5",
       },
@@ -393,7 +393,7 @@
 
     "@babel/types": ["@babel/types@8.0.0-beta.4", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-beta.4", "@babel/helper-validator-identifier": "^8.0.0-beta.4" } }, "sha512-xjk2xqYp25ePzAs0I08hN2lrbUDDQFfCjwq6MIEa8HwHa0WK8NfNtdvtXod8Ku2CbE1iui7qwWojGvjQiyrQeA=="],
 
-    "@cashu/cashu-ts": ["@cashu/cashu-ts@4.5.0", "", { "dependencies": { "@noble/curves": "^2.2.0", "@noble/hashes": "^2.2.0", "@scure/base": "^2.2.0", "@scure/bip32": "^2.2.0" } }, "sha512-NoUOitUMaxzmA3k4qLozZyFM1qonBdNB2ZM55U45X9SwFIQovRDttVDFL6Dn39q3H8v6pUTYxOHeUKdAmY/V/g=="],
+    "@cashu/cashu-ts": ["@cashu/cashu-ts@4.6.1", "", { "dependencies": { "@noble/curves": "^2.2.0", "@noble/hashes": "^2.2.0", "@scure/base": "^2.2.0", "@scure/bip32": "^2.2.0" } }, "sha512-63X9AI9nrN8auPYld+EGd24CMFrnOraUNs7FaOR5+XeKG9FwyFK43Qh2qGOq+dXfq575bmEL9AWN5uFw6qbe4w=="],
 
     "@cashu/coco-adapter-tests": ["@cashu/coco-adapter-tests@workspace:packages/adapter-tests"],
 

--- a/packages/adapter-tests/package.json
+++ b/packages/adapter-tests/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@cashu/coco-core": "^1.0.0",
     "typescript": "^5",
-    "@cashu/cashu-ts": "4.5"
+    "@cashu/cashu-ts": "4.6.1"
   },
   "dependencies": {
     "fake-bolt11": "^0.1.0"

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -1303,6 +1303,61 @@ export async function runSendOperationRepositoryContract(
         await dispose();
       }
     });
+
+    it('round-trips legacy P2PK send operation method data', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const publicKey = `02${'11'.repeat(32)}`;
+        const operation = createDummyPreparedSendOperation({
+          id: 'send-p2pk-legacy',
+          method: 'p2pk',
+          methodData: { pubkey: publicKey },
+        });
+
+        await repositories.sendOperationRepository.create(operation);
+
+        const stored = await repositories.sendOperationRepository.getById(operation.id);
+        expect(stored).toBeDefined();
+        expect(stored!.method).toBe('p2pk');
+        expect(JSON.stringify(stored!.methodData)).toBe(JSON.stringify({ pubkey: publicKey }));
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('round-trips structured P2PK send operation method data', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const primaryKey = `02${'22'.repeat(32)}`;
+        const secondKey = `03${'33'.repeat(32)}`;
+        const refundKey = `02${'44'.repeat(32)}`;
+        const methodData = {
+          options: {
+            pubkey: [primaryKey, secondKey],
+            requiredSignatures: 2,
+            locktime: 1_730_000_000,
+            refundKeys: [refundKey],
+            requiredRefundSignatures: 1,
+            sigFlag: 'SIG_ALL',
+            additionalTags: [['memo', 'payment-request']],
+          },
+        };
+        const operation = createDummyPreparedSendOperation({
+          id: 'send-p2pk-structured',
+          method: 'p2pk',
+          methodData: methodData as unknown as PreparedSendOperation['methodData'],
+        });
+
+        await repositories.sendOperationRepository.create(operation);
+
+        const stored = await repositories.sendOperationRepository.getById(operation.id);
+        expect(stored).toBeDefined();
+        expect(stored!.method).toBe('p2pk');
+        expect(JSON.stringify(stored!.methodData)).toBe(JSON.stringify(methodData));
+      } finally {
+        await dispose();
+      }
+    });
   });
 }
 

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -1022,6 +1022,7 @@ export class Manager {
     const paymentRequestService = new PaymentRequestService(
       sendOperationService,
       proofService,
+      mintService,
       paymentRequestLogger,
     );
     const paymentRequestReceiveLogger = this.getChildLogger('PaymentRequestReceiveService');

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -17,7 +17,11 @@ export type { CoreEvents } from './events/types.ts';
 export type { EventHandler } from './events/EventBus.ts';
 export { type Logger, ConsoleLogger } from './logging/index.ts';
 export { MemoryRepositories } from './repositories/memory/MemoryRepositories.ts';
-export type { SendMethod, SendMethodData } from './operations/send/SendMethodHandler.ts';
+export type {
+  P2pkSendMethodData,
+  SendMethod,
+  SendMethodData,
+} from './operations/send/SendMethodHandler.ts';
 export type {
   InitSendOperation,
   PreparedSendOperation,

--- a/packages/core/infra/handlers/send/P2pkSendHandler.ts
+++ b/packages/core/infra/handlers/send/P2pkSendHandler.ts
@@ -4,6 +4,7 @@ import {
   type Token,
   type Proof,
   type OutputConfig,
+  type P2PKOptions,
   type OutputDataCreator,
 } from '@cashu/cashu-ts';
 import type {
@@ -77,7 +78,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
 
     const keyset = wallet.getKeyset();
 
-    const sendOT = this.outputDataCreator.createP2PKData({ pubkey }, amount, keyset);
+    const sendOT = this.outputDataCreator.createP2PKData(p2pkOptions, amount, keyset);
 
     // Serialize for storage
     const serializedOutputData = serializeOutputData({
@@ -213,6 +214,9 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
 
   private getP2pkOptions(methodData: SendMethodData<'p2pk'>): P2PKOptions {
     if ('options' in methodData && methodData.options) {
+      if ((methodData.options as { hashlock?: unknown }).hashlock !== undefined) {
+        throw new ProofValidationError('P2PK send does not support hashlock/HTLC options');
+      }
       return methodData.options;
     }
 

--- a/packages/core/infra/handlers/send/P2pkSendHandler.ts
+++ b/packages/core/infra/handlers/send/P2pkSendHandler.ts
@@ -15,6 +15,7 @@ import type {
   RecoverExecutingContext,
   ExecutionResult,
   RecoveryResult,
+  SendMethodData,
 } from '../../../operations/send/SendMethodHandler';
 import type {
   PreparedSendOperation,
@@ -47,14 +48,11 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
    * P2PK sends always require a swap to lock the proofs to the pubkey.
    */
   async prepare(ctx: BasePrepareContext): Promise<PreparedSendOperation> {
-    const { operation, wallet, proofService, logger } = ctx;
+    const { operation, wallet, proofService, mintService, logger } = ctx;
     const { mintUrl, amount, unit } = operation;
 
-    // Validate that we have a pubkey in methodData
-    const pubkey = (operation.methodData as { pubkey: string })?.pubkey;
-    if (!pubkey) {
-      throw new ProofValidationError('P2PK send requires a pubkey in methodData');
-    }
+    const p2pkOptions = this.getP2pkOptions(operation.methodData as SendMethodData<'p2pk'>);
+    await mintService.assertNutSupported(mintUrl, 11, 'P2PK send');
 
     // P2PK always requires a swap to lock proofs to the pubkey
     // Select proofs including fees
@@ -96,7 +94,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
       proofCount: selected.length,
       keepOutputs: outputResult.keep.length,
       sendOutputs: sendOT.length,
-      pubkey,
+      p2pkPubkey: p2pkOptions.pubkey,
     });
 
     // Reserve the selected proofs
@@ -126,7 +124,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
       operationId: operation.id,
       fee,
       inputProofCount: inputSecrets.length,
-      pubkey,
+      p2pkPubkey: p2pkOptions.pubkey,
     });
 
     return prepared;
@@ -139,11 +137,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
     const { operation, wallet, reservedProofs, proofService, logger } = ctx;
     const { mintUrl, amount, inputProofSecrets } = operation;
 
-    // Get the pubkey from methodData
-    const pubkey = (operation.methodData as { pubkey: string })?.pubkey;
-    if (!pubkey) {
-      throw new Error('P2PK send requires a pubkey in methodData');
-    }
+    const p2pkOptions = this.getP2pkOptions(operation.methodData as SendMethodData<'p2pk'>);
 
     const inputProofs = reservedProofs.filter((p: Proof) => inputProofSecrets.includes(p.secret));
 
@@ -163,7 +157,7 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
       operationId: operation.id,
       keepOutputs: outputData.keep.length,
       sendOutputs: outputData.send.length,
-      pubkey,
+      p2pkPubkey: p2pkOptions.pubkey,
     });
 
     const outputConfig: OutputConfig = {
@@ -211,10 +205,22 @@ export class P2pkSendHandler implements SendMethodHandler<'p2pk'> {
       operationId: operation.id,
       sendProofCount: sendProofs.length,
       keepProofCount: keepProofs.length,
-      pubkey,
+      p2pkPubkey: p2pkOptions.pubkey,
     });
 
     return { status: 'PENDING', pending, token };
+  }
+
+  private getP2pkOptions(methodData: SendMethodData<'p2pk'>): P2PKOptions {
+    if ('options' in methodData && methodData.options) {
+      return methodData.options;
+    }
+
+    if ('pubkey' in methodData && methodData.pubkey) {
+      return { pubkey: methodData.pubkey };
+    }
+
+    throw new ProofValidationError('P2PK send requires P2PK options or a pubkey in methodData');
   }
 
   /**

--- a/packages/core/operations/send/SendMethodHandler.ts
+++ b/packages/core/operations/send/SendMethodHandler.ts
@@ -16,11 +16,22 @@ import type {
 } from './SendOperation';
 
 /**
- * Registry of supported send methods and their payload shapes.
- * Extend via declaration merging if you need to add methods externally.
+ * Structured P2PK send options accepted by Coco.
  *
- * Future methods may include:
- * - htlc: { hash: string; timeout: number } - HTLC locked tokens
+ * `hashlock` is intentionally unavailable because cashu-ts treats hashlocked
+ * P2PK options as HTLC/NUT-14 data, which this send method does not support.
+ */
+export type P2pkSendOptions = Omit<P2PKOptions, 'hashlock'> & {
+  /** HTLC/NUT-14 hashlocks are out of scope for P2PK sends. */
+  hashlock?: never;
+};
+
+/**
+ * Payload accepted by the P2PK send method.
+ *
+ * `pubkey` is the legacy shorthand for locking outputs to a single public key.
+ * Prefer `options` for full NUT-11 P2PK conditions such as `sigflag`,
+ * multisig tags, locktime, and refund keys.
  */
 export type P2pkSendMethodData =
   | {
@@ -29,11 +40,18 @@ export type P2pkSendMethodData =
       options?: never;
     }
   | {
-      /** Full NUT-11 P2PK options accepted by cashu-ts output builders. */
-      options: P2PKOptions;
+      /** Full NUT-11 P2PK options accepted by Coco output builders. */
+      options: P2pkSendOptions;
       pubkey?: never;
     };
 
+/**
+ * Registry of supported send methods and their payload shapes.
+ * Extend via declaration merging if you need to add methods externally.
+ *
+ * Future methods may include:
+ * - htlc: { hash: string; timeout: number } - HTLC locked tokens
+ */
 export interface SendMethodDefinitions {
   default: Record<string, never>;
   p2pk: P2pkSendMethodData;

--- a/packages/core/operations/send/SendMethodHandler.ts
+++ b/packages/core/operations/send/SendMethodHandler.ts
@@ -1,4 +1,4 @@
-import type { Wallet, Proof, Token } from '@cashu/cashu-ts';
+import type { Wallet, Proof, Token, P2PKOptions } from '@cashu/cashu-ts';
 import type { ProofRepository } from '../../repositories';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
@@ -22,9 +22,21 @@ import type {
  * Future methods may include:
  * - htlc: { hash: string; timeout: number } - HTLC locked tokens
  */
+export type P2pkSendMethodData =
+  | {
+      /** Legacy/direct shorthand for sending to one P2PK lock key. */
+      pubkey: string;
+      options?: never;
+    }
+  | {
+      /** Full NUT-11 P2PK options accepted by cashu-ts output builders. */
+      options: P2PKOptions;
+      pubkey?: never;
+    };
+
 export interface SendMethodDefinitions {
   default: Record<string, never>;
-  p2pk: { pubkey: string };
+  p2pk: P2pkSendMethodData;
 }
 
 export type SendMethod = keyof SendMethodDefinitions;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@cashu/cashu-ts": "4.5",
+    "@cashu/cashu-ts": "4.6.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@scure/bip32": "^2.0.1"

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -225,6 +225,14 @@ export class MintService {
     return mint.mintInfo;
   }
 
+  /**
+   * Returns whether a mint advertises support for a top-level NUT capability.
+   *
+   * This currently supports NUT-11 checks only. Mint information is resolved via
+   * `getMintInfo()`, so stale local records may be refreshed and fetch failures
+   * propagate to the caller. Missing, malformed, or disabled settings return
+   * `false` rather than throwing.
+   */
   async supportsNut(mintUrl: string, nut: 11): Promise<boolean> {
     this.assertSupportCapabilityNut(nut);
     const normalizedMintUrl = normalizeMintUrl(mintUrl);
@@ -233,6 +241,13 @@ export class MintService {
     return settings?.supported === true;
   }
 
+  /**
+   * Requires a mint to advertise a top-level NUT capability.
+   *
+   * This currently supports NUT-11 checks only. Returns when support is
+   * advertised, throws `ProofValidationError` when support is absent, and lets
+   * mint-info refresh/fetch failures propagate unchanged.
+   */
   async assertNutSupported(mintUrl: string, nut: 11, scope?: string): Promise<void> {
     if (await this.supportsNut(mintUrl, nut)) {
       return;

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -80,6 +80,10 @@ type NutMethodSettings = {
   disabled?: boolean;
 };
 
+type NutSupportSettings = {
+  supported?: boolean;
+};
+
 export class MintService {
   private readonly mintRepo: MintRepository;
   private readonly keysetRepo: KeysetRepository;
@@ -219,6 +223,25 @@ export class MintService {
     // ensureUpdatedMint already normalizes, but normalize here for consistency
     const { mint } = await this.ensureUpdatedMint(normalizeMintUrl(mintUrl));
     return mint.mintInfo;
+  }
+
+  async supportsNut(mintUrl: string, nut: 11): Promise<boolean> {
+    this.assertSupportCapabilityNut(nut);
+    const normalizedMintUrl = normalizeMintUrl(mintUrl);
+    const mintInfo = await this.getMintInfo(normalizedMintUrl);
+    const settings = this.getNutSupportSettings(mintInfo, nut);
+    return settings?.supported === true;
+  }
+
+  async assertNutSupported(mintUrl: string, nut: 11, scope?: string): Promise<void> {
+    if (await this.supportsNut(mintUrl, nut)) {
+      return;
+    }
+
+    const context = scope ? ` for ${scope}` : '';
+    throw new ProofValidationError(
+      `${this.formatNut(nut)} support is required${context} but is not advertised by mint ${normalizeMintUrl(mintUrl)}`,
+    );
   }
 
   async checkPaymentMethodCapability(
@@ -416,6 +439,15 @@ export class MintService {
     return nuts?.[String(nut)] as NutMethodSettings | undefined;
   }
 
+  private getNutSupportSettings(mintInfo: MintInfo, nut: 11): NutSupportSettings | undefined {
+    const nuts = mintInfo.nuts as Record<string, unknown> | undefined;
+    const settings = nuts?.[String(nut)];
+    if (!settings || typeof settings !== 'object') {
+      return undefined;
+    }
+    return settings as NutSupportSettings;
+  }
+
   private assertMethodCapabilityNut(nut: number): asserts nut is 4 | 5 {
     if (nut !== 4 && nut !== 5) {
       throw new ProofValidationError(
@@ -424,8 +456,14 @@ export class MintService {
     }
   }
 
-  private formatNut(nut: 4 | 5): string {
-    return `NUT-0${nut}`;
+  private assertSupportCapabilityNut(nut: number): asserts nut is 11 {
+    if (nut !== 11) {
+      throw new ProofValidationError(`NUT-${nut} support capability checks are not implemented`);
+    }
+  }
+
+  private formatNut(nut: number): string {
+    return `NUT-${String(nut).padStart(2, '0')}`;
   }
 
   private assertPaymentMethodCapabilityOperation(

--- a/packages/core/services/PaymentRequestService.ts
+++ b/packages/core/services/PaymentRequestService.ts
@@ -13,6 +13,7 @@ import type { ProofService } from '../services';
 import type { MintService } from '../services/MintService.ts';
 import type {
   CreateSendOperationOptions,
+  P2pkSendOptions,
   PendingSendOperation,
   PreparedSendOperation,
   SendOperationService,
@@ -31,29 +32,57 @@ type PaymentRequestTransport =
   | HttpPaymentRequestTransport
   | NostrPaymentRequestTransport;
 
+/**
+ * A NUT-18 payment request spending condition that was successfully normalized
+ * as a NUT-11 P2PK lock by cashu-ts.
+ */
 export type PaymentRequestP2pkRequirement = {
+  /** The supported NUT-10 spending condition kind. */
   kind: 'P2PK';
-  options: P2PKOptions;
+  /** Normalized NUT-11 P2PK options used when preparing locked outputs. */
+  options: P2pkSendOptions;
+  /** Original NUT-10 option carried by the payment request. */
   rawNut10: NUT10Option;
 };
 
+/**
+ * Diagnostic for a payment request that carries a NUT-10 kind Coco cannot pay
+ * yet. Parse returns this value with no payable mints; prepare rejects before
+ * initializing a send operation.
+ */
 export type PaymentRequestUnsupportedSpendingCondition = {
   kind: 'unsupported';
+  /** Unsupported NUT-10 kind, for example HTLC. */
   nut10Kind: string;
+  /** Human-readable reason suitable for surfacing to callers. */
   reason: string;
+  /** Original NUT-10 option carried by the payment request. */
   rawNut10: NUT10Option;
 };
 
+/**
+ * Diagnostic for a payment request whose NUT-10 option is present but cannot
+ * be normalized by cashu-ts. Parse returns this value with no payable mints;
+ * prepare rejects before initializing a send operation.
+ */
 export type PaymentRequestMalformedSpendingCondition = {
   kind: 'malformed';
+  /** NUT-10 kind that failed normalization. */
   nut10Kind: string;
+  /** Human-readable normalization failure reason. */
   reason: string;
+  /** Original malformed NUT-10 option carried by the payment request. */
   rawNut10: NUT10Option;
 };
 
+/**
+ * Spending-condition requirement or diagnostic exposed on resolved payment
+ * requests. Absence means the request has no NUT-10 spending condition.
+ */
 export type PaymentRequestSpendingConditionRequirement =
   | {
       kind: 'P2PK';
+      /** Normalized P2PK requirement that prepare will encode into outputs. */
       p2pk: PaymentRequestP2pkRequirement;
     }
   | PaymentRequestUnsupportedSpendingCondition
@@ -312,11 +341,18 @@ export class PaymentRequestService {
         balance.spendable.greaterThanOrEqual(amount) &&
         (!mintRequirement || mintRequirement.includes(mintUrl))
       ) {
-        if (
-          spendingCondition?.kind === 'P2PK' &&
-          !(await this.mintService.supportsNut(mintUrl, 11))
-        ) {
-          continue;
+        if (spendingCondition?.kind === 'P2PK') {
+          try {
+            if (!(await this.mintService.supportsNut(mintUrl, 11))) {
+              continue;
+            }
+          } catch (cause) {
+            this.logger?.warn(
+              'Skipping mint for P2PK payment request because NUT-11 support could not be verified',
+              { mintUrl, cause },
+            );
+            continue;
+          }
         }
         matchingMints.push(mintUrl);
       }
@@ -357,7 +393,7 @@ export class PaymentRequestService {
         kind: 'P2PK',
         p2pk: {
           kind: 'P2PK',
-          options,
+          options: this.requireP2pkOnlyOptions(options),
           rawNut10,
         },
       };
@@ -418,16 +454,23 @@ export class PaymentRequestService {
     };
   }
 
-  private normalizeP2pkOptionsForPrepare(paymentRequest: PaymentRequest): P2PKOptions {
+  private normalizeP2pkOptionsForPrepare(paymentRequest: PaymentRequest): P2pkSendOptions {
     try {
       const options = paymentRequest.toP2PKOptions();
       if (!options) {
         throw new PaymentRequestError('NUT-10 P2PK spending condition could not be normalized');
       }
-      return options;
+      return this.requireP2pkOnlyOptions(options);
     } catch (cause) {
       throw new PaymentRequestError('Malformed NUT-10 P2PK spending condition', cause);
     }
+  }
+
+  private requireP2pkOnlyOptions(options: P2PKOptions): P2pkSendOptions {
+    if (options.hashlock !== undefined) {
+      throw new PaymentRequestError('P2PK payment requests cannot include hashlock/HTLC options');
+    }
+    return options as P2pkSendOptions;
   }
 
   private throwMalformedSpendingCondition(

--- a/packages/core/services/PaymentRequestService.ts
+++ b/packages/core/services/PaymentRequestService.ts
@@ -4,11 +4,15 @@ import {
   JSONInt,
   PaymentRequest,
   PaymentRequestTransportType,
+  type NUT10Option,
+  type P2PKOptions,
   type Token,
 } from '@cashu/cashu-ts';
 import { PaymentRequestError } from '../models/Error';
 import type { ProofService } from '../services';
+import type { MintService } from '../services/MintService.ts';
 import type {
+  CreateSendOperationOptions,
   PendingSendOperation,
   PreparedSendOperation,
   SendOperationService,
@@ -27,6 +31,34 @@ type PaymentRequestTransport =
   | HttpPaymentRequestTransport
   | NostrPaymentRequestTransport;
 
+export type PaymentRequestP2pkRequirement = {
+  kind: 'P2PK';
+  options: P2PKOptions;
+  rawNut10: NUT10Option;
+};
+
+export type PaymentRequestUnsupportedSpendingCondition = {
+  kind: 'unsupported';
+  nut10Kind: string;
+  reason: string;
+  rawNut10: NUT10Option;
+};
+
+export type PaymentRequestMalformedSpendingCondition = {
+  kind: 'malformed';
+  nut10Kind: string;
+  reason: string;
+  rawNut10: NUT10Option;
+};
+
+export type PaymentRequestSpendingConditionRequirement =
+  | {
+      kind: 'P2PK';
+      p2pk: PaymentRequestP2pkRequirement;
+    }
+  | PaymentRequestUnsupportedSpendingCondition
+  | PaymentRequestMalformedSpendingCondition;
+
 type ResolvedPaymentRequest = {
   paymentRequest: PaymentRequest;
   payableMints: string[];
@@ -34,6 +66,7 @@ type ResolvedPaymentRequest = {
   amount?: Amount;
   unit: string;
   transport: PaymentRequestTransport;
+  spendingCondition?: PaymentRequestSpendingConditionRequirement;
 };
 
 export type PreparedPaymentRequest = {
@@ -79,15 +112,18 @@ export type {
 export class PaymentRequestService {
   private readonly sendOperationService: SendOperationService;
   private readonly proofService: ProofService;
+  private readonly mintService: MintService;
   private readonly logger?: Logger;
 
   constructor(
     sendOperationService: SendOperationService,
     proofService: ProofService,
+    mintService: MintService,
     logger?: Logger,
   ) {
     this.sendOperationService = sendOperationService;
     this.proofService = proofService;
+    this.mintService = mintService;
     this.logger = logger;
   }
 
@@ -100,7 +136,12 @@ export class PaymentRequestService {
     const decodedPaymentRequest = await this.readPaymentRequest(paymentRequest);
     const transport = this.getPaymentRequestTransport(decodedPaymentRequest);
     const unit = normalizeUnit(decodedPaymentRequest.unit, { defaultUnit: DEFAULT_UNIT });
-    const payableMints = await this.findMatchingMints(decodedPaymentRequest, unit);
+    const spendingCondition = this.resolveSpendingCondition(decodedPaymentRequest);
+    const payableMints = await this.findMatchingMints(
+      decodedPaymentRequest,
+      unit,
+      spendingCondition,
+    );
     const allowedMints = decodedPaymentRequest.mints ?? [];
     return {
       paymentRequest: decodedPaymentRequest,
@@ -109,6 +150,7 @@ export class PaymentRequestService {
       amount: decodedPaymentRequest.amount,
       unit,
       transport,
+      spendingCondition,
     };
   }
 
@@ -123,8 +165,9 @@ export class PaymentRequestService {
     this.validateMint(mintUrl, request.allowedMints);
     const finalAmount = this.validateAmount(request, amount);
     const preparedRequest = await this.resolvePreparedRequest(request, finalAmount);
+    const sendOptions = await this.resolveSendOptions(preparedRequest, mintUrl);
     this.logger?.debug('Preparing payment request transaction', { mintUrl, amount: finalAmount });
-    const initSend = await this.sendOperationService.init(mintUrl, finalAmount);
+    const initSend = await this.sendOperationService.init(mintUrl, finalAmount, sendOptions);
     const preparedSend = await this.sendOperationService.prepare(initSend);
     this.logger?.debug('Payment request transaction prepared', { mintUrl, amount: finalAmount });
     return { sendOperation: preparedSend, request: preparedRequest };
@@ -244,7 +287,18 @@ export class PaymentRequestService {
     );
   }
 
-  private async findMatchingMints(paymentRequest: PaymentRequest, unit: string): Promise<string[]> {
+  private async findMatchingMints(
+    paymentRequest: PaymentRequest,
+    unit: string,
+    spendingCondition?: PaymentRequestSpendingConditionRequirement,
+  ): Promise<string[]> {
+    if (
+      spendingCondition &&
+      (spendingCondition.kind === 'unsupported' || spendingCondition.kind === 'malformed')
+    ) {
+      return [];
+    }
+
     const normalizedUnit = normalizeUnit(unit, { defaultUnit: DEFAULT_UNIT });
     const balances = await this.proofService.getBalancesByMint({
       trustedOnly: true,
@@ -258,10 +312,141 @@ export class PaymentRequestService {
         balance.spendable.greaterThanOrEqual(amount) &&
         (!mintRequirement || mintRequirement.includes(mintUrl))
       ) {
+        if (
+          spendingCondition?.kind === 'P2PK' &&
+          !(await this.mintService.supportsNut(mintUrl, 11))
+        ) {
+          continue;
+        }
         matchingMints.push(mintUrl);
       }
     }
     return matchingMints;
+  }
+
+  private resolveSpendingCondition(
+    paymentRequest: PaymentRequest,
+  ): PaymentRequestSpendingConditionRequirement | undefined {
+    const rawNut10 = paymentRequest.nut10;
+    if (!rawNut10) {
+      return undefined;
+    }
+
+    const nut10Kind = this.getNut10Kind(rawNut10);
+    if (nut10Kind !== 'P2PK') {
+      return {
+        kind: 'unsupported',
+        nut10Kind,
+        reason: `Unsupported NUT-10 spending condition '${nut10Kind}'`,
+        rawNut10,
+      };
+    }
+
+    try {
+      const options = paymentRequest.toP2PKOptions();
+      if (!options) {
+        return {
+          kind: 'malformed',
+          nut10Kind,
+          reason: 'NUT-10 P2PK spending condition could not be normalized',
+          rawNut10,
+        };
+      }
+
+      return {
+        kind: 'P2PK',
+        p2pk: {
+          kind: 'P2PK',
+          options,
+          rawNut10,
+        },
+      };
+    } catch (error) {
+      return {
+        kind: 'malformed',
+        nut10Kind,
+        reason: error instanceof Error ? error.message : String(error),
+        rawNut10,
+      };
+    }
+  }
+
+  private getNut10Kind(nut10: NUT10Option): string {
+    const compact = nut10 as NUT10Option & { k?: unknown };
+    if (typeof nut10.kind === 'string' && nut10.kind.length > 0) {
+      return nut10.kind;
+    }
+    if (typeof compact.k === 'string' && compact.k.length > 0) {
+      return compact.k;
+    }
+    return 'unknown';
+  }
+
+  private async resolveSendOptions(
+    request: ResolvedPaymentRequest,
+    mintUrl: string,
+  ): Promise<CreateSendOperationOptions | undefined> {
+    const spendingCondition = request.spendingCondition;
+    if (!spendingCondition) {
+      return undefined;
+    }
+
+    if (spendingCondition.kind === 'unsupported') {
+      throw new PaymentRequestError(
+        `Unsupported NUT-10 spending condition '${spendingCondition.nut10Kind}'`,
+      );
+    }
+
+    if (spendingCondition.kind === 'malformed') {
+      this.throwMalformedSpendingCondition(spendingCondition, request.paymentRequest);
+    }
+
+    const options = this.normalizeP2pkOptionsForPrepare(request.paymentRequest);
+
+    try {
+      await this.mintService.assertNutSupported(mintUrl, 11, 'payment request P2PK');
+    } catch (cause) {
+      throw new PaymentRequestError(
+        `Mint ${mintUrl} does not support NUT-11 required by payment request P2PK`,
+        cause,
+      );
+    }
+
+    return {
+      method: 'p2pk',
+      methodData: { options },
+    };
+  }
+
+  private normalizeP2pkOptionsForPrepare(paymentRequest: PaymentRequest): P2PKOptions {
+    try {
+      const options = paymentRequest.toP2PKOptions();
+      if (!options) {
+        throw new PaymentRequestError('NUT-10 P2PK spending condition could not be normalized');
+      }
+      return options;
+    } catch (cause) {
+      throw new PaymentRequestError('Malformed NUT-10 P2PK spending condition', cause);
+    }
+  }
+
+  private throwMalformedSpendingCondition(
+    spendingCondition: PaymentRequestMalformedSpendingCondition,
+    paymentRequest: PaymentRequest,
+  ): never {
+    const message =
+      `Malformed NUT-10 spending condition '${spendingCondition.nut10Kind}': ` +
+      spendingCondition.reason;
+
+    if (spendingCondition.nut10Kind === 'P2PK') {
+      try {
+        this.normalizeP2pkOptionsForPrepare(paymentRequest);
+      } catch (cause) {
+        throw new PaymentRequestError(message, cause);
+      }
+    }
+
+    throw new PaymentRequestError(message);
   }
 
   private validateAmount(request: ResolvedPaymentRequest, amount?: UnitAmount): UnitAmount {
@@ -290,21 +475,29 @@ export class PaymentRequestService {
     intent: UnitAmount,
   ): Promise<ResolvedPaymentRequest> {
     const amount = intent.amount;
-    if (request.amount?.equals(amount)) {
+    const amountUnchanged = request.amount?.equals(amount) === true;
+    if (amountUnchanged && !request.paymentRequest.nut10 && !request.spendingCondition) {
       return request;
     }
 
-    const paymentRequest = new PaymentRequest(
-      request.paymentRequest.transport,
-      request.paymentRequest.id,
-      amount,
+    const paymentRequest = amountUnchanged
+      ? request.paymentRequest
+      : new PaymentRequest(
+          request.paymentRequest.transport,
+          request.paymentRequest.id,
+          amount,
+          request.unit,
+          request.paymentRequest.mints,
+          request.paymentRequest.description,
+          request.paymentRequest.singleUse,
+          request.paymentRequest.nut10,
+        );
+    const spendingCondition = this.resolveSpendingCondition(paymentRequest);
+    const payableMints = await this.findMatchingMints(
+      paymentRequest,
       request.unit,
-      request.paymentRequest.mints,
-      request.paymentRequest.description,
-      request.paymentRequest.singleUse,
-      request.paymentRequest.nut10,
+      spendingCondition,
     );
-    const payableMints = await this.findMatchingMints(paymentRequest, request.unit);
 
     return {
       ...request,
@@ -312,6 +505,7 @@ export class PaymentRequestService {
       unit: request.unit,
       payableMints,
       paymentRequest,
+      spendingCondition,
     };
   }
 }

--- a/packages/core/test/unit/MintService.test.ts
+++ b/packages/core/test/unit/MintService.test.ts
@@ -279,6 +279,105 @@ describe('MintService', () => {
     });
   });
 
+  describe('nut support capabilities', () => {
+    const useMintInfo = (mintInfo: MintInfo) => {
+      mockAdapter.fetchMintInfo = mock(() => Promise.resolve(mintInfo));
+    };
+
+    it('returns true when NUT-11 support is advertised', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '11': { supported: true },
+        },
+      } as MintInfo);
+
+      await expect(service.supportsNut(testMintUrl, 11)).resolves.toBe(true);
+      await expect(
+        service.assertNutSupported(testMintUrl, 11, 'P2PK send'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns false and rejects when NUT-11 metadata is missing', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          '4': { methods: [], disabled: false },
+          '5': { methods: [], disabled: false },
+        },
+      } as MintInfo);
+
+      await expect(service.supportsNut(testMintUrl, 11)).resolves.toBe(false);
+      await expect(
+        service.assertNutSupported(testMintUrl, 11, 'payment request P2PK'),
+      ).rejects.toThrow(ProofValidationError);
+    });
+
+    it('returns false when NUT-11 support is explicitly false', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '11': { supported: false },
+        },
+      } as MintInfo);
+
+      await expect(service.supportsNut(testMintUrl, 11)).resolves.toBe(false);
+    });
+
+    it('returns false when NUT-11 metadata is malformed', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '11': true,
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.supportsNut(testMintUrl, 11)).resolves.toBe(false);
+    });
+
+    it('returns false when NUT-11 supported is not the boolean true', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '11': { supported: 'true' },
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.supportsNut(testMintUrl, 11)).resolves.toBe(false);
+    });
+
+    it('keeps existing NUT-04 and NUT-05 method-unit capability checks unchanged', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          '4': { methods: [{ method: 'bolt11', unit: 'sat' }], disabled: false },
+          '5': { methods: [{ method: 'bolt11', unit: 'sat' }], disabled: false },
+          '11': { supported: true },
+        },
+      } as unknown as MintInfo);
+
+      const mintCapability = await service.getMintMethodUnitCapability(
+        testMintUrl,
+        4,
+        'bolt11',
+        'sat',
+      );
+      const meltCapability = await service.getMintMethodUnitCapability(
+        testMintUrl,
+        5,
+        'bolt11',
+        'sat',
+      );
+
+      expect(mintCapability.supported).toBe(true);
+      expect(meltCapability.supported).toBe(true);
+    });
+  });
+
   describe('method-unit capabilities', () => {
     const mintInfoWithMethods = (
       methods4: Array<{

--- a/packages/core/test/unit/P2pkSendHandler.test.ts
+++ b/packages/core/test/unit/P2pkSendHandler.test.ts
@@ -1,4 +1,4 @@
-import { Amount, OutputData, type OutputDataLike } from '@cashu/cashu-ts';
+import { Amount, OutputData, type OutputDataLike, type P2PKOptions } from '@cashu/cashu-ts';
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
 import { P2pkSendHandler } from '../../infra/handlers/send/P2pkSendHandler';
 import { EventBus } from '../../events/EventBus';
@@ -10,6 +10,7 @@ import type { Logger } from '../../logging/Logger';
 import type { CoreProof } from '../../types';
 import type { ProofRepository } from '../../repositories';
 import { ProofValidationError } from '../../models/Error';
+import { getSecretsFromSerializedOutputData } from '../../utils';
 import type {
   InitSendOperation,
   PreparedSendOperation,
@@ -30,6 +31,9 @@ describe('P2pkSendHandler', () => {
   const mintUrl = 'https://mint.test';
   const keysetId = 'keyset-1';
   const testPubkey = '02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9';
+  const secondPubkey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+  const refundPubkey = '02c6047f9441ed7d6d3045406e95c07cd85a2a1ac9f278e80f2ea26a1f8f1c287c';
+  const secondRefundPubkey = '02e493dbf1c10d80f3581e4904930b1404cc6c139f1a77d71642c9efe2e5a95c8f';
 
   let handler: P2pkSendHandler;
   let proofRepository: ProofRepository;
@@ -80,6 +84,15 @@ describe('P2pkSendHandler', () => {
       secret: Buffer.from(secret).toString('hex'),
     })),
   });
+
+  const getSendSecretPayloads = (operation: PreparedSendOperation): unknown[] => {
+    if (!operation.outputData) {
+      throw new Error('expected output data');
+    }
+    return getSecretsFromSerializedOutputData(operation.outputData).sendSecrets.map((secret) =>
+      JSON.parse(secret),
+    );
+  };
 
   const makeInitOp = (id: string, overrides?: Partial<InitSendOperation>): InitSendOperation => ({
     id,
@@ -205,6 +218,7 @@ describe('P2pkSendHandler', () => {
     // Mock MintService
     mintService = {
       isTrustedMint: mock(() => Promise.resolve(true)),
+      assertNutSupported: mock(() => Promise.resolve()),
     } as unknown as MintService;
 
     // Mock WalletService
@@ -345,15 +359,37 @@ describe('P2pkSendHandler', () => {
       ]);
     });
 
-    it('should throw if pubkey is missing from methodData', async () => {
+    it('should throw if P2PK target data is missing from methodData', async () => {
       const operation = makeInitOp('op-1', {
-        methodData: {}, // No pubkey
+        methodData: {}, // No P2PK target
       });
       const ctx = buildPrepareContext(operation);
 
       await expect(handler.prepare(ctx)).rejects.toThrow(
-        'P2PK send requires a pubkey in methodData',
+        'P2PK send requires P2PK options or a pubkey in methodData',
       );
+    });
+
+    it('should assert that the mint advertises NUT-11 before preparing outputs', async () => {
+      const operation = makeInitOp('op-nut11');
+      const ctx = buildPrepareContext(operation);
+
+      await handler.prepare(ctx);
+
+      expect(mintService.assertNutSupported).toHaveBeenCalledWith(mintUrl, 11, 'P2PK send');
+    });
+
+    it('should reject prepare when the mint does not advertise NUT-11', async () => {
+      (mintService.assertNutSupported as Mock<any>).mockRejectedValueOnce(
+        new ProofValidationError('NUT-11 support is required'),
+      );
+      const operation = makeInitOp('op-no-nut11');
+
+      await expect(handler.prepare(buildPrepareContext(operation))).rejects.toThrow(
+        'NUT-11 support is required',
+      );
+      expect(proofService.createOutputsAndIncrementCounters).not.toHaveBeenCalled();
+      expect(proofService.reserveProofs).not.toHaveBeenCalled();
     });
 
     it('should throw if balance is insufficient', async () => {
@@ -389,6 +425,57 @@ describe('P2pkSendHandler', () => {
       expect(result.methodData).toEqual({ pubkey: testPubkey });
       expect(result.inputProofSecrets).toEqual(['input-1', 'input-2']);
       expect(result.outputData).toBeDefined();
+    });
+
+    it('should create P2PK outputs from legacy pubkey method data', async () => {
+      const operation = makeInitOp('op-legacy', {
+        methodData: { pubkey: testPubkey },
+      });
+
+      const result = await handler.prepare(buildPrepareContext(operation));
+      const [secret] = getSendSecretPayloads(result);
+
+      expect(secret).toEqual([
+        'P2PK',
+        expect.objectContaining({
+          data: testPubkey,
+        }),
+      ]);
+    });
+
+    it('should create P2PK outputs from structured NUT-11 options', async () => {
+      const options: P2PKOptions = {
+        pubkey: [testPubkey, secondPubkey],
+        requiredSignatures: 2,
+        locktime: 1_735_689_600,
+        refundKeys: [refundPubkey, secondRefundPubkey],
+        requiredRefundSignatures: 2,
+        sigFlag: 'SIG_ALL',
+        additionalTags: [['memo', 'preserve-me']],
+      };
+      const operation = makeInitOp('op-structured', {
+        methodData: { options },
+      });
+
+      const result = await handler.prepare(buildPrepareContext(operation));
+      const [secret] = getSendSecretPayloads(result);
+
+      expect(Array.isArray(secret)).toBe(true);
+      const [kind, payload] = secret as [string, { nonce: string; data: string; tags: string[][] }];
+      expect(kind).toBe('P2PK');
+      expect(payload.nonce).toEqual(expect.any(String));
+      expect(payload.data).toBe(testPubkey);
+      expect(payload.tags).toEqual(
+        expect.arrayContaining([
+          ['pubkeys', secondPubkey],
+          ['n_sigs', '2'],
+          ['locktime', '1735689600'],
+          ['refund', refundPubkey, secondRefundPubkey],
+          ['n_sigs_refund', '2'],
+          ['sigflag', 'SIG_ALL'],
+          ['memo', 'preserve-me'],
+        ]),
+      );
     });
 
     it('should reserve proofs for the operation', async () => {
@@ -467,7 +554,7 @@ describe('P2pkSendHandler', () => {
       expect(proofService.reserveProofs).not.toHaveBeenCalled();
     });
 
-    it('should log preparation with pubkey', async () => {
+    it('should log preparation with P2PK pubkey data', async () => {
       const operation = makeInitOp('op-1');
       const ctx = buildPrepareContext(operation);
 
@@ -477,7 +564,7 @@ describe('P2pkSendHandler', () => {
         'P2PK send operation prepared',
         expect.objectContaining({
           operationId: 'op-1',
-          pubkey: testPubkey,
+          p2pkPubkey: testPubkey,
         }),
       );
     });
@@ -548,16 +635,30 @@ describe('P2pkSendHandler', () => {
         });
       });
 
-      it('should throw if pubkey is missing during execute', async () => {
+      it('should accept structured P2PK method data during execute', async () => {
+        const operation = makeExecutingOp('op-structured-execute', {
+          methodData: { options: { pubkey: [testPubkey, secondPubkey], requiredSignatures: 2 } },
+          inputProofSecrets: ['input-1', 'input-2'],
+        });
+        const inputProofs = [makeProof('input-1', 60), makeProof('input-2', 50)];
+
+        const ctx = buildExecuteContext(operation, inputProofs);
+
+        await expect(handler.execute(ctx)).resolves.toMatchObject({
+          status: 'PENDING',
+        });
+      });
+
+      it('should throw if P2PK target data is missing during execute', async () => {
         const operation = makeExecutingOp('op-1', {
-          methodData: {}, // No pubkey
+          methodData: {}, // No P2PK target
         });
         const inputProofs = [makeProof('input-1', 110)];
 
         const ctx = buildExecuteContext(operation, inputProofs);
 
         await expect(handler.execute(ctx)).rejects.toThrow(
-          'P2PK send requires a pubkey in methodData',
+          'P2PK send requires P2PK options or a pubkey in methodData',
         );
       });
 

--- a/packages/core/test/unit/P2pkSendHandler.test.ts
+++ b/packages/core/test/unit/P2pkSendHandler.test.ts
@@ -1,4 +1,4 @@
-import { Amount, OutputData, type OutputDataLike, type P2PKOptions } from '@cashu/cashu-ts';
+import { Amount, OutputData, type OutputDataLike } from '@cashu/cashu-ts';
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
 import { P2pkSendHandler } from '../../infra/handlers/send/P2pkSendHandler';
 import { EventBus } from '../../events/EventBus';
@@ -21,6 +21,7 @@ import type {
   BasePrepareContext,
   ExecuteContext,
   FinalizeContext,
+  P2pkSendOptions,
   RollbackContext,
   RecoverExecutingContext,
 } from '../../operations/send/SendMethodHandler';
@@ -444,7 +445,7 @@ describe('P2pkSendHandler', () => {
     });
 
     it('should create P2PK outputs from structured NUT-11 options', async () => {
-      const options: P2PKOptions = {
+      const options: P2pkSendOptions = {
         pubkey: [testPubkey, secondPubkey],
         requiredSignatures: 2,
         locktime: 1_735_689_600,
@@ -476,6 +477,22 @@ describe('P2pkSendHandler', () => {
           ['memo', 'preserve-me'],
         ]),
       );
+    });
+
+    it('should reject structured P2PK options with hashlock data', async () => {
+      const operation = makeInitOp('op-hashlock', {
+        methodData: {
+          options: {
+            pubkey: testPubkey,
+            hashlock: 'hash',
+          } as unknown as P2pkSendOptions,
+        },
+      });
+
+      await expect(handler.prepare(buildPrepareContext(operation))).rejects.toThrow(
+        'P2PK send does not support hashlock/HTLC options',
+      );
+      expect(mintService.assertNutSupported).not.toHaveBeenCalled();
     });
 
     it('should reserve proofs for the operation', async () => {

--- a/packages/core/test/unit/PaymentRequestService.test.ts
+++ b/packages/core/test/unit/PaymentRequestService.test.ts
@@ -1,6 +1,11 @@
-import { Amount } from '@cashu/cashu-ts';
+import { Amount, JSONInt } from '@cashu/cashu-ts';
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { PaymentRequest, PaymentRequestTransportType, type Token } from '@cashu/cashu-ts';
+import {
+  PaymentRequest,
+  PaymentRequestTransportType,
+  type NUT10Option,
+  type Token,
+} from '@cashu/cashu-ts';
 import {
   PaymentRequestService,
   type PreparedPaymentRequest,
@@ -12,6 +17,7 @@ import type {
   SendOperationService,
 } from '../../operations/send';
 import type { ProofService } from '../../services/ProofService';
+import type { MintService } from '../../services/MintService';
 import { PaymentRequestError } from '../../models/Error';
 
 describe('PaymentRequestService', () => {
@@ -22,7 +28,16 @@ describe('PaymentRequestService', () => {
   let service: PaymentRequestService;
   let mockSendOperationService: SendOperationService;
   let mockProofService: ProofService;
+  let mockMintService: MintService;
   const originalFetch = globalThis.fetch;
+
+  const testPubkey = '02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9';
+  const p2pkNut10 = (overrides: Partial<NUT10Option> = {}): NUT10Option => ({
+    kind: 'P2PK',
+    data: testPubkey,
+    tags: [['sigflag', 'SIG_INPUTS']],
+    ...overrides,
+  });
 
   const mockPendingOperation: PendingSendOperation = {
     id: 'test-op-id',
@@ -50,6 +65,8 @@ describe('PaymentRequestService', () => {
     mintUrl: string,
     amount: Amount,
     unit = 'sat',
+    method: PreparedSendOperation['method'] = 'default',
+    methodData: PreparedSendOperation['methodData'] = {},
   ): PreparedSendOperation => ({
     id: 'test-op-id',
     state: 'prepared',
@@ -62,8 +79,8 @@ describe('PaymentRequestService', () => {
     fee: Amount.from(0),
     inputAmount: amount,
     inputProofSecrets: ['secret-1'],
-    method: 'default',
-    methodData: {},
+    method,
+    methodData,
   });
 
   const createResolvedRequest = (
@@ -97,6 +114,38 @@ describe('PaymentRequestService', () => {
     };
   };
 
+  const createP2pkResolvedRequest = (
+    options: {
+      amount?: Amount;
+      allowedMints?: string[];
+      transport?: ResolvedPaymentRequest['transport'];
+      unit?: string;
+    } = {},
+  ): ResolvedPaymentRequest => {
+    const resolved = createResolvedRequest(options);
+    return {
+      ...resolved,
+      paymentRequest: new PaymentRequest(
+        resolved.paymentRequest.transport,
+        resolved.paymentRequest.id,
+        resolved.amount,
+        resolved.unit,
+        resolved.allowedMints,
+        resolved.paymentRequest.description,
+        resolved.paymentRequest.singleUse,
+        p2pkNut10(),
+      ),
+      spendingCondition: {
+        kind: 'P2PK',
+        p2pk: {
+          kind: 'P2PK',
+          options: { pubkey: testPubkey },
+          rawNut10: p2pkNut10(),
+        },
+      },
+    };
+  };
+
   const createPreparedRequest = (
     request: ResolvedPaymentRequest,
     mintUrl = testMintUrl,
@@ -107,17 +156,41 @@ describe('PaymentRequestService', () => {
 
   beforeEach(() => {
     mockSendOperationService = {
-      init: mock(async (mintUrl: string, amountInput: { amount: Amount; unit: string }) => ({
-        id: 'test-op-id',
-        state: 'init',
-        mintUrl,
-        amount: amountInput.amount,
-        unit: amountInput.unit,
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      })),
-      prepare: mock(async (initOp: { mintUrl: string; amount: Amount; unit: string }) =>
-        createMockPreparedSendOperation(initOp.mintUrl, initOp.amount, initOp.unit),
+      init: mock(
+        async (
+          mintUrl: string,
+          amountInput: { amount: Amount; unit: string },
+          options: {
+            method: PreparedSendOperation['method'];
+            methodData: PreparedSendOperation['methodData'];
+          } = { method: 'default', methodData: {} },
+        ) => ({
+          id: 'test-op-id',
+          state: 'init',
+          mintUrl,
+          amount: amountInput.amount,
+          unit: amountInput.unit,
+          method: options.method,
+          methodData: options.methodData,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        }),
+      ),
+      prepare: mock(
+        async (initOp: {
+          mintUrl: string;
+          amount: Amount;
+          unit: string;
+          method?: PreparedSendOperation['method'];
+          methodData?: PreparedSendOperation['methodData'];
+        }) =>
+          createMockPreparedSendOperation(
+            initOp.mintUrl,
+            initOp.amount,
+            initOp.unit,
+            initOp.method ?? 'default',
+            initOp.methodData ?? {},
+          ),
       ),
       execute: mock(async () => ({
         operation: mockPendingOperation,
@@ -143,7 +216,21 @@ describe('PaymentRequestService', () => {
       })),
     } as unknown as ProofService;
 
-    service = new PaymentRequestService(mockSendOperationService, mockProofService);
+    mockMintService = {
+      supportsNut: mock(async (mintUrl: string, nut: 11) => nut === 11 && mintUrl === testMintUrl),
+      assertNutSupported: mock(async (mintUrl: string, nut: 11) => {
+        if (nut === 11 && mintUrl === testMintUrl) {
+          return;
+        }
+        throw new Error(`NUT-11 unsupported by ${mintUrl}`);
+      }),
+    } as unknown as MintService;
+
+    service = new PaymentRequestService(
+      mockSendOperationService,
+      mockProofService,
+      mockMintService,
+    );
 
     // @ts-ignore
     globalThis.fetch = originalFetch;
@@ -196,6 +283,130 @@ describe('PaymentRequestService', () => {
 
       expect(result.transport.type).toBe('inband');
       expect(result.amount).toBeUndefined();
+    });
+
+    it('should expose a normalized P2PK spending condition requirement', async () => {
+      const pr = new PaymentRequest(
+        [],
+        'request-id-p2pk',
+        100,
+        'sat',
+        [testMintUrl],
+        'P2PK payment',
+        false,
+        p2pkNut10(),
+      );
+      const encoded = pr.toEncodedRequest();
+
+      const result = await service.parse(encoded);
+
+      expect(result.spendingCondition).toEqual({
+        kind: 'P2PK',
+        p2pk: {
+          kind: 'P2PK',
+          options: { pubkey: testPubkey },
+          rawNut10: p2pkNut10(),
+        },
+      });
+      expect(result.payableMints).toEqual([testMintUrl]);
+    });
+
+    it('filters P2PK payable mints to trusted sufficient allowed mints with NUT-11 support', async () => {
+      const pr = new PaymentRequest(
+        [],
+        'request-id-p2pk-filter',
+        100,
+        'sat',
+        [testMintUrl, testMintUrl2],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const encoded = pr.toEncodedRequest();
+
+      const result = await service.parse(encoded);
+
+      expect(result.payableMints).toEqual([testMintUrl]);
+      expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl, 11);
+      expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl2, 11);
+    });
+
+    it('returns no payable mints for P2PK requests when no matching mint advertises NUT-11', async () => {
+      (mockMintService.supportsNut as unknown as ReturnType<typeof mock>).mockImplementation(
+        async () => false,
+      );
+      const pr = new PaymentRequest(
+        [],
+        'request-id-p2pk-no-mints',
+        100,
+        'sat',
+        [testMintUrl, testMintUrl2],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const encoded = pr.toEncodedRequest();
+
+      const result = await service.parse(encoded);
+
+      expect(result.spendingCondition?.kind).toBe('P2PK');
+      expect(result.payableMints).toEqual([]);
+    });
+
+    it('keeps unsupported NUT-10 requirements as diagnostics and returns no payable mints', async () => {
+      const unsupportedNut10: NUT10Option = {
+        kind: 'UNKNOWN',
+        data: 'value',
+        tags: [],
+      };
+      const pr = new PaymentRequest(
+        [],
+        'request-id-unsupported',
+        100,
+        'sat',
+        [testMintUrl],
+        undefined,
+        false,
+        unsupportedNut10,
+      );
+      const encoded = pr.toEncodedRequest();
+
+      const result = await service.parse(encoded);
+
+      expect(result.spendingCondition).toEqual({
+        kind: 'unsupported',
+        nut10Kind: 'UNKNOWN',
+        reason: "Unsupported NUT-10 spending condition 'UNKNOWN'",
+        rawNut10: unsupportedNut10,
+      });
+      expect(result.payableMints).toEqual([]);
+      expect(mockMintService.supportsNut).not.toHaveBeenCalled();
+    });
+
+    it('keeps malformed P2PK requirements as diagnostics and returns no payable mints', async () => {
+      const malformedNut10 = p2pkNut10({ data: '' });
+      const pr = new PaymentRequest(
+        [],
+        'request-id-malformed',
+        100,
+        'sat',
+        [testMintUrl],
+        undefined,
+        false,
+        malformedNut10,
+      );
+      const encoded = pr.toEncodedRequest();
+
+      const result = await service.parse(encoded);
+
+      expect(result.spendingCondition).toEqual({
+        kind: 'malformed',
+        nut10Kind: 'P2PK',
+        reason: 'NUT-10 P2PK option is missing its data field',
+        rawNut10: malformedNut10,
+      });
+      expect(result.payableMints).toEqual([]);
+      expect(mockMintService.supportsNut).not.toHaveBeenCalled();
     });
 
     it('should decode a Nostr payment request for plugin delivery', async () => {
@@ -288,10 +499,14 @@ describe('PaymentRequestService', () => {
       expect(transaction.sendOperation).toBeDefined();
       expect(transaction.sendOperation.mintUrl).toBe(testMintUrl);
       expect(transaction.request).toBe(request);
-      expect(mockSendOperationService.init).toHaveBeenCalledWith(testMintUrl, {
-        amount: Amount.from(100),
-        unit: 'sat',
-      });
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'sat',
+        },
+        undefined,
+      );
       expect(mockSendOperationService.prepare).toHaveBeenCalled();
     });
 
@@ -306,14 +521,383 @@ describe('PaymentRequestService', () => {
         amount: { amount: Amount.from(750), unit: 'sat' },
       });
 
-      expect(mockSendOperationService.init).toHaveBeenCalledWith(testMintUrl, {
-        amount: Amount.from(750),
-        unit: 'sat',
-      });
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(750),
+          unit: 'sat',
+        },
+        undefined,
+      );
       expect(transaction.request).not.toBe(request);
       expect(transaction.request.amount).toEqual(Amount.from(750));
       expect(transaction.request.paymentRequest.amount).toEqual(Amount.from(750));
       expect(transaction.request.payableMints).toEqual([testMintUrl]);
+    });
+
+    it('recomputes P2PK-aware payable mints when preparing amountless requests', async () => {
+      const paymentRequest = new PaymentRequest(
+        [],
+        'request-id-amountless-p2pk',
+        undefined,
+        'sat',
+        [testMintUrl, testMintUrl2],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const request: ResolvedPaymentRequest = {
+        paymentRequest,
+        payableMints: [],
+        allowedMints: [testMintUrl, testMintUrl2],
+        unit: 'sat',
+        transport: { type: 'inband' },
+        spendingCondition: {
+          kind: 'P2PK',
+          p2pk: {
+            kind: 'P2PK',
+            options: { pubkey: testPubkey },
+            rawNut10: p2pkNut10(),
+          },
+        },
+      };
+
+      const transaction = await service.prepare(request, {
+        mintUrl: testMintUrl,
+        amount: { amount: Amount.from(100), unit: 'sat' },
+      });
+
+      expect(transaction.request).not.toBe(request);
+      expect(transaction.request.amount).toEqual(Amount.from(100));
+      expect(transaction.request.spendingCondition).toEqual(request.spendingCondition);
+      expect(transaction.request.payableMints).toEqual([testMintUrl]);
+      expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl, 11);
+      expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl2, 11);
+      expect(mockMintService.assertNutSupported).toHaveBeenCalledWith(
+        testMintUrl,
+        11,
+        'payment request P2PK',
+      );
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'sat',
+        },
+        {
+          method: 'p2pk',
+          methodData: {
+            options: { pubkey: testPubkey },
+          },
+        },
+      );
+    });
+
+    it('initializes P2PK send operations for valid P2PK payment requests', async () => {
+      const paymentRequest = new PaymentRequest(
+        [],
+        'request-id-prepare-p2pk',
+        100,
+        'sat',
+        [testMintUrl],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const request: ResolvedPaymentRequest = {
+        paymentRequest,
+        payableMints: [testMintUrl],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+        spendingCondition: {
+          kind: 'P2PK',
+          p2pk: {
+            kind: 'P2PK',
+            options: { pubkey: testPubkey },
+            rawNut10: p2pkNut10(),
+          },
+        },
+      };
+
+      const transaction = await service.prepare(request, { mintUrl: testMintUrl });
+
+      expect(mockMintService.assertNutSupported).toHaveBeenCalledWith(
+        testMintUrl,
+        11,
+        'payment request P2PK',
+      );
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'sat',
+        },
+        {
+          method: 'p2pk',
+          methodData: {
+            options: { pubkey: testPubkey },
+          },
+        },
+      );
+      expect(transaction.sendOperation.method).toBe('p2pk');
+      expect(transaction.sendOperation.methodData).toEqual({ options: { pubkey: testPubkey } });
+    });
+
+    it('re-derives P2PK requirements during prepare when the cached condition is missing', async () => {
+      const paymentRequest = new PaymentRequest(
+        [],
+        'request-id-prepare-p2pk-missing-condition',
+        100,
+        'sat',
+        [testMintUrl],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const request: ResolvedPaymentRequest = {
+        paymentRequest,
+        payableMints: [testMintUrl],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+      };
+
+      const transaction = await service.prepare(request, { mintUrl: testMintUrl });
+
+      expect(transaction.request).not.toBe(request);
+      expect(transaction.request.spendingCondition?.kind).toBe('P2PK');
+      expect(mockMintService.assertNutSupported).toHaveBeenCalledWith(
+        testMintUrl,
+        11,
+        'payment request P2PK',
+      );
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'sat',
+        },
+        {
+          method: 'p2pk',
+          methodData: {
+            options: { pubkey: testPubkey },
+          },
+        },
+      );
+    });
+
+    it('ignores stale cached spending conditions when the payment request has no NUT-10', async () => {
+      const request: ResolvedPaymentRequest = {
+        ...createResolvedRequest({ amount: Amount.from(100) }),
+        spendingCondition: {
+          kind: 'P2PK',
+          p2pk: {
+            kind: 'P2PK',
+            options: { pubkey: testPubkey },
+            rawNut10: p2pkNut10(),
+          },
+        },
+      };
+
+      const transaction = await service.prepare(request, { mintUrl: testMintUrl });
+
+      expect(transaction.request).not.toBe(request);
+      expect(transaction.request.spendingCondition).toBeUndefined();
+      expect(mockMintService.assertNutSupported).not.toHaveBeenCalled();
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'sat',
+        },
+        undefined,
+      );
+    });
+
+    it('rejects unsupported NUT-10 requirements before initializing a send operation', async () => {
+      const unsupportedNut10: NUT10Option = { kind: 'UNKNOWN', data: 'value', tags: [] };
+      const request: ResolvedPaymentRequest = {
+        paymentRequest: new PaymentRequest(
+          [],
+          'request-id-unsupported-prepare',
+          100,
+          'sat',
+          [testMintUrl],
+          undefined,
+          false,
+          unsupportedNut10,
+        ),
+        payableMints: [],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+        spendingCondition: {
+          kind: 'unsupported',
+          nut10Kind: 'UNKNOWN',
+          reason: "Unsupported NUT-10 spending condition 'UNKNOWN'",
+          rawNut10: unsupportedNut10,
+        },
+      };
+
+      await expect(service.prepare(request, { mintUrl: testMintUrl })).rejects.toThrow(
+        "Unsupported NUT-10 spending condition 'UNKNOWN'",
+      );
+      expect(mockSendOperationService.init).not.toHaveBeenCalled();
+      expect(mockMintService.assertNutSupported).not.toHaveBeenCalled();
+    });
+
+    it('rejects HTLC requirements before initializing a send operation', async () => {
+      const htlcNut10: NUT10Option = { kind: 'HTLC', data: 'hash', tags: [] };
+      const request: ResolvedPaymentRequest = {
+        paymentRequest: new PaymentRequest(
+          [],
+          'request-id-htlc-prepare',
+          100,
+          'sat',
+          [testMintUrl],
+          undefined,
+          false,
+          htlcNut10,
+        ),
+        payableMints: [],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+      };
+
+      await expect(service.prepare(request, { mintUrl: testMintUrl })).rejects.toThrow(
+        "Unsupported NUT-10 spending condition 'HTLC'",
+      );
+      expect(mockSendOperationService.init).not.toHaveBeenCalled();
+      expect(mockMintService.assertNutSupported).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed P2PK requirements before initializing a send operation', async () => {
+      const malformedNut10 = p2pkNut10({ data: '' });
+      const request: ResolvedPaymentRequest = {
+        paymentRequest: new PaymentRequest(
+          [],
+          'request-id-malformed-prepare',
+          100,
+          'sat',
+          [testMintUrl],
+          undefined,
+          false,
+          malformedNut10,
+        ),
+        payableMints: [],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+        spendingCondition: {
+          kind: 'malformed',
+          nut10Kind: 'P2PK',
+          reason: 'NUT-10 P2PK option is missing its data field',
+          rawNut10: malformedNut10,
+        },
+      };
+
+      await expect(service.prepare(request, { mintUrl: testMintUrl })).rejects.toThrow(
+        "Malformed NUT-10 spending condition 'P2PK': NUT-10 P2PK option is missing its data field",
+      );
+      expect(mockSendOperationService.init).not.toHaveBeenCalled();
+      expect(mockMintService.assertNutSupported).not.toHaveBeenCalled();
+    });
+
+    it('wraps malformed P2PK helper failures as PaymentRequestError causes during prepare', async () => {
+      const malformedNut10 = p2pkNut10({ data: '' });
+      const request: ResolvedPaymentRequest = {
+        paymentRequest: new PaymentRequest(
+          [],
+          'request-id-malformed-helper',
+          100,
+          'sat',
+          [testMintUrl],
+          undefined,
+          false,
+          malformedNut10,
+        ),
+        payableMints: [testMintUrl],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+        spendingCondition: {
+          kind: 'P2PK',
+          p2pk: {
+            kind: 'P2PK',
+            options: { pubkey: testPubkey },
+            rawNut10: malformedNut10,
+          },
+        },
+      };
+
+      let thrown: unknown;
+      try {
+        await service.prepare(request, { mintUrl: testMintUrl });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(PaymentRequestError);
+      expect((thrown as Error).message).toBe(
+        "Malformed NUT-10 spending condition 'P2PK': NUT-10 P2PK option is missing its data field",
+      );
+      expect((thrown as { cause?: unknown }).cause).toBeInstanceOf(Error);
+      expect(mockSendOperationService.init).not.toHaveBeenCalled();
+    });
+
+    it('rejects selected mints without NUT-11 support before initializing a send operation', async () => {
+      const unsupportedError = new Error('NUT-11 unsupported');
+      (mockMintService.assertNutSupported as unknown as ReturnType<typeof mock>).mockRejectedValue(
+        unsupportedError,
+      );
+      const paymentRequest = new PaymentRequest(
+        [],
+        'request-id-p2pk-mint-unsupported',
+        100,
+        'sat',
+        [testMintUrl],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const request: ResolvedPaymentRequest = {
+        paymentRequest,
+        payableMints: [testMintUrl],
+        allowedMints: [testMintUrl],
+        amount: Amount.from(100),
+        unit: 'sat',
+        transport: { type: 'inband' },
+        spendingCondition: {
+          kind: 'P2PK',
+          p2pk: {
+            kind: 'P2PK',
+            options: { pubkey: testPubkey },
+            rawNut10: p2pkNut10(),
+          },
+        },
+      };
+
+      let thrown: unknown;
+      try {
+        await service.prepare(request, { mintUrl: testMintUrl });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(PaymentRequestError);
+      expect((thrown as Error).message).toBe(
+        `Mint ${testMintUrl} does not support NUT-11 required by payment request P2PK`,
+      );
+      expect((thrown as { cause?: unknown }).cause).toBe(unsupportedError);
+      expect(mockSendOperationService.init).not.toHaveBeenCalled();
     });
 
     it('should throw if mint is not in allowed list', async () => {
@@ -335,10 +919,14 @@ describe('PaymentRequestService', () => {
 
       await service.prepare(request, { mintUrl: testMintUrl });
 
-      expect(mockSendOperationService.init).toHaveBeenCalledWith(testMintUrl, {
-        amount: Amount.from(100),
-        unit: 'sat',
-      });
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'sat',
+        },
+        undefined,
+      );
     });
 
     it('should throw if no amount is provided anywhere', async () => {
@@ -385,10 +973,14 @@ describe('PaymentRequestService', () => {
 
       const transaction = await service.prepare(request, { mintUrl: testMintUrl });
 
-      expect(mockSendOperationService.init).toHaveBeenCalledWith(testMintUrl, {
-        amount: Amount.from(100),
-        unit: 'usd',
-      });
+      expect(mockSendOperationService.init).toHaveBeenCalledWith(
+        testMintUrl,
+        {
+          amount: Amount.from(100),
+          unit: 'usd',
+        },
+        undefined,
+      );
       expect(transaction.sendOperation.unit).toBe('usd');
     });
   });
@@ -400,6 +992,30 @@ describe('PaymentRequestService', () => {
       const result = await service.execute(prepared);
 
       expect(mockSendOperationService.execute).toHaveBeenCalledWith(prepared.sendOperation);
+      expect(result.type).toBe('inband');
+      if (result.type === 'inband') {
+        expect(result.token).toBe(mockToken);
+        expect(result.operation).toBe(mockPendingOperation);
+      }
+    });
+
+    it('should execute an inband P2PK payment request without changing token delivery', async () => {
+      const request = createP2pkResolvedRequest({ amount: Amount.from(100) });
+      const prepared: PreparedPaymentRequest = {
+        sendOperation: createMockPreparedSendOperation(
+          testMintUrl,
+          Amount.from(100),
+          'sat',
+          'p2pk',
+          { options: { pubkey: testPubkey } },
+        ),
+        request,
+      };
+
+      const result = await service.execute(prepared);
+
+      expect(mockSendOperationService.execute).toHaveBeenCalledWith(prepared.sendOperation);
+      expect(mockSendOperationService.rollback).not.toHaveBeenCalled();
       expect(result.type).toBe('inband');
       if (result.type === 'inband') {
         expect(result.token).toBe(mockToken);
@@ -430,12 +1046,84 @@ describe('PaymentRequestService', () => {
       expect(fetchCalls[0]?.input).toBe(testHttpTarget);
       expect(fetchCalls[0]?.init?.method).toBe('POST');
       expect(fetchCalls[0]?.init?.headers).toEqual({ 'Content-Type': 'application/json' });
-      expect(fetchCalls[0]?.init?.body).toContain('"amount":100');
+      expect(fetchCalls[0]?.init?.body).toBe(JSONInt.stringify(mockToken));
       expect(fetchCalls[0]?.init?.body).not.toContain('"amount":"100"');
       if (result.type === 'http') {
         expect(result.response.status).toBe(200);
         expect(result.operation).toBe(mockPendingOperation);
       }
+    });
+
+    it('should execute an HTTP P2PK payment request without changing POST payload format', async () => {
+      const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+      // @ts-ignore
+      globalThis.fetch = async (input: string, init?: RequestInit) => {
+        fetchCalls.push({ input, init });
+        return new Response(JSON.stringify({ success: true }), { status: 200 });
+      };
+
+      const request = createP2pkResolvedRequest({
+        amount: Amount.from(100),
+        transport: { type: 'http', url: testHttpTarget },
+      });
+      const prepared: PreparedPaymentRequest = {
+        sendOperation: createMockPreparedSendOperation(
+          testMintUrl,
+          Amount.from(100),
+          'sat',
+          'p2pk',
+          { options: { pubkey: testPubkey } },
+        ),
+        request,
+      };
+
+      const result = await service.execute(prepared);
+
+      expect(mockSendOperationService.execute).toHaveBeenCalledWith(prepared.sendOperation);
+      expect(result.type).toBe('http');
+      expect(fetchCalls).toHaveLength(1);
+      expect(fetchCalls[0]?.input).toBe(testHttpTarget);
+      expect(fetchCalls[0]?.init?.method).toBe('POST');
+      expect(fetchCalls[0]?.init?.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(fetchCalls[0]?.init?.body).toBe(JSONInt.stringify(mockToken));
+      if (result.type === 'http') {
+        expect(result.response.status).toBe(200);
+        expect(result.operation).toBe(mockPendingOperation);
+      }
+    });
+
+    it('should keep Nostr P2PK payment request execution plugin-owned and roll back', async () => {
+      const request = createP2pkResolvedRequest({
+        amount: Amount.from(100),
+        transport: { type: 'nostr', target: 'npub123...' },
+      });
+      const prepared: PreparedPaymentRequest = {
+        sendOperation: createMockPreparedSendOperation(
+          testMintUrl,
+          Amount.from(100),
+          'sat',
+          'p2pk',
+          { options: { pubkey: testPubkey } },
+        ),
+        request,
+      };
+
+      let thrown: unknown;
+      try {
+        await service.execute(prepared);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(PaymentRequestError);
+      expect((thrown as Error).message).toBe(
+        'Nostr payment request execution requires a transport plugin',
+      );
+      expect(mockSendOperationService.rollback).toHaveBeenCalledWith(
+        prepared.sendOperation.id,
+        'Nostr payment request execution requires a transport plugin',
+      );
+      expect(mockSendOperationService.execute).not.toHaveBeenCalled();
     });
 
     it('should return fetch error responses without throwing', async () => {

--- a/packages/core/test/unit/PaymentRequestService.test.ts
+++ b/packages/core/test/unit/PaymentRequestService.test.ts
@@ -331,6 +331,36 @@ describe('PaymentRequestService', () => {
       expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl2, 11);
     });
 
+    it('excludes individual P2PK payable mints when their NUT-11 lookup fails', async () => {
+      const lookupError = new Error('mint info unavailable');
+      (mockMintService.supportsNut as unknown as ReturnType<typeof mock>).mockImplementation(
+        async (mintUrl: string) => {
+          if (mintUrl === testMintUrl) {
+            throw lookupError;
+          }
+          return mintUrl === testMintUrl2;
+        },
+      );
+      const pr = new PaymentRequest(
+        [],
+        'request-id-p2pk-filter-offline-mint',
+        100,
+        'sat',
+        [testMintUrl, testMintUrl2],
+        undefined,
+        false,
+        p2pkNut10(),
+      );
+      const encoded = pr.toEncodedRequest();
+
+      const result = await service.parse(encoded);
+
+      expect(result.spendingCondition?.kind).toBe('P2PK');
+      expect(result.payableMints).toEqual([testMintUrl2]);
+      expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl, 11);
+      expect(mockMintService.supportsNut).toHaveBeenCalledWith(testMintUrl2, 11);
+    });
+
     it('returns no payable mints for P2PK requests when no matching mint advertises NUT-11', async () => {
       (mockMintService.supportsNut as unknown as ReturnType<typeof mock>).mockImplementation(
         async () => false,

--- a/packages/core/test/unit/SendOperationService.recovery.test.ts
+++ b/packages/core/test/unit/SendOperationService.recovery.test.ts
@@ -224,6 +224,7 @@ describe('SendOperationService - recoverPendingOperations', () => {
     // Mock MintService
     mintService = {
       isTrustedMint: mock(() => Promise.resolve(true)),
+      assertNutSupported: mock(() => Promise.resolve()),
     } as unknown as MintService;
 
     // Mock WalletService

--- a/packages/core/test/unit/SendOperationService.test.ts
+++ b/packages/core/test/unit/SendOperationService.test.ts
@@ -57,6 +57,7 @@ describe('SendOperationService', () => {
 
     mintService = {
       isTrustedMint: mock(async () => true),
+      assertNutSupported: mock(async () => {}),
     } as unknown as MintService;
 
     const wallet = {

--- a/packages/core/test/unit/SendOpsApi.test.ts
+++ b/packages/core/test/unit/SendOpsApi.test.ts
@@ -1,4 +1,4 @@
-import { Amount, type P2PKOptions } from '@cashu/cashu-ts';
+import { Amount } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { SendOperationService } from '../../operations/send/SendOperationService.ts';
 import type {
@@ -7,9 +7,17 @@ import type {
   PreparedSendOperation,
   SendOperation,
 } from '../../operations/send/SendOperation.ts';
+import type { P2pkSendOptions } from '../../operations/send/SendMethodHandler.ts';
 import { SendOpsApi } from '../../api/SendOpsApi.ts';
 
 const mintUrl = 'https://mint.test';
+
+const p2pkOptionsRejectHashlock = {
+  pubkey: 'pubkey-1',
+  // @ts-expect-error Hashlocks produce HTLC/NUT-14 data and are out of scope for P2PK sends.
+  hashlock: 'hash',
+} satisfies P2pkSendOptions;
+void p2pkOptionsRejectHashlock;
 
 const makePreparedOperation = (): PreparedSendOperation => ({
   id: 'op-1',
@@ -98,7 +106,7 @@ describe('SendOpsApi', () => {
   });
 
   it('prepare maps structured p2pk target options to send method options', async () => {
-    const options: P2PKOptions = {
+    const options: P2pkSendOptions = {
       pubkey: ['pubkey-1', 'pubkey-2'],
       requiredSignatures: 2,
       additionalTags: [['memo', 'test']],

--- a/packages/core/test/unit/SendOpsApi.test.ts
+++ b/packages/core/test/unit/SendOpsApi.test.ts
@@ -1,4 +1,4 @@
-import { Amount } from '@cashu/cashu-ts';
+import { Amount, type P2PKOptions } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type { SendOperationService } from '../../operations/send/SendOperationService.ts';
 import type {
@@ -93,6 +93,32 @@ describe('SendOpsApi', () => {
       {
         method: 'p2pk',
         methodData: { pubkey: 'pubkey-1' },
+      },
+    );
+  });
+
+  it('prepare maps structured p2pk target options to send method options', async () => {
+    const options: P2PKOptions = {
+      pubkey: ['pubkey-1', 'pubkey-2'],
+      requiredSignatures: 2,
+      additionalTags: [['memo', 'test']],
+    };
+
+    await api.prepare({
+      mintUrl,
+      amount: Amount.from(20),
+      target: { type: 'p2pk', options },
+    });
+
+    expect(sendOperationService.init).toHaveBeenCalledWith(
+      mintUrl,
+      {
+        amount: Amount.from(20),
+        unit: 'sat',
+      },
+      {
+        method: 'p2pk',
+        methodData: { options },
       },
     );
   });

--- a/packages/docs/pages/keyring.md
+++ b/packages/docs/pages/keyring.md
@@ -75,6 +75,42 @@ Removing a keypair will prevent you from spending any P2PK tokens locked to that
 
 ## Working with P2PK Tokens
 
+### Sending P2PK Tokens
+
+P2PK sends use Coco's normal send operation saga with a P2PK target. The simple
+form locks the token to one public key:
+
+```ts
+const prepared = await coco.ops.send.prepare({
+  mintUrl,
+  amount: 100,
+  target: { type: 'p2pk', pubkey: recipientPublicKey },
+});
+```
+
+Structured NUT-11 options are also supported for multisig, locktime, refund keys,
+signature flags, and non-reserved extra tags:
+
+```ts
+await coco.ops.send.prepare({
+  mintUrl,
+  amount: 100,
+  target: {
+    type: 'p2pk',
+    options: {
+      pubkey: [recipientPublicKey, cosignerPublicKey],
+      requiredSignatures: 2,
+      refundKeys: [refundPublicKey],
+      locktime: 1_730_000_000,
+    },
+  },
+});
+```
+
+Mints must advertise NUT-11 support before Coco creates P2PK outputs. Valid P2PK
+payment requests are prepared through the same send path, using the P2PK options
+from the request.
+
 ### Receiving P2PK Tokens
 
 When you receive a P2PK token, Coco automatically handles the signature verification if you have the corresponding keypair:

--- a/packages/docs/pages/send-operations.md
+++ b/packages/docs/pages/send-operations.md
@@ -84,6 +84,46 @@ console.log(token.memo); // "Dinner"
 Memos are trimmed before persistence. Whitespace-only memos are treated as
 omitted.
 
+### P2PK Sends
+
+Use a P2PK target when the token should be locked to one or more public keys:
+
+```ts
+const prepared = await coco.ops.send.prepare({
+  mintUrl,
+  amount: 100,
+  target: {
+    type: 'p2pk',
+    pubkey: recipientPublicKey,
+  },
+});
+```
+
+For richer NUT-11 requirements, pass structured P2PK options:
+
+```ts
+const prepared = await coco.ops.send.prepare({
+  mintUrl,
+  amount: 100,
+  target: {
+    type: 'p2pk',
+    options: {
+      pubkey: [primaryPublicKey, backupPublicKey],
+      requiredSignatures: 2,
+      locktime: 1_730_000_000,
+      refundKeys: [refundPublicKey],
+      requiredRefundSignatures: 1,
+      sigFlag: 'SIG_ALL',
+      additionalTags: [['memo', 'escrow-payment']],
+    },
+  },
+});
+```
+
+The selected mint must advertise NUT-11 support. P2PK payment requests use this
+same structured send method internally: `paymentRequests.prepare()` converts a
+valid NUT-18 P2PK requirement into a P2PK send operation before funds move.
+
 ### Cancelling a Prepared Send
 
 If the user decides not to proceed after seeing the fee:

--- a/packages/docs/starting/payment-requests.md
+++ b/packages/docs/starting/payment-requests.md
@@ -24,7 +24,37 @@ The returned `ResolvedPaymentRequest` contains:
 - **amount** - The requested amount (optional, but required for payment)
 - **unit** - The requested unit, normalized to lowercase
 - **allowedMints** - List of allowed mints from the request
-- **payableMints** - Trusted mints with sufficient balance
+- **payableMints** - Trusted mints with sufficient balance. For P2PK requests,
+  this also requires NUT-11 support.
+- **spendingCondition** - Optional NUT-10 requirement details. Valid P2PK
+  requirements are exposed as normalized P2PK options; unsupported or malformed
+  requirements are exposed as diagnostics.
+
+## P2PK Payment Request Requirements
+
+Payment requests can include a NUT-10 spending condition. Coco currently supports
+payer-side NUT-11 P2PK requirements. When `paymentRequests.parse()` sees a valid
+P2PK requirement, the resolved request includes normalized P2PK options:
+
+```ts
+const prepared = await coco.paymentRequests.parse(paymentRequest);
+
+if (prepared.spendingCondition?.kind === 'P2PK') {
+  console.log('P2PK options:', prepared.spendingCondition.p2pk.options);
+}
+```
+
+For P2PK payment requests, `payableMints` only includes mints that are:
+
+- trusted by this Coco instance
+- holding enough spendable balance for the requested unit and amount
+- allowed by the payment request's mint list, if present
+- advertising NUT-11 support in mint info
+
+If a request contains unsupported NUT-10, HTLC, or malformed P2PK requirements,
+`parse()` returns `payableMints: []` and preserves the reason in
+`spendingCondition`. `prepare()` also enforces the requirement before creating a
+send operation, so funds are not moved for unsupported or malformed requirements.
 
 ## Transport Types
 
@@ -142,6 +172,10 @@ await coco.paymentRequests.incoming.create({
 Core then validates the payload, deduplicates redeliveries, runs the normal receive
 operation, and completes the request if it is single-use.
 
+Incoming payment request creation with `nut10` is not supported yet. Receiver-side
+validation of incoming payloads against a request's `nut10` requirement is also
+out of scope for core today.
+
 ## Specifying the Amount
 
 If the payment request doesn't include an amount, you must provide one:
@@ -188,6 +222,9 @@ const transaction = await coco.paymentRequests.prepare(prepared, { mintUrl });
 await coco.paymentRequests.execute(transaction);
 ```
 
+For P2PK requests, do not choose from `allowedMints` directly. Use
+`payableMints`, because it also applies the NUT-11 mint capability check.
+
 ## Error Handling
 
 Payment request operations can throw errors in several cases:
@@ -204,6 +241,8 @@ try {
   // - Mint not in allowed list
   // - Amount mismatch
   // - Insufficient balance
+  // - Unsupported or malformed NUT-10 requirement
+  // - Selected mint does not advertise NUT-11 for a P2PK request
   console.error('Payment failed:', error.message);
 }
 ```

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -31,7 +31,7 @@
     "test": "bun test"
   },
   "peerDependencies": {
-    "@cashu/cashu-ts": "4.5",
+    "@cashu/cashu-ts": "4.6.1",
     "typescript": "^5",
     "expo-sqlite": "*",
     "@cashu/coco-core": "1.0.0"

--- a/packages/indexeddb/package.json
+++ b/packages/indexeddb/package.json
@@ -36,7 +36,7 @@
     "test:browser": "vitest run"
   },
   "peerDependencies": {
-    "@cashu/cashu-ts": "4.5",
+    "@cashu/cashu-ts": "4.6.1",
     "typescript": "^5",
     "@cashu/coco-core": "1.0.0"
   }

--- a/packages/indexeddb/src/repositories/SendOperationRepository.test.ts
+++ b/packages/indexeddb/src/repositories/SendOperationRepository.test.ts
@@ -103,4 +103,59 @@ describe('IdbSendOperationRepository', () => {
       },
     });
   });
+
+  it('loads structured P2PK method data from methodDataJson', async () => {
+    const primaryKey = `02${'22'.repeat(32)}`;
+    const secondKey = `03${'33'.repeat(32)}`;
+    const refundKey = `02${'44'.repeat(32)}`;
+    const methodData = {
+      options: {
+        pubkey: [primaryKey, secondKey],
+        requiredSignatures: 2,
+        locktime: 1_730_000_000,
+        refundKeys: [refundKey],
+        requiredRefundSignatures: 1,
+        sigFlag: 'SIG_ALL',
+        additionalTags: [['memo', 'payment-request']],
+      },
+    };
+    const row = {
+      id: 'op-p2pk-structured',
+      mintUrl: 'https://mint.test',
+      amount: 100,
+      unit: 'sat',
+      state: 'prepared',
+      createdAt: 1,
+      updatedAt: 2,
+      error: null,
+      method: 'p2pk',
+      methodDataJson: JSON.stringify(methodData),
+      needsSwap: 1,
+      fee: 1,
+      inputAmount: 101,
+      inputProofSecretsJson: JSON.stringify(['secret-1']),
+      outputDataJson: JSON.stringify({ keep: [], send: [] }),
+      tokenJson: null,
+    } satisfies SendOperationRow;
+
+    const repository = new IdbSendOperationRepository(createDbStub(row) as any);
+
+    await expect(repository.getById('op-p2pk-structured')).resolves.toEqual({
+      id: 'op-p2pk-structured',
+      mintUrl: 'https://mint.test',
+      amount: Amount.from(100),
+      unit: 'sat',
+      state: 'prepared',
+      createdAt: 1000,
+      updatedAt: 2000,
+      error: undefined,
+      method: 'p2pk',
+      methodData,
+      needsSwap: true,
+      fee: Amount.from(1),
+      inputAmount: Amount.from(101),
+      inputProofSecrets: ['secret-1'],
+      outputData: { keep: [], send: [] },
+    });
+  });
 });

--- a/packages/sql-storage/package.json
+++ b/packages/sql-storage/package.json
@@ -31,7 +31,7 @@
     "test": "bun test"
   },
   "peerDependencies": {
-    "@cashu/cashu-ts": "4.5",
+    "@cashu/cashu-ts": "4.6.1",
     "@cashu/coco-core": "1.0.0",
     "typescript": "^5"
   },

--- a/packages/sqlite-bun/package.json
+++ b/packages/sqlite-bun/package.json
@@ -31,7 +31,7 @@
     "test": "bun test"
   },
   "peerDependencies": {
-    "@cashu/cashu-ts": "4.5",
+    "@cashu/cashu-ts": "4.6.1",
     "@cashu/coco-core": "1.0.0",
     "typescript": "^5"
   }

--- a/packages/sqlite3/package.json
+++ b/packages/sqlite3/package.json
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@cashu/cashu-ts": "4.5",
+    "@cashu/cashu-ts": "4.6.1",
     "@cashu/coco-core": "1.0.0",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Description

This pull request adds payer-side NUT-18 P2PK payment request support using cashu-ts NUT-10/NUT-11 normalization. #286 

## Problem

Coco could parse and pay normal payment requests, but P2PK requests needed explicit NUT-11 mint support checks, locked-output send preparation, and clear failure behavior for malformed or unsupported spending conditions before funds move.

## Summary

- Adds normalized P2PK payment request requirements, NUT-11 payable-mint filtering, and prepare-time NUT-11 assertions.
- Routes payment request P2PK sends through the general P2PK send handler with structured cashu-ts options.
- Keeps HTTP/inband/Nostr delivery semantics unchanged and documents the new payer-side behavior.
- Adds adapter contract coverage for structured send method persistence.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/PaymentRequestService.test.ts`
- `bun run --filter='@cashu/coco-core' test -- test/unit/P2pkSendHandler.test.ts test/unit/SendOpsApi.test.ts test/unit/MintService.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run typecheck`
- `bun run docs:build`
- `git diff --check`

## Changeset

- Added `.changeset/p2pk-payment-requests.md`.