### PR TITLE
fix(core): export P2PK payment request types

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -19,9 +19,16 @@ export { type Logger, ConsoleLogger } from './logging/index.ts';
 export { MemoryRepositories } from './repositories/memory/MemoryRepositories.ts';
 export type {
   P2pkSendMethodData,
+  P2pkSendOptions,
   SendMethod,
   SendMethodData,
 } from './operations/send/SendMethodHandler.ts';
+export type {
+  PaymentRequestMalformedSpendingCondition,
+  PaymentRequestP2pkRequirement,
+  PaymentRequestSpendingConditionRequirement,
+  PaymentRequestUnsupportedSpendingCondition,
+} from './services/PaymentRequestService.ts';
 export type {
   InitSendOperation,
   PreparedSendOperation,


### PR DESCRIPTION
## Summary

- Export `P2pkSendOptions` from the core package root.
- Export the P2PK payment-request requirement and diagnostic types from the core package root.

## Why

Follow-up to #309. The merged implementation exposes these types through public API shapes, but consumers could not import the named types from `@cashu/coco-core`.

## Verification

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `git diff --check origin/master...HEAD`