### PR TITLE
docs(agents): update skill setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Guidance for agentic coding in this repo.
 
 ### Issue tracker
 
-Issues are tracked in GitHub Issues for `cashubtc/coco`. See `docs/agents/issue-tracker.md`.
+Issues are tracked in GitHub Issues for `cashubtc/coco`. External pull requests are not a
+triage request surface. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,41 +1,46 @@
 # Domain Docs
 
-How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+How the engineering skills should consume this repo's domain documentation.
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root.
-- **`docs/adr/`**; read ADRs that touch the area you're about to work in.
+- **`CONTEXT.md`** at the repository root.
+- **`docs/adr/`**; read ADRs relevant to the area being changed.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+If either is absent, proceed silently. The `/domain-modeling` skill creates domain
+documentation lazily when terminology or decisions are resolved.
 
 ## File structure
 
-Single-context repo:
+This is a single-context repository:
 
 ```
 /
 ├── CONTEXT.md
 ├── docs/adr/
 └── packages/
-    ├── core/
-    ├── react/
-    ├── sqlite3/
-    ├── indexeddb/
-    ├── expo-sqlite/
-    ├── sqlite-bun/
     ├── adapter-tests/
-    └── docs/
+    ├── core/
+    ├── docs/
+    ├── expo-sqlite/
+    ├── indexeddb/
+    ├── react/
+    ├── sql-storage/
+    ├── sqlite-bun/
+    └── sqlite3/
 ```
 
 ## Use the glossary's vocabulary
 
-When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+When output names a domain concept, use the term defined in `CONTEXT.md`. Do not
+drift to synonyms the glossary explicitly avoids.
 
-If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+If a needed concept is absent, reconsider whether the project uses that language or
+note the gap for `/domain-modeling`.
 
 ## Flag ADR conflicts
 
-If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+If output contradicts an existing ADR, surface the conflict explicitly rather than
+silently overriding it:
 
-> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because..._
+> _Contradicts ADR-0007 (event-sourced orders)—but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,14 +4,22 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Create an issue**: `gh issue create --title "..." --body "..."`.
+- **Read an issue**: `gh issue view <number> --comments`.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments`.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
-- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close <number> --comment "..."`
+- **Apply/remove labels**: `gh issue edit <number> --add-label "..."` or `--remove-label "..."`.
+- **Close an issue**: `gh issue close <number> --comment "..."`.
 
-Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+Infer the repository from `git remote -v`; `gh` does this automatically inside the clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+External pull requests do not enter the `/triage` issue queue. GitHub shares one number
+space across issues and pull requests, so resolve ambiguous references with
+`gh pr view <number>` and fall back to `gh issue view <number>`.
 
 ## When a skill says "publish to the issue tracker"
 
@@ -20,3 +28,55 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. A map is one issue whose tickets are native GitHub sub-issues.
+
+- **Map**: create an issue labelled `wayfinder:map`. Its body contains Destination,
+  Notes, Decisions so far, Not yet specified, and Out of scope.
+- **Child ticket**: create the issue with its `wayfinder:<type>` label, obtain its
+  numeric database ID, and attach it to the map:
+
+  ```bash
+  child_db_id="$(gh api repos/<owner>/<repo>/issues/<child> --jq .id)"
+  gh api --method POST \
+    repos/<owner>/<repo>/issues/<map>/sub_issues \
+    -F sub_issue_id="$child_db_id"
+  ```
+
+  Verify the relationship with:
+
+  ```bash
+  gh api repos/<owner>/<repo>/issues/<map>/sub_issues \
+    --jq '.[] | [.number, .title] | @tsv'
+  ```
+
+  If native sub-issues are unavailable, add the child to a task list in the map body
+  and put `Part of #<map>` at the top of the child body.
+
+- **Blocking**: add a native dependency after all involved issues exist:
+
+  ```bash
+  blocker_db_id="$(gh api repos/<owner>/<repo>/issues/<blocker> --jq .id)"
+  gh api --method POST \
+    repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by \
+    -F issue_id="$blocker_db_id"
+  ```
+
+  Verify it with:
+
+  ```bash
+  gh api repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by \
+    --jq '.[] | [.number, .title] | @tsv'
+  ```
+
+  If native dependencies are unavailable, put `Blocked by: #<number>` near the top
+  of the child body.
+
+- **Frontier query**: list the map's open sub-issues in map order. Exclude tickets
+  with an assignee or any open `blocked_by` dependency. The remaining tickets form
+  the frontier; the first is selected by default.
+- **Claim**: run `gh issue edit <number> --add-assignee @me` before beginning work.
+- **Resolve**: post the answer with `gh issue comment`, close the ticket, and append
+  a linked one-line gist to the map's Decisions-so-far section.


### PR DESCRIPTION
## Summary

- record GitHub Issues as the tracker and keep external pull requests outside the triage request surface
- document native GitHub sub-issue and blocking-dependency operations for `/wayfinder`, including verification and fallbacks
- align the single-context domain guide with the current package layout and `/domain-modeling` workflow

## Why

The repository setup predates the current `setup-matt-pocock-skills` structure. In particular, its tracker configuration did not define the Wayfinding operations needed to create native GitHub sub-issues and dependency edges.

## Impact

Engineering skills now have repository-local instructions for creating, querying, claiming, and resolving Wayfinder tickets while preserving the confirmed GitHub tracker, default triage labels, and single-context domain layout.

## Validation

- `git diff origin/master...HEAD --check`
- verified the GitHub sub-issue and issue-dependency read endpoints
- confirmed the branch contains one commit and only the three approved documentation files

Documentation-only change; code builds and tests were not required.