### PR TITLE
feat(core): recover confirmed mint batch rejections

### DIFF
--- a/.changeset/recover-confirmed-mint-batches.md
+++ b/.changeset/recover-confirmed-mint-batches.md
@@ -1,0 +1,9 @@
+---
+'@cashu/coco-core': major
+---
+
+Recover conclusively unissued NUT-29 Mint Batches through canonical quote observations and fresh
+attempts. Confirmed size, compatibility, state, and validation rejections now rechunk or fall back
+without reusing outputs or counters, while ambiguous submissions preserve exact recovery state.
+Repository adapters must implement `listByMintUrl` for durable Mint Issuance Attempt policy
+recovery.

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -490,12 +490,17 @@ export async function runMintIssuanceAttemptRepositoryContract(
         const all = await repositories.mintIssuanceAttemptRepository.listRecoverable();
         const mintOnly =
           await repositories.mintIssuanceAttemptRepository.listRecoverable('https://mint.test/');
+        const mintHistory =
+          await repositories.mintIssuanceAttemptRepository.listByMintUrl('https://mint.test/');
 
         expect(all.map((attempt) => attempt.id).join(',')).toBe(
           'submitting,recovering,prepared,other-mint',
         );
         expect(mintOnly.map((attempt) => attempt.id).join(',')).toBe(
           'submitting,recovering,prepared',
+        );
+        expect(mintHistory.map((attempt) => attempt.id).join(',')).toBe(
+          'submitting,recovering,prepared,succeeded',
         );
         expect(all[3]?.mintUrl).toBe('https://other-mint.test');
       } finally {

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -1026,6 +1026,7 @@ export class Manager {
       logger: mintIssuanceLogger,
       mintScopedLock,
       nut29BatchLimitCache,
+      mintQuotePollingChecker: quoteLifecycle,
     });
     const mintOperationService = new MintOperationService(
       mintHandlerProvider,

--- a/packages/core/operations/mint/MintIssuanceAttempt.ts
+++ b/packages/core/operations/mint/MintIssuanceAttempt.ts
@@ -30,7 +30,7 @@ export type MintIssuanceRequestMetadata =
       quoteAmounts: Amount[];
     };
 
