### PR TITLE
docs: clarify storage encryption responsibility

### DIFF
--- a/packages/docs/pages/keyring.md
+++ b/packages/docs/pages/keyring.md
@@ -117,9 +117,12 @@ interface KeyRingApi {
 
 ## Storage
 
-All keypairs are persisted across sessions using your chosen storage adapter (SQLite, IndexedDB, etc.). The secret keys are stored encrypted along with the public keys and derivation indices.
+All keypairs are persisted across sessions using your chosen storage adapter (SQLite, IndexedDB,
+etc.). Coco's built-in storage adapters do not encrypt keypair data at rest. This includes P2PK
+private keys and NUT-20 mint-quote private keys.
 
-See [Storage Adapters](./storage-adapters.md) for more information on how data is persisted.
+See [Storage Adapters](./storage-adapters.md#security) for the storage security model and guidance
+on protecting wallet data.
 
 ## Error Handling
 

--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -30,6 +30,17 @@ Concrete core services, operation service classes, handler providers, transport
 internals, and individual memory repository classes are not part of the
 app-facing root API.
 
+## Security
+
+Coco's built-in storage adapters do not encrypt wallet data at rest. Stored data can include
+bearer proofs, proof secrets, P2PK private keys, and NUT-20 mint-quote private keys. Treat the
+underlying database and any associated journals, write-ahead logs, and backups as sensitive.
+
+The embedding application is responsible for storage protection. Applications that require
+encryption at rest should use an encrypted database, encrypted filesystem or platform storage, or
+a custom `Repositories` implementation that provides the required protection. Ensure that the
+chosen protection also covers database journals and backups.
+
 ## SQLite adapter public API
 
 The SQLite adapter packages share the same public shape. Import


### PR DESCRIPTION
## Summary

- clarify that Coco's built-in storage adapters do not encrypt wallet data at rest
- identify bearer proofs, proof secrets, P2PK keys, and NUT-20 mint-quote keys as sensitive stored data
- document the embedding application's responsibility for protecting databases, journals, WALs, and backups
- link the keyring documentation to the central storage security guidance

## Why

The keyring documentation previously stated that secret keys were encrypted, but the built-in adapters serialize them directly into their backing stores. Coco also stores bearer proofs and proof secrets in those stores, so encryption at rest is an application-level storage concern rather than a security boundary enforced by the repository API.

## Impact

This changes documentation only. It makes the existing storage model explicit so applications can choose an encrypted database, platform storage protection, or a custom repository when their threat model requires encryption at rest.

## Validation

- `bunx prettier --check packages/docs/pages/keyring.md packages/docs/pages/storage-adapters.md`
- `bun run docs:build`

---

This issue was found by https://github.com/project-loupe/loupe