### PR TITLE
refactor(core): return canonical melt quote from upsert

### DIFF
--- a/.changeset/canonical-melt-quote-upserts.md
+++ b/.changeset/canonical-melt-quote-upserts.md
@@ -1,0 +1,10 @@
+---
+'@cashu/coco-core': patch
+'@cashu/coco-adapter-tests': patch
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+---
+
+Return the canonical persisted melt quote from repository upserts.

--- a/.changeset/canonical-melt-quote-upserts.md
+++ b/.changeset/canonical-melt-quote-upserts.md
@@ -1,5 +1,5 @@
 ---
-'@cashu/coco-core': patch
+'@cashu/coco-core': major
 '@cashu/coco-adapter-tests': patch
 '@cashu/coco-indexeddb': patch
 '@cashu/coco-sqlite': patch

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -145,7 +145,7 @@ type ExpectApi = {
   toBeDefined(): void;
 };
 
-async function expectThrows(fn: () => Promise<void>, expect: Expectation) {
+async function expectThrows(fn: () => Promise<unknown>, expect: Expectation) {
   let didThrow = false;
   try {
     await fn();
@@ -156,7 +156,7 @@ async function expectThrows(fn: () => Promise<void>, expect: Expectation) {
 }
 
 async function expectThrowsError(
-  fn: () => Promise<void>,
+  fn: () => Promise<unknown>,
   errorClass: Function,
   expect: Expectation,
 ) {
@@ -883,7 +883,7 @@ export async function runMeltQuoteRepositoryContract(
           lastObservedRemoteStateAt: 20,
         });
 
-        await repositories.meltQuoteRepository.upsertMeltQuote(quote);
+        const persisted = await repositories.meltQuoteRepository.upsertMeltQuote(quote);
 
         const stored = await repositories.meltQuoteRepository.getMeltQuote(
           'https://mint.test',
@@ -891,6 +891,11 @@ export async function runMeltQuoteRepositoryContract(
           'canonical-melt-quote',
         );
 
+        expect(persisted.mintUrl).toBe(stored?.mintUrl);
+        expect(persisted.quote).toBe(stored?.quote);
+        expect(persisted.createdAt).toBe(stored?.createdAt);
+        expect(persisted.updatedAt).toBe(stored?.updatedAt);
+        expect(persisted.amount.equals(stored!.amount)).toBe(true);
         expect(stored).toBeDefined();
         expect(stored!.mintUrl).toBe('https://mint.test');
         expect(stored!.method).toBe('bolt11');

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -811,18 +811,7 @@ export class QuoteLifecycle {
   }
 
   private async persistCanonicalMeltQuote(canonicalQuote: MeltQuote): Promise<MeltQuote> {
-    await this.meltQuoteRepository.upsertMeltQuote(canonicalQuote);
-    const quote = await this.meltQuoteRepository.getMeltQuote(
-      canonicalQuote.mintUrl,
-      canonicalQuote.method,
-      canonicalQuote.quoteId,
-    );
-    if (!quote) {
-      throw new Error(
-        `Cannot persist quote observation: melt quote ${canonicalQuote.quoteId} for ${canonicalQuote.method} at ${canonicalQuote.mintUrl} was not found after persistence`,
-      );
-    }
-    return quote;
+    return this.meltQuoteRepository.upsertMeltQuote(canonicalQuote);
   }
 
   private async emitMeltQuoteUpdatedIfNeeded(

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -191,9 +191,10 @@ export interface MeltQuoteRepository {
    *
    * Upserting the same normalized `{ mintUrl, method, quoteId }` updates that quote. Upserting a
    * different method with the same normalized `{ mintUrl, quoteId }` must fail with a quote
-   * identity conflict instead of creating an ambiguous methodless public identity.
+   * identity conflict instead of creating an ambiguous methodless public identity. Returns the
+   * canonical persisted quote after applying repository normalization.
    */
-  upsertMeltQuote(quote: MeltQuote): Promise<void>;
+  upsertMeltQuote(quote: MeltQuote): Promise<MeltQuote>;
   getPendingMeltQuotes(method?: string): Promise<MeltQuote[]>;
 }
 

--- a/packages/core/repositories/memory/MemoryMeltQuoteRepository.ts
+++ b/packages/core/repositories/memory/MemoryMeltQuoteRepository.ts
@@ -32,7 +32,7 @@ export class MemoryMeltQuoteRepository implements MeltQuoteRepository {
     return quote ? { ...quote } : null;
   }
 
-  async upsertMeltQuote(quote: MeltQuote): Promise<void> {
+  async upsertMeltQuote(quote: MeltQuote): Promise<MeltQuote> {
     const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
     const now = Date.now();
     const identityOwner = await this.getMeltQuoteById({
@@ -49,13 +49,15 @@ export class MemoryMeltQuoteRepository implements MeltQuoteRepository {
       );
     }
     const existing = await this.getMeltQuote(normalizedMintUrl, quote.method, quote.quoteId);
-    this.quotes.set(this.makeKey(normalizedMintUrl, quote.method, quote.quoteId), {
+    const persisted = {
       ...quote,
       mintUrl: normalizedMintUrl,
       quote: quote.quoteId,
       createdAt: existing?.createdAt ?? quote.createdAt,
       updatedAt: now,
-    });
+    };
+    this.quotes.set(this.makeKey(normalizedMintUrl, quote.method, quote.quoteId), persisted);
+    return { ...persisted };
   }
 
   async getPendingMeltQuotes(method?: string): Promise<MeltQuote[]> {

--- a/packages/indexeddb/src/repositories/MeltQuoteRepository.ts
+++ b/packages/indexeddb/src/repositories/MeltQuoteRepository.ts
@@ -83,7 +83,7 @@ export class IdbMeltQuoteRepository implements MeltQuoteRepository {
     return row ? rowToQuote(row) : null;
   }
 
-  async upsertMeltQuote(quote: MeltQuote): Promise<void> {
+  async upsertMeltQuote(quote: MeltQuote): Promise<MeltQuote> {
     const now = Date.now();
     const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
     const identityOwner = await this.getMeltQuoteById({
@@ -127,6 +127,7 @@ export class IdbMeltQuoteRepository implements MeltQuoteRepository {
       updatedAt: now,
     };
     await (this.db as any).table('coco_cashu_melt_quotes').put(row);
+    return rowToQuote(row);
   }
 
   async getPendingMeltQuotes(method?: string): Promise<MeltQuote[]> {

--- a/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
+++ b/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
@@ -114,7 +114,7 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
     return row ? rowToQuote(row) : null;
   }
 
-  async upsertMeltQuote(quote: MeltQuote): Promise<void> {
+  async upsertMeltQuote(quote: MeltQuote): Promise<MeltQuote> {
     const now = Date.now();
     const normalizedMintUrl = normalizeMintUrl(quote.mintUrl);
     const identityOwner = await this.getMeltQuoteById({
@@ -130,6 +130,33 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
         `Melt quote ${quote.quoteId} at ${normalizedMintUrl} already exists for method ${identityOwner.method}`,
       );
     }
+    const row: MeltQuoteRow = {
+      mintUrl: normalizedMintUrl,
+      method: quote.method,
+      quoteId: quote.quoteId,
+      state: quote.state,
+      request: quote.request,
+      amount: serializeAmount(quote.amount),
+      unit: quote.unit,
+      fee_reserve: quote.method === 'onchain' ? null : serializeAmount(quote.fee_reserve),
+      expiry: quote.expiry,
+      payment_preimage: quote.method === 'onchain' ? null : (quote.payment_preimage ?? null),
+      fee_options_json:
+        quote.method === 'onchain'
+          ? stringifyJson(
+              quote.fee_options.map((option) => ({
+                ...option,
+                fee_reserve: serializeAmount(option.fee_reserve),
+              })),
+            )
+          : null,
+      outpoint: quote.method === 'onchain' ? (quote.outpoint ?? null) : null,
+      changeJson: quote.change ? stringifyJson(quote.change) : null,
+      lastObservedRemoteState: quote.lastObservedRemoteState ?? quote.state,
+      lastObservedRemoteStateAt: quote.lastObservedRemoteStateAt ?? now,
+      createdAt: identityOwner?.createdAt ?? quote.createdAt,
+      updatedAt: quote.updatedAt || now,
+    };
     await this.db.run(
       `INSERT INTO coco_cashu_melt_quotes
          (mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
@@ -151,32 +178,26 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
          lastObservedRemoteStateAt=excluded.lastObservedRemoteStateAt,
          updatedAt=excluded.updatedAt`,
       [
-        normalizedMintUrl,
-        quote.method,
-        quote.quoteId,
-        quote.state,
-        quote.request,
-        serializeAmount(quote.amount),
-        quote.unit,
-        quote.method === 'onchain' ? null : serializeAmount(quote.fee_reserve),
-        quote.expiry,
-        quote.method === 'onchain' ? null : (quote.payment_preimage ?? null),
-        quote.method === 'onchain'
-          ? stringifyJson(
-              quote.fee_options.map((option) => ({
-                ...option,
-                fee_reserve: serializeAmount(option.fee_reserve),
-              })),
-            )
-          : null,
-        quote.method === 'onchain' ? (quote.outpoint ?? null) : null,
-        quote.change ? stringifyJson(quote.change) : null,
-        quote.lastObservedRemoteState ?? quote.state,
-        quote.lastObservedRemoteStateAt ?? now,
-        quote.createdAt,
-        quote.updatedAt || now,
+        row.mintUrl,
+        row.method,
+        row.quoteId,
+        row.state,
+        row.request,
+        row.amount,
+        row.unit,
+        row.fee_reserve ?? null,
+        row.expiry,
+        row.payment_preimage ?? null,
+        row.fee_options_json ?? null,
+        row.outpoint ?? null,
+        row.changeJson ?? null,
+        row.lastObservedRemoteState ?? null,
+        row.lastObservedRemoteStateAt ?? null,
+        row.createdAt,
+        row.updatedAt,
       ],
     );
+    return rowToQuote(row);
   }
 
   async getPendingMeltQuotes(method?: string): Promise<MeltQuote[]> {

--- a/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
+++ b/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
@@ -154,10 +154,10 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
       changeJson: quote.change ? stringifyJson(quote.change) : null,
       lastObservedRemoteState: quote.lastObservedRemoteState ?? quote.state,
       lastObservedRemoteStateAt: quote.lastObservedRemoteStateAt ?? now,
-      createdAt: identityOwner?.createdAt ?? quote.createdAt,
+      createdAt: quote.createdAt,
       updatedAt: quote.updatedAt || now,
     };
-    await this.db.run(
+    const persisted = await this.db.get<MeltQuoteRow>(
       `INSERT INTO coco_cashu_melt_quotes
          (mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
           payment_preimage, fee_options_json, outpoint, changeJson, lastObservedRemoteState,
@@ -176,7 +176,10 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
          changeJson=excluded.changeJson,
          lastObservedRemoteState=excluded.lastObservedRemoteState,
          lastObservedRemoteStateAt=excluded.lastObservedRemoteStateAt,
-         updatedAt=excluded.updatedAt`,
+         updatedAt=excluded.updatedAt
+       RETURNING mintUrl, method, quoteId, state, request, amount, unit, fee_reserve, expiry,
+                 payment_preimage, fee_options_json, outpoint, changeJson,
+                 lastObservedRemoteState, lastObservedRemoteStateAt, createdAt, updatedAt`,
       [
         row.mintUrl,
         row.method,
@@ -197,7 +200,12 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
         row.updatedAt,
       ],
     );
-    return rowToQuote(row);
+    if (!persisted) {
+      throw new Error(
+        `Melt quote ${quote.quoteId} for ${quote.method} at ${normalizedMintUrl} was not returned after persistence`,
+      );
+    }
+    return rowToQuote(persisted);
   }
 
   async getPendingMeltQuotes(method?: string): Promise<MeltQuote[]> {


### PR DESCRIPTION
## Problem

`MeltQuoteRepository.upsertMeltQuote()` returned `void`, so `QuoteLifecycle` had to reread every melt quote immediately after persistence to obtain the adapter's canonical representation.

## Summary

- return canonical persisted melt quotes from memory, IndexedDB, and SQL repositories
- use atomic SQLite `INSERT ... RETURNING` so conflict-preserved fields reflect the stored row
- remove the lifecycle reread and use the returned quote for subsequent events
- extend the shared adapter contract and add a patch changeset

Adapter implementers must now return `MeltQuote` from `upsertMeltQuote()`.

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run format:check`
- `bun run --filter='@cashu/coco-core' test:unit` (995 tests)
- SQL-storage and SQLite/Expo adapter contract suites
- IndexedDB Chromium browser contract suite

Mint-network integration tests were not run because `MINT_URL` was not configured.

Closes #274