### PR TITLE
fix(core): treat zero mint quote expiry as no expiry

### DIFF
--- a/.changeset/fair-quotes-wait.md
+++ b/.changeset/fair-quotes-wait.md
@@ -1,0 +1,8 @@
+---
+'@cashu/coco-core': patch
+---
+
+Treat `expiry: 0` on mint quotes as no expiry.
+
+BOLT12 and onchain reusable quotes that use the zero no-expiry sentinel now remain watched and
+claimable, while positive timestamps in the past continue to expire normally.

--- a/packages/core/infra/HybridTransport.ts
+++ b/packages/core/infra/HybridTransport.ts
@@ -3,6 +3,7 @@ import type { RealTimeTransport, TransportEvent } from './RealTimeTransport.ts';
 import type { WsRequest } from './SubscriptionProtocol.ts';
 import type { WebSocketFactory } from './WsConnectionManager.ts';
 import type { Logger } from '../logging/Logger.ts';
+import { isMintQuoteExpired } from '../models/MintQuoteExpiry.ts';
 import type { MintAdapter } from './MintAdapter.ts';
 import { WsTransport } from './WsTransport.ts';
 import { PollingTransport } from './PollingTransport.ts';
@@ -285,11 +286,11 @@ export class HybridTransport implements RealTimeTransport {
   }
 
   private getExpirySignature(payload: { expiry?: unknown }): string {
-    if (typeof payload.expiry !== 'number') {
+    if (typeof payload.expiry !== 'number' || payload.expiry === 0) {
       return 'no-expiry';
     }
 
-    const status = payload.expiry * 1000 <= Date.now() ? 'expired' : 'active';
+    const status = isMintQuoteExpired({ expiry: payload.expiry }) ? 'expired' : 'active';
     return `${payload.expiry}:${status}`;
   }
 }

--- a/packages/core/infra/handlers/mint/MintBolt12Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt12Handler.ts
@@ -5,6 +5,7 @@ import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from 
 import { bytesToHex } from '@noble/curves/utils.js';
 import { MintOperationError } from '../../../models/Error';
 import { mintQuoteFromBolt12Response, type MintQuote } from '../../../models/MintQuote';
