### PR TITLE
feat(core): redeem processor mint operations in batches

### DIFF
--- a/.changeset/processor-mint-batches.md
+++ b/.changeset/processor-mint-batches.md
@@ -1,0 +1,9 @@
+---
+'@cashu/coco-core': patch
+---
+
+Redeem compatible processor-selected BOLT11 Mint Operations through bounded NUT-29 Mint Batches.
+
+Batch redemption is enabled by default for trusted compatible mints, remains target-isolated for
+explicit calls, rotates ready groups fairly, and supports force-single and normalized-mint
+denylist controls.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -15,6 +15,7 @@ import {
   MintService,
   MintOperationWatcherService,
   MintOperationProcessor,
+  type MintOperationProcessorOptions,
   MeltQuoteWatcherService,
   MeltSettlementProcessor,
   ProofService,
@@ -33,7 +34,10 @@ import {
 import { SendOperationService } from './operations/send/SendOperationService';
 import { MeltOperationService } from './operations/melt/MeltOperationService';
 import { MintOperationService } from './operations/mint/MintOperationService';
-import { MintIssuanceCoordinator } from './operations/mint/MintIssuanceCoordinator';
+import {
+  MintIssuanceCoordinator,
+  type ProcessorRedemptionOptions,
+} from './operations/mint/MintIssuanceCoordinator';
 import { ReceiveOperationService } from './operations/receive/ReceiveOperationService';
 import { MintScopedLock } from './operations/MintScopedLock';
 import {
@@ -75,15 +79,20 @@ import { PluginHost } from './plugins/PluginHost.ts';
 import type { MintMethodQuoteSnapshot } from './operations/mint';
 import type { Plugin, PluginExtensions, ServiceMap } from './plugin.ts';
 import { QuoteLifecycle } from './quotes/QuoteLifecycle.ts';
+import { Nut29BatchLimitCache } from './quotes/MintQuoteBatchTransport.ts';
 import {
   getMintQuoteAmount,
   isStatefulMintQuote,
   mintQuoteToMethodSnapshot,
 } from './models/MintQuote.ts';
 
-/**
- * Configuration options for initializing the Coco Cashu manager
- */
+/** Configuration for automatic Mint Operation processing and redemption transport policy. */
+export type MintOperationProcessorConfig = MintOperationProcessorOptions &
+  ProcessorRedemptionOptions & {
+    disabled?: boolean;
+  };
+
+/** Configuration options for initializing the Coco Cashu manager. */
 export interface CocoConfig {
   /** Repository implementations for data persistence */
   repo: Repositories;
@@ -139,14 +148,7 @@ export interface CocoConfig {
    */
   processors?: {
     /** Mint operation processor (enabled by default) */
-    mintOperationProcessor?: {
-      disabled?: boolean;
-      processIntervalMs?: number;
-      maxRetries?: number;
-      baseRetryDelayMs?: number;
-      initialEnqueueDelayMs?: number;
-      autoClaimMintQuotes?: boolean;
-    };
+    mintOperationProcessor?: MintOperationProcessorConfig;
     /** Melt settlement processor (enabled by default) */
     meltSettlementProcessor?: {
       disabled?: boolean;
@@ -492,18 +494,14 @@ export class Manager {
     this.mintOperationWatcher = undefined;
   }
 
-  async enableMintOperationProcessor(options?: {
-    processIntervalMs?: number;
-    maxRetries?: number;
-    baseRetryDelayMs?: number;
-    initialEnqueueDelayMs?: number;
-    autoClaimMintQuotes?: boolean;
-  }): Promise<boolean> {
+  /** Starts automatic Mint Operation processing with the requested redemption policy. */
+  async enableMintOperationProcessor(options?: MintOperationProcessorConfig): Promise<boolean> {
     if (this.disposed) return false;
     if (this.mintOperationProcessor?.isRunning()) return false;
     const processorLogger = this.logger.child
       ? this.logger.child({ module: 'MintOperationProcessor' })
       : this.logger;
+    this.mintOperationService.configureProcessorRedemption(options);
     this.mintOperationProcessor = new MintOperationProcessor(
       this.mintOperationService,
       this.quoteLifecycle,
@@ -985,6 +983,7 @@ export class Manager {
       onchain: new MintOnchainHandler(keyRingService),
       bolt12: new MintBolt12Handler(keyRingService),
     });
+    const nut29BatchLimitCache = new Nut29BatchLimitCache();
     const quoteLifecycle = new QuoteLifecycle({
       mintHandlerProvider,
       meltHandlerProvider,
@@ -997,6 +996,7 @@ export class Manager {
       mintAdapter: this.mintAdapter,
       eventBus: this.eventBus,
       logger: quoteLifecycleLogger,
+      nut29BatchLimitCache,
     });
     const meltOperationService = new MeltOperationService(
       meltHandlerProvider,
@@ -1025,6 +1025,7 @@ export class Manager {
       eventBus: this.eventBus,
       logger: mintIssuanceLogger,
       mintScopedLock,
+      nut29BatchLimitCache,
     });
     const mintOperationService = new MintOperationService(
       mintHandlerProvider,

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -333,7 +333,8 @@ export class MintIssuanceCoordinator {
     return `${normalizeMintUrl(operation.mintUrl)}::bolt11::${operation.unit}`;
   }
 
-  private unschedule(operationId: string): void {
+  /** Removes a Mint Operation from the ephemeral processor-ready pool. */
+  unschedule(operationId: string): void {
     this.scheduledOperationIds.delete(operationId);
     this.scheduledNotBefore.delete(operationId);
   }

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -1,8 +1,9 @@
-import type { Proof } from '@cashu/cashu-ts';
+import type { BatchMintPreview, Proof } from '@cashu/cashu-ts';
 import type { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
+import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { Logger } from '../../logging/Logger.ts';
 import { MintOperationError, UnknownMintError } from '../../models/Error.ts';
 import {
@@ -10,6 +11,11 @@ import {
   getMintQuoteRemoteState,
   type MintQuote,
 } from '../../models/MintQuote.ts';
+import {
+  getNut29MintQuoteCheckLimit,
+  Nut29BatchLimitCache,
+  supportsNut29MintQuoteCheck,
+} from '../../quotes/MintQuoteBatchTransport.ts';
 import type { Repositories } from '../../repositories/index.ts';
 import type { MintService } from '../../services/MintService.ts';
 import type { ProofService } from '../../services/ProofService.ts';
@@ -47,14 +53,30 @@ interface MintIssuanceCoordinatorOptions {
   eventBus: EventBus<CoreEvents>;
   logger?: Logger;
   mintScopedLock?: MintScopedLock;
+  nut29BatchLimitCache?: Nut29BatchLimitCache;
 }
 
-interface CreatedAttempt {
-  attempt: MintIssuanceAttempt;
-  operation: ExecutingMintOperationRecord<'bolt11'>;
+type CreatedAttempt =
+  | {
+      attempt: MintIssuanceAttempt;
+      operationId: string;
+      newlyCreated: false;
+    }
+  | {
+      attempt: MintIssuanceAttempt;
+      operations: ExecutingMintOperationRecord<'bolt11'>[];
+      newlyCreated: true;
+    };
+
+export interface ProcessorRedemptionOptions {
+  /** Force every processor turn to create at most a single-member attempt. */
+  forceSingleRedemption?: boolean;
+  /** Mint URLs that must use single-member processor redemption after normalization. */
+  batchRedemptionDenylist?: string[];
 }
 
 const activeCoordinations = new WeakMap<Repositories, Map<string, Promise<MintOperation>>>();
+const activeAttemptDispatches = new WeakMap<Repositories, Map<string, Promise<void>>>();
 
 function isTerminalAttempt(attempt: MintIssuanceAttempt): boolean {
   return (
@@ -78,14 +100,23 @@ export class MintIssuanceCoordinator {
   private readonly eventBus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
   private readonly mintScopedLock: MintScopedLock;
+  private readonly nut29BatchLimitCache: Nut29BatchLimitCache;
   private readonly scheduledOperationIds = new Set<string>();
+  private readonly scheduledNotBefore = new Map<string, number>();
   private readonly activeByOperationId: Map<string, Promise<MintOperation>>;
+  private readonly activeByAttemptId: Map<string, Promise<void>>;
+  private forceSingleRedemption = false;
+  private batchRedemptionDenylist = new Set<string>();
+  private lastSelectedGroupKey?: string;
 
   constructor(options: MintIssuanceCoordinatorOptions) {
     this.repositories = options.repositories;
     const sharedActive = activeCoordinations.get(options.repositories) ?? new Map();
     activeCoordinations.set(options.repositories, sharedActive);
     this.activeByOperationId = sharedActive;
+    const sharedAttemptDispatches = activeAttemptDispatches.get(options.repositories) ?? new Map();
+    activeAttemptDispatches.set(options.repositories, sharedAttemptDispatches);
+    this.activeByAttemptId = sharedAttemptDispatches;
     this.proofService = options.proofService;
     this.mintService = options.mintService;
     this.walletService = options.walletService;
@@ -94,22 +125,32 @@ export class MintIssuanceCoordinator {
     this.eventBus = options.eventBus;
     this.logger = options.logger;
     this.mintScopedLock = options.mintScopedLock ?? new MintScopedLock();
+    this.nut29BatchLimitCache = options.nut29BatchLimitCache ?? new Nut29BatchLimitCache();
   }
 
-  schedule(operationId: string): void {
+  /** Adds a Mint Operation to the ephemeral processor-ready pool. */
+  schedule(operationId: string, notBefore = 0): void {
     this.scheduledOperationIds.add(operationId);
+    const existing = this.scheduledNotBefore.get(operationId);
+    this.scheduledNotBefore.set(
+      operationId,
+      existing === undefined ? notBefore : Math.min(existing, notBefore),
+    );
+  }
+
+  /** Replaces the processor redemption policy, normalizing configured mint URLs once. */
+  configureProcessorRedemption(options?: ProcessorRedemptionOptions): void {
+    this.forceSingleRedemption = options?.forceSingleRedemption ?? false;
+    this.batchRedemptionDenylist = new Set(
+      (options?.batchRedemptionDenylist ?? []).map((mintUrl) => normalizeMintUrl(mintUrl)),
+    );
   }
 
   coordinate(): Promise<void>;
   coordinate(operationId: string): Promise<MintOperation>;
   coordinate(operationId?: string): Promise<void> | Promise<MintOperation> {
     if (operationId === undefined) {
-      const next = this.scheduledOperationIds.values().next().value as string | undefined;
-      if (!next) return Promise.resolve();
-      this.scheduledOperationIds.delete(next);
-      return (async () => {
-        await this.coordinate(next);
-      })();
+      return this.coordinateScheduled();
     }
 
     const active = this.activeByOperationId.get(operationId);
@@ -128,6 +169,181 @@ export class MintIssuanceCoordinator {
     return this.activeByOperationId.has(operationId);
   }
 
+  private async coordinateScheduled(): Promise<void> {
+    const scheduled = (
+      await Promise.all(
+        [...this.scheduledOperationIds]
+          .filter((operationId) => (this.scheduledNotBefore.get(operationId) ?? 0) <= Date.now())
+          .map(async (operationId) => ({
+            operationId,
+            operation: await this.repositories.mintOperationRepository.getById(operationId),
+          })),
+      )
+    ).sort((left, right) => {
+      const leftOperation = left.operation;
+      const rightOperation = right.operation;
+      if (!leftOperation || !rightOperation)
+        return left.operationId.localeCompare(right.operationId);
+      return (
+        leftOperation.createdAt - rightOperation.createdAt ||
+        leftOperation.id.localeCompare(rightOperation.id)
+      );
+    });
+
+    for (const { operationId, operation } of scheduled) {
+      if (!operation || isTerminalOperation(operation)) {
+        this.unschedule(operationId);
+        continue;
+      }
+      if (operation.attemptId) {
+        this.unschedule(operationId);
+        await this.coordinate(operationId);
+        return;
+      }
+    }
+
+    const candidates: PendingMintOperationRecord<'bolt11'>[] = [];
+    for (const { operationId, operation } of scheduled) {
+      if (
+        !operation ||
+        operation.state !== 'pending' ||
+        operation.method !== 'bolt11' ||
+        operation.attemptId
+      ) {
+        continue;
+      }
+      const quote = await this.repositories.mintQuoteRepository.getMintQuote(
+        normalizeMintUrl(operation.mintUrl),
+        'bolt11',
+        operation.quoteId,
+      );
+      const bolt11Operation = operation as PendingMintOperationRecord<'bolt11'>;
+      if (!this.isEligibleProcessorCandidate(bolt11Operation, quote)) {
+        this.unschedule(operationId);
+        continue;
+      }
+      candidates.push(bolt11Operation);
+    }
+    if (candidates.length === 0) return;
+
+    const groups = new Map<string, PendingMintOperationRecord<'bolt11'>[]>();
+    for (const candidate of candidates) {
+      const groupKey = this.processorGroupKey(candidate);
+      const group = groups.get(groupKey) ?? [];
+      group.push(candidate);
+      groups.set(groupKey, group);
+    }
+    const groupKeys = [...groups.keys()].sort();
+    const groupKey = this.selectNextGroupKey(groupKeys);
+    const group = groups.get(groupKey)!;
+    group.sort(
+      (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
+    );
+
+    const limit = await this.getProcessorBatchLimit(group[0]!.mintUrl);
+    const uniqueQuoteIds = new Set<string>();
+    const selected = group
+      .filter((operation) => {
+        if (uniqueQuoteIds.has(operation.quoteId)) return false;
+        uniqueQuoteIds.add(operation.quoteId);
+        return true;
+      })
+      .slice(0, limit);
+    const created = await this.createBolt11Attempt(selected, selected.length > 1);
+    if (!created.newlyCreated) {
+      this.unschedule(created.operationId);
+      await this.coordinate(created.operationId);
+      return;
+    }
+    for (const operation of created.operations) {
+      this.unschedule(operation.id);
+    }
+
+    let startDispatch!: () => void;
+    const dispatchGate = new Promise<void>((resolve) => {
+      startDispatch = resolve;
+    });
+    const dispatch = this.runAttemptDispatch(
+      created.attempt.id,
+      created.operations[0]!.id,
+      async () => {
+        await dispatchGate;
+        if (created.operations.length === 1) {
+          await this.performSingleAttempt(created.attempt, created.operations[0]!);
+        } else {
+          await this.performBatchAttempt(created.attempt, created.operations);
+        }
+      },
+    );
+    const joins = new Map<string, Promise<MintOperation>>();
+    for (const operation of created.operations) {
+      const join = dispatch.then(async () => {
+        const completed = await this.requireOperation(operation.id);
+        return toMintOperation(completed);
+      });
+      joins.set(operation.id, join);
+      this.activeByOperationId.set(operation.id, join);
+    }
+
+    try {
+      await this.emitAttemptPrepared(created);
+      startDispatch();
+      await dispatch;
+    } finally {
+      startDispatch();
+      for (const [operationId, join] of joins) {
+        if (this.activeByOperationId.get(operationId) === join) {
+          this.activeByOperationId.delete(operationId);
+        }
+      }
+    }
+  }
+
+  private processorGroupKey(operation: PendingMintOperationRecord<'bolt11'>): string {
+    return `${normalizeMintUrl(operation.mintUrl)}::bolt11::${operation.unit}`;
+  }
+
+  private unschedule(operationId: string): void {
+    this.scheduledOperationIds.delete(operationId);
+    this.scheduledNotBefore.delete(operationId);
+  }
+
+  private selectNextGroupKey(groupKeys: string[]): string {
+    let selected = groupKeys[0]!;
+    if (this.lastSelectedGroupKey) {
+      selected = groupKeys.find((groupKey) => groupKey > this.lastSelectedGroupKey!) ?? selected;
+    }
+    this.lastSelectedGroupKey = selected;
+    return selected;
+  }
+
+  private async getProcessorBatchLimit(mintUrl: string): Promise<number> {
+    const normalizedMintUrl = normalizeMintUrl(mintUrl);
+    if (
+      this.forceSingleRedemption ||
+      this.batchRedemptionDenylist.has(normalizedMintUrl) ||
+      !(await this.mintService.isTrustedMint(normalizedMintUrl))
+    ) {
+      return 1;
+    }
+    const mintInfo = await this.mintService.getMintInfo(normalizedMintUrl);
+    const advertisedLimit = getNut29MintQuoteCheckLimit(mintInfo, 'bolt11') ?? 1;
+    return this.nut29BatchLimitCache.get(
+      mintQuoteGroupKey(normalizedMintUrl, 'bolt11'),
+      advertisedLimit,
+    );
+  }
+
+  private isEligibleProcessorCandidate(
+    operation: PendingMintOperationRecord<'bolt11'>,
+    quote: MintQuote | null,
+  ): quote is MintQuote<'bolt11'> {
+    if (!quote || quote.method !== 'bolt11' || quote.pubkey) return false;
+    if (quote.reusable || getMintQuoteRemoteState(quote) !== 'PAID') return false;
+    const amount = getMintQuoteAmount(quote);
+    return Boolean(amount?.equals(operation.amount) && quote.unit === operation.unit);
+  }
+
   private async coordinateTarget(operationId: string): Promise<MintOperation> {
     let operation = await this.requireOperation(operationId);
     if (isTerminalOperation(operation)) return toMintOperation(operation);
@@ -142,7 +358,12 @@ export class MintIssuanceCoordinator {
       }
       const created = await this.createSingleBolt11Attempt(operation);
       attempt = created.attempt;
-      operation = created.operation;
+      if (created.newlyCreated) {
+        operation = created.operations[0]!;
+        await this.emitAttemptPrepared(created);
+      } else {
+        operation = await this.requireOperation(operationId);
+      }
     }
 
     if (!attempt.memberOperationIds.includes(operationId)) {
@@ -152,10 +373,18 @@ export class MintIssuanceCoordinator {
     }
 
     switch (attempt.state) {
-      case 'prepared':
+      case 'prepared': {
+        if (attempt.request.kind === 'batch') {
+          const members = await this.requireExecutingBolt11Members(attempt);
+          return this.dispatchBatchAttempt(attempt, members, operationId);
+        }
         return this.dispatchSingleAttempt(attempt, operation);
+      }
       case 'submitting':
       case 'recovering':
+        if (attempt.request.kind === 'batch') {
+          throw new Error(`Mint Batch ${attempt.id} requires exact-attempt recovery`);
+        }
         return this.reconcileSingleAttempt(attempt, operation);
       case 'succeeded': {
         const completed = await this.requireOperation(operationId);
@@ -182,41 +411,100 @@ export class MintIssuanceCoordinator {
       throw new Error(`Single issuance attempts currently support BOLT11, not ${candidate.method}`);
     }
 
-    const mintUrl = normalizeMintUrl(candidate.mintUrl);
+    return this.createBolt11Attempt([candidate as PendingMintOperationRecord<'bolt11'>], false);
+  }
+
+  private async createBolt11Attempt(
+    candidates: PendingMintOperationRecord<'bolt11'>[],
+    allowBatch: boolean,
+  ): Promise<CreatedAttempt> {
+    if (candidates.length === 0) throw new Error('Mint issuance cohort must not be empty');
+
+    const mintUrl = normalizeMintUrl(candidates[0]!.mintUrl);
     const releaseMintLock = await this.mintScopedLock.acquire(mintUrl);
     try {
-      const current = await this.requireOperation(candidate.id);
-      if (current.attemptId) {
+      let currentCandidates = await Promise.all(
+        candidates.map((candidate) => this.requireOperation(candidate.id)),
+      );
+      const attached = currentCandidates.find((candidate) => candidate.attemptId);
+      if (attached?.attemptId) {
         const attempt = await this.repositories.mintIssuanceAttemptRepository.getById(
-          current.attemptId,
+          attached.attemptId,
         );
-        if (!attempt || current.state !== 'executing' || current.method !== 'bolt11') {
-          throw new Error(`Operation ${current.id} has an invalid issuance attempt attachment`);
+        if (!attempt || attached.method !== 'bolt11') {
+          throw new Error(`Operation ${attached.id} has an invalid issuance attempt attachment`);
         }
-        return { attempt, operation: current as ExecutingMintOperationRecord<'bolt11'> };
+        return {
+          attempt,
+          operationId: attached.id,
+          newlyCreated: false,
+        };
       }
-      if (current.state !== 'pending' || current.method !== 'bolt11') {
-        throw new Error(
-          `Cannot create BOLT11 issuance attempt for operation ${current.id} in state ${current.state}`,
-        );
+      if (
+        currentCandidates.some(
+          (candidate) => candidate.state !== 'pending' || candidate.method !== 'bolt11',
+        )
+      ) {
+        throw new Error('Cannot create a BOLT11 issuance attempt from an ineligible operation');
       }
 
       if (!(await this.mintService.isTrustedMint(mintUrl))) {
         throw new UnknownMintError(`Mint ${mintUrl} is not trusted`);
       }
+      let revalidatedLimit = 1;
+      if (allowBatch && !this.forceSingleRedemption && !this.batchRedemptionDenylist.has(mintUrl)) {
+        const mintInfo = await this.mintService.getMintInfo(mintUrl);
+        const advertisedLimit = supportsNut29MintQuoteCheck(mintInfo, 'bolt11')
+          ? (getNut29MintQuoteCheckLimit(mintInfo, 'bolt11') ?? 1)
+          : 1;
+        revalidatedLimit = this.nut29BatchLimitCache.get(
+          mintQuoteGroupKey(mintUrl, 'bolt11'),
+          advertisedLimit,
+        );
+      }
+      currentCandidates = currentCandidates.slice(0, revalidatedLimit);
+      const first = currentCandidates[0]! as PendingMintOperationRecord<'bolt11'>;
+      if (
+        currentCandidates.some(
+          (candidate) =>
+            normalizeMintUrl(candidate.mintUrl) !== mintUrl ||
+            candidate.method !== 'bolt11' ||
+            candidate.unit !== first.unit,
+        )
+      ) {
+        throw new Error('Mint issuance cohort must share mint, method, and unit');
+      }
       await this.mintService.assertMethodUnitSupported(mintUrl, 4, 'bolt11', {
-        amount: current.amount,
-        unit: current.unit,
+        amount: first.amount,
+        unit: first.unit,
       });
       const { keysetId } = await this.walletService.getWalletWithActiveKeysetId(
         mintUrl,
-        current.unit,
+        first.unit,
       );
       const storedCounter = await this.repositories.counterRepository.getCounter(mintUrl, keysetId);
       const counterStart = storedCounter?.counter ?? 0;
+      const quotes = await Promise.all(
+        currentCandidates.map(async (candidate) => {
+          const quote = await this.repositories.mintQuoteRepository.getMintQuote(
+            mintUrl,
+            'bolt11',
+            candidate.quoteId,
+          );
+          this.assertEligibleSingleQuote(candidate as PendingMintOperationRecord<'bolt11'>, quote);
+          if (currentCandidates.length > 1 && quote.pubkey) {
+            throw new Error(`Mint quote ${quote.quoteId} requires NUT-20 signing`);
+          }
+          return quote;
+        }),
+      );
+      const quoteAmounts = quotes.map((quote) => getMintQuoteAmount(quote)!);
+      const totalAmount = quoteAmounts
+        .slice(1)
+        .reduce((total, amount) => total.add(amount), quoteAmounts[0]!);
       const outputs = await this.proofService.createMintOutputsAtCounter(
         mintUrl,
-        { amount: current.amount, unit: current.unit },
+        { amount: totalAmount, unit: first.unit },
         counterStart,
       );
       if (outputs.keysetId !== keysetId || outputs.counterStart !== counterStart) {
@@ -226,26 +514,54 @@ export class MintIssuanceCoordinator {
       }
       const attemptId = generateSubId();
       const created = await this.repositories.withTransaction(async (tx) => {
-        const operation = await tx.mintOperationRepository.getById(current.id);
-        if (
-          !operation ||
-          operation.state !== 'pending' ||
-          operation.method !== 'bolt11' ||
-          operation.attemptId
-        ) {
-          throw new Error(`Mint operation ${current.id} is no longer eligible for issuance`);
+        const operations = await Promise.all(
+          currentCandidates.map((candidate) => tx.mintOperationRepository.getById(candidate.id)),
+        );
+        if (operations.some((operation) => !operation)) {
+          throw new Error('A Mint Operation disappeared before attempt creation');
         }
         if (!(await tx.mintRepository.isTrustedMint(mintUrl))) {
           throw new UnknownMintError(`Mint ${mintUrl} is not trusted`);
         }
+        if (currentCandidates.length > 1) {
+          const currentMint = await tx.mintRepository.getMintByUrl(mintUrl);
+          const advertisedLimit = supportsNut29MintQuoteCheck(currentMint.mintInfo, 'bolt11')
+            ? (getNut29MintQuoteCheckLimit(currentMint.mintInfo, 'bolt11') ?? 1)
+            : 1;
+          const currentLimit = this.nut29BatchLimitCache.get(
+            mintQuoteGroupKey(mintUrl, 'bolt11'),
+            advertisedLimit,
+          );
+          if (currentCandidates.length > currentLimit) {
+            throw new Error('Mint NUT-29 capability changed before attempt creation committed');
+          }
+        }
 
-        const quote = await tx.mintQuoteRepository.getMintQuote(
-          mintUrl,
-          'bolt11',
-          operation.quoteId,
-        );
-        const bolt11Operation = operation as PendingMintOperationRecord<'bolt11'>;
-        this.assertEligibleSingleQuote(bolt11Operation, quote);
+        const bolt11Operations = operations.map((operation) => {
+          if (
+            !operation ||
+            operation.state !== 'pending' ||
+            operation.method !== 'bolt11' ||
+            operation.attemptId
+          ) {
+            throw new Error('A Mint Operation is no longer eligible for issuance');
+          }
+          return operation as PendingMintOperationRecord<'bolt11'>;
+        });
+        for (const [index, operation] of bolt11Operations.entries()) {
+          const quote = await tx.mintQuoteRepository.getMintQuote(
+            mintUrl,
+            'bolt11',
+            operation.quoteId,
+          );
+          this.assertEligibleSingleQuote(operation, quote);
+          if (!getMintQuoteAmount(quote!)?.equals(quoteAmounts[index]!)) {
+            throw new Error(`Mint quote ${operation.quoteId} changed before attempt creation`);
+          }
+          if (bolt11Operations.length > 1 && quote.pubkey) {
+            throw new Error(`Mint quote ${quote.quoteId} requires NUT-20 signing`);
+          }
+        }
 
         const transactionCounter = await tx.counterRepository.getCounter(mintUrl, keysetId);
         if ((transactionCounter?.counter ?? 0) !== counterStart) {
@@ -253,39 +569,48 @@ export class MintIssuanceCoordinator {
         }
 
         const now = Date.now();
-        const amount = getMintQuoteAmount(quote!);
-        if (!amount) throw new Error(`Mint quote ${bolt11Operation.quoteId} has no fixed amount`);
         const attempt: MintIssuanceAttempt = {
           id: attemptId,
           mintUrl,
           method: 'bolt11',
-          unit: bolt11Operation.unit,
+          unit: first.unit,
           keysetId,
           state: 'prepared',
-          memberOperationIds: [bolt11Operation.id],
-          quoteIds: [bolt11Operation.quoteId],
-          quoteAmounts: [amount],
-          signingRequirements: [null],
+          memberOperationIds: bolt11Operations.map((operation) => operation.id),
+          quoteIds: bolt11Operations.map((operation) => operation.quoteId),
+          quoteAmounts,
+          signingRequirements: bolt11Operations.map(() => null),
           outputData: outputs.outputData,
           counterStart,
           counterEnd: outputs.counterEnd,
-          request: { kind: 'single', quoteId: bolt11Operation.quoteId },
+          request:
+            bolt11Operations.length === 1
+              ? { kind: 'single', quoteId: bolt11Operations[0]!.quoteId }
+              : {
+                  kind: 'batch',
+                  quoteIds: bolt11Operations.map((operation) => operation.quoteId),
+                  quoteAmounts,
+                },
           createdAt: now,
           updatedAt: now,
         };
-        const executing: ExecutingMintOperationRecord<'bolt11'> = {
-          ...bolt11Operation,
-          state: 'executing',
-          attemptId,
-          outputData: outputs.outputData,
-          error: undefined,
-          updatedAt: now,
-        };
+        const executing = bolt11Operations.map(
+          (operation): ExecutingMintOperationRecord<'bolt11'> => ({
+            ...operation,
+            state: 'executing',
+            attemptId,
+            outputData: outputs.outputData,
+            error: undefined,
+            updatedAt: now,
+          }),
+        );
 
         await tx.mintIssuanceAttemptRepository.create(attempt);
-        await tx.mintOperationRepository.update(executing);
+        for (const operation of executing) {
+          await tx.mintOperationRepository.update(operation);
+        }
         await tx.counterRepository.setCounter(mintUrl, keysetId, outputs.counterEnd);
-        return { attempt, operation: executing };
+        return { attempt, operations: executing, newlyCreated: true as const };
       });
 
       await this.eventBus.emit('counter:updated', {
@@ -293,22 +618,47 @@ export class MintIssuanceCoordinator {
         keysetId,
         counter: created.attempt.counterEnd!,
       });
-      await this.eventBus.emit('mint-op:executing', {
-        mintUrl,
-        operationId: created.operation.id,
-        operation: toMintOperation(created.operation),
-      });
-      this.logger?.info('Mint issuance attempt prepared', {
-        attemptId: created.attempt.id,
-        memberOperationIds: created.attempt.memberOperationIds,
-        mintUrl,
-        method: 'bolt11',
-        unit: created.attempt.unit,
-      });
       return created;
     } finally {
       releaseMintLock();
     }
+  }
+
+  private async emitAttemptPrepared(
+    created: Extract<CreatedAttempt, { newlyCreated: true }>,
+  ): Promise<void> {
+    for (const operation of created.operations) {
+      await this.eventBus.emit('mint-op:executing', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
+    this.logger?.info('Mint issuance attempt prepared', {
+      attemptId: created.attempt.id,
+      memberOperationIds: created.attempt.memberOperationIds,
+      mintUrl: created.attempt.mintUrl,
+      method: 'bolt11',
+      unit: created.attempt.unit,
+    });
+  }
+
+  private async requireExecutingBolt11Members(
+    attempt: MintIssuanceAttempt,
+  ): Promise<ExecutingMintOperationRecord<'bolt11'>[]> {
+    const operations = await Promise.all(
+      attempt.memberOperationIds.map((operationId) => this.requireOperation(operationId)),
+    );
+    return operations.map((operation) => {
+      if (
+        operation.state !== 'executing' ||
+        operation.method !== 'bolt11' ||
+        operation.attemptId !== attempt.id
+      ) {
+        throw new Error(`Operation ${operation.id} no longer belongs to attempt ${attempt.id}`);
+      }
+      return operation as ExecutingMintOperationRecord<'bolt11'>;
+    });
   }
 
   private assertEligibleSingleQuote(
@@ -329,7 +679,33 @@ export class MintIssuanceCoordinator {
     }
   }
 
+  private async markSubmitting(attempt: MintIssuanceAttempt): Promise<MintIssuanceAttempt> {
+    return this.repositories.withTransaction(async (tx) => {
+      const current = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+      if (!current) throw new Error(`Mint issuance attempt ${attempt.id} no longer exists`);
+      if (isTerminalAttempt(current)) return current;
+      const now = Date.now();
+      const submitting: MintIssuanceAttempt = {
+        ...current,
+        state: 'submitting',
+        submittedAt: current.submittedAt ?? now,
+        updatedAt: now,
+      };
+      await tx.mintIssuanceAttemptRepository.update(submitting);
+      return submitting;
+    });
+  }
+
   private async dispatchSingleAttempt(
+    attempt: MintIssuanceAttempt,
+    operation: MintOperationRecord,
+  ): Promise<MintOperation> {
+    return this.runAttemptDispatch(attempt.id, operation.id, async () => {
+      await this.performSingleAttempt(attempt, operation);
+    });
+  }
+
+  private async performSingleAttempt(
     attempt: MintIssuanceAttempt,
     operation: MintOperationRecord,
   ): Promise<MintOperation> {
@@ -341,21 +717,7 @@ export class MintIssuanceCoordinator {
     }
     const executing = operation as ExecutingMintOperationRecord<'bolt11'>;
 
-    const submitting = await this.repositories.withTransaction(async (tx) => {
-      const current = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
-      if (!current) throw new Error(`Mint issuance attempt ${attempt.id} no longer exists`);
-      if (isTerminalAttempt(current)) return current;
-
-      const now = Date.now();
-      const updated: MintIssuanceAttempt = {
-        ...current,
-        state: 'submitting',
-        submittedAt: current.submittedAt ?? now,
-        updatedAt: now,
-      };
-      await tx.mintIssuanceAttemptRepository.update(updated);
-      return updated;
-    });
+    const submitting = await this.markSubmitting(attempt);
     if (isTerminalAttempt(submitting)) {
       return this.requireTerminalOperation(operation.id, submitting.id);
     }
@@ -387,6 +749,80 @@ export class MintIssuanceCoordinator {
       }
       throw error;
     }
+  }
+
+  private async dispatchBatchAttempt(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    targetOperationId = operations[0]!.id,
+  ): Promise<MintOperation> {
+    return this.runAttemptDispatch(attempt.id, targetOperationId, async () => {
+      await this.performBatchAttempt(attempt, operations, targetOperationId);
+    });
+  }
+
+  private async performBatchAttempt(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    targetOperationId = operations[0]!.id,
+  ): Promise<MintOperation> {
+    if (attempt.request.kind !== 'batch' || operations.length < 2) {
+      throw new Error(`Attempt ${attempt.id} is not a Mint Batch`);
+    }
+    const submitting = await this.markSubmitting(attempt);
+    if (isTerminalAttempt(submitting)) {
+      return this.requireTerminalOperation(targetOperationId, submitting.id);
+    }
+
+    const outputData = deserializeOutputData(attempt.outputData);
+    if (outputData.send.length > 0) {
+      throw new Error(`Mint Batch ${attempt.id} contains unsupported send outputs`);
+    }
+    const { wallet } = await this.walletService.getWalletWithActiveKeysetId(
+      attempt.mintUrl,
+      attempt.unit,
+    );
+    const preview: BatchMintPreview<Pick<{ quote: string }, 'quote'>> = {
+      method: 'bolt11',
+      payload: {
+        quotes: [...attempt.request.quoteIds],
+        quote_amounts: attempt.request.quoteAmounts.map((amount) => amount),
+        outputs: outputData.keep.map((output) => output.blindedMessage),
+      },
+      outputData: outputData.keep,
+      keysetId: attempt.keysetId,
+      quotes: attempt.request.quoteIds.map((quote) => ({ quote })),
+    };
+    try {
+      const proofs = await wallet.completeBatchMint(preview);
+      this.assertExactProofSet(attempt, proofs);
+      return this.completeBatchAttempt(attempt, operations, proofs, false, targetOperationId);
+    } catch (error) {
+      const recovering = await this.markRecovering(submitting, error);
+      if (isTerminalAttempt(recovering)) {
+        return this.requireTerminalOperation(targetOperationId, recovering.id);
+      }
+      throw error;
+    }
+  }
+
+  private runAttemptDispatch(
+    attemptId: string,
+    targetOperationId: string,
+    dispatch: () => Promise<void>,
+  ): Promise<MintOperation> {
+    let active = this.activeByAttemptId.get(attemptId);
+    if (!active) {
+      const started = dispatch();
+      const tracked = started.finally(() => {
+        if (this.activeByAttemptId.get(attemptId) === tracked) {
+          this.activeByAttemptId.delete(attemptId);
+        }
+      });
+      active = tracked;
+      this.activeByAttemptId.set(attemptId, tracked);
+    }
+    return active.then(async () => toMintOperation(await this.requireOperation(targetOperationId)));
   }
 
   private async reconcileSingleAttempt(
@@ -512,20 +948,7 @@ export class MintIssuanceCoordinator {
     operation: MintOperationRecord,
   ): Promise<MintOperation> {
     this.assertLegacyMethodAttempt(attempt, operation);
-    const submitting = await this.repositories.withTransaction(async (tx) => {
-      const current = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
-      if (!current) throw new Error(`Mint issuance attempt ${attempt.id} no longer exists`);
-      if (isTerminalAttempt(current)) return current;
-      const now = Date.now();
-      const updated: MintIssuanceAttempt = {
-        ...current,
-        state: 'submitting',
-        submittedAt: current.submittedAt ?? now,
-        updatedAt: now,
-      };
-      await tx.mintIssuanceAttemptRepository.update(updated);
-      return updated;
-    });
+    const submitting = await this.markSubmitting(attempt);
     if (isTerminalAttempt(submitting)) {
       return this.requireTerminalOperation(operation.id, submitting.id);
     }
@@ -847,6 +1270,137 @@ export class MintIssuanceCoordinator {
       unit: attempt.unit,
     });
     return toMintOperation(completed.operation);
+  }
+
+  private async completeBatchAttempt(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    proofs: Proof[],
+    recovered: boolean,
+    targetOperationId: string,
+  ): Promise<MintOperation> {
+    const now = Date.now();
+    const coreProofs = mapProofToCoreProof(attempt.mintUrl, 'ready', proofs, {
+      unit: attempt.unit,
+      createdByAttemptId: attempt.id,
+    });
+    const completed = await this.repositories.withTransaction(async (tx) => {
+      const currentAttempt = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+      if (!currentAttempt) {
+        throw new Error(`Mint issuance attempt ${attempt.id} disappeared during reconciliation`);
+      }
+      const currentOperations = await Promise.all(
+        attempt.memberOperationIds.map((operationId) =>
+          tx.mintOperationRepository.getById(operationId),
+        ),
+      );
+      if (
+        currentAttempt.state === 'succeeded' &&
+        currentOperations.every((operation) => operation?.state === 'finalized')
+      ) {
+        return {
+          operations: currentOperations as FinalizedMintOperationRecord<'bolt11'>[],
+          quotes: [] as MintQuote<'bolt11'>[],
+          committed: false,
+        };
+      }
+      if (
+        currentOperations.some(
+          (operation) =>
+            !operation ||
+            operation.state !== 'executing' ||
+            operation.method !== 'bolt11' ||
+            operation.attemptId !== attempt.id,
+        )
+      ) {
+        throw new Error(`Mint Batch ${attempt.id} no longer owns all of its members`);
+      }
+
+      const quoteEvents: MintQuote<'bolt11'>[] = [];
+      await tx.proofRepository.saveProofs(attempt.mintUrl, coreProofs);
+      const finalized: FinalizedMintOperationRecord<'bolt11'>[] = [];
+      for (const [index, operation] of currentOperations.entries()) {
+        const currentOperation = operation as ExecutingMintOperationRecord<'bolt11'>;
+        const quoteId = attempt.quoteIds[index]!;
+        const quoteBefore = await tx.mintQuoteRepository.getMintQuote(
+          attempt.mintUrl,
+          'bolt11',
+          quoteId,
+        );
+        if (!quoteBefore || quoteBefore.method !== 'bolt11') {
+          throw new Error(`Mint quote ${quoteId} disappeared during reconciliation`);
+        }
+        await tx.mintQuoteRepository.setMintQuoteState(
+          attempt.mintUrl,
+          'bolt11',
+          quoteId,
+          'ISSUED',
+          now,
+        );
+        const finalizedOperation: FinalizedMintOperationRecord<'bolt11'> = {
+          ...currentOperation,
+          state: 'finalized',
+          outputData: attempt.outputData,
+          attemptId: attempt.id,
+          error: undefined,
+          updatedAt: now,
+        };
+        await tx.mintOperationRepository.update(finalizedOperation);
+        finalized.push(finalizedOperation);
+        if (getMintQuoteRemoteState(quoteBefore) !== 'ISSUED') {
+          const updatedQuote = await tx.mintQuoteRepository.getMintQuote(
+            attempt.mintUrl,
+            'bolt11',
+            quoteId,
+          );
+          if (updatedQuote?.method === 'bolt11') quoteEvents.push(updatedQuote);
+        }
+      }
+      const succeeded: MintIssuanceAttempt = {
+        ...currentAttempt,
+        state: 'succeeded',
+        updatedAt: now,
+        recoveredAt: recovered ? now : currentAttempt.recoveredAt,
+        terminalError: undefined,
+      };
+      await tx.mintIssuanceAttemptRepository.update(succeeded);
+      return { operations: finalized, quotes: quoteEvents, committed: true };
+    });
+
+    const target = completed.operations.find((operation) => operation.id === targetOperationId);
+    if (!target) throw new Error(`Mint Batch ${attempt.id} does not contain ${targetOperationId}`);
+    if (!completed.committed) return toMintOperation(target);
+
+    for (const keysetId of new Set(coreProofs.map((proof) => proof.id))) {
+      await this.eventBus.emit('proofs:saved', {
+        mintUrl: attempt.mintUrl,
+        keysetId,
+        proofs: coreProofs.filter((proof) => proof.id === keysetId),
+      });
+    }
+    for (const quote of completed.quotes) {
+      await this.eventBus.emit('mint-quote:updated', {
+        mintUrl: quote.mintUrl,
+        method: quote.method,
+        quoteId: quote.quoteId,
+        quote,
+      });
+    }
+    for (const operation of completed.operations) {
+      await this.eventBus.emit('mint-op:finalized', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
+    this.logger?.info('Mint issuance attempt succeeded', {
+      attemptId: attempt.id,
+      memberOperationIds: attempt.memberOperationIds,
+      mintUrl: attempt.mintUrl,
+      method: attempt.method,
+      unit: attempt.unit,
+    });
+    return toMintOperation(target);
   }
 
   private async failAttemptAsExternallyRedeemed(

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -108,6 +108,7 @@ export class MintIssuanceCoordinator {
   private forceSingleRedemption = false;
   private batchRedemptionDenylist = new Set<string>();
   private lastSelectedGroupKey?: string;
+  private lastProcessorSelection = new Set<string>();
 
   constructor(options: MintIssuanceCoordinatorOptions) {
     this.repositories = options.repositories;
@@ -169,7 +170,31 @@ export class MintIssuanceCoordinator {
     return this.activeByOperationId.has(operationId);
   }
 
+  /** Returns whether a Mint Operation remains in the ephemeral processor-ready pool. */
+  isScheduled(operationId: string): boolean {
+    return this.scheduledOperationIds.has(operationId);
+  }
+
+  /** Returns whether the last processor turn selected a Mint Operation for coordination. */
+  wasSelectedInLastProcessorTurn(operationId: string): boolean {
+    return this.lastProcessorSelection.has(operationId);
+  }
+
+  /** Returns whether the current attempt can safely make progress through coordinate(). */
+  async canRetry(operationId: string): Promise<boolean> {
+    const operation = await this.repositories.mintOperationRepository.getById(operationId);
+    if (!operation || isTerminalOperation(operation)) return false;
+    if (operation.state !== 'executing' || !operation.attemptId) return false;
+
+    const attempt = await this.repositories.mintIssuanceAttemptRepository.getById(
+      operation.attemptId,
+    );
+    if (!attempt || isTerminalAttempt(attempt)) return false;
+    return attempt.request.kind !== 'batch' || attempt.state === 'prepared';
+  }
+
   private async coordinateScheduled(): Promise<void> {
+    this.lastProcessorSelection.clear();
     const scheduled = (
       await Promise.all(
         [...this.scheduledOperationIds]
@@ -196,6 +221,7 @@ export class MintIssuanceCoordinator {
         continue;
       }
       if (operation.attemptId) {
+        this.lastProcessorSelection.add(operationId);
         this.unschedule(operationId);
         await this.coordinate(operationId);
         return;
@@ -239,6 +265,7 @@ export class MintIssuanceCoordinator {
     group.sort(
       (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
     );
+    this.lastProcessorSelection = new Set(group.map((operation) => operation.id));
 
     const limit = await this.getProcessorBatchLimit(group[0]!.mintUrl);
     const uniqueQuoteIds = new Set<string>();
@@ -249,12 +276,15 @@ export class MintIssuanceCoordinator {
         return true;
       })
       .slice(0, limit);
+    this.lastProcessorSelection = new Set(selected.map((operation) => operation.id));
     const created = await this.createBolt11Attempt(selected, selected.length > 1);
     if (!created.newlyCreated) {
+      this.lastProcessorSelection = new Set([created.operationId]);
       this.unschedule(created.operationId);
       await this.coordinate(created.operationId);
       return;
     }
+    this.lastProcessorSelection = new Set(created.operations.map((operation) => operation.id));
     for (const operation of created.operations) {
       this.unschedule(operation.id);
     }

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -166,6 +166,21 @@ export class MintOperationService {
     await this.issuanceCoordinator.coordinate();
   }
 
+  /** Returns whether an attached issuance attempt is safe for the processor to retry. */
+  async canRetryIssuance(operationId: string): Promise<boolean> {
+    return (await this.issuanceCoordinator?.canRetry(operationId)) ?? false;
+  }
+
+  /** Returns whether an operation remains scheduled for a later processor coordination turn. */
+  isIssuanceScheduled(operationId: string): boolean {
+    return this.issuanceCoordinator?.isScheduled(operationId) ?? false;
+  }
+
+  /** Returns whether the last processor turn selected an operation for coordination. */
+  wasIssuanceSelectedInLastTurn(operationId: string): boolean {
+    return this.issuanceCoordinator?.wasSelectedInLastProcessorTurn(operationId) ?? false;
+  }
+
   isRecoveryInProgress(): boolean {
     return this.recoveryLock !== null;
   }

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -52,7 +52,10 @@ import {
 import { isMintQuoteExpired } from '../../models/MintQuoteExpiry';
 import type { MintQuoteRef } from '../../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
-import type { MintIssuanceCoordinator } from './MintIssuanceCoordinator.ts';
+import type {
+  MintIssuanceCoordinator,
+  ProcessorRedemptionOptions,
+} from './MintIssuanceCoordinator.ts';
 
 export interface ClaimMintQuoteOptions {
   autoClaimRemaining?: boolean;
@@ -140,6 +143,27 @@ export class MintOperationService {
       this.operationIdLock.isLocked(operationId) ||
       Boolean(this.issuanceCoordinator?.isCoordinating(operationId))
     );
+  }
+
+  /** Configures automatic redemption without changing explicit execution semantics. */
+  configureProcessorRedemption(options?: ProcessorRedemptionOptions): void {
+    this.issuanceCoordinator?.configureProcessorRedemption(options);
+  }
+
+  /** Adds an operation to the coordinator's ephemeral processor-ready pool. */
+  scheduleIssuance(operationId: string, notBefore?: number): void {
+    if (!this.issuanceCoordinator) {
+      throw new Error('Mint issuance coordinator is unavailable');
+    }
+    this.issuanceCoordinator.schedule(operationId, notBefore);
+  }
+
+  /** Processes one bounded ready cohort through the issuance coordinator. */
+  async coordinateScheduledIssuance(): Promise<void> {
+    if (!this.issuanceCoordinator) {
+      throw new Error('Mint issuance coordinator is unavailable');
+    }
+    await this.issuanceCoordinator.coordinate();
   }
 
   isRecoveryInProgress(): boolean {

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -158,6 +158,11 @@ export class MintOperationService {
     this.issuanceCoordinator.schedule(operationId, notBefore);
   }
 
+  /** Removes an operation from the coordinator's ephemeral processor-ready pool. */
+  unscheduleIssuance(operationId: string): void {
+    this.issuanceCoordinator?.unschedule(operationId);
+  }
+
   /** Processes one bounded ready cohort through the issuance coordinator. */
   async coordinateScheduledIssuance(): Promise<void> {
     if (!this.issuanceCoordinator) {

--- a/packages/core/quotes/MintQuoteBatchTransport.ts
+++ b/packages/core/quotes/MintQuoteBatchTransport.ts
@@ -60,25 +60,45 @@ type MintQuoteBatchRequestResult =
       partialFailure?: { error: unknown };
     };
 
+/** Session-scoped effective NUT-29 limits shared by quote checks and redemption. */
+export class Nut29BatchLimitCache {
+  private readonly limits = new Map<string, number>();
+
+  get(groupKey: string, advertisedLimit: number): number {
+    return Math.min(advertisedLimit, this.limits.get(groupKey) ?? advertisedLimit);
+  }
+
+  lower(groupKey: string, limit: number): void {
+    const current = this.limits.get(groupKey);
+    this.limits.set(groupKey, current === undefined ? limit : Math.min(current, limit));
+  }
+
+  reset(groupKey: string): void {
+    this.limits.delete(groupKey);
+  }
+}
+
 /**
  * Owns NUT-29 request policy: capability fallback, bounded retries, effective-limit
  * downshifts, atomic validation-error isolation, and incompatibility reset on mint refresh.
  */
 export class MintQuoteBatchTransport {
-  private readonly effectiveLimit = new Map<string, number>();
   private readonly incompatibleGroups = new Set<string>();
+  private readonly batchLimitCache: Nut29BatchLimitCache;
 
   constructor(
     private readonly mintAdapter: MintAdapter,
     eventBus: EventBus<CoreEvents>,
     private readonly logger?: Logger,
+    batchLimitCache?: Nut29BatchLimitCache,
   ) {
+    this.batchLimitCache = batchLimitCache ?? new Nut29BatchLimitCache();
     eventBus.on('mint:updated', ({ mint }) => {
       const mintUrl = normalizeMintUrl(mint.mintUrl);
       for (const method of MINT_METHODS) {
         const groupKey = mintQuoteGroupKey(mintUrl, method);
         this.incompatibleGroups.delete(groupKey);
-        this.effectiveLimit.delete(groupKey);
+        this.batchLimitCache.reset(groupKey);
       }
     });
   }
@@ -95,10 +115,7 @@ export class MintQuoteBatchTransport {
       return { kind: 'single', attemptedQuoteIds: [quoteIds[0]!] };
     }
 
-    let attemptedQuoteIds = quoteIds.slice(
-      0,
-      Math.min(limit, this.effectiveLimit.get(groupKey) ?? limit),
-    );
+    let attemptedQuoteIds = quoteIds.slice(0, this.batchLimitCache.get(groupKey, limit));
     while (true) {
       try {
         const isolated = await this.checkWithIsolation(mintUrl, method, attemptedQuoteIds);
@@ -117,7 +134,7 @@ export class MintQuoteBatchTransport {
           return { kind: 'single', attemptedQuoteIds: [attemptedQuoteIds[0]!] };
         }
         const loweredLimit = Math.max(1, Math.floor(attemptedQuoteIds.length / 2));
-        this.effectiveLimit.set(groupKey, loweredLimit);
+        this.batchLimitCache.lower(groupKey, loweredLimit);
         attemptedQuoteIds = attemptedQuoteIds.slice(0, loweredLimit);
       }
     }

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -14,6 +14,7 @@ import { mintQuoteWorkKey } from '../infra/MintQuotePollingKey.ts';
 import {
   getNut29MintQuoteCheckLimit,
   MintQuoteBatchTransport,
+  type Nut29BatchLimitCache,
   supportsNut29MintQuoteCheck,
 } from './MintQuoteBatchTransport.ts';
 import type { MeltHandlerProvider } from '../infra/handlers/melt';
@@ -307,6 +308,7 @@ export interface QuoteLifecycleDeps {
   mintAdapter: MintAdapter;
   eventBus: EventBus<CoreEvents>;
   logger?: Logger;
+  nut29BatchLimitCache?: Nut29BatchLimitCache;
 }
 
 export class QuoteLifecycle {
@@ -340,6 +342,7 @@ export class QuoteLifecycle {
       deps.mintAdapter,
       deps.eventBus,
       deps.logger,
+      deps.nut29BatchLimitCache,
     );
   }
 

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -403,7 +403,6 @@ export class MintOperationProcessor {
       try {
         await this.processReadyBolt11Cohort(now);
       } catch (err) {
-        await this.removeAttachedOrTerminalBolt11Items(now);
         this.logger?.error('Failed to coordinate ready Mint Operations', { err });
       } finally {
         this.lastTurnWasBolt11Cohort = true;
@@ -472,28 +471,50 @@ export class MintOperationProcessor {
     for (const item of ready) {
       this.mintOperations.scheduleIssuance(item.operationId);
     }
-    await this.mintOperations.coordinateScheduledIssuance();
-
-    const completed = new Set<string>();
-    for (const item of ready) {
-      const operation = await this.mintOperations.getOperation(item.operationId);
-      if (operation?.state === 'finalized' || operation?.state === 'failed') {
-        completed.add(this.queueItemKey(item));
-      }
+    try {
+      await this.mintOperations.coordinateScheduledIssuance();
+    } catch (error) {
+      await this.reconcileReadyBolt11Items(ready, error);
+      throw error;
     }
-    this.queue = this.queue.filter((item) => !completed.has(this.queueItemKey(item)));
+    await this.reconcileReadyBolt11Items(ready);
   }
 
-  private async removeAttachedOrTerminalBolt11Items(now: number): Promise<void> {
+  private async reconcileReadyBolt11Items(ready: QueueItem[], error?: unknown): Promise<void> {
     const removable = new Set<string>();
-    for (const item of this.queue) {
-      if (item.method !== 'bolt11' || item.nextRetryAt > now) continue;
+    const operations = this.mintOperations as Partial<MintOperationService>;
+    for (const item of ready) {
       const operation = await this.mintOperations.getOperation(item.operationId);
+      if (!operation || operation.state === 'finalized' || operation.state === 'failed') {
+        removable.add(this.queueItemKey(item));
+        continue;
+      }
+      if (operation.state === 'pending') {
+        const remainsScheduled =
+          typeof operations.isIssuanceScheduled === 'function' &&
+          operations.isIssuanceScheduled(item.operationId);
+        const wasSelected =
+          typeof operations.wasIssuanceSelectedInLastTurn === 'function' &&
+          operations.wasIssuanceSelectedInLastTurn(item.operationId);
+        if (!remainsScheduled) {
+          removable.add(this.queueItemKey(item));
+        } else if (error !== undefined && wasSelected && !this.scheduleNetworkRetry(item, error)) {
+          removable.add(this.queueItemKey(item));
+        }
+        continue;
+      }
+      if (operation.state !== 'executing' || error === undefined) continue;
       if (
-        operation?.state === 'executing' ||
-        operation?.state === 'finalized' ||
-        operation?.state === 'failed'
+        typeof operations.wasIssuanceSelectedInLastTurn !== 'function' ||
+        !operations.wasIssuanceSelectedInLastTurn(item.operationId)
       ) {
+        continue;
+      }
+
+      const canRetry =
+        typeof operations.canRetryIssuance === 'function' &&
+        (await operations.canRetryIssuance(item.operationId));
+      if (!canRetry || !this.scheduleNetworkRetry(item, error)) {
         removable.add(this.queueItemKey(item));
       }
     }
@@ -527,32 +548,40 @@ export class MintOperationProcessor {
       return;
     }
 
-    if (err instanceof NetworkError || (err instanceof Error && err.message.includes('network'))) {
-      item.retryCount++;
-      if (item.retryCount <= this.maxRetries) {
-        const delay = this.baseRetryDelayMs * Math.pow(2, item.retryCount - 1);
-        item.nextRetryAt = Date.now() + delay;
-
-        this.logger?.warn('Network error, will retry', {
-          mintUrl,
-          operationId,
-          attempt: item.retryCount,
-          maxRetries: this.maxRetries,
-          retryInMs: delay,
-        });
-
-        this.queue.push(item);
-        return;
-      }
-
-      this.logger?.error('Max retries exceeded for network error', {
-        mintUrl,
-        operationId,
-        maxRetries: this.maxRetries,
-      });
+    if (this.isNetworkError(err)) {
+      if (this.scheduleNetworkRetry(item, err)) this.queue.push(item);
       return;
     }
 
     this.logger?.error('Failed to process mint operation', { mintUrl, operationId, err });
+  }
+
+  private scheduleNetworkRetry(item: QueueItem, err: unknown): boolean {
+    if (!this.isNetworkError(err)) return false;
+
+    item.retryCount++;
+    if (item.retryCount > this.maxRetries) {
+      this.logger?.error('Max retries exceeded for network error', {
+        mintUrl: item.mintUrl,
+        operationId: item.operationId,
+        maxRetries: this.maxRetries,
+      });
+      return false;
+    }
+
+    const delay = this.baseRetryDelayMs * Math.pow(2, item.retryCount - 1);
+    item.nextRetryAt = Date.now() + delay;
+    this.logger?.warn('Network error, will retry', {
+      mintUrl: item.mintUrl,
+      operationId: item.operationId,
+      attempt: item.retryCount,
+      maxRetries: this.maxRetries,
+      retryInMs: delay,
+    });
+    return true;
+  }
+
+  private isNetworkError(err: unknown): boolean {
+    return err instanceof NetworkError || (err instanceof Error && err.message.includes('network'));
   }
 }

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -52,6 +52,7 @@ export class MintOperationProcessor {
   private offUntrusted?: () => void;
   private claimingQuotes = new Set<string>();
   private claimTasks = new Set<Promise<void>>();
+  private lastTurnWasBolt11Cohort = false;
 
   private handlers = new Map<string, OperationHandler>();
   private readonly processIntervalMs: number;
@@ -377,7 +378,13 @@ export class MintOperationProcessor {
 
     // Find next item that's ready to process
     const now = Date.now();
-    const readyIndex = this.queue.findIndex((item) => item.nextRetryAt <= now);
+    let readyIndex = this.queue.findIndex((item) => item.nextRetryAt <= now);
+    if (this.lastTurnWasBolt11Cohort) {
+      const readyNonBolt11Index = this.queue.findIndex(
+        (item) => item.method !== 'bolt11' && item.nextRetryAt <= now,
+      );
+      if (readyNonBolt11Index !== -1) readyIndex = readyNonBolt11Index;
+    }
 
     if (readyIndex === -1) {
       // No items ready yet, schedule for when the next one will be
@@ -390,12 +397,29 @@ export class MintOperationProcessor {
       return;
     }
 
+    const readyItem = this.queue[readyIndex];
+    if (readyItem?.method === 'bolt11' && this.supportsProcessorCoordination()) {
+      this.processing = true;
+      try {
+        await this.processReadyBolt11Cohort(now);
+      } catch (err) {
+        await this.removeAttachedOrTerminalBolt11Items(now);
+        this.logger?.error('Failed to coordinate ready Mint Operations', { err });
+      } finally {
+        this.lastTurnWasBolt11Cohort = true;
+        this.processing = false;
+        if (this.running) this.scheduleNextProcess();
+      }
+      return;
+    }
+
     // Remove item from queue
     const [item] = this.queue.splice(readyIndex, 1);
     if (!item) {
       // This shouldn't happen, but handle it gracefully
       return;
     }
+    this.lastTurnWasBolt11Cohort = false;
     this.processing = true;
 
     try {
@@ -432,6 +456,52 @@ export class MintOperationProcessor {
 
     await handler.process(mintUrl, operationId);
     this.logger?.info('Successfully processed mint operation', { mintUrl, operationId, method });
+  }
+
+  private supportsProcessorCoordination(): boolean {
+    const operations = this.mintOperations as Partial<MintOperationService>;
+    return (
+      typeof operations.scheduleIssuance === 'function' &&
+      typeof operations.coordinateScheduledIssuance === 'function' &&
+      typeof operations.getOperation === 'function'
+    );
+  }
+
+  private async processReadyBolt11Cohort(now: number): Promise<void> {
+    const ready = this.queue.filter((item) => item.method === 'bolt11' && item.nextRetryAt <= now);
+    for (const item of ready) {
+      this.mintOperations.scheduleIssuance(item.operationId);
+    }
+    await this.mintOperations.coordinateScheduledIssuance();
+
+    const completed = new Set<string>();
+    for (const item of ready) {
+      const operation = await this.mintOperations.getOperation(item.operationId);
+      if (operation?.state === 'finalized' || operation?.state === 'failed') {
+        completed.add(this.queueItemKey(item));
+      }
+    }
+    this.queue = this.queue.filter((item) => !completed.has(this.queueItemKey(item)));
+  }
+
+  private async removeAttachedOrTerminalBolt11Items(now: number): Promise<void> {
+    const removable = new Set<string>();
+    for (const item of this.queue) {
+      if (item.method !== 'bolt11' || item.nextRetryAt > now) continue;
+      const operation = await this.mintOperations.getOperation(item.operationId);
+      if (
+        operation?.state === 'executing' ||
+        operation?.state === 'finalized' ||
+        operation?.state === 'failed'
+      ) {
+        removable.add(this.queueItemKey(item));
+      }
+    }
+    this.queue = this.queue.filter((item) => !removable.has(this.queueItemKey(item)));
+  }
+
+  private queueItemKey(item: Pick<QueueItem, 'mintUrl' | 'operationId'>): string {
+    return `${item.mintUrl}::${item.operationId}`;
   }
 
   private handleProcessingError(item: QueueItem, err: unknown): void {

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -496,9 +496,12 @@ export class MintOperationProcessor {
         const wasSelected =
           typeof operations.wasIssuanceSelectedInLastTurn === 'function' &&
           operations.wasIssuanceSelectedInLastTurn(item.operationId);
-        if (!remainsScheduled) {
-          removable.add(this.queueItemKey(item));
-        } else if (error !== undefined && wasSelected && !this.scheduleNetworkRetry(item, error)) {
+        if (error !== undefined && wasSelected) {
+          operations.unscheduleIssuance?.(item.operationId);
+          if (!this.scheduleNetworkRetry(item, error)) {
+            removable.add(this.queueItemKey(item));
+          }
+        } else if (!remainsScheduled) {
           removable.add(this.queueItemKey(item));
         }
         continue;

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -409,6 +409,15 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(walletMint).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels processor-scheduled issuance before a later coordination turn', () => {
+    service.scheduleIssuance(operationId);
+    expect(service.isIssuanceScheduled(operationId)).toBe(true);
+
+    service.unscheduleIssuance(operationId);
+
+    expect(service.isIssuanceScheduled(operationId)).toBe(false);
+  });
+
   it('redeems a processor-selected cohort through one successful Mint Batch', async () => {
     const peerQuoteId = 'quote-peer';
     const peerOperationId = 'operation-peer';

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -1,11 +1,12 @@
-import { Amount, OutputData, type Proof } from '@cashu/cashu-ts';
+import { Amount, OutputData, type BatchMintPreview, type Proof } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
 import { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
+import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
 import { MintOperationError } from '../../models/Error.ts';
-import { mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
+import { getMintQuoteRemoteState, mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
 import { MintScopedLock } from '../../operations/MintScopedLock.ts';
 import { MintIssuanceCoordinator } from '../../operations/mint/MintIssuanceCoordinator.ts';
 import type { MintIssuanceAttempt } from '../../operations/mint/MintIssuanceAttempt.ts';
@@ -16,11 +17,12 @@ import type {
 import { MintOperationService } from '../../operations/mint/MintOperationService.ts';
 import type { MintMethodHandler } from '../../operations/mint/MintMethodHandler.ts';
 import { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
+import { Nut29BatchLimitCache } from '../../quotes/MintQuoteBatchTransport.ts';
 import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
 import type { MintService } from '../../services/MintService.ts';
 import type { ProofService } from '../../services/ProofService.ts';
 import type { WalletService } from '../../services/WalletService.ts';
-import type { CoreProof } from '../../types.ts';
+import type { CoreProof, MintInfo } from '../../types.ts';
 import { serializeOutputData } from '../../utils.ts';
 
 describe('MintOperationService durable single BOLT11 issuance', () => {
@@ -37,6 +39,10 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
   let proofService: ProofService;
   let mintAdapter: MintAdapter;
   let walletMint: Mock<any>;
+  let walletBatchMint: Mock<(preview: BatchMintPreview) => Promise<Proof[]>>;
+  let createMintOutputsAtCounter: Mock<ProofService['createMintOutputsAtCounter']>;
+  let getMintInfo: Mock<MintService['getMintInfo']>;
+  let nut29BatchLimitCache: Nut29BatchLimitCache;
   let coordinator: MintIssuanceCoordinator;
   let service: MintOperationService;
 
@@ -57,6 +63,14 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     secret: outputSecret,
     C: 'C_output-secret',
   };
+
+  const compatibleMintInfo = (): MintInfo =>
+    ({
+      nuts: {
+        '4': { methods: [{ method: 'bolt11', unit: 'sat' }] },
+        '29': { methods: ['bolt11'], max_batch_size: 100 },
+      },
+    }) as MintInfo;
 
   const pendingOperation = (): PendingMintOperationRecord<'bolt11'> => ({
     id: operationId,
@@ -106,6 +120,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       mintAdapter,
       eventBus,
       mintScopedLock,
+      nut29BatchLimitCache,
     });
 
     return new MintOperationService(
@@ -165,26 +180,31 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
   beforeEach(async () => {
     repositories = new MemoryRepositories();
+    nut29BatchLimitCache = new Nut29BatchLimitCache();
     eventBus = new EventBus<CoreEvents>();
     walletMint = mock(async () => [proof]);
+    walletBatchMint = mock(async (_preview: BatchMintPreview) => [proof]);
     walletService = {
       getWalletWithActiveKeysetId: mock(async () => ({
-        wallet: { mintProofsBolt11: walletMint },
+        wallet: { mintProofsBolt11: walletMint, completeBatchMint: walletBatchMint },
         keysetId,
         keys: { id: keysetId, unit: 'sat', keys: {} },
       })),
     } as unknown as WalletService;
+    getMintInfo = mock(async () => compatibleMintInfo());
     mintService = {
       isTrustedMint: mock(async () => true),
       assertMethodUnitSupported: mock(async () => {}),
+      getMintInfo,
     } as unknown as MintService;
+    createMintOutputsAtCounter = mock(async (_mintUrl, _intent, counterStart) => ({
+      keysetId,
+      outputData,
+      counterStart,
+      counterEnd: counterStart + 1,
+    }));
     proofService = {
-      createMintOutputsAtCounter: mock(async (_mintUrl, _intent, counterStart) => ({
-        keysetId,
-        outputData,
-        counterStart,
-        counterEnd: counterStart + 1,
-      })),
+      createMintOutputsAtCounter,
       recoverProofsFromOutputData: mock(async () => []),
     } as unknown as ProofService;
     mintAdapter = {
@@ -200,9 +220,12 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
     await repositories.mintRepository.addNewMint({
       mintUrl,
+      name: 'Test Mint',
+      mintInfo: compatibleMintInfo(),
       trusted: true,
+      createdAt: Date.now(),
       updatedAt: Date.now(),
-    } as any);
+    });
     await repositories.mintQuoteRepository.upsertMintQuote(
       mintQuoteFromBolt11Response(mintUrl, {
         quote: quoteId,
@@ -383,6 +406,624 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(repeated.state).toBe('finalized');
     expect(peer?.state).toBe('pending');
     expect(peerAttempt).toBeNull();
+    expect(walletMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('redeems a processor-selected cohort through one successful Mint Batch', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    const batchSecret = 'batch-output-secret';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_batch-output-secret' },
+          2n,
+          new TextEncoder().encode(batchSecret),
+        ),
+      ],
+      send: [],
+    });
+    const batchProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: batchSecret,
+      C: 'C_batch-output-secret',
+    };
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+      createdAt: pendingOperation().createdAt + 1,
+    });
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+    walletBatchMint.mockResolvedValueOnce([batchProof]);
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    const first = await repositories.mintOperationRepository.getById(operationId);
+    const peer = await repositories.mintOperationRepository.getById(peerOperationId);
+    const saved = await repositories.proofRepository.getProofBySecret(mintUrl, batchSecret);
+
+    expect(attempt?.memberOperationIds).toEqual([operationId, peerOperationId]);
+    expect(attempt?.quoteIds).toEqual([quoteId, peerQuoteId]);
+    expect(attempt?.request.kind).toBe('batch');
+    expect(attempt?.state).toBe('succeeded');
+    expect(first?.state).toBe('finalized');
+    expect(peer?.state).toBe('finalized');
+    expect(saved?.createdByAttemptId).toBe(attempt?.id);
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+    expect(walletMint).not.toHaveBeenCalled();
+    expect(walletBatchMint.mock.calls[0]?.[0]).toMatchObject({
+      method: 'bolt11',
+      keysetId,
+      payload: {
+        quotes: [quoteId, peerQuoteId],
+        quote_amounts: [Amount.from(10), Amount.from(10)],
+      },
+    });
+  });
+
+  it('lets an explicit target join its processor-created Mint Batch', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    const batchSecret = 'joined-batch-output';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_joined-batch-output' },
+          3n,
+          new TextEncoder().encode(batchSecret),
+        ),
+      ],
+      send: [],
+    });
+    const batchProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: batchSecret,
+      C: 'C_joined-batch-output',
+    };
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+    let releaseBatch!: () => void;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    walletBatchMint.mockImplementationOnce(async () => {
+      markStarted();
+      await new Promise<void>((resolve) => {
+        releaseBatch = resolve;
+      });
+      return [batchProof];
+    });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    const processorTurn = coordinator.coordinate();
+    await started;
+    const joined = coordinator.coordinate(peerOperationId);
+    releaseBatch();
+
+    await expect(joined).resolves.toMatchObject({ id: peerOperationId, state: 'finalized' });
+    await processorTurn;
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates an explicit join immediately after the processor attempt commits', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    const batchSecret = 'commit-race-batch-output';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_commit-race-batch-output' },
+          4n,
+          new TextEncoder().encode(batchSecret),
+        ),
+      ],
+      send: [],
+    });
+    const batchProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: batchSecret,
+      C: 'C_commit-race-batch-output',
+    };
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+
+    let markCounterCommitted!: () => void;
+    let releaseCounterEvent!: () => void;
+    const counterCommitted = new Promise<void>((resolve) => {
+      markCounterCommitted = resolve;
+    });
+    eventBus.once('counter:updated', async () => {
+      markCounterCommitted();
+      await new Promise<void>((resolve) => {
+        releaseCounterEvent = resolve;
+      });
+    });
+    let markExecutingEmitted!: () => void;
+    const executingEmitted = new Promise<void>((resolve) => {
+      markExecutingEmitted = resolve;
+    });
+    eventBus.once('mint-op:executing', () => markExecutingEmitted());
+    let markBatchStarted!: () => void;
+    let releaseBatch!: () => void;
+    const batchStarted = new Promise<void>((resolve) => {
+      markBatchStarted = resolve;
+    });
+    walletBatchMint.mockImplementationOnce(async () => {
+      markBatchStarted();
+      await new Promise<void>((resolve) => {
+        releaseBatch = resolve;
+      });
+      return [batchProof];
+    });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    const processorTurn = coordinator.coordinate();
+    await counterCommitted;
+    const explicit = coordinator.coordinate(peerOperationId);
+    await batchStarted;
+    releaseCounterEvent();
+    await executingEmitted;
+    releaseBatch();
+
+    await expect(explicit).resolves.toMatchObject({ id: peerOperationId, state: 'finalized' });
+    await processorTurn;
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins an explicit attempt attached while a processor cohort is being selected', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+
+    let releaseCapability!: () => void;
+    let markCapabilityStarted!: () => void;
+    const capabilityStarted = new Promise<void>((resolve) => {
+      markCapabilityStarted = resolve;
+    });
+    getMintInfo.mockImplementationOnce(async () => {
+      markCapabilityStarted();
+      await new Promise<void>((resolve) => {
+        releaseCapability = resolve;
+      });
+      return {
+        nuts: {
+          '4': { methods: [{ method: 'bolt11', unit: 'sat' }] },
+          '29': { methods: ['bolt11'], max_batch_size: 100 },
+        },
+      } as MintInfo;
+    });
+    let releaseSingle!: () => void;
+    let markSingleStarted!: () => void;
+    const singleStarted = new Promise<void>((resolve) => {
+      markSingleStarted = resolve;
+    });
+    walletMint.mockImplementationOnce(async () => {
+      markSingleStarted();
+      await new Promise<void>((resolve) => {
+        releaseSingle = resolve;
+      });
+      return [proof];
+    });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    const processorTurn = coordinator.coordinate();
+    await capabilityStarted;
+    const explicit = coordinator.coordinate(operationId);
+    await singleStarted;
+    releaseCapability();
+    releaseSingle();
+
+    await Promise.all([processorTurn, explicit]);
+    expect(walletMint).toHaveBeenCalledTimes(1);
+    expect(walletBatchMint).not.toHaveBeenCalled();
+    expect((await repositories.mintOperationRepository.getById(operationId))?.state).toBe(
+      'finalized',
+    );
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'pending',
+    );
+  });
+
+  it('uses single-member attempts when processor batch redemption is forced off', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+    coordinator.configureProcessorRedemption({ forceSingleRedemption: true });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const first = await repositories.mintOperationRepository.getById(operationId);
+    const peer = await repositories.mintOperationRepository.getById(peerOperationId);
+    expect([first?.state, peer?.state].filter((state) => state === 'finalized')).toHaveLength(1);
+    expect([first?.state, peer?.state].filter((state) => state === 'pending')).toHaveLength(1);
+    expect(walletMint).toHaveBeenCalledTimes(1);
+    expect(walletBatchMint).not.toHaveBeenCalled();
+
+    const secondSecret = 'force-single-second-output';
+    const secondOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(10), id: keysetId, B_: 'B_force-single-second-output' },
+          5n,
+          new TextEncoder().encode(secondSecret),
+        ),
+      ],
+      send: [],
+    });
+    createMintOutputsAtCounter.mockImplementationOnce(async (_mint, _intent, counterStart) => ({
+      keysetId,
+      outputData: secondOutputData,
+      counterStart,
+      counterEnd: counterStart + 1,
+    }));
+    walletMint.mockResolvedValueOnce([
+      {
+        id: keysetId,
+        amount: Amount.from(10),
+        secret: secondSecret,
+        C: 'C_force-single-second-output',
+      },
+    ]);
+
+    await coordinator.coordinate();
+
+    const completed = await Promise.all([
+      repositories.mintOperationRepository.getById(operationId),
+      repositories.mintOperationRepository.getById(peerOperationId),
+    ]);
+    const attempts = await Promise.all(
+      completed.map((operation) =>
+        repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operation!.id),
+      ),
+    );
+    const quoteStates = await Promise.all(
+      [quoteId, peerQuoteId].map(async (id) =>
+        getMintQuoteRemoteState(
+          (await repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', id))!,
+        ),
+      ),
+    );
+    const savedProofs = (
+      await Promise.all(
+        attempts.map((attempt) =>
+          repositories.proofRepository.getProofsByAttemptId(mintUrl, attempt!.id),
+        ),
+      )
+    ).flat();
+    expect(completed.map((operation) => operation?.state)).toEqual(['finalized', 'finalized']);
+    expect(attempts.map((attempt) => attempt?.request.kind)).toEqual(['single', 'single']);
+    expect(quoteStates).toEqual(['ISSUED', 'ISSUED']);
+    expect(savedProofs.reduce((total, saved) => total.add(saved.amount), Amount.zero())).toEqual(
+      Amount.from(20),
+    );
+    expect(walletMint).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes the mint denylist before selecting a processor cohort', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+    coordinator.configureProcessorRedemption({
+      batchRedemptionDenylist: ['https://mint.test/'],
+    });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const attempts = await repositories.mintIssuanceAttemptRepository.listRecoverable();
+    const first = await repositories.mintOperationRepository.getById(operationId);
+    const peer = await repositories.mintOperationRepository.getById(peerOperationId);
+    expect(attempts).toHaveLength(0);
+    expect([first?.state, peer?.state].filter((state) => state === 'finalized')).toHaveLength(1);
+    expect([first?.state, peer?.state].filter((state) => state === 'pending')).toHaveLength(1);
+    expect(walletBatchMint).not.toHaveBeenCalled();
+  });
+
+  it('falls back to single transport when the mint no longer advertises NUT-29', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+    getMintInfo.mockResolvedValue({
+      nuts: { '4': { methods: [{ method: 'bolt11', unit: 'sat' }] } },
+    } as MintInfo);
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const first = await repositories.mintOperationRepository.getById(operationId);
+    const peer = await repositories.mintOperationRepository.getById(peerOperationId);
+    expect([first?.state, peer?.state].filter((state) => state === 'finalized')).toHaveLength(1);
+    expect([first?.state, peer?.state].filter((state) => state === 'pending')).toHaveLength(1);
+    expect(walletMint).toHaveBeenCalledTimes(1);
+    expect(walletBatchMint).not.toHaveBeenCalled();
+  });
+
+  it('aborts when NUT-29 capability changes during multi-member attempt construction', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request: 'lnbc1peer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request: 'lnbc1peer',
+    });
+    createMintOutputsAtCounter.mockImplementationOnce(async (_mint, _intent, counterStart) => {
+      const storedMint = await repositories.mintRepository.getMintByUrl(mintUrl);
+      await repositories.mintRepository.updateMint({
+        ...storedMint,
+        mintInfo: {
+          nuts: { '4': { methods: [{ method: 'bolt11', unit: 'sat' }] } },
+        } as MintInfo,
+        updatedAt: Date.now(),
+      });
+      return {
+        keysetId,
+        outputData,
+        counterStart,
+        counterEnd: counterStart + 1,
+      };
+    });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+
+    await expect(coordinator.coordinate()).rejects.toThrow(
+      'Mint NUT-29 capability changed before attempt creation committed',
+    );
+    expect(
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId),
+    ).toBeNull();
+    expect((await repositories.mintOperationRepository.getById(operationId))?.state).toBe(
+      'pending',
+    );
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'pending',
+    );
+    expect(walletMint).not.toHaveBeenCalled();
+    expect(walletBatchMint).not.toHaveBeenCalled();
+  });
+
+  it('chunks at the advertised limit and rotates the next ready mint group fairly', async () => {
+    const baseCreatedAt = pendingOperation().createdAt;
+    const batchSecret = 'limited-batch-output';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_limited-batch-output' },
+          4n,
+          new TextEncoder().encode(batchSecret),
+        ),
+      ],
+      send: [],
+    });
+    const batchProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: batchSecret,
+      C: 'C_limited-batch-output',
+    };
+    getMintInfo.mockResolvedValue({
+      nuts: {
+        '4': { methods: [{ method: 'bolt11', unit: 'sat' }] },
+        '29': { methods: ['bolt11'], max_batch_size: 100 },
+      },
+    } as MintInfo);
+    nut29BatchLimitCache.lower(mintQuoteGroupKey(mintUrl, 'bolt11'), 2);
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+    walletBatchMint.mockResolvedValueOnce([batchProof]);
+
+    for (const [index, suffix] of ['a', 'b'].entries()) {
+      const peerQuoteId = `quote-${suffix}`;
+      await repositories.mintQuoteRepository.upsertMintQuote(
+        mintQuoteFromBolt11Response(mintUrl, {
+          quote: peerQuoteId,
+          request: `lnbc1${suffix}`,
+          amount: Amount.from(10),
+          unit: 'sat',
+          expiry: Math.floor(Date.now() / 1000) + 3600,
+          state: 'PAID',
+        }),
+      );
+      await repositories.mintOperationRepository.create({
+        ...pendingOperation(),
+        id: `operation-${suffix}`,
+        quoteId: peerQuoteId,
+        request: `lnbc1${suffix}`,
+        createdAt: baseCreatedAt + index + 1,
+      });
+    }
+    const otherMintUrl = 'https://z-mint.test';
+    const otherOperationId = 'operation-z';
+    await repositories.mintRepository.addNewMint({
+      mintUrl: otherMintUrl,
+      name: 'Z Mint',
+      mintInfo: {} as MintInfo,
+      trusted: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(otherMintUrl, {
+        quote: 'quote-z',
+        request: 'lnbc1z',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: otherOperationId,
+      mintUrl: otherMintUrl,
+      quoteId: 'quote-z',
+      request: 'lnbc1z',
+      createdAt: baseCreatedAt + 3,
+    });
+
+    for (const id of [operationId, 'operation-a', 'operation-b', otherOperationId]) {
+      coordinator.schedule(id);
+    }
+    await coordinator.coordinate();
+    await coordinator.coordinate();
+
+    const batch =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    expect(batch?.memberOperationIds).toEqual([operationId, 'operation-a']);
+    expect((await repositories.mintOperationRepository.getById('operation-b'))?.state).toBe(
+      'pending',
+    );
+    expect((await repositories.mintOperationRepository.getById(otherOperationId))?.state).toBe(
+      'finalized',
+    );
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
     expect(walletMint).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -5,7 +5,7 @@ import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
-import { MintOperationError } from '../../models/Error.ts';
+import { MintOperationError, NetworkError } from '../../models/Error.ts';
 import { getMintQuoteRemoteState, mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
 import { MintScopedLock } from '../../operations/MintScopedLock.ts';
 import { MintIssuanceCoordinator } from '../../operations/mint/MintIssuanceCoordinator.ts';
@@ -481,6 +481,65 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         quote_amounts: [Amount.from(10), Amount.from(10)],
       },
     });
+  });
+
+  it('retries single attempts while deferring ambiguous Mint Batch recovery', async () => {
+    walletMint.mockRejectedValueOnce(new NetworkError('single transport unavailable'));
+    await expect(service.execute(operationId)).rejects.toThrow('single transport unavailable');
+    await expect(service.canRetryIssuance(operationId)).resolves.toBe(true);
+
+    const batchAttemptId = 'attempt-batch-recovering';
+    const batchOperationIds = ['operation-batch-a', 'operation-batch-b'];
+    const batchQuoteIds = ['quote-batch-a', 'quote-batch-b'];
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_deferred-batch-output' },
+          4n,
+          new TextEncoder().encode('deferred-batch-output'),
+        ),
+      ],
+      send: [],
+    });
+    for (const [index, batchOperationId] of batchOperationIds.entries()) {
+      const batchQuoteId = batchQuoteIds[index]!;
+      await repositories.mintOperationRepository.create({
+        ...pendingOperation(),
+        id: batchOperationId,
+        state: 'executing',
+        quoteId: batchQuoteId,
+        request: `lnbc1${batchQuoteId}`,
+        outputData: batchOutputData,
+        attemptId: batchAttemptId,
+        createdAt: pendingOperation().createdAt + index + 1,
+      });
+    }
+    const now = Date.now();
+    await repositories.mintIssuanceAttemptRepository.create({
+      id: batchAttemptId,
+      mintUrl,
+      method: 'bolt11',
+      unit: 'sat',
+      keysetId,
+      state: 'recovering',
+      memberOperationIds: batchOperationIds,
+      quoteIds: batchQuoteIds,
+      quoteAmounts: [Amount.from(10), Amount.from(10)],
+      signingRequirements: [null, null],
+      outputData: batchOutputData,
+      request: {
+        kind: 'batch',
+        quoteIds: batchQuoteIds,
+        quoteAmounts: [Amount.from(10), Amount.from(10)],
+      },
+      createdAt: now,
+      updatedAt: now,
+      submittedAt: now,
+      recoveryStartedAt: now,
+    });
+
+    await expect(service.canRetryIssuance(batchOperationIds[0]!)).resolves.toBe(false);
+    await expect(service.canRetryIssuance(batchOperationIds[1]!)).resolves.toBe(false);
   });
 
   it('lets an explicit target join its processor-created Mint Batch', async () => {

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -202,6 +202,192 @@ describe('MintOperationProcessor', () => {
     expect(finalizeCalls).toEqual([]);
   });
 
+  it('retries safe pending and attached issuance after a transient coordinator failure', async () => {
+    for (const stateAfterFailure of ['pending', 'executing'] as const) {
+      let state: 'pending' | 'executing' | 'finalized' = 'pending';
+      const operation = () => ({
+        id: `mint-op-retry-${stateAfterFailure}`,
+        state,
+        mintUrl: 'https://mint.test',
+        method: 'bolt11' as const,
+        quoteId: `quote-retry-${stateAfterFailure}`,
+        amount: Amount.from(10),
+        unit: 'sat' as const,
+      });
+      const coordinateScheduledIssuance = mock(async () => {
+        state = 'finalized';
+      });
+      coordinateScheduledIssuance.mockImplementationOnce(async () => {
+        state = stateAfterFailure;
+        throw new NetworkError('transient issuance failure');
+      });
+      mockMintOperationService = {
+        scheduleIssuance() {},
+        coordinateScheduledIssuance,
+        async getOperation() {
+          return operation();
+        },
+        async canRetryIssuance() {
+          return true;
+        },
+        isIssuanceScheduled() {
+          return true;
+        },
+        wasIssuanceSelectedInLastTurn() {
+          return true;
+        },
+        async claimPendingMintQuotes() {
+          return [];
+        },
+      } as unknown as MintOperationService;
+      processor = new MintOperationProcessor(
+        mockMintOperationService,
+        mockQuoteLifecycle,
+        bus,
+        undefined,
+        {
+          processIntervalMs: 1,
+          baseRetryDelayMs: 1,
+          initialEnqueueDelayMs: 0,
+        },
+      );
+      await processor.start();
+      await bus.emit('mint-op:requeue', {
+        mintUrl: operation().mintUrl,
+        operationId: operation().id,
+        operation: operation() as CoreEvents['mint-op:requeue']['operation'],
+      });
+
+      await processor.waitForCompletion();
+
+      expect(operation().state).toBe('finalized');
+      expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(2);
+      await processor.stop();
+    }
+  });
+
+  it('drains a pending BOLT11 item that the coordinator declines as ineligible', async () => {
+    let markRepeated!: () => void;
+    const repeated = new Promise<void>((resolve) => {
+      markRepeated = resolve;
+    });
+    const operation = {
+      id: 'mint-op-ineligible',
+      state: 'pending' as const,
+      mintUrl: 'https://mint.test',
+      method: 'bolt11' as const,
+      quoteId: 'quote-ineligible',
+      amount: Amount.from(10),
+      unit: 'sat' as const,
+    };
+    const coordinateScheduledIssuance = mock(async () => {
+      markRepeated();
+    });
+    coordinateScheduledIssuance.mockImplementationOnce(async () => {});
+    mockMintOperationService = {
+      scheduleIssuance() {},
+      coordinateScheduledIssuance,
+      async getOperation() {
+        return operation;
+      },
+      isIssuanceScheduled() {
+        return false;
+      },
+      async claimPendingMintQuotes() {
+        return [];
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: 1,
+        initialEnqueueDelayMs: 0,
+      },
+    );
+    await processor.start();
+    await bus.emit('mint-op:requeue', {
+      mintUrl: operation.mintUrl,
+      operationId: operation.id,
+      operation: operation as CoreEvents['mint-op:requeue']['operation'],
+    });
+
+    const drainedBeforeRepeat = await Promise.race([
+      processor.waitForCompletion().then(() => true),
+      repeated.then(() => false),
+    ]);
+
+    expect(drainedBeforeRepeat).toBe(true);
+    expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps eligible unselected work after another cohort fails', async () => {
+    const states = new Map<string, 'pending' | 'executing' | 'finalized'>([
+      ['mint-op-selected', 'pending'],
+      ['mint-op-unselected', 'pending'],
+    ]);
+    const coordinateScheduledIssuance = mock(async () => {
+      states.set('mint-op-unselected', 'finalized');
+    });
+    coordinateScheduledIssuance.mockImplementationOnce(async () => {
+      states.set('mint-op-selected', 'executing');
+      throw new Error('selected cohort failed validation');
+    });
+    mockMintOperationService = {
+      scheduleIssuance() {},
+      coordinateScheduledIssuance,
+      async getOperation(operationId: string) {
+        return {
+          id: operationId,
+          state: states.get(operationId),
+          mintUrl: 'https://mint.test',
+          method: 'bolt11',
+        };
+      },
+      async canRetryIssuance() {
+        return false;
+      },
+      isIssuanceScheduled(operationId: string) {
+        return operationId === 'mint-op-unselected';
+      },
+      wasIssuanceSelectedInLastTurn(operationId: string) {
+        return operationId === 'mint-op-selected';
+      },
+      async claimPendingMintQuotes() {
+        return [];
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: 1,
+        initialEnqueueDelayMs: 0,
+      },
+    );
+    await processor.start();
+    for (const operationId of states.keys()) {
+      await bus.emit('mint-op:requeue', {
+        mintUrl: 'https://mint.test',
+        operationId,
+        operation: {
+          id: operationId,
+          mintUrl: 'https://mint.test',
+          method: 'bolt11',
+        } as CoreEvents['mint-op:requeue']['operation'],
+      });
+    }
+
+    await processor.waitForCompletion();
+
+    expect(states.get('mint-op-unselected')).toBe('finalized');
+    expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(2);
+  });
+
   it('rotates ready non-BOLT11 work ahead of the next BOLT11 cohort', async () => {
     const turns: string[] = [];
     let markNonBolt11Processed!: () => void;

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, beforeEach, afterEach, expect } from 'bun:test';
+import { Amount } from '@cashu/cashu-ts';
+import { describe, it, beforeEach, afterEach, expect, mock } from 'bun:test';
 import { MintOperationProcessor } from '../../services/watchers/MintOperationProcessor';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { MintOperationService } from '../../operations/mint/MintOperationService';
 import { MintOperationError, NetworkError } from '../../models/Error';
+import { mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -121,6 +123,145 @@ describe('MintOperationProcessor', () => {
     await sleep(TEST_PROCESS_INTERVAL * 2 + 50);
 
     expect(finalizeCalls).toEqual(['mint-op-1']);
+  });
+
+  it('offers all ready BOLT11 operations to one processor coordination turn', async () => {
+    const scheduled: string[] = [];
+    const states = new Map([
+      ['mint-op-1', 'pending'],
+      ['mint-op-2', 'pending'],
+    ]);
+    let markCoordinationStarted!: () => void;
+    const coordinationStarted = new Promise<void>((resolve) => {
+      markCoordinationStarted = resolve;
+    });
+    const coordinateScheduledIssuance = mock(async () => {
+      markCoordinationStarted();
+      for (const operationId of scheduled) states.set(operationId, 'finalized');
+    });
+    mockMintOperationService = {
+      async getOperationsForQuote(_mintUrl: string, _method: string, quoteId: string) {
+        const id = quoteId.replace('quote', 'mint-op');
+        return [
+          {
+            id,
+            state: states.get(id),
+            mintUrl: 'https://mint.test',
+            method: 'bolt11',
+          },
+        ];
+      },
+      scheduleIssuance(operationId: string) {
+        scheduled.push(operationId);
+      },
+      coordinateScheduledIssuance,
+      async getOperation(operationId: string) {
+        return {
+          id: operationId,
+          state: states.get(operationId),
+          mintUrl: 'https://mint.test',
+          method: 'bolt11',
+        };
+      },
+      async claimPendingMintQuotes() {
+        return [];
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: TEST_PROCESS_INTERVAL,
+        initialEnqueueDelayMs: TEST_INITIAL_DELAY,
+      },
+    );
+    await processor.start();
+
+    for (const quoteId of ['quote-1', 'quote-2']) {
+      await bus.emit('mint-quote:updated', {
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+        quoteId,
+        quote: mintQuoteFromBolt11Response('https://mint.test', {
+          quote: quoteId,
+          request: `lnbc1${quoteId}`,
+          amount: Amount.from(10),
+          unit: 'sat',
+          expiry: Math.floor(Date.now() / 1000) + 3600,
+          state: 'PAID',
+        }),
+      });
+    }
+    await coordinationStarted;
+    await processor.waitForCompletion();
+
+    expect(scheduled).toEqual(['mint-op-1', 'mint-op-2']);
+    expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(1);
+    expect(finalizeCalls).toEqual([]);
+  });
+
+  it('rotates ready non-BOLT11 work ahead of the next BOLT11 cohort', async () => {
+    const turns: string[] = [];
+    let markNonBolt11Processed!: () => void;
+    const nonBolt11Processed = new Promise<void>((resolve) => {
+      markNonBolt11Processed = resolve;
+    });
+    mockMintOperationService = {
+      scheduleIssuance() {},
+      async coordinateScheduledIssuance() {
+        turns.push('bolt11');
+      },
+      async getOperation(operationId: string) {
+        return {
+          id: operationId,
+          state: 'pending',
+          mintUrl: 'https://mint.test',
+          method: 'bolt11',
+        };
+      },
+      async claimPendingMintQuotes() {
+        return [];
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: TEST_PROCESS_INTERVAL,
+        initialEnqueueDelayMs: TEST_INITIAL_DELAY,
+      },
+    );
+    processor.registerHandler('bolt12', {
+      async process() {
+        turns.push('bolt12');
+        markNonBolt11Processed();
+      },
+    });
+    await processor.start();
+
+    for (const [operationId, method] of [
+      ['mint-op-bolt11-a', 'bolt11'],
+      ['mint-op-bolt11-b', 'bolt11'],
+      ['mint-op-bolt12', 'bolt12'],
+    ] as const) {
+      await bus.emit('mint-op:requeue', {
+        mintUrl: 'https://mint.test',
+        operationId,
+        operation: {
+          id: operationId,
+          mintUrl: 'https://mint.test',
+          method,
+        } as CoreEvents['mint-op:requeue']['operation'],
+      });
+    }
+
+    await nonBolt11Processed;
+
+    expect(turns.slice(0, 2)).toEqual(['bolt11', 'bolt12']);
   });
 
   it('processes all pending operations that share a paid quote', async () => {

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -217,12 +217,14 @@ describe('MintOperationProcessor', () => {
       const coordinateScheduledIssuance = mock(async () => {
         state = 'finalized';
       });
+      const unscheduleIssuance = mock(() => {});
       coordinateScheduledIssuance.mockImplementationOnce(async () => {
         state = stateAfterFailure;
         throw new NetworkError('transient issuance failure');
       });
       mockMintOperationService = {
         scheduleIssuance() {},
+        unscheduleIssuance,
         coordinateScheduledIssuance,
         async getOperation() {
           return operation();
@@ -262,6 +264,10 @@ describe('MintOperationProcessor', () => {
 
       expect(operation().state).toBe('finalized');
       expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(2);
+      expect(unscheduleIssuance).toHaveBeenCalledTimes(stateAfterFailure === 'pending' ? 1 : 0);
+      if (stateAfterFailure === 'pending') {
+        expect(unscheduleIssuance).toHaveBeenCalledWith(operation().id);
+      }
       await processor.stop();
     }
   });

--- a/packages/docs/pages/coco-config.md
+++ b/packages/docs/pages/coco-config.md
@@ -37,6 +37,8 @@ export interface CocoConfig {
       baseRetryDelayMs?: number;
       initialEnqueueDelayMs?: number;
       autoClaimMintQuotes?: boolean;
+      forceSingleRedemption?: boolean;
+      batchRedemptionDenylist?: string[];
     };
     meltSettlementProcessor?: {
       disabled?: boolean;
@@ -54,6 +56,11 @@ export interface CocoConfig {
 - outputDataCreator (optional): A session-wide strategy used only to construct Cashu output material. See [Custom output construction](#custom-output-construction).
 - watchers (optional): Can be used to disable or configure the available watchers. See [Watchers & Processors](./watchers-processors.md) for more information
 - processors (optional): Can be used to disable or configure the available processors. See [Watchers & Processors](./watchers-processors.md) for more information
+
+`mintOperationProcessor` uses NUT-29 Mint Batches by default when a trusted mint advertises
+compatible BOLT11 support. Set `forceSingleRedemption` to disable processor batch redemption
+globally, or list mint URLs in `batchRedemptionDenylist` to disable it for selected mints. Denylist
+URLs are normalized. These controls do not disable automatic settlement or NUT-29 quote checking.
 
 ## Custom output construction
 


### PR DESCRIPTION
## Parent map

- #332

## Slice

This pull request resolves #340.

## Summary

- Batch one bounded, compatible cohort of processor-selected paid BOLT11 Mint Operations through NUT-29 while keeping explicit execution target-scoped.
- Persist a single durable attempt with coalesced outputs, ordered quote amounts, exact proof provenance, post-commit independent outcomes/events, and attempt-level concurrent dispatch deduplication.
- Share learned NUT-29 limits with quote checking, add default-on force-single/normalized-denylist policy controls, and rotate both BOLT11 groups and ready non-BOLT11 processor work fairly.
- Preserve bounded retries for safely repeatable selected work, drain coordinator-rejected queue items, and retain eligible work not selected in the current turn, and clear selected coordinator schedules before backoff or removal.
- Document the public configuration and add a core patch changeset.

## Acceptance criteria

- [x] Default-on batching is gated to trusted mints currently advertising compatible NUT-29.
- [x] Global force-single and normalized-mint denylist controls leave auto settlement and batch quote checks enabled.
- [x] Admission requires pending, unattached, fixed, non-reusable BOLT11 operations backed by canonical PAID quotes.
- [x] Mint-scoped creation revalidates trust, capability, effective limit, members, quotes, keyset counter, mint/method/unit grouping, and deterministic order before commit.
- [x] Only no-argument processor turns can create multi-member attempts; singleton cohorts use single transport.
- [x] Batch attempts persist coalesced outputs and ordered quote amounts, respect learned effective limits, and save attempt-attributed proofs.
- [x] Each turn processes one bounded cohort, rotates BOLT11 groups, and yields to ready non-BOLT11 work.
- [x] Explicit targets create fresh single attempts when unattached, join attached processor attempts, deduplicate races, and return terminal state idempotently.
- [x] Quote, operation, proof, and attempt reconciliation is atomic; independent public events emit only after commit.
- [x] Processor cleanup distinguishes rejected, unselected, safely retryable, and deferred-recovery work.
- [x] Deterministic tests cover success, configuration, capability fallback/change, explicit immediacy, both concurrent-join races, chunking, retry handling, queue cleanup, and fairness.

## Validation

- `bun run --filter='@cashu/coco-core' test -- test/unit/MintIssuanceCoordinator.test.ts test/unit/MintQuoteProcessor.test.ts test/unit/MintOperationService.test.ts` - 121 passed
- `bun run --filter='@cashu/coco-core' test:unit` - 1,137 passed
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run typecheck`
- `bun run build`
- `bun run docs:build`
- `bun run --filter='@cashu/coco-core' test` - attempted; unit coverage passes, while the environment-dependent integration portion reports 6 failures / 3 setup errors because local mint/auth services and required integration configuration are unavailable (including live invoice reuse in pause/resume coverage).
- Parallel Standards and Spec reviews: no remaining hard violation or acceptance gap.

## Review boundaries

- Submitted or recovering Mint Batch exact-attempt recovery remains in #342.
- Redemption-endpoint NUT-29 incompatibility fallback remains in #341; quote-polling incompatibility is endpoint-specific.

## Changeset

- Added `.changeset/processor-mint-batches.md` for `@cashu/coco-core`.