-/** Structured terminal failure retained with a rejected or locally failed attempt. */
+/** Structured rejection/recovery classification or terminal local failure metadata. */
 export interface MintIssuanceAttemptError {
   message: string;
   code?: string;

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -3,14 +3,16 @@ import type { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
+import type { MintQuotePollingChecker } from '../../infra/MintQuotePollingChecker.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { Logger } from '../../logging/Logger.ts';
-import { MintOperationError, UnknownMintError } from '../../models/Error.ts';
+import { HttpResponseError, MintOperationError, UnknownMintError } from '../../models/Error.ts';
 import {
   getMintQuoteAmount,
   getMintQuoteRemoteState,
   type MintQuote,
 } from '../../models/MintQuote.ts';
+import { isMintQuoteExpired } from '../../models/MintQuoteExpiry.ts';
 import {
   getNut29MintQuoteCheckLimit,
   Nut29BatchLimitCache,
@@ -25,6 +27,7 @@ import {
   generateSubId,
   mapProofToCoreProof,
   normalizeMintUrl,
+  serializeOutputData,
 } from '../../utils.ts';
 import { MintScopedLock } from '../MintScopedLock.ts';
 import type { MintIssuanceAttempt } from './MintIssuanceAttempt.ts';
@@ -54,6 +57,7 @@ interface MintIssuanceCoordinatorOptions {
   logger?: Logger;
   mintScopedLock?: MintScopedLock;
   nut29BatchLimitCache?: Nut29BatchLimitCache;
+  mintQuotePollingChecker?: MintQuotePollingChecker;
 }
 
 type CreatedAttempt =
@@ -67,6 +71,62 @@ type CreatedAttempt =
       operations: ExecutingMintOperationRecord<'bolt11'>[];
       newlyCreated: true;
     };
+
+type ConfirmedBatchRejectionKind = 'state' | 'batch-size' | 'incompatibility' | 'validation';
+
+interface ConfirmedBatchRejection {
+  kind: ConfirmedBatchRejectionKind;
+  error: Error;
+  protocolCode?: number;
+  httpStatus?: number;
+}
+
+const CONFIRMED_BATCH_REJECTION_CODE = 'CONFIRMED_BATCH_REJECTION';
+const AUTHENTICATION_ERROR_CODE_MIN = 30_000;
+const NUT29_BATCH_SIZE_ERROR_CODE = 11_017;
+const MINT_QUOTE_STATE_ERROR_CODES = new Set([20_001, 20_002]);
+const INCOMPATIBLE_ENDPOINT_STATUSES = new Set([404, 405, 501]);
+const CONFIRMED_BATCH_REJECTION_KINDS: ConfirmedBatchRejectionKind[] = [
+  'state',
+  'batch-size',
+  'incompatibility',
+  'validation',
+];
+
+interface ConfirmedBatchRejectionProgress {
+  kind: ConfirmedBatchRejectionKind;
+  observedQuoteIds: string[];
+  capabilityUpdatedAt?: number;
+  replacementBatchLimit?: number;
+}
+
+function isConfirmedBatchRejectionKind(value: unknown): value is ConfirmedBatchRejectionKind {
+  return (
+    typeof value === 'string' && CONFIRMED_BATCH_REJECTION_KINDS.some((kind) => kind === value)
+  );
+}
+
+function getConfirmedBatchRejectionProgress(
+  attempt: MintIssuanceAttempt,
+): ConfirmedBatchRejectionProgress | null {
+  if (attempt.terminalError?.code !== CONFIRMED_BATCH_REJECTION_CODE) return null;
+  const details = attempt.terminalError.details;
+  const kind = details?.kind;
+  if (!isConfirmedBatchRejectionKind(kind)) return null;
+  const observedQuoteIds = details?.observedQuoteIds;
+  return {
+    kind,
+    observedQuoteIds: Array.isArray(observedQuoteIds)
+      ? observedQuoteIds.filter((quoteId): quoteId is string => typeof quoteId === 'string')
+      : [],
+    capabilityUpdatedAt:
+      typeof details?.capabilityUpdatedAt === 'number' ? details.capabilityUpdatedAt : undefined,
+    replacementBatchLimit:
+      typeof details?.replacementBatchLimit === 'number'
+        ? details.replacementBatchLimit
+        : undefined,
+  };
+}
 
 export interface ProcessorRedemptionOptions {
   /** Force every processor turn to create at most a single-member attempt. */
@@ -101,8 +161,11 @@ export class MintIssuanceCoordinator {
   private readonly logger?: Logger;
   private readonly mintScopedLock: MintScopedLock;
   private readonly nut29BatchLimitCache: Nut29BatchLimitCache;
+  private readonly mintQuotePollingChecker?: MintQuotePollingChecker;
   private readonly scheduledOperationIds = new Set<string>();
   private readonly scheduledNotBefore = new Map<string, number>();
+  private readonly singleFallbackOperationIds = new Set<string>();
+  private readonly incompatibleRedemptionGroups = new Set<string>();
   private readonly activeByOperationId: Map<string, Promise<MintOperation>>;
   private readonly activeByAttemptId: Map<string, Promise<void>>;
   private forceSingleRedemption = false;
@@ -127,6 +190,7 @@ export class MintIssuanceCoordinator {
     this.logger = options.logger;
     this.mintScopedLock = options.mintScopedLock ?? new MintScopedLock();
     this.nut29BatchLimitCache = options.nut29BatchLimitCache ?? new Nut29BatchLimitCache();
+    this.mintQuotePollingChecker = options.mintQuotePollingChecker;
   }
 
   /** Adds a Mint Operation to the ephemeral processor-ready pool. */
@@ -189,7 +253,9 @@ export class MintIssuanceCoordinator {
     const attempt = await this.repositories.mintIssuanceAttemptRepository.getById(
       operation.attemptId,
     );
-    if (!attempt || isTerminalAttempt(attempt)) return false;
+    if (!attempt) return false;
+    if (this.isConfirmedBatchRejection(attempt)) return true;
+    if (isTerminalAttempt(attempt)) return false;
     return attempt.request.kind !== 'batch' || attempt.state === 'prepared';
   }
 
@@ -215,12 +281,20 @@ export class MintIssuanceCoordinator {
       );
     });
 
+    let deferredRejectedOperationId: string | undefined;
     for (const { operationId, operation } of scheduled) {
       if (!operation || isTerminalOperation(operation)) {
         this.unschedule(operationId);
         continue;
       }
       if (operation.attemptId) {
+        const attempt = await this.repositories.mintIssuanceAttemptRepository.getById(
+          operation.attemptId,
+        );
+        if (attempt && this.isConfirmedBatchRejection(attempt)) {
+          deferredRejectedOperationId ??= operationId;
+          continue;
+        }
         this.lastProcessorSelection.add(operationId);
         this.unschedule(operationId);
         await this.coordinate(operationId);
@@ -250,7 +324,14 @@ export class MintIssuanceCoordinator {
       }
       candidates.push(bolt11Operation);
     }
-    if (candidates.length === 0) return;
+    if (candidates.length === 0) {
+      if (deferredRejectedOperationId) {
+        this.lastProcessorSelection.add(deferredRejectedOperationId);
+        this.unschedule(deferredRejectedOperationId);
+        await this.coordinate(deferredRejectedOperationId);
+      }
+      return;
+    }
 
     const groups = new Map<string, PendingMintOperationRecord<'bolt11'>[]>();
     for (const candidate of candidates) {
@@ -266,10 +347,15 @@ export class MintIssuanceCoordinator {
       (left, right) => left.createdAt - right.createdAt || left.id.localeCompare(right.id),
     );
     this.lastProcessorSelection = new Set(group.map((operation) => operation.id));
+    await this.restoreConfirmedRejectionPolicies(group);
 
-    const limit = await this.getProcessorBatchLimit(group[0]!.mintUrl);
+    const forcedSingle = group.find((operation) =>
+      this.singleFallbackOperationIds.has(operation.id),
+    );
+    const selectionPool = forcedSingle ? [forcedSingle] : group;
+    const limit = forcedSingle ? 1 : await this.getProcessorBatchLimit(group[0]!.mintUrl);
     const uniqueQuoteIds = new Set<string>();
-    const selected = group
+    const selected = selectionPool
       .filter((operation) => {
         if (uniqueQuoteIds.has(operation.quoteId)) return false;
         uniqueQuoteIds.add(operation.quoteId);
@@ -277,7 +363,7 @@ export class MintIssuanceCoordinator {
       })
       .slice(0, limit);
     this.lastProcessorSelection = new Set(selected.map((operation) => operation.id));
-    const created = await this.createBolt11Attempt(selected, selected.length > 1);
+    const created = await this.createBolt11Attempt(selected, selected.length > 1 && !forcedSingle);
     if (!created.newlyCreated) {
       this.lastProcessorSelection = new Set([created.operationId]);
       this.unschedule(created.operationId);
@@ -286,6 +372,7 @@ export class MintIssuanceCoordinator {
     }
     this.lastProcessorSelection = new Set(created.operations.map((operation) => operation.id));
     for (const operation of created.operations) {
+      this.singleFallbackOperationIds.delete(operation.id);
       this.unschedule(operation.id);
     }
 
@@ -311,6 +398,7 @@ export class MintIssuanceCoordinator {
         const completed = await this.requireOperation(operation.id);
         return toMintOperation(completed);
       });
+      void join.catch(() => undefined);
       joins.set(operation.id, join);
       this.activeByOperationId.set(operation.id, join);
     }
@@ -333,6 +421,47 @@ export class MintIssuanceCoordinator {
     return `${normalizeMintUrl(operation.mintUrl)}::bolt11::${operation.unit}`;
   }
 
+  private async restoreConfirmedRejectionPolicies(
+    operations: PendingMintOperationRecord<'bolt11'>[],
+  ): Promise<void> {
+    const mintUrl = normalizeMintUrl(operations[0]!.mintUrl);
+    const groupKey = mintQuoteGroupKey(mintUrl, 'bolt11');
+    this.incompatibleRedemptionGroups.delete(groupKey);
+    const [mint, mintAttempts] = await Promise.all([
+      this.repositories.mintRepository.getMintByUrl(mintUrl),
+      this.repositories.mintIssuanceAttemptRepository.listByMintUrl(mintUrl),
+    ]);
+
+    for (const attempt of mintAttempts) {
+      if (attempt.method !== 'bolt11' || attempt.state !== 'rejected') continue;
+      const progress = getConfirmedBatchRejectionProgress(attempt);
+      if (!progress || progress.kind === 'validation') continue;
+      const capabilityHasRefreshed =
+        mint !== null &&
+        progress.capabilityUpdatedAt !== undefined &&
+        mint.updatedAt > progress.capabilityUpdatedAt;
+      if (capabilityHasRefreshed) continue;
+      if (progress.kind === 'incompatibility') {
+        this.incompatibleRedemptionGroups.add(groupKey);
+      } else if (progress.replacementBatchLimit !== undefined) {
+        this.nut29BatchLimitCache.lower(groupKey, progress.replacementBatchLimit);
+      }
+    }
+
+    for (const operation of operations) {
+      this.singleFallbackOperationIds.delete(operation.id);
+      const previousAttempt =
+        await this.repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operation.id);
+      if (!previousAttempt || previousAttempt.state !== 'rejected') continue;
+      const progress = getConfirmedBatchRejectionProgress(previousAttempt);
+      if (!progress) continue;
+
+      if (progress.kind === 'validation') {
+        this.singleFallbackOperationIds.add(operation.id);
+      }
+    }
+  }
+
   /** Removes a Mint Operation from the ephemeral processor-ready pool. */
   unschedule(operationId: string): void {
     this.scheduledOperationIds.delete(operationId);
@@ -350,19 +479,18 @@ export class MintIssuanceCoordinator {
 
   private async getProcessorBatchLimit(mintUrl: string): Promise<number> {
     const normalizedMintUrl = normalizeMintUrl(mintUrl);
+    const groupKey = mintQuoteGroupKey(normalizedMintUrl, 'bolt11');
     if (
       this.forceSingleRedemption ||
       this.batchRedemptionDenylist.has(normalizedMintUrl) ||
+      this.incompatibleRedemptionGroups.has(groupKey) ||
       !(await this.mintService.isTrustedMint(normalizedMintUrl))
     ) {
       return 1;
     }
     const mintInfo = await this.mintService.getMintInfo(normalizedMintUrl);
     const advertisedLimit = getNut29MintQuoteCheckLimit(mintInfo, 'bolt11') ?? 1;
-    return this.nut29BatchLimitCache.get(
-      mintQuoteGroupKey(normalizedMintUrl, 'bolt11'),
-      advertisedLimit,
-    );
+    return this.nut29BatchLimitCache.get(groupKey, advertisedLimit);
   }
 
   private isEligibleProcessorCandidate(
@@ -414,6 +542,10 @@ export class MintIssuanceCoordinator {
       case 'submitting':
       case 'recovering':
         if (attempt.request.kind === 'batch') {
+          if (this.isConfirmedBatchRejection(attempt)) {
+            const members = await this.requireExecutingBolt11Members(attempt);
+            return this.reconcileConfirmedBatchRejection(attempt, members, operationId);
+          }
           throw new Error(`Mint Batch ${attempt.id} requires exact-attempt recovery`);
         }
         return this.reconcileSingleAttempt(attempt, operation);
@@ -426,7 +558,19 @@ export class MintIssuanceCoordinator {
         }
         return toMintOperation(completed);
       }
-      case 'rejected':
+      case 'rejected': {
+        if (
+          this.isConfirmedBatchRejection(attempt) &&
+          operation.state === 'executing' &&
+          operation.attemptId === attempt.id
+        ) {
+          const members = await this.getUnreconciledBolt11Members(attempt);
+          return this.reconcileConfirmedBatchRejection(attempt, members, operationId);
+        }
+        const completed = await this.requireOperation(operationId);
+        if (isTerminalOperation(completed)) return toMintOperation(completed);
+        throw new Error(`Rejected attempt ${attempt.id} has non-terminal operation ${operationId}`);
+      }
       case 'failed': {
         const completed = await this.requireOperation(operationId);
         if (isTerminalOperation(completed)) return toMintOperation(completed);
@@ -483,15 +627,18 @@ export class MintIssuanceCoordinator {
         throw new UnknownMintError(`Mint ${mintUrl} is not trusted`);
       }
       let revalidatedLimit = 1;
-      if (allowBatch && !this.forceSingleRedemption && !this.batchRedemptionDenylist.has(mintUrl)) {
+      const groupKey = mintQuoteGroupKey(mintUrl, 'bolt11');
+      if (
+        allowBatch &&
+        !this.forceSingleRedemption &&
+        !this.batchRedemptionDenylist.has(mintUrl) &&
+        !this.incompatibleRedemptionGroups.has(groupKey)
+      ) {
         const mintInfo = await this.mintService.getMintInfo(mintUrl);
         const advertisedLimit = supportsNut29MintQuoteCheck(mintInfo, 'bolt11')
           ? (getNut29MintQuoteCheckLimit(mintInfo, 'bolt11') ?? 1)
           : 1;
-        revalidatedLimit = this.nut29BatchLimitCache.get(
-          mintQuoteGroupKey(mintUrl, 'bolt11'),
-          advertisedLimit,
-        );
+        revalidatedLimit = this.nut29BatchLimitCache.get(groupKey, advertisedLimit);
       }
       currentCandidates = currentCandidates.slice(0, revalidatedLimit);
       const first = currentCandidates[0]! as PendingMintOperationRecord<'bolt11'>;
@@ -692,6 +839,20 @@ export class MintIssuanceCoordinator {
     });
   }
 
+  private async getUnreconciledBolt11Members(
+    attempt: MintIssuanceAttempt,
+  ): Promise<ExecutingMintOperationRecord<'bolt11'>[]> {
+    const operations = await Promise.all(
+      attempt.memberOperationIds.map((operationId) => this.requireOperation(operationId)),
+    );
+    return operations.filter(
+      (operation): operation is ExecutingMintOperationRecord<'bolt11'> =>
+        operation.state === 'executing' &&
+        operation.method === 'bolt11' &&
+        operation.attemptId === attempt.id,
+    );
+  }
+
   private assertEligibleSingleQuote(
     operation: PendingMintOperationRecord<'bolt11'>,
     quote: MintQuote | null,
@@ -782,6 +943,224 @@ export class MintIssuanceCoordinator {
     }
   }
 
+  private classifyConfirmedBatchRejection(error: unknown): ConfirmedBatchRejection | null {
+    if (error instanceof HttpResponseError && INCOMPATIBLE_ENDPOINT_STATUSES.has(error.status)) {
+      return { kind: 'incompatibility', error, httpStatus: error.status };
+    }
+    if (!(error instanceof MintOperationError) || error.code >= AUTHENTICATION_ERROR_CODE_MIN) {
+      return null;
+    }
+    if (error.code === NUT29_BATCH_SIZE_ERROR_CODE) {
+      return { kind: 'batch-size', error, protocolCode: error.code };
+    }
+    if (MINT_QUOTE_STATE_ERROR_CODES.has(error.code)) {
+      return { kind: 'state', error, protocolCode: error.code };
+    }
+    return { kind: 'validation', error, protocolCode: error.code };
+  }
+
+  private isConfirmedBatchRejection(attempt: MintIssuanceAttempt): boolean {
+    return getConfirmedBatchRejectionProgress(attempt) !== null;
+  }
+
+  private async markConfirmedBatchRejection(
+    attempt: MintIssuanceAttempt,
+    rejection: ConfirmedBatchRejection,
+  ): Promise<MintIssuanceAttempt> {
+    return this.repositories.withTransaction(async (tx) => {
+      const current = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+      if (!current) throw new Error(`Mint issuance attempt ${attempt.id} no longer exists`);
+      if (isTerminalAttempt(current)) return current;
+      const mint = await tx.mintRepository.getMintByUrl(current.mintUrl);
+      const now = Date.now();
+      const rejected: MintIssuanceAttempt = {
+        ...current,
+        state: 'rejected',
+        recoveryStartedAt: current.recoveryStartedAt ?? now,
+        updatedAt: now,
+        terminalError: {
+          message: rejection.error.message,
+          code: CONFIRMED_BATCH_REJECTION_CODE,
+          details: {
+            kind: rejection.kind,
+            protocolCode: rejection.protocolCode,
+            httpStatus: rejection.httpStatus,
+            observedQuoteIds: [],
+            capabilityUpdatedAt: mint?.updatedAt,
+            replacementBatchLimit:
+              rejection.kind === 'batch-size'
+                ? Math.max(1, Math.floor(current.memberOperationIds.length / 2))
+                : undefined,
+          },
+        },
+      };
+      await tx.mintIssuanceAttemptRepository.update(rejected);
+      return rejected;
+    });
+  }
+
+  /**
+   * Reconciles only conclusively unissued batches. Canonical quote observations commit before any
+   * member advances; the attempt is already terminal before any observed member is requeued; and
+   * missing members remain attached for later checks without blocking fresh-output replacements.
+   */
+  private async reconcileConfirmedBatchRejection(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    targetOperationId: string,
+  ): Promise<MintOperation> {
+    const progress = getConfirmedBatchRejectionProgress(attempt);
+    if (!progress) throw new Error(`Mint Batch ${attempt.id} lost its rejection classification`);
+    const { kind } = progress;
+    const observedQuoteIds = new Set(progress.observedQuoteIds);
+    const unreconciledQuoteIds = attempt.quoteIds.filter(
+      (quoteId) => !observedQuoteIds.has(quoteId),
+    );
+    const newlyObservedQuoteIds = new Set<string>();
+    if (kind === 'state' || kind === 'validation') {
+      if (!this.mintQuotePollingChecker) {
+        throw new Error(`Mint Batch ${attempt.id} cannot recheck its canonical quotes`);
+      }
+      const result = await this.mintQuotePollingChecker.checkMintQuotesForPolling(
+        attempt.mintUrl,
+        'bolt11',
+        unreconciledQuoteIds,
+      );
+      for (const observation of result.observations) {
+        if (unreconciledQuoteIds.includes(observation.quote)) {
+          newlyObservedQuoteIds.add(observation.quote);
+        }
+      }
+    } else {
+      for (const quoteId of unreconciledQuoteIds) newlyObservedQuoteIds.add(quoteId);
+    }
+    if (newlyObservedQuoteIds.size === 0) {
+      return toMintOperation(await this.requireOperation(targetOperationId));
+    }
+
+    const quotesById = new Map<string, MintQuote<'bolt11'>>();
+    for (const quoteId of newlyObservedQuoteIds) {
+      const quote = await this.repositories.mintQuoteRepository.getMintQuote(
+        attempt.mintUrl,
+        'bolt11',
+        quoteId,
+      );
+      if (!quote || quote.method !== 'bolt11') {
+        throw new Error(`Mint Batch ${attempt.id} lost canonical quote ${quoteId}`);
+      }
+      quotesById.set(quoteId, quote);
+    }
+
+    const now = Date.now();
+    const reconciled = await this.repositories.withTransaction(async (tx) => {
+      const currentAttempt = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+      if (!currentAttempt) throw new Error(`Mint issuance attempt ${attempt.id} no longer exists`);
+      const currentProgress = getConfirmedBatchRejectionProgress(currentAttempt);
+      if (!currentProgress) {
+        throw new Error(`Mint Batch ${attempt.id} lost its rejection classification`);
+      }
+      const currentObservedQuoteIds = new Set(currentProgress.observedQuoteIds);
+      const pendingOperations: PendingMintOperationRecord<'bolt11'>[] = [];
+      const failedOperations: FailedMintOperationRecord<'bolt11'>[] = [];
+      for (const operation of operations) {
+        const memberIndex = attempt.memberOperationIds.indexOf(operation.id);
+        const quoteId = attempt.quoteIds[memberIndex];
+        if (!quoteId || !newlyObservedQuoteIds.has(quoteId)) continue;
+        const current = await tx.mintOperationRepository.getById(operation.id);
+        if (
+          !current ||
+          current.state !== 'executing' ||
+          current.method !== 'bolt11' ||
+          current.attemptId !== attempt.id
+        ) {
+          currentObservedQuoteIds.add(quoteId);
+          continue;
+        }
+        const executing = current as ExecutingMintOperationRecord<'bolt11'>;
+        const quote = quotesById.get(quoteId)!;
+        const remoteState = getMintQuoteRemoteState(quote);
+        if (remoteState === 'PAID' || (remoteState === 'UNPAID' && !isMintQuoteExpired(quote))) {
+          const pending: PendingMintOperationRecord<'bolt11'> = {
+            ...executing,
+            state: 'pending',
+            attemptId: undefined,
+            outputData: serializeOutputData({ keep: [], send: [] }),
+            error: undefined,
+            terminalFailure: undefined,
+            updatedAt: now,
+          };
+          await tx.mintOperationRepository.update(pending);
+          pendingOperations.push(pending);
+          currentObservedQuoteIds.add(quoteId);
+          continue;
+        }
+
+        const error =
+          remoteState === 'ISSUED'
+            ? `Mint quote ${current.quoteId} was issued but its exact proofs could not be recovered`
+            : `Mint quote ${current.quoteId} expired before issuance`;
+        const failed: FailedMintOperationRecord<'bolt11'> = {
+          ...executing,
+          state: 'failed',
+          attemptId: attempt.id,
+          outputData: attempt.outputData,
+          error,
+          terminalFailure: { reason: error, observedAt: now },
+          updatedAt: now,
+        };
+        await tx.mintOperationRepository.update(failed);
+        failedOperations.push(failed);
+        currentObservedQuoteIds.add(quoteId);
+      }
+      const rejectionReconciled = currentObservedQuoteIds.size === attempt.quoteIds.length;
+      const updatedAttempt: MintIssuanceAttempt = {
+        ...currentAttempt,
+        state: 'rejected',
+        updatedAt: now,
+        recoveredAt: rejectionReconciled ? now : currentAttempt.recoveredAt,
+        terminalError: {
+          ...currentAttempt.terminalError!,
+          details: {
+            ...currentAttempt.terminalError?.details,
+            observedQuoteIds: attempt.quoteIds.filter((quoteId) =>
+              currentObservedQuoteIds.has(quoteId),
+            ),
+          },
+        },
+      };
+      await tx.mintIssuanceAttemptRepository.update(updatedAttempt);
+      return { pendingOperations, failedOperations };
+    });
+    const groupKey = mintQuoteGroupKey(attempt.mintUrl, 'bolt11');
+    if (kind === 'batch-size' && progress.replacementBatchLimit !== undefined) {
+      this.nut29BatchLimitCache.lower(groupKey, progress.replacementBatchLimit);
+    }
+    if (kind === 'incompatibility') {
+      this.incompatibleRedemptionGroups.add(groupKey);
+    }
+    if (kind === 'validation') {
+      for (const operation of reconciled.pendingOperations) {
+        this.singleFallbackOperationIds.add(operation.id);
+      }
+    }
+    for (const operation of reconciled.pendingOperations) {
+      this.schedule(operation.id);
+      await this.eventBus.emit('mint-op:requeue', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
+    for (const operation of reconciled.failedOperations) {
+      await this.eventBus.emit('mint-op:failed', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
+    return toMintOperation(await this.requireOperation(targetOperationId));
+  }
+
   private async dispatchBatchAttempt(
     attempt: MintIssuanceAttempt,
     operations: ExecutingMintOperationRecord<'bolt11'>[],
@@ -829,6 +1208,11 @@ export class MintIssuanceCoordinator {
       this.assertExactProofSet(attempt, proofs);
       return this.completeBatchAttempt(attempt, operations, proofs, false, targetOperationId);
     } catch (error) {
+      const rejection = this.classifyConfirmedBatchRejection(error);
+      if (rejection) {
+        const recovering = await this.markConfirmedBatchRejection(submitting, rejection);
+        return this.reconcileConfirmedBatchRejection(recovering, operations, targetOperationId);
+      }
       const recovering = await this.markRecovering(submitting, error);
       if (isTerminalAttempt(recovering)) {
         return this.requireTerminalOperation(targetOperationId, recovering.id);

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -311,6 +311,8 @@ export interface MintIssuanceAttemptRepository {
   getById(id: string): Promise<MintIssuanceAttempt | null>;
   /** Returns the newest attempt containing the member, including historical rejected attempts. */
   getByMemberOperationId(operationId: string): Promise<MintIssuanceAttempt | null>;
+  /** Lists every attempt for a mint in deterministic creation order. */
+  listByMintUrl(mintUrl: string): Promise<MintIssuanceAttempt[]>;
   /** Lists prepared, possibly submitted, and recovering attempts in deterministic order. */
   listRecoverable(mintUrl?: string): Promise<MintIssuanceAttempt[]>;
 }

--- a/packages/core/repositories/memory/MemoryMintIssuanceAttemptRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintIssuanceAttemptRepository.ts
@@ -38,6 +38,14 @@ export class MemoryMintIssuanceAttemptRepository implements MintIssuanceAttemptR
     return attempts[0] ? normalizeMintIssuanceAttempt(attempts[0]) : null;
   }
 
+  async listByMintUrl(mintUrl: string): Promise<MintIssuanceAttempt[]> {
+    const normalizedMintUrl = normalizeMintUrl(mintUrl);
+    return Array.from(this.attempts.values())
+      .filter((attempt) => attempt.mintUrl === normalizedMintUrl)
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+      .map(normalizeMintIssuanceAttempt);
+  }
+
   async listRecoverable(mintUrl?: string): Promise<MintIssuanceAttempt[]> {
     const normalizedMintUrl = mintUrl ? normalizeMintUrl(mintUrl) : undefined;
     return Array.from(this.attempts.values())

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -5,8 +5,12 @@ import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
-import { MintOperationError, NetworkError } from '../../models/Error.ts';
-import { getMintQuoteRemoteState, mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
+import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error.ts';
+import {
+  getMintQuoteRemoteState,
+  mintQuoteFromBolt11Response,
+  mintQuoteToMethodSnapshot,
+} from '../../models/MintQuote.ts';
 import { MintScopedLock } from '../../operations/MintScopedLock.ts';
 import { MintIssuanceCoordinator } from '../../operations/mint/MintIssuanceCoordinator.ts';
 import type { MintIssuanceAttempt } from '../../operations/mint/MintIssuanceAttempt.ts';
@@ -42,6 +46,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
   let walletBatchMint: Mock<(preview: BatchMintPreview) => Promise<Proof[]>>;
   let createMintOutputsAtCounter: Mock<ProofService['createMintOutputsAtCounter']>;
   let getMintInfo: Mock<MintService['getMintInfo']>;
+  let checkMintQuoteBatch: Mock<MintAdapter['checkMintQuoteBatch']>;
   let nut29BatchLimitCache: Nut29BatchLimitCache;
   let coordinator: MintIssuanceCoordinator;
   let service: MintOperationService;
@@ -88,6 +93,31 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     updatedAt: Date.now(),
   });
 
+  async function seedPeerOperation(
+    peerQuoteId: string,
+    peerOperationId: string,
+    request: string,
+    createdAtOffset = 1,
+  ): Promise<void> {
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: peerQuoteId,
+        request,
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create({
+      ...pendingOperation(),
+      id: peerOperationId,
+      quoteId: peerQuoteId,
+      request,
+      createdAt: pendingOperation().createdAt + createdAtOffset,
+    });
+  }
+
   function createService(): MintOperationService {
     const handler = {
       checkPending: mock(async () => ({
@@ -121,6 +151,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       eventBus,
       mintScopedLock,
       nut29BatchLimitCache,
+      mintQuotePollingChecker: quoteLifecycle,
     });
 
     return new MintOperationService(
@@ -207,6 +238,19 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       createMintOutputsAtCounter,
       recoverProofsFromOutputData: mock(async () => []),
     } as unknown as ProofService;
+    checkMintQuoteBatch = mock(async (_mintUrl, method, quoteIds: string[]) =>
+      Promise.all(
+        quoteIds.map(async (requestedQuoteId) => {
+          const quote = await repositories.mintQuoteRepository.getMintQuote(
+            mintUrl,
+            method,
+            requestedQuoteId,
+          );
+          if (!quote) throw new Error(`Missing test quote ${requestedQuoteId}`);
+          return mintQuoteToMethodSnapshot(quote);
+        }),
+      ),
+    );
     mintAdapter = {
       checkMintQuote: mock(async () => ({
         quote: quoteId,
@@ -216,6 +260,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         expiry: Math.floor(Date.now() / 1000) + 3600,
         state: 'PAID' as const,
       })),
+      checkMintQuoteBatch,
     } as unknown as MintAdapter;
 
     await repositories.mintRepository.addNewMint({
@@ -438,23 +483,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       secret: batchSecret,
       C: 'C_batch-output-secret',
     };
-    await repositories.mintQuoteRepository.upsertMintQuote(
-      mintQuoteFromBolt11Response(mintUrl, {
-        quote: peerQuoteId,
-        request: 'lnbc1peer',
-        amount: Amount.from(10),
-        unit: 'sat',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        state: 'PAID',
-      }),
-    );
-    await repositories.mintOperationRepository.create({
-      ...pendingOperation(),
-      id: peerOperationId,
-      quoteId: peerQuoteId,
-      request: 'lnbc1peer',
-      createdAt: pendingOperation().createdAt + 1,
-    });
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1peer');
     createMintOutputsAtCounter.mockResolvedValueOnce({
       keysetId,
       outputData: batchOutputData,
@@ -490,6 +519,473 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         quote_amounts: [Amount.from(10), Amount.from(10)],
       },
     });
+  });
+
+  it('requeues a conclusively unissued Mint Batch and succeeds through fresh outputs', async () => {
+    const peerQuoteId = 'quote-peer';
+    const peerOperationId = 'operation-peer';
+    const rejectedOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_rejected-batch-output' },
+          2n,
+          new TextEncoder().encode('rejected-batch-output'),
+        ),
+      ],
+      send: [],
+    });
+    const freshOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_fresh-batch-output' },
+          3n,
+          new TextEncoder().encode('fresh-batch-output'),
+        ),
+      ],
+      send: [],
+    });
+    const freshProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: 'fresh-batch-output',
+      C: 'C_fresh-batch-output',
+    };
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1peer');
+    createMintOutputsAtCounter
+      .mockResolvedValueOnce({
+        keysetId,
+        outputData: rejectedOutputData,
+        counterStart: 0,
+        counterEnd: 1,
+      })
+      .mockResolvedValueOnce({
+        keysetId,
+        outputData: freshOutputData,
+        counterStart: 1,
+        counterEnd: 2,
+      });
+    walletBatchMint
+      .mockRejectedValueOnce(new MintOperationError(20001, 'Mint quote is not paid'))
+      .mockResolvedValueOnce([freshProof]);
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const rejectedOperation = await repositories.mintOperationRepository.getById(operationId);
+    const rejectedAttempt =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    expect(rejectedAttempt?.state).toBe('rejected');
+    expect(rejectedOperation).toMatchObject({ state: 'pending', attemptId: undefined });
+    expect(await repositories.mintOperationRepository.getById(peerOperationId)).toMatchObject({
+      state: 'pending',
+      attemptId: undefined,
+    });
+
+    await coordinator.coordinate();
+
+    const completedOperation = await repositories.mintOperationRepository.getById(operationId);
+    const freshAttempt = await repositories.mintIssuanceAttemptRepository.getById(
+      completedOperation!.attemptId!,
+    );
+    expect(freshAttempt).toMatchObject({ state: 'succeeded', counterStart: 1, counterEnd: 2 });
+    expect(freshAttempt?.id).not.toBe(rejectedAttempt?.id);
+    expect(freshAttempt?.outputData).toEqual(freshOutputData);
+    expect(freshAttempt?.outputData).not.toEqual(rejectedOutputData);
+    expect((await repositories.counterRepository.getCounter(mintUrl, keysetId))?.counter).toBe(2);
+  });
+
+  it('isolates invalid recovery checks and reconciles each observed quote independently', async () => {
+    const peerQuoteId = 'quote-invalid-peer';
+    const peerOperationId = 'operation-invalid-peer';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_isolated-batch-output' },
+          4n,
+          new TextEncoder().encode('isolated-batch-output'),
+        ),
+      ],
+      send: [],
+    });
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1invalidpeer');
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+    walletBatchMint.mockRejectedValueOnce(new MintOperationError(20002, 'Quote state conflict'));
+    checkMintQuoteBatch.mockImplementation(
+      async (_mint: string, _method: string, quoteIds: string[]) => {
+        if (quoteIds.includes(peerQuoteId)) {
+          throw new MintOperationError(10000, 'invalid quote in recovery check');
+        }
+        return [
+          {
+            ...mintQuoteToMethodSnapshot(
+              (await repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', quoteId))!,
+            ),
+            state: 'ISSUED',
+          },
+        ];
+      },
+    );
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const rejected =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    expect(rejected?.state).toBe('rejected');
+    expect(rejected?.terminalError?.details?.observedQuoteIds).toEqual([quoteId]);
+    expect((await repositories.mintOperationRepository.getById(operationId))?.state).toBe('failed');
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'executing',
+    );
+    expect(
+      getMintQuoteRemoteState(
+        (await repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', peerQuoteId))!,
+      ),
+    ).toBe('PAID');
+
+    checkMintQuoteBatch.mockResolvedValue([]);
+
+    await coordinator.coordinate(peerOperationId);
+
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'executing',
+    );
+    expect(
+      (await repositories.mintIssuanceAttemptRepository.getById(rejected!.id))?.terminalError
+        ?.details?.observedQuoteIds,
+    ).toEqual([quoteId]);
+  });
+
+  it('lowers the effective limit and rechunks a rejected Mint Batch with fresh counters', async () => {
+    const peerQuoteId = 'quote-limit-peer';
+    const peerOperationId = 'operation-limit-peer';
+    const rejectedOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_limit-rejected-output' },
+          5n,
+          new TextEncoder().encode('limit-rejected-output'),
+        ),
+      ],
+      send: [],
+    });
+    const freshOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(10), id: keysetId, B_: 'B_limit-fresh-output' },
+          6n,
+          new TextEncoder().encode('limit-fresh-output'),
+        ),
+      ],
+      send: [],
+    });
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1limitpeer');
+    createMintOutputsAtCounter
+      .mockResolvedValueOnce({
+        keysetId,
+        outputData: rejectedOutputData,
+        counterStart: 0,
+        counterEnd: 1,
+      })
+      .mockResolvedValueOnce({
+        keysetId,
+        outputData: freshOutputData,
+        counterStart: 1,
+        counterEnd: 2,
+      });
+    walletBatchMint.mockRejectedValueOnce(new MintOperationError(11017, 'Batch too large'));
+    walletMint.mockResolvedValueOnce([
+      {
+        id: keysetId,
+        amount: Amount.from(10),
+        secret: 'limit-fresh-output',
+        C: 'C_limit-fresh-output',
+      },
+    ]);
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const rejected =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    expect(rejected?.state).toBe('rejected');
+    expect(nut29BatchLimitCache.get(mintQuoteGroupKey(mintUrl, 'bolt11'), 100)).toBe(1);
+
+    nut29BatchLimitCache = new Nut29BatchLimitCache();
+    service = createService();
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    const first = await repositories.mintOperationRepository.getById(operationId);
+    const peer = await repositories.mintOperationRepository.getById(peerOperationId);
+    const replacement = await repositories.mintIssuanceAttemptRepository.getById(first!.attemptId!);
+    expect(first?.state).toBe('finalized');
+    expect(peer?.state).toBe('pending');
+    expect(replacement).toMatchObject({
+      state: 'succeeded',
+      request: { kind: 'single', quoteId },
+      counterStart: 1,
+      counterEnd: 2,
+    });
+    expect(replacement?.outputData).not.toEqual(rejectedOutputData);
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+  });
+
+  it('falls back directly to fresh singles after one validation eligibility recheck', async () => {
+    const peerQuoteId = 'quote-validation-peer';
+    const peerOperationId = 'operation-validation-peer';
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1validationpeer');
+    const attempts = [
+      { secret: 'validation-rejected', amount: 20 },
+      { secret: 'validation-single-a', amount: 10 },
+      { secret: 'validation-single-b', amount: 10 },
+    ];
+    createMintOutputsAtCounter.mockImplementation(async (_mint, _intent, counterStart: number) => {
+      const fixture = attempts[counterStart]!;
+      return {
+        keysetId,
+        outputData: serializeOutputData({
+          keep: [
+            new OutputData(
+              {
+                amount: Amount.from(fixture.amount),
+                id: keysetId,
+                B_: `B_${fixture.secret}`,
+              },
+              BigInt(counterStart + 10),
+              new TextEncoder().encode(fixture.secret),
+            ),
+          ],
+          send: [],
+        }),
+        counterStart,
+        counterEnd: counterStart + 1,
+      };
+    });
+    walletBatchMint.mockRejectedValueOnce(
+      new MintOperationError(10000, 'Invalid batch redemption request'),
+    );
+    walletMint
+      .mockResolvedValueOnce([
+        {
+          id: keysetId,
+          amount: Amount.from(10),
+          secret: 'validation-single-a',
+          C: 'C_validation-single-a',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: keysetId,
+          amount: Amount.from(10),
+          secret: 'validation-single-b',
+          C: 'C_validation-single-b',
+        },
+      ]);
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    nut29BatchLimitCache = new Nut29BatchLimitCache();
+    service = createService();
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+    await coordinator.coordinate();
+
+    expect((await repositories.mintOperationRepository.getById(operationId))?.state).toBe(
+      'finalized',
+    );
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'finalized',
+    );
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+    expect(walletMint).toHaveBeenCalledTimes(2);
+    expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledTimes(1);
+    expect((await repositories.counterRepository.getCounter(mintUrl, keysetId))?.counter).toBe(3);
+  });
+
+  it('uses fresh singles after endpoint incompatibility until capability refresh', async () => {
+    const peerQuoteId = 'quote-incompatible-peer';
+    const peerOperationId = 'operation-incompatible-peer';
+    const laterOperations = [
+      { quoteId: 'quote-incompatible-later-a', operationId: 'operation-incompatible-later-a' },
+      { quoteId: 'quote-incompatible-later-b', operationId: 'operation-incompatible-later-b' },
+      { quoteId: 'quote-incompatible-later-c', operationId: 'operation-incompatible-later-c' },
+    ];
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1incompatiblepeer');
+    const fixtures = [
+      { secret: 'incompatible-rejected', amount: 20 },
+      { secret: 'incompatible-single-a', amount: 10 },
+      { secret: 'incompatible-single-b', amount: 10 },
+      { secret: 'incompatible-later-single', amount: 10 },
+      { secret: 'incompatible-refreshed-batch', amount: 20 },
+    ];
+    createMintOutputsAtCounter.mockImplementation(async (_mint, _intent, counterStart: number) => {
+      const fixture = fixtures[counterStart]!;
+      return {
+        keysetId,
+        outputData: serializeOutputData({
+          keep: [
+            new OutputData(
+              {
+                amount: Amount.from(fixture.amount),
+                id: keysetId,
+                B_: `B_${fixture.secret}`,
+              },
+              BigInt(counterStart + 20),
+              new TextEncoder().encode(fixture.secret),
+            ),
+          ],
+          send: [],
+        }),
+        counterStart,
+        counterEnd: counterStart + 1,
+      };
+    });
+    walletBatchMint
+      .mockRejectedValueOnce(new HttpResponseError('NUT-29 method unavailable', 405))
+      .mockResolvedValueOnce([
+        {
+          id: keysetId,
+          amount: Amount.from(20),
+          secret: 'incompatible-refreshed-batch',
+          C: 'C_incompatible-refreshed-batch',
+        },
+      ]);
+    for (const secret of [
+      'incompatible-single-a',
+      'incompatible-single-b',
+      'incompatible-later-single',
+    ]) {
+      walletMint.mockResolvedValueOnce([
+        {
+          id: keysetId,
+          amount: Amount.from(10),
+          secret,
+          C: `C_${secret}`,
+        },
+      ]);
+    }
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+
+    nut29BatchLimitCache = new Nut29BatchLimitCache();
+    service = createService();
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await coordinator.coordinate();
+    await coordinator.coordinate();
+
+    expect((await repositories.mintOperationRepository.getById(operationId))?.state).toBe(
+      'finalized',
+    );
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'finalized',
+    );
+    expect(walletMint).toHaveBeenCalledTimes(2);
+
+    for (const [index, later] of laterOperations.entries()) {
+      await seedPeerOperation(
+        later.quoteId,
+        later.operationId,
+        `lnbc1incompatiblelater${index}`,
+        index + 2,
+      );
+    }
+
+    nut29BatchLimitCache = new Nut29BatchLimitCache();
+    service = createService();
+    for (const later of laterOperations) coordinator.schedule(later.operationId);
+    await coordinator.coordinate();
+
+    const beforeRefreshStates = await Promise.all(
+      laterOperations.map(
+        async ({ operationId: laterOperationId }) =>
+          (await repositories.mintOperationRepository.getById(laterOperationId))?.state,
+      ),
+    );
+    expect(beforeRefreshStates.filter((state) => state === 'finalized')).toHaveLength(1);
+    expect(beforeRefreshStates.filter((state) => state === 'pending')).toHaveLength(2);
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+    expect(walletMint).toHaveBeenCalledTimes(3);
+
+    const mintBeforeRefresh = await repositories.mintRepository.getMintByUrl(mintUrl);
+    await repositories.mintRepository.updateMint({
+      ...mintBeforeRefresh!,
+      updatedAt: mintBeforeRefresh!.updatedAt + 1,
+    });
+    await eventBus.emit('mint:updated', {
+      mint: await repositories.mintRepository.getMintByUrl(mintUrl),
+      keysets: [],
+    });
+    await coordinator.coordinate();
+
+    const afterRefreshStates = await Promise.all(
+      laterOperations.map(
+        async ({ operationId: laterOperationId }) =>
+          (await repositories.mintOperationRepository.getById(laterOperationId))?.state,
+      ),
+    );
+    expect(afterRefreshStates).toEqual(['finalized', 'finalized', 'finalized']);
+    expect(walletBatchMint).toHaveBeenCalledTimes(2);
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+  });
+
+  it('preserves an ambiguous Mint Batch without creating fallback attempts', async () => {
+    const peerQuoteId = 'quote-ambiguous-peer';
+    const peerOperationId = 'operation-ambiguous-peer';
+    const ambiguousOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: 'B_ambiguous-batch-output' },
+          30n,
+          new TextEncoder().encode('ambiguous-batch-output'),
+        ),
+      ],
+      send: [],
+    });
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1ambiguouspeer');
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: ambiguousOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+    walletBatchMint.mockRejectedValueOnce(new NetworkError('connection lost after submission'));
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await expect(coordinator.coordinate()).rejects.toThrow('connection lost after submission');
+
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    expect(attempt).toMatchObject({
+      state: 'recovering',
+      memberOperationIds: [operationId, peerOperationId],
+      outputData: ambiguousOutputData,
+    });
+    expect((await repositories.mintOperationRepository.getById(operationId))?.state).toBe(
+      'executing',
+    );
+    expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
+      'executing',
+    );
+    expect(await service.canRetryIssuance(operationId)).toBe(false);
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+    expect(createMintOutputsAtCounter).toHaveBeenCalledTimes(1);
   });
 
   it('retries single attempts while deferring ambiguous Mint Batch recovery', async () => {

--- a/packages/indexeddb/src/repositories/MintIssuanceAttemptRepository.ts
+++ b/packages/indexeddb/src/repositories/MintIssuanceAttemptRepository.ts
@@ -135,6 +135,17 @@ export class IdbMintIssuanceAttemptRepository implements MintIssuanceAttemptRepo
     return rows[0] ? rowToAttempt(rows[0]) : null;
   }
 
+  async listByMintUrl(mintUrl: string): Promise<MintIssuanceAttempt[]> {
+    const rows = (await this.db
+      .table('coco_cashu_mint_issuance_attempts')
+      .where('mintUrl')
+      .equals(normalizeMintUrl(mintUrl))
+      .toArray()) as MintIssuanceAttemptRow[];
+    return rows
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+      .map(rowToAttempt);
+  }
+
   async listRecoverable(mintUrl?: string): Promise<MintIssuanceAttempt[]> {
     const normalizedMintUrl = mintUrl ? normalizeMintUrl(mintUrl) : undefined;
     const rows = (await this.db

--- a/packages/sql-storage/src/repositories/MintIssuanceAttemptRepository.ts
+++ b/packages/sql-storage/src/repositories/MintIssuanceAttemptRepository.ts
@@ -177,6 +177,18 @@ export class SqliteMintIssuanceAttemptRepository implements MintIssuanceAttemptR
     return row ? rowToAttempt(row, await this.getMembers(row.id, this.db)) : null;
   }
 
+  async listByMintUrl(mintUrl: string): Promise<MintIssuanceAttempt[]> {
+    const rows = await this.db.all<AttemptRow>(
+      `SELECT * FROM coco_cashu_mint_issuance_attempts
+       WHERE mintUrl = ?
+       ORDER BY createdAt ASC, id ASC`,
+      [normalizeMintUrl(mintUrl)],
+    );
+    return Promise.all(
+      rows.map(async (row) => rowToAttempt(row, await this.getMembers(row.id, this.db))),
+    );
+  }
+
   async listRecoverable(mintUrl?: string): Promise<MintIssuanceAttempt[]> {
     const params: SqlValue[] = [];
     let where = "state IN ('prepared', 'submitting', 'recovering')";


### PR DESCRIPTION
## Problem

Confirmed atomic NUT-29 Mint Batch rejections left member operations attached to unusable attempt
outputs. Recovery needs to distinguish those rejections from ambiguous submissions, reconcile
canonical quote state independently, and continue claimable work without reusing counters or
blinded outputs.

Map: https://github.com/cashubtc/coco/issues/332  
Slice: https://github.com/cashubtc/coco/issues/341

This pull request resolves #341.

## Summary

- Classify confirmed state, size, validation, and endpoint incompatibility rejections while
  preserving ambiguous submissions for exact-attempt recovery.
- Mark rejected attempts terminal before independently reconciling attributable canonical quote
  observations and scheduling fresh attempts.
- Persist mint-wide rejection history so reduced limits and endpoint fallback survive restarts
  until capability refresh; keep validation fallback member-scoped.
- Allocate fresh outputs and counters for rechunked or single-member replacement attempts.
- Add deterministic coordinator and cross-adapter repository contract coverage.

Compatibility note: third-party repository adapters must implement
`MintIssuanceAttemptRepository.listByMintUrl()`.

## Acceptance criteria

- [x] Distinguish confirmed atomic non-issuance from ambiguous submission and limit fallback to the
  confirmed class.
- [x] Batch-check state-error members and apply canonical per-quote reconciliation.
- [x] Isolate validation-rejected recovery checks deterministically through the existing NUT-29
  quote-check transport.
- [x] Leave invalid or missing quotes without fabricated state and reconcile attributable peers.
- [x] Return claimable members to normal eligibility without artificial retry history.
- [x] Lower the cached effective limit after `11017` and rechunk deterministically.
- [x] Use fresh singles after confirmed endpoint/method incompatibility until capability refresh.
- [x] Use fresh singles after one eligibility recheck for other confirmed validation rejection.
- [x] Mark the rejected attempt terminal before replacement creation.
- [x] Allocate fresh outputs and counters for every replacement attempt.
- [x] Cover state changes, missing/invalid observations, check isolation, rechunking,
  incompatibility, direct single fallback, restart durability, and output/counter non-reuse.

## Review

- Standards: clean; no remaining actionable findings.
- Spec: clean against #341 and parent specification section 8.

## Verification

- `bun run build`
- `bun run typecheck`
- `bun run format:check`
- `bun run --filter='@cashu/coco-core' test:unit` (1,143 passed)
- `bun run --filter='@cashu/coco-core' test -- test/unit/MintIssuanceCoordinator.test.ts`
  (30 passed)
- SQLite3 adapter contract (65 passed)
- SQLite Bun adapter contract (65 passed)
- Expo SQLite adapter contract (67 passed)
- IndexedDB Chromium adapter contract (58 passed)
- React tests (49 passed)
- SQL storage tests (27 passed)

The all-tests commands were also run. Their self-contained tests passed, while external integration
suites requiring `MINT_URL`, a local mint at `localhost:3338`, or auth credentials could not run in
this environment. Core reported 1,147 passes before those four environment-dependent failures.

## Changeset

- Added `.changeset/recover-confirmed-mint-batches.md` with a major core release note for the
  required adapter interface method and confirmed-rejection behavior.