+import { isMintQuoteExpired } from '../../../models/MintQuoteExpiry';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
@@ -422,7 +423,7 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
   }
 
   private isExpired(quote: MintQuoteBolt12Response): boolean {
-    return quote.expiry !== null && quote.expiry * 1000 <= Date.now();
+    return isMintQuoteExpired(quote);
   }
 
   private isAlreadyIssuedError(error: unknown): boolean {

--- a/packages/core/infra/handlers/mint/MintOnchainHandler.ts
+++ b/packages/core/infra/handlers/mint/MintOnchainHandler.ts
@@ -9,6 +9,7 @@ import {
   type MintQuote,
   type MintQuoteOnchainResponse,
 } from '../../../models/MintQuote';
+import { isMintQuoteExpired } from '../../../models/MintQuoteExpiry';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
@@ -382,7 +383,7 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
   }
 
   private isExpired(quote: MintQuoteOnchainResponse): boolean {
-    return quote.expiry !== null && quote.expiry * 1000 <= Date.now();
+    return isMintQuoteExpired(quote);
   }
 
   private isAlreadyIssuedError(error: unknown): boolean {

--- a/packages/core/models/MintQuoteExpiry.ts
+++ b/packages/core/models/MintQuoteExpiry.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns whether a mint quote's expiry is in the past.
+ *
+ * Some mints use `0` as a no-expiry sentinel, so it has the same semantics as
+ * a missing or null expiry here.
+ */
+export function isMintQuoteExpired(quote: { expiry?: number | null }, now = Date.now()): boolean {
+  return (
+    quote.expiry !== null &&
+    quote.expiry !== undefined &&
+    quote.expiry !== 0 &&
+    quote.expiry * 1000 <= now
+  );
+}

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -45,15 +45,12 @@ import {
   getMintQuoteAmount,
   type MintQuote,
 } from '../../models/MintQuote';
+import { isMintQuoteExpired } from '../../models/MintQuoteExpiry';
 import type { MintQuoteRef } from '../../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 
 export interface ClaimMintQuoteOptions {
   autoClaimRemaining?: boolean;
-}
-
-function isExpiredMintQuote(quote: Pick<MintQuote, 'expiry'>): boolean {
-  return quote.expiry !== null && quote.expiry * 1000 <= Date.now();
 }
 
 /**
@@ -866,7 +863,7 @@ export class MintOperationService {
     quote: MintQuote,
     targetOperationId?: string,
   ): Promise<Amount> {
-    if (isExpiredMintQuote(quote)) {
+    if (isMintQuoteExpired(quote)) {
       return Amount.zero();
     }
 

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -23,6 +23,7 @@ import {
   type MintQuote,
 } from '../models/MintQuote';
 import { meltQuoteToMethodSnapshot, type MeltQuote } from '../models/MeltQuote';
+import { isMintQuoteExpired } from '../models/MintQuoteExpiry';
 import {
   ProofValidationError,
   QuoteIdentityConflictError,
@@ -852,7 +853,7 @@ export class QuoteLifecycle {
   }
 
   private assertMintQuoteCanPrepare(quote: MintQuote, context: string): void {
-    if (quote.expiry !== null && quote.expiry * 1000 <= Date.now()) {
+    if (isMintQuoteExpired(quote)) {
       throw new Error(`Cannot prepare ${context}: quote is expired`);
     }
 

--- a/packages/core/services/watchers/MintOperationWatcherService.ts
+++ b/packages/core/services/watchers/MintOperationWatcherService.ts
@@ -10,20 +10,13 @@ import type {
 } from '@core/operations/mint';
 import type { SubscriptionKind } from '@core/infra/SubscriptionProtocol.ts';
 import { mintQuoteToMethodSnapshot, type MintQuote } from '../../models/MintQuote.ts';
+import { isMintQuoteExpired } from '../../models/MintQuoteExpiry.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 
 type QuoteKey = string; // `${mintUrl}::${method}::${quoteId}`
 
 function toKey(mintUrl: string, method: string, quoteId: string): QuoteKey {
   return `${mintUrl}::${method}::${quoteId}`;
-}
-
-function isExpiredMintQuoteSnapshot(snapshot: { expiry?: number | null }): boolean {
-  return (
-    snapshot.expiry !== null &&
-    snapshot.expiry !== undefined &&
-    snapshot.expiry * 1000 <= Date.now()
-  );
 }
 
 interface MintQuoteWatchPolicy<M extends MintMethod = MintMethod> {
@@ -41,15 +34,14 @@ const mintQuoteWatchPolicies: {
     subscriptionKind: 'bolt11_mint_quote',
     getPayloadQuoteId: (payload) => payload.quote,
     shouldRecordPayload: (payload) => payload.state === 'PAID' || payload.state === 'ISSUED',
-    shouldStopWatching: (payload) =>
-      payload.state === 'ISSUED' || isExpiredMintQuoteSnapshot(payload),
+    shouldStopWatching: (payload) => payload.state === 'ISSUED' || isMintQuoteExpired(payload),
   },
   onchain: {
     subscriptionKind: 'onchain_mint_quote',
     getPayloadQuoteId: (payload) => payload.quote,
     shouldRecordPayload: (payload) =>
       payload.amount_paid !== undefined && payload.amount_issued !== undefined,
-    shouldStopWatching: (payload) => isExpiredMintQuoteSnapshot(payload),
+    shouldStopWatching: (payload) => isMintQuoteExpired(payload),
     keepWatchingWithoutOperationInterest: true,
   },
   bolt12: {
@@ -57,7 +49,7 @@ const mintQuoteWatchPolicies: {
     getPayloadQuoteId: (payload) => payload.quote,
     shouldRecordPayload: (payload) =>
       payload.amount_paid !== undefined && payload.amount_issued !== undefined,
-    shouldStopWatching: (payload) => isExpiredMintQuoteSnapshot(payload),
+    shouldStopWatching: (payload) => isMintQuoteExpired(payload),
     keepWatchingWithoutOperationInterest: true,
   },
 };

--- a/packages/core/test/unit/HybridTransport.test.ts
+++ b/packages/core/test/unit/HybridTransport.test.ts
@@ -302,6 +302,34 @@ describe('HybridTransport', () => {
       expect(messageHandler.mock.calls.length).toBe(countAfterFirst);
     });
 
+    it('should dedupe no-expiry sentinel and null quote notifications', async () => {
+      const messageHandler = mock(() => {});
+      transport.on(mintUrl, 'message', messageHandler);
+
+      const notificationWithSentinel = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: {
+          subId: 'sub1',
+          payload: { quote: 'q1', amount_paid: 10, amount_issued: 0, expiry: 0 },
+        },
+      });
+      const notificationWithNull = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: {
+          subId: 'sub1',
+          payload: { quote: 'q1', amount_paid: 10, amount_issued: 0, expiry: null },
+        },
+      });
+
+      mockSocket.triggerMessage(notificationWithSentinel);
+      const countAfterFirst = messageHandler.mock.calls.length;
+
+      mockSocket.triggerMessage(notificationWithNull);
+      expect(messageHandler.mock.calls.length).toBe(countAfterFirst);
+    });
+
     it('should not dedupe changed onchain quote counters', async () => {
       const messageHandler = mock(() => {});
       transport.on(mintUrl, 'message', messageHandler);

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -317,6 +317,59 @@ describe('MintBolt12Handler', () => {
     expect(result.category).toBe('ready');
   });
 
+  it('keeps a funded quote with no-expiry sentinel claimable', async () => {
+    const result = await handler.checkPending(
+      buildPendingContext(
+        quote({
+          expiry: 0,
+          amount_paid: Amount.from(10),
+        }),
+      ),
+    );
+
+    expect(result.category).toBe('ready');
+  });
+
+  it('keeps a funded quote with null expiry claimable', async () => {
+    const result = await handler.checkPending(
+      buildPendingContext(
+        quote({
+          expiry: null,
+          amount_paid: Amount.from(10),
+        }),
+      ),
+    );
+
+    expect(result.category).toBe('ready');
+  });
+
+  it('keeps a funded quote with a future positive expiry claimable', async () => {
+    const result = await handler.checkPending(
+      buildPendingContext(
+        quote({
+          expiry: Math.floor(Date.now() / 1000) + 60,
+          amount_paid: Amount.from(10),
+        }),
+      ),
+    );
+
+    expect(result.category).toBe('ready');
+  });
+
+  it('treats a funded quote with a past positive expiry as terminal', async () => {
+    const result = await handler.checkPending(
+      buildPendingContext(
+        quote({
+          expiry: Math.floor(Date.now() / 1000) - 1,
+          amount_paid: Amount.from(10),
+        }),
+      ),
+    );
+
+    expect(result.category).toBe('terminal');
+    expect(result.terminalFailure?.code).toBe('quote_expired');
+  });
+
   it('mints with the keyring private key and custom outputs', async () => {
     await handler.execute(
       buildExecuteContext(

--- a/packages/core/test/unit/MintOnchainHandler.test.ts
+++ b/packages/core/test/unit/MintOnchainHandler.test.ts
@@ -398,6 +398,17 @@ describe('MintOnchainHandler', () => {
     expect(result.quoteSnapshot).toBe(remoteQuote);
   });
 
+  it('keeps a funded onchain quote with no-expiry sentinel claimable', async () => {
+    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
+      ...remoteQuote,
+      expiry: 0,
+    });
+
+    const result = await handler.checkPending(buildPendingContext());
+
+    expect(result.category).toBe('ready');
+  });
+
   it('checks pending onchain operations as waiting when the quote cannot cover the amount', async () => {
     (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
       ...remoteQuote,

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -1297,6 +1297,27 @@ describe('MintOperationService', () => {
     expect(operations[0]?.amount.equals(Amount.from(10))).toBe(true);
   });
 
+  it('claimMintQuote keeps a reusable no-expiry sentinel quote claimable', async () => {
+    const onchainQuoteId = 'onchain-quote-no-expiry';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.zero(),
+      expiry: 0,
+    });
+    useAutoClaimOnchainHandler(Amount.from(10));
+
+    const hasClaimableBalance = await service.hasLocallyClaimableMintQuoteBalance(
+      mintUrl,
+      'onchain',
+      onchainQuoteId,
+    );
+    const claimed = await service.claimMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(hasClaimableBalance).toBe(true);
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0]?.state).toBe('finalized');
+  });
+
   it('claimMintQuote treats expired reusable onchain quotes as unclaimable', async () => {
     const onchainQuoteId = 'onchain-quote-expired';
     await persistOnchainQuote(onchainQuoteId, {

--- a/packages/core/test/unit/MintOperationWatcherService.test.ts
+++ b/packages/core/test/unit/MintOperationWatcherService.test.ts
@@ -114,6 +114,24 @@ describe('MintOperationWatcherService', () => {
     updatedAt: Date.now(),
   });
 
+  const makeBolt12Quote = (expiry: number | null = 0): MintQuote<'bolt12'> => ({
+    mintUrl,
+    method: 'bolt12',
+    quoteId,
+    quote: quoteId,
+    request: 'lno1offer',
+    unit: 'sat',
+    expiry,
+    reusable: true,
+    quoteData: {
+      pubkey: 'pubkey-1',
+      amountPaid: Amount.zero(),
+      amountIssued: Amount.zero(),
+    },
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+
   const makeQuoteLifecycle = (
     overrides: Partial<
       Pick<QuoteLifecycle, 'getPendingMintQuotes' | 'recordMintQuoteSnapshot'>
@@ -197,6 +215,66 @@ describe('MintOperationWatcherService', () => {
     const watcher = makeWatcher({
       quoteLifecycle: makeQuoteLifecycle({
         getPendingMintQuotes: mock(async () => [makeOnchainQuote()]),
+      }),
+      options: { watchExistingPendingOnStart: false },
+    });
+
+    await watcher.start();
+
+    expect(subscribe).toHaveBeenCalledWith(
+      mintUrl,
+      'onchain_mint_quote',
+      [quoteId],
+      expect.any(Function),
+    );
+
+    await watcher.stop();
+  });
+
+  it('watches a pending canonical BOLT12 quote with no-expiry sentinel on startup', async () => {
+    const watcher = makeWatcher({
+      quoteLifecycle: makeQuoteLifecycle({
+        getPendingMintQuotes: mock(async () => [makeBolt12Quote()]),
+      }),
+      options: { watchExistingPendingOnStart: false },
+    });
+
+    await watcher.start();
+
+    expect(subscribe).toHaveBeenCalledWith(
+      mintUrl,
+      'bolt12_mint_quote',
+      [quoteId],
+      expect.any(Function),
+    );
+
+    await watcher.stop();
+  });
+
+  it('keeps null-expiry BOLT12 quote behavior unchanged on startup', async () => {
+    const watcher = makeWatcher({
+      quoteLifecycle: makeQuoteLifecycle({
+        getPendingMintQuotes: mock(async () => [makeBolt12Quote(null)]),
+      }),
+      options: { watchExistingPendingOnStart: false },
+    });
+
+    await watcher.start();
+
+    expect(subscribe).toHaveBeenCalledWith(
+      mintUrl,
+      'bolt12_mint_quote',
+      [quoteId],
+      expect.any(Function),
+    );
+
+    await watcher.stop();
+  });
+
+  it('watches a pending canonical onchain quote with no-expiry sentinel on startup', async () => {
+    const watcher = makeWatcher({
+      quoteLifecycle: makeQuoteLifecycle({
+        getPendingMintQuotes: mock(async () => [{ ...makeOnchainQuote(), expiry: 0 }]),
       }),
       options: { watchExistingPendingOnStart: false },
     });
@@ -513,6 +591,42 @@ describe('MintOperationWatcherService', () => {
         amount_paid: Amount.from(10),
         amount_issued: Amount.zero(),
       }),
+    );
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    await watcher.stop();
+  });
+
+  it('keeps watching after a BOLT12 update with no-expiry sentinel', async () => {
+    const quote = makeBolt12Quote();
+    const recordMintQuoteSnapshot = mock(async () => quote);
+    const watcher = makeWatcher({
+      quoteLifecycle: makeQuoteLifecycle({
+        getPendingMintQuotes: mock(async () => [quote]),
+        recordMintQuoteSnapshot,
+      }),
+      options: { watchExistingPendingOnStart: false },
+    });
+
+    await watcher.start();
+    if (!callback) {
+      throw new Error('Expected watcher subscription callback');
+    }
+
+    await callback({
+      quote: quoteId,
+      request: quote.request,
+      unit: quote.unit,
+      expiry: 0,
+      pubkey: quote.quoteData.pubkey,
+      amount_paid: Amount.from(10),
+      amount_issued: Amount.zero(),
+    });
+
+    expect(recordMintQuoteSnapshot).toHaveBeenCalledWith(
+      mintUrl,
+      'bolt12',
+      expect.objectContaining({ quote: quoteId, expiry: 0 }),
     );
     expect(unsubscribe).not.toHaveBeenCalled();
 


### PR DESCRIPTION
## Problem

Mints can use `expiry: 0` as a no-expiry sentinel for reusable BOLT12 and onchain mint quotes. Coco treated zero as the Unix epoch, so background watching stopped immediately and later payments were never observed or claimed.

## Summary

- treat zero, null, and missing mint-quote expiry as non-expiring
- apply the rule consistently to watcher startup and updates, reusable handlers, canonical preparation, claimability, and transport deduplication
- preserve positive past-expiry behavior and leave melt-quote expiry handling unchanged
- add a core patch changeset

This pull request resolves #292.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit` — 1,054 passed
- `bun run build`
- `bun run typecheck`

The complete core test command ran 1,062 tests; 1,058 passed and four integration entries require unavailable local mint/auth services.