### PR TITLE
feat(core): recover ambiguous mint issuance attempts

### DIFF
--- a/.changeset/recover-ambiguous-mint-batches.md
+++ b/.changeset/recover-ambiguous-mint-batches.md
@@ -3,4 +3,4 @@
 ---
 
 Recover ambiguous Mint Batches through attributable quote checks, identical resubmission, and exact
-NUT-09 output recovery while preserving atomic proof persistence and per-operation outcomes.
+NUT-09 output restoration while preserving atomic proof persistence and per-operation outcomes.

--- a/.changeset/recover-ambiguous-mint-batches.md
+++ b/.changeset/recover-ambiguous-mint-batches.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Recover ambiguous Mint Batches through attributable quote checks, identical resubmission, and exact
+NUT-09 output recovery while preserving atomic proof persistence and per-operation outcomes.

--- a/packages/core/models/MintIssuanceRetryError.ts
+++ b/packages/core/models/MintIssuanceRetryError.ts
@@ -1,0 +1,31 @@
+import { HttpResponseError, NetworkError } from './Error.ts';
+
+/** Signals that durable issuance state is intact and processor retry backoff should apply. */
+export class MintIssuanceRetryError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'MintIssuanceRetryError';
+    (this as unknown as { cause?: unknown }).cause = cause;
+  }
+}
+
+/** Recognizes retryable issuance failures through domain wrappers such as MintFetchError. */
+export function isRetryableMintIssuanceError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current = error;
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    if (
+      current instanceof MintIssuanceRetryError ||
+      current instanceof NetworkError ||
+      (current instanceof HttpResponseError && (current.status === 429 || current.status >= 500))
+    ) {
+      return true;
+    }
+    seen.add(current);
+    current =
+      typeof current === 'object' && 'cause' in current
+        ? (current as { cause?: unknown }).cause
+        : undefined;
+  }
+  return false;
+}

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -18,7 +18,7 @@ import {
   Nut29BatchLimitCache,
   supportsNut29MintQuoteCheck,
 } from '../../quotes/MintQuoteBatchTransport.ts';
-import type { Repositories } from '../../repositories/index.ts';
+import type { Repositories, RepositoryTransactionScope } from '../../repositories/index.ts';
 import type { MintService } from '../../services/MintService.ts';
 import type { ProofService } from '../../services/ProofService.ts';
 import type { WalletService } from '../../services/WalletService.ts';
@@ -98,6 +98,12 @@ interface ConfirmedBatchRejectionProgress {
   observedQuoteIds: string[];
   capabilityUpdatedAt?: number;
   replacementBatchLimit?: number;
+}
+
+interface BatchRecoveryContext {
+  attempt: MintIssuanceAttempt;
+  operations: ExecutingMintOperationRecord<'bolt11'>[];
+  targetOperationId: string;
 }
 
 function isConfirmedBatchRejectionKind(value: unknown): value is ConfirmedBatchRejectionKind {
@@ -1312,16 +1318,22 @@ export class MintIssuanceCoordinator {
     operations: ExecutingMintOperationRecord<'bolt11'>[],
     targetOperationId: string,
   ): Promise<MintOperation> {
+    const context: BatchRecoveryContext = { attempt, operations, targetOperationId };
     return this.runAttemptDispatch(attempt.id, targetOperationId, async () => {
-      await this.performBatchRecovery(attempt, operations, targetOperationId);
+      await this.performBatchRecovery(context);
     });
   }
 
-  private async performBatchRecovery(
-    attempt: MintIssuanceAttempt,
-    operations: ExecutingMintOperationRecord<'bolt11'>[],
-    targetOperationId: string,
-  ): Promise<void> {
+  /**
+   * Reconciles one exact Mint Batch after an ambiguous remote boundary.
+   *
+   * The polling checker persists Attributable Quote Observations before this method reads canonical
+   * rows. A complete all-PAID observation resubmits the immutable request, all-ISSUED invokes
+   * NUT-09 Restore, and other complete state sets reconcile each member independently. Missing or
+   * unusable observations leave the exact attempt and every member recoverable.
+   */
+  private async performBatchRecovery(context: BatchRecoveryContext): Promise<void> {
+    const { attempt, operations, targetOperationId } = context;
     if (
       attempt.request.kind !== 'batch' ||
       operations.length !== attempt.memberOperationIds.length
@@ -1369,17 +1381,14 @@ export class MintIssuanceCoordinator {
       return;
     }
     if (states.every((state) => state === 'ISSUED')) {
-      await this.recoverIssuedBatchAttempt(recovering, operations, targetOperationId);
+      await this.recoverIssuedBatchAttempt({ ...context, attempt: recovering });
       return;
     }
-    await this.reconcileMixedBatchRecovery(recovering, operations, bolt11Quotes, targetOperationId);
+    await this.reconcileMixedBatchRecovery({ ...context, attempt: recovering }, bolt11Quotes);
   }
 
-  private async recoverIssuedBatchAttempt(
-    attempt: MintIssuanceAttempt,
-    operations: ExecutingMintOperationRecord<'bolt11'>[],
-    targetOperationId: string,
-  ): Promise<void> {
+  private async recoverIssuedBatchAttempt(context: BatchRecoveryContext): Promise<void> {
+    const { attempt, operations, targetOperationId } = context;
     let recovered: Proof[];
     try {
       recovered = await this.proofService.recoverProofsFromOutputData(
@@ -1403,8 +1412,7 @@ export class MintIssuanceCoordinator {
     }
     if (recovered.length === 0) {
       await this.failBatchRecovery(
-        attempt,
-        operations,
+        context,
         {
           message: `Mint Batch ${attempt.id} was issued but none of its exact outputs could be recovered`,
           code: 'EXACT_PROOFS_UNRECOVERABLE',
@@ -1421,8 +1429,7 @@ export class MintIssuanceCoordinator {
       return;
     }
     await this.failBatchRecovery(
-      attempt,
-      operations,
+      context,
       {
         message: `Critical partial signing recovered only part of Mint Batch ${attempt.id}`,
         code: 'CRITICAL_PARTIAL_SIGNING',
@@ -1456,11 +1463,10 @@ export class MintIssuanceCoordinator {
   }
 
   private async reconcileMixedBatchRecovery(
-    attempt: MintIssuanceAttempt,
-    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    context: BatchRecoveryContext,
     quotes: MintQuote<'bolt11'>[],
-    targetOperationId: string,
   ): Promise<void> {
+    const { attempt, operations, targetOperationId } = context;
     const now = Date.now();
     const reconciled = await this.repositories.withTransaction(async (tx) => {
       const currentAttempt = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
@@ -1473,16 +1479,7 @@ export class MintIssuanceCoordinator {
       const pending: PendingMintOperationRecord<'bolt11'>[] = [];
       const failed: FailedMintOperationRecord<'bolt11'>[] = [];
       for (const [index, operation] of operations.entries()) {
-        const current = await tx.mintOperationRepository.getById(operation.id);
-        if (
-          !current ||
-          current.state !== 'executing' ||
-          current.method !== 'bolt11' ||
-          current.attemptId !== attempt.id
-        ) {
-          throw new Error(`Mint Batch ${attempt.id} no longer owns operation ${operation.id}`);
-        }
-        const executing = current as ExecutingMintOperationRecord<'bolt11'>;
+        const executing = await this.requireOwnedBolt11Member(tx, attempt.id, operation.id);
         const quote = quotes[index]!;
         const state = getMintQuoteRemoteState(quote);
         if (state === 'PAID' || (state === 'UNPAID' && !isMintQuoteExpired(quote))) {
@@ -1501,8 +1498,8 @@ export class MintIssuanceCoordinator {
         }
         const error =
           state === 'ISSUED'
-            ? `Mint quote ${current.quoteId} was issued outside the complete exact Mint Batch proof set`
-            : `Mint quote ${current.quoteId} expired before issuance`;
+            ? `Mint quote ${executing.quoteId} was issued outside the complete exact Mint Batch proof set`
+            : `Mint quote ${executing.quoteId} expired before issuance`;
         const updated: FailedMintOperationRecord<'bolt11'> = {
           ...executing,
           state: 'failed',
@@ -1548,11 +1545,11 @@ export class MintIssuanceCoordinator {
   }
 
   private async failBatchRecovery(
-    attempt: MintIssuanceAttempt,
-    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    context: BatchRecoveryContext,
     terminalError: { message: string; code: string },
     recoveredProofs: Proof[],
   ): Promise<void> {
+    const { attempt, operations } = context;
     const now = Date.now();
     const coreProofs = mapProofToCoreProof(attempt.mintUrl, 'ready', recoveredProofs, {
       unit: attempt.unit,
@@ -1566,16 +1563,7 @@ export class MintIssuanceCoordinator {
         await tx.proofRepository.saveProofs(attempt.mintUrl, coreProofs);
       }
       for (const operation of operations) {
-        const current = await tx.mintOperationRepository.getById(operation.id);
-        if (
-          !current ||
-          current.state !== 'executing' ||
-          current.method !== 'bolt11' ||
-          current.attemptId !== attempt.id
-        ) {
-          throw new Error(`Mint Batch ${attempt.id} no longer owns operation ${operation.id}`);
-        }
-        const executing = current as ExecutingMintOperationRecord<'bolt11'>;
+        const executing = await this.requireOwnedBolt11Member(tx, attempt.id, operation.id);
         const updated: FailedMintOperationRecord<'bolt11'> = {
           ...executing,
           state: 'failed',
@@ -1612,6 +1600,23 @@ export class MintIssuanceCoordinator {
         operation: toMintOperation(operation),
       });
     }
+  }
+
+  private async requireOwnedBolt11Member(
+    tx: RepositoryTransactionScope,
+    attemptId: string,
+    operationId: string,
+  ): Promise<ExecutingMintOperationRecord<'bolt11'>> {
+    const operation = await tx.mintOperationRepository.getById(operationId);
+    if (
+      !operation ||
+      operation.state !== 'executing' ||
+      operation.method !== 'bolt11' ||
+      operation.attemptId !== attemptId
+    ) {
+      throw new Error(`Mint Batch ${attemptId} no longer owns operation ${operationId}`);
+    }
+    return operation as ExecutingMintOperationRecord<'bolt11'>;
   }
 
   private handlerDeps() {

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -256,7 +256,7 @@ export class MintIssuanceCoordinator {
     if (!attempt) return false;
     if (this.isConfirmedBatchRejection(attempt)) return true;
     if (isTerminalAttempt(attempt)) return false;
-    return attempt.request.kind !== 'batch' || attempt.state === 'prepared';
+    return true;
   }
 
   private async coordinateScheduled(): Promise<void> {
@@ -546,7 +546,8 @@ export class MintIssuanceCoordinator {
             const members = await this.requireExecutingBolt11Members(attempt);
             return this.reconcileConfirmedBatchRejection(attempt, members, operationId);
           }
-          throw new Error(`Mint Batch ${attempt.id} requires exact-attempt recovery`);
+          const members = await this.requireExecutingBolt11Members(attempt);
+          return this.reconcileBatchAttempt(attempt, members, operationId);
         }
         return this.reconcileSingleAttempt(attempt, operation);
       case 'succeeded': {
@@ -1304,6 +1305,313 @@ export class MintIssuanceCoordinator {
       return this.failAttemptAsExternallyRedeemed(recovering, executing);
     }
     return this.completeAttempt(recovering, executing, recovered, true);
+  }
+
+  private async reconcileBatchAttempt(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    targetOperationId: string,
+  ): Promise<MintOperation> {
+    return this.runAttemptDispatch(attempt.id, targetOperationId, async () => {
+      await this.performBatchRecovery(attempt, operations, targetOperationId);
+    });
+  }
+
+  private async performBatchRecovery(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    targetOperationId: string,
+  ): Promise<void> {
+    if (
+      attempt.request.kind !== 'batch' ||
+      operations.length !== attempt.memberOperationIds.length
+    ) {
+      throw new Error(`Attempt ${attempt.id} is not a complete recoverable Mint Batch`);
+    }
+    const recovering =
+      attempt.state === 'recovering'
+        ? attempt
+        : await this.markRecovering(attempt, new Error('Mint Batch recovery started'));
+    if (isTerminalAttempt(recovering) || !this.mintQuotePollingChecker) return;
+
+    let result;
+    try {
+      result = await this.mintQuotePollingChecker.checkMintQuotesForPolling(
+        recovering.mintUrl,
+        'bolt11',
+        recovering.quoteIds,
+      );
+    } catch (error) {
+      await this.markRecovering(recovering, error);
+      return;
+    }
+
+    const observedQuoteIds = new Set(
+      result.observations
+        .map((observation) => observation.quote)
+        .filter((quoteId) => recovering.quoteIds.includes(quoteId)),
+    );
+    if (recovering.quoteIds.some((quoteId) => !observedQuoteIds.has(quoteId))) return;
+
+    const quotes = await Promise.all(
+      recovering.quoteIds.map((quoteId) =>
+        this.repositories.mintQuoteRepository.getMintQuote(recovering.mintUrl, 'bolt11', quoteId),
+      ),
+    );
+    const bolt11Quotes = quotes.filter(
+      (quote): quote is MintQuote<'bolt11'> => quote?.method === 'bolt11',
+    );
+    if (bolt11Quotes.length !== recovering.quoteIds.length) return;
+    const states = bolt11Quotes.map((quote) => getMintQuoteRemoteState(quote));
+
+    if (states.every((state) => state === 'PAID')) {
+      await this.performBatchAttempt(recovering, operations, targetOperationId);
+      return;
+    }
+    if (states.every((state) => state === 'ISSUED')) {
+      await this.recoverIssuedBatchAttempt(recovering, operations, targetOperationId);
+      return;
+    }
+    await this.reconcileMixedBatchRecovery(recovering, operations, bolt11Quotes, targetOperationId);
+  }
+
+  private async recoverIssuedBatchAttempt(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    targetOperationId: string,
+  ): Promise<void> {
+    let recovered: Proof[];
+    try {
+      recovered = await this.proofService.recoverProofsFromOutputData(
+        attempt.mintUrl,
+        attempt.outputData,
+        {
+          unit: attempt.unit,
+          createdByAttemptId: attempt.id,
+          persistRecoveredProofs: false,
+        },
+      );
+    } catch (error) {
+      await this.markRecovering(attempt, error);
+      return;
+    }
+
+    const validProofs = this.getValidRecoveredProofs(attempt, recovered);
+    if (this.matchesExactProofSet(attempt, validProofs)) {
+      await this.completeBatchAttempt(attempt, operations, validProofs, true, targetOperationId);
+      return;
+    }
+    if (recovered.length === 0) {
+      await this.failBatchRecovery(
+        attempt,
+        operations,
+        {
+          message: `Mint Batch ${attempt.id} was issued but none of its exact outputs could be recovered`,
+          code: 'EXACT_PROOFS_UNRECOVERABLE',
+        },
+        [],
+      );
+      return;
+    }
+    if (validProofs.length === 0) {
+      await this.markRecovering(
+        attempt,
+        new Error(`Mint Batch ${attempt.id} returned unusable recovered proofs`),
+      );
+      return;
+    }
+    await this.failBatchRecovery(
+      attempt,
+      operations,
+      {
+        message: `Critical partial signing recovered only part of Mint Batch ${attempt.id}`,
+        code: 'CRITICAL_PARTIAL_SIGNING',
+      },
+      validProofs,
+    );
+  }
+
+  private getValidRecoveredProofs(attempt: MintIssuanceAttempt, proofs: Proof[]): Proof[] {
+    const outputs = deserializeOutputData(attempt.outputData);
+    const expected = new Map(
+      [...outputs.keep, ...outputs.send].map((output) => [
+        new TextDecoder().decode(output.secret),
+        output.blindedMessage,
+      ]),
+    );
+    const seen = new Set<string>();
+    return proofs.filter((proof) => {
+      const output = expected.get(proof.secret);
+      if (
+        !output ||
+        seen.has(proof.secret) ||
+        output.id !== proof.id ||
+        !output.amount.equals(proof.amount)
+      ) {
+        return false;
+      }
+      seen.add(proof.secret);
+      return true;
+    });
+  }
+
+  private async reconcileMixedBatchRecovery(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    quotes: MintQuote<'bolt11'>[],
+    targetOperationId: string,
+  ): Promise<void> {
+    const now = Date.now();
+    const reconciled = await this.repositories.withTransaction(async (tx) => {
+      const currentAttempt = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+      if (!currentAttempt || isTerminalAttempt(currentAttempt)) {
+        return { pending: [], failed: [] } as {
+          pending: PendingMintOperationRecord<'bolt11'>[];
+          failed: FailedMintOperationRecord<'bolt11'>[];
+        };
+      }
+      const pending: PendingMintOperationRecord<'bolt11'>[] = [];
+      const failed: FailedMintOperationRecord<'bolt11'>[] = [];
+      for (const [index, operation] of operations.entries()) {
+        const current = await tx.mintOperationRepository.getById(operation.id);
+        if (
+          !current ||
+          current.state !== 'executing' ||
+          current.method !== 'bolt11' ||
+          current.attemptId !== attempt.id
+        ) {
+          throw new Error(`Mint Batch ${attempt.id} no longer owns operation ${operation.id}`);
+        }
+        const executing = current as ExecutingMintOperationRecord<'bolt11'>;
+        const quote = quotes[index]!;
+        const state = getMintQuoteRemoteState(quote);
+        if (state === 'PAID' || (state === 'UNPAID' && !isMintQuoteExpired(quote))) {
+          const updated: PendingMintOperationRecord<'bolt11'> = {
+            ...executing,
+            state: 'pending',
+            attemptId: undefined,
+            outputData: serializeOutputData({ keep: [], send: [] }),
+            error: undefined,
+            terminalFailure: undefined,
+            updatedAt: now,
+          };
+          await tx.mintOperationRepository.update(updated);
+          pending.push(updated);
+          continue;
+        }
+        const error =
+          state === 'ISSUED'
+            ? `Mint quote ${current.quoteId} was issued outside the complete exact Mint Batch proof set`
+            : `Mint quote ${current.quoteId} expired before issuance`;
+        const updated: FailedMintOperationRecord<'bolt11'> = {
+          ...executing,
+          state: 'failed',
+          attemptId: attempt.id,
+          outputData: attempt.outputData,
+          error,
+          terminalFailure: { reason: error, observedAt: now },
+          updatedAt: now,
+        };
+        await tx.mintOperationRepository.update(updated);
+        failed.push(updated);
+      }
+      const updatedAttempt: MintIssuanceAttempt = {
+        ...currentAttempt,
+        state: 'failed',
+        updatedAt: now,
+        recoveredAt: now,
+        terminalError: {
+          message: `Mint Batch ${attempt.id} had independently reconcilable mixed quote states`,
+          code: 'MIXED_QUOTE_STATES',
+        },
+      };
+      await tx.mintIssuanceAttemptRepository.update(updatedAttempt);
+      return { pending, failed };
+    });
+
+    for (const operation of reconciled.pending) {
+      this.schedule(operation.id);
+      await this.eventBus.emit('mint-op:requeue', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
+    for (const operation of reconciled.failed) {
+      await this.eventBus.emit('mint-op:failed', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
+    await this.requireOperation(targetOperationId);
+  }
+
+  private async failBatchRecovery(
+    attempt: MintIssuanceAttempt,
+    operations: ExecutingMintOperationRecord<'bolt11'>[],
+    terminalError: { message: string; code: string },
+    recoveredProofs: Proof[],
+  ): Promise<void> {
+    const now = Date.now();
+    const coreProofs = mapProofToCoreProof(attempt.mintUrl, 'ready', recoveredProofs, {
+      unit: attempt.unit,
+      createdByAttemptId: attempt.id,
+    });
+    const failed = await this.repositories.withTransaction(async (tx) => {
+      const currentAttempt = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+      if (!currentAttempt) throw new Error(`Mint issuance attempt ${attempt.id} no longer exists`);
+      const failedOperations: FailedMintOperationRecord<'bolt11'>[] = [];
+      if (coreProofs.length > 0) {
+        await tx.proofRepository.saveProofs(attempt.mintUrl, coreProofs);
+      }
+      for (const operation of operations) {
+        const current = await tx.mintOperationRepository.getById(operation.id);
+        if (
+          !current ||
+          current.state !== 'executing' ||
+          current.method !== 'bolt11' ||
+          current.attemptId !== attempt.id
+        ) {
+          throw new Error(`Mint Batch ${attempt.id} no longer owns operation ${operation.id}`);
+        }
+        const executing = current as ExecutingMintOperationRecord<'bolt11'>;
+        const updated: FailedMintOperationRecord<'bolt11'> = {
+          ...executing,
+          state: 'failed',
+          attemptId: attempt.id,
+          outputData: attempt.outputData,
+          error: terminalError.message,
+          terminalFailure: { reason: terminalError.message, observedAt: now },
+          updatedAt: now,
+        };
+        await tx.mintOperationRepository.update(updated);
+        failedOperations.push(updated);
+      }
+      await tx.mintIssuanceAttemptRepository.update({
+        ...currentAttempt,
+        state: 'failed',
+        updatedAt: now,
+        recoveredAt: now,
+        terminalError,
+      });
+      return failedOperations;
+    });
+
+    for (const keysetId of new Set(coreProofs.map((proof) => proof.id))) {
+      await this.eventBus.emit('proofs:saved', {
+        mintUrl: attempt.mintUrl,
+        keysetId,
+        proofs: coreProofs.filter((proof) => proof.id === keysetId),
+      });
+    }
+    for (const operation of failed) {
+      await this.eventBus.emit('mint-op:failed', {
+        mintUrl: operation.mintUrl,
+        operationId: operation.id,
+        operation: toMintOperation(operation),
+      });
+    }
   }
 
   private handlerDeps() {

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -6,12 +6,11 @@ import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerP
 import type { MintQuotePollingChecker } from '../../infra/MintQuotePollingChecker.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { Logger } from '../../logging/Logger.ts';
+import { HttpResponseError, MintOperationError, UnknownMintError } from '../../models/Error.ts';
 import {
-  HttpResponseError,
-  MintOperationError,
-  NetworkError,
-  UnknownMintError,
-} from '../../models/Error.ts';
+  isRetryableMintIssuanceError,
+  MintIssuanceRetryError,
+} from '../../models/MintIssuanceRetryError.ts';
 import {
   getMintQuoteAmount,
   getMintQuoteRemoteState,
@@ -97,13 +96,6 @@ const CONFIRMED_BATCH_REJECTION_KINDS: ConfirmedBatchRejectionKind[] = [
   'incompatibility',
   'validation',
 ];
-
-function isRetryableTransportError(error: unknown): boolean {
-  return (
-    error instanceof NetworkError ||
-    (error instanceof HttpResponseError && (error.status === 429 || error.status >= 500))
-  );
-}
 
 interface ConfirmedBatchRejectionProgress {
   kind: ConfirmedBatchRejectionKind;
@@ -313,8 +305,15 @@ export class MintIssuanceCoordinator {
           deferredRejectedOperationId ??= operationId;
           continue;
         }
-        this.lastProcessorSelection.add(operationId);
-        this.unschedule(operationId);
+        const attemptMemberIds = scheduled
+          .filter(
+            (candidate) =>
+              candidate.operation?.state === 'executing' &&
+              candidate.operation.attemptId === operation.attemptId,
+          )
+          .map((candidate) => candidate.operationId);
+        this.lastProcessorSelection = new Set(attemptMemberIds);
+        for (const attemptMemberId of attemptMemberIds) this.unschedule(attemptMemberId);
         await this.coordinate(operationId);
         return;
       }
@@ -1358,25 +1357,23 @@ export class MintIssuanceCoordinator {
         : await this.markRecovering(attempt, new Error('Mint Batch recovery started'));
     if (isTerminalAttempt(recovering) || !this.mintQuotePollingChecker) return;
 
-    let result;
+    let observedQuoteIds: Set<string>;
     try {
-      result = await this.mintQuotePollingChecker.checkMintQuotesForPolling(
-        recovering.mintUrl,
-        'bolt11',
-        recovering.quoteIds,
-      );
+      observedQuoteIds = await this.collectBatchRecoveryObservations(recovering);
     } catch (error) {
-      await this.markRecovering(recovering, error);
-      if (isRetryableTransportError(error)) throw error;
-      return;
+      await this.throwRecoverableBatchError(
+        recovering,
+        this.toRetryableRecoveryError(error, `Mint Batch ${recovering.id} quote check failed`),
+      );
     }
 
-    const observedQuoteIds = new Set(
-      result.observations
-        .map((observation) => observation.quote)
-        .filter((quoteId) => recovering.quoteIds.includes(quoteId)),
-    );
-    if (recovering.quoteIds.some((quoteId) => !observedQuoteIds.has(quoteId))) return;
+    const missingQuoteIds = recovering.quoteIds.filter((quoteId) => !observedQuoteIds.has(quoteId));
+    if (missingQuoteIds.length > 0) {
+      const error = new MintIssuanceRetryError(
+        `Mint Batch ${recovering.id} is missing attributable quote observations for ${missingQuoteIds.join(', ')}`,
+      );
+      await this.throwRecoverableBatchError(recovering, error);
+    }
 
     const quotes = await Promise.all(
       recovering.quoteIds.map((quoteId) =>
@@ -1386,7 +1383,12 @@ export class MintIssuanceCoordinator {
     const bolt11Quotes = quotes.filter(
       (quote): quote is MintQuote<'bolt11'> => quote?.method === 'bolt11',
     );
-    if (bolt11Quotes.length !== recovering.quoteIds.length) return;
+    if (bolt11Quotes.length !== recovering.quoteIds.length) {
+      const error = new MintIssuanceRetryError(
+        `Mint Batch ${recovering.id} is missing canonical quote state after recovery checks`,
+      );
+      await this.throwRecoverableBatchError(recovering, error);
+    }
     const states = bolt11Quotes.map((quote) => getMintQuoteRemoteState(quote));
 
     if (states.every((state) => state === 'PAID')) {
@@ -1398,6 +1400,39 @@ export class MintIssuanceCoordinator {
       return;
     }
     await this.reconcileMixedBatchRecovery({ ...context, attempt: recovering }, bolt11Quotes);
+  }
+
+  private async collectBatchRecoveryObservations(
+    attempt: MintIssuanceAttempt,
+  ): Promise<Set<string>> {
+    const checker = this.mintQuotePollingChecker;
+    if (!checker) throw new Error('Mint quote polling checker is unavailable');
+    const observedQuoteIds = new Set<string>();
+    let remainingQuoteIds = [...attempt.quoteIds];
+    while (remainingQuoteIds.length > 0) {
+      const result = await checker.checkMintQuotesForPolling(
+        attempt.mintUrl,
+        'bolt11',
+        remainingQuoteIds,
+      );
+      const attemptedQuoteIds = result.attemptedQuoteIds.filter((quoteId) =>
+        remainingQuoteIds.includes(quoteId),
+      );
+      if (attemptedQuoteIds.length === 0) {
+        throw new MintIssuanceRetryError(
+          `Mint Batch ${attempt.id} quote recovery made no progress`,
+        );
+      }
+      for (const observation of result.observations) {
+        if (attempt.quoteIds.includes(observation.quote)) {
+          observedQuoteIds.add(observation.quote);
+        }
+      }
+      if (result.partialFailure) throw result.partialFailure.error;
+      const attempted = new Set(attemptedQuoteIds);
+      remainingQuoteIds = remainingQuoteIds.filter((quoteId) => !attempted.has(quoteId));
+    }
+    return observedQuoteIds;
   }
 
   private async recoverIssuedBatchAttempt(context: BatchRecoveryContext): Promise<void> {
@@ -1414,9 +1449,13 @@ export class MintIssuanceCoordinator {
         },
       );
     } catch (error) {
-      await this.markRecovering(attempt, error);
-      if (isRetryableTransportError(error)) throw error;
-      return;
+      return this.throwRecoverableBatchError(
+        attempt,
+        this.toRetryableRecoveryError(
+          error,
+          `Mint Batch ${attempt.id} exact-output recovery failed`,
+        ),
+      );
     }
 
     const validProofs = this.getValidRecoveredProofs(attempt, recovered);
@@ -1436,11 +1475,10 @@ export class MintIssuanceCoordinator {
       return;
     }
     if (validProofs.length === 0) {
-      await this.markRecovering(
-        attempt,
-        new Error(`Mint Batch ${attempt.id} returned unusable recovered proofs`),
+      const error = new MintIssuanceRetryError(
+        `Mint Batch ${attempt.id} returned unusable recovered proofs`,
       );
-      return;
+      await this.throwRecoverableBatchError(attempt, error);
     }
     await this.failBatchRecovery(
       context,
@@ -1450,6 +1488,20 @@ export class MintIssuanceCoordinator {
       },
       validProofs,
     );
+  }
+
+  private toRetryableRecoveryError(error: unknown, context: string): Error {
+    if (isRetryableMintIssuanceError(error) && error instanceof Error) return error;
+    const detail = error instanceof Error ? error.message : String(error);
+    return new MintIssuanceRetryError(`${context}: ${detail}`, error);
+  }
+
+  private async throwRecoverableBatchError(
+    attempt: MintIssuanceAttempt,
+    error: Error,
+  ): Promise<never> {
+    await this.markRecovering(attempt, error);
+    throw error;
   }
 
   private getValidRecoveredProofs(attempt: MintIssuanceAttempt, proofs: Proof[]): Proof[] {

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -305,15 +305,15 @@ export class MintIssuanceCoordinator {
           deferredRejectedOperationId ??= operationId;
           continue;
         }
-        const attemptMemberIds = scheduled
+        const scheduledAttemptMemberIds = scheduled
           .filter(
             (candidate) =>
               candidate.operation?.state === 'executing' &&
               candidate.operation.attemptId === operation.attemptId,
           )
           .map((candidate) => candidate.operationId);
-        this.lastProcessorSelection = new Set(attemptMemberIds);
-        for (const attemptMemberId of attemptMemberIds) this.unschedule(attemptMemberId);
+        this.lastProcessorSelection = new Set(attempt?.memberOperationIds ?? [operationId]);
+        for (const attemptMemberId of scheduledAttemptMemberIds) this.unschedule(attemptMemberId);
         await this.coordinate(operationId);
         return;
       }

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -98,6 +98,13 @@ const CONFIRMED_BATCH_REJECTION_KINDS: ConfirmedBatchRejectionKind[] = [
   'validation',
 ];
 
+function isRetryableTransportError(error: unknown): boolean {
+  return (
+    error instanceof NetworkError ||
+    (error instanceof HttpResponseError && (error.status === 429 || error.status >= 500))
+  );
+}
+
 interface ConfirmedBatchRejectionProgress {
   kind: ConfirmedBatchRejectionKind;
   observedQuoteIds: string[];
@@ -1360,12 +1367,7 @@ export class MintIssuanceCoordinator {
       );
     } catch (error) {
       await this.markRecovering(recovering, error);
-      if (
-        error instanceof NetworkError ||
-        (error instanceof HttpResponseError && (error.status === 429 || error.status >= 500))
-      ) {
-        throw error;
-      }
+      if (isRetryableTransportError(error)) throw error;
       return;
     }
 
@@ -1413,6 +1415,7 @@ export class MintIssuanceCoordinator {
       );
     } catch (error) {
       await this.markRecovering(attempt, error);
+      if (isRetryableTransportError(error)) throw error;
       return;
     }
 

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -6,7 +6,12 @@ import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerP
 import type { MintQuotePollingChecker } from '../../infra/MintQuotePollingChecker.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { Logger } from '../../logging/Logger.ts';
-import { HttpResponseError, MintOperationError, UnknownMintError } from '../../models/Error.ts';
+import {
+  HttpResponseError,
+  MintOperationError,
+  NetworkError,
+  UnknownMintError,
+} from '../../models/Error.ts';
 import {
   getMintQuoteAmount,
   getMintQuoteRemoteState,
@@ -1355,6 +1360,12 @@ export class MintIssuanceCoordinator {
       );
     } catch (error) {
       await this.markRecovering(recovering, error);
+      if (
+        error instanceof NetworkError ||
+        (error instanceof HttpResponseError && (error.status === 429 || error.status >= 500))
+      ) {
+        throw error;
+      }
       return;
     }
 

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -1097,27 +1097,38 @@ export class ProofService {
 
     // Call mint restore endpoint
     const restoreResult = await wallet.mint.restore({ outputs: blindedMessages });
+    if (
+      !Array.isArray(restoreResult.outputs) ||
+      !Array.isArray(restoreResult.signatures) ||
+      restoreResult.outputs.length !== restoreResult.signatures.length
+    ) {
+      throw new ProofValidationError('Mint restore response has unpaired outputs and signatures');
+    }
 
     // Match signatures back to outputs and unblind to construct proofs
     const restoredProofs: Proof[] = [];
+    const matchedBlindedMessages = new Set<string>();
     for (let i = 0; i < restoreResult.outputs.length; i++) {
-      const output = allOutputs.find((o) => o.blindedMessage.B_ === restoreResult.outputs[i]?.B_);
+      const restoredOutput = restoreResult.outputs[i];
       const signature = restoreResult.signatures[i];
-      if (output && signature) {
-        const keyset = keysetMap[signature.id];
-        if (!keyset) {
-          this.logger?.warn('Missing keyset for restored signature', { id: signature.id });
-          continue;
-        }
-        assertSameUnit(
-          normalizeUnit(keyset.unit, { defaultUnit: DEFAULT_UNIT }),
-          unit,
-          'Restored proof keyset',
-        );
-        restoredProofs.push(
-          output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }),
-        );
+      const blindedMessage = restoredOutput?.B_;
+      const output = allOutputs.find((candidate) => candidate.blindedMessage.B_ === blindedMessage);
+      if (!output || !signature || !blindedMessage || matchedBlindedMessages.has(blindedMessage)) {
+        throw new ProofValidationError('Mint restore response contains an unattributable output');
       }
+      matchedBlindedMessages.add(blindedMessage);
+      const keyset = keysetMap[signature.id];
+      if (!keyset) {
+        throw new ProofValidationError(`Missing keyset for restored signature ${signature.id}`);
+      }
+      assertSameUnit(
+        normalizeUnit(keyset.unit, { defaultUnit: DEFAULT_UNIT }),
+        unit,
+        'Restored proof keyset',
+      );
+      restoredProofs.push(
+        output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }),
+      );
     }
 
     if (restoredProofs.length === 0) {
@@ -1127,6 +1138,9 @@ export class ProofService {
 
     // Check which proofs are still unspent
     const proofStates = await wallet.checkProofsStates(restoredProofs);
+    if (!Array.isArray(proofStates) || proofStates.length !== restoredProofs.length) {
+      throw new ProofValidationError('Mint proof-state response is incomplete during recovery');
+    }
     const unspentProofs = restoredProofs.filter((_, index) => {
       const state = proofStates[index];
       return state && state.state === 'UNSPENT';

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -1141,6 +1141,9 @@ export class ProofService {
     if (!Array.isArray(proofStates) || proofStates.length !== restoredProofs.length) {
       throw new ProofValidationError('Mint proof-state response is incomplete during recovery');
     }
+    if (proofStates.some((state) => state?.state !== 'UNSPENT' && state?.state !== 'SPENT')) {
+      throw new ProofValidationError('Mint proof-state response is indeterminate during recovery');
+    }
     const unspentProofs = restoredProofs.filter((_, index) => {
       const state = proofStates[index];
       return state && state.state === 'UNSPENT';

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -1,7 +1,7 @@
 import type { EventBus, CoreEvents } from '@core/events';
 import type { Logger } from '../../logging/Logger.ts';
 import type { MintMethod, MintOperationService } from '@core/operations/mint';
-import { MintOperationError, NetworkError } from '../../models/Error';
+import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error';
 import { getMintQuoteRemoteState } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 
@@ -585,6 +585,10 @@ export class MintOperationProcessor {
   }
 
   private isNetworkError(err: unknown): boolean {
-    return err instanceof NetworkError || (err instanceof Error && err.message.includes('network'));
+    return (
+      err instanceof NetworkError ||
+      (err instanceof HttpResponseError && (err.status === 429 || err.status >= 500)) ||
+      (err instanceof Error && err.message.includes('network'))
+    );
   }
 }

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -1,7 +1,8 @@
 import type { EventBus, CoreEvents } from '@core/events';
-import type { Logger } from '../../logging/Logger.ts';
 import type { MintMethod, MintOperationService } from '@core/operations/mint';
-import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error';
+import type { Logger } from '../../logging/Logger.ts';
+import { MintOperationError } from '../../models/Error';
+import { isRetryableMintIssuanceError } from '../../models/MintIssuanceRetryError.ts';
 import { getMintQuoteRemoteState } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 
@@ -498,7 +499,7 @@ export class MintOperationProcessor {
           operations.wasIssuanceSelectedInLastTurn(item.operationId);
         if (error !== undefined && wasSelected) {
           operations.unscheduleIssuance?.(item.operationId);
-          if (!this.scheduleNetworkRetry(item, error)) {
+          if (!this.scheduleRetry(item, error)) {
             removable.add(this.queueItemKey(item));
           }
         } else if (!remainsScheduled) {
@@ -517,7 +518,7 @@ export class MintOperationProcessor {
       const canRetry =
         typeof operations.canRetryIssuance === 'function' &&
         (await operations.canRetryIssuance(item.operationId));
-      if (!canRetry || !this.scheduleNetworkRetry(item, error)) {
+      if (!canRetry || !this.scheduleRetry(item, error)) {
         removable.add(this.queueItemKey(item));
       }
     }
@@ -551,20 +552,20 @@ export class MintOperationProcessor {
       return;
     }
 
-    if (this.isNetworkError(err)) {
-      if (this.scheduleNetworkRetry(item, err)) this.queue.push(item);
+    if (this.isRetryableError(err)) {
+      if (this.scheduleRetry(item, err)) this.queue.push(item);
       return;
     }
 
     this.logger?.error('Failed to process mint operation', { mintUrl, operationId, err });
   }
 
-  private scheduleNetworkRetry(item: QueueItem, err: unknown): boolean {
-    if (!this.isNetworkError(err)) return false;
+  private scheduleRetry(item: QueueItem, err: unknown): boolean {
+    if (!this.isRetryableError(err)) return false;
 
     item.retryCount++;
     if (item.retryCount > this.maxRetries) {
-      this.logger?.error('Max retries exceeded for network error', {
+      this.logger?.error('Max retries exceeded for retryable mint operation error', {
         mintUrl: item.mintUrl,
         operationId: item.operationId,
         maxRetries: this.maxRetries,
@@ -574,7 +575,7 @@ export class MintOperationProcessor {
 
     const delay = this.baseRetryDelayMs * Math.pow(2, item.retryCount - 1);
     item.nextRetryAt = Date.now() + delay;
-    this.logger?.warn('Network error, will retry', {
+    this.logger?.warn('Retryable mint operation error, will retry', {
       mintUrl: item.mintUrl,
       operationId: item.operationId,
       attempt: item.retryCount,
@@ -584,11 +585,9 @@ export class MintOperationProcessor {
     return true;
   }
 
-  private isNetworkError(err: unknown): boolean {
+  private isRetryableError(err: unknown): boolean {
     return (
-      err instanceof NetworkError ||
-      (err instanceof HttpResponseError && (err.status === 429 || err.status >= 500)) ||
-      (err instanceof Error && err.message.includes('network'))
+      isRetryableMintIssuanceError(err) || (err instanceof Error && err.message.includes('network'))
     );
   }
 }

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -475,10 +475,32 @@ export class MintOperationProcessor {
     try {
       await this.mintOperations.coordinateScheduledIssuance();
     } catch (error) {
-      await this.reconcileReadyBolt11Items(ready, error);
+      await this.reconcileReadyBolt11Items(this.getSelectedReadyBolt11Items(ready, now), error);
       throw error;
     }
     await this.reconcileReadyBolt11Items(ready);
+  }
+
+  private getSelectedReadyBolt11Items(ready: QueueItem[], now: number): QueueItem[] {
+    const operations = this.mintOperations as Partial<MintOperationService>;
+    if (typeof operations.wasIssuanceSelectedInLastTurn !== 'function') return ready;
+
+    const selected = [...ready];
+    const included = new Set(ready.map((item) => this.queueItemKey(item)));
+    for (const item of this.queue) {
+      const key = this.queueItemKey(item);
+      if (
+        item.method !== 'bolt11' ||
+        item.nextRetryAt > now ||
+        included.has(key) ||
+        !operations.wasIssuanceSelectedInLastTurn(item.operationId)
+      ) {
+        continue;
+      }
+      selected.push(item);
+      included.add(key);
+    }
+    return selected;
   }
 
   private async reconcileReadyBolt11Items(ready: QueueItem[], error?: unknown): Promise<void> {

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -475,7 +475,9 @@ export class MintOperationProcessor {
     try {
       await this.mintOperations.coordinateScheduledIssuance();
     } catch (error) {
-      await this.reconcileReadyBolt11Items(this.getSelectedReadyBolt11Items(ready, now), error);
+      const selectedReady = this.getSelectedReadyBolt11Items(ready, now);
+      this.alignSelectedRetryCounts(selectedReady);
+      await this.reconcileReadyBolt11Items(selectedReady, error);
       throw error;
     }
     await this.reconcileReadyBolt11Items(ready);
@@ -501,6 +503,17 @@ export class MintOperationProcessor {
       included.add(key);
     }
     return selected;
+  }
+
+  private alignSelectedRetryCounts(items: QueueItem[]): void {
+    const operations = this.mintOperations as Partial<MintOperationService>;
+    if (typeof operations.wasIssuanceSelectedInLastTurn !== 'function') return;
+
+    const selected = items.filter((item) =>
+      operations.wasIssuanceSelectedInLastTurn?.(item.operationId),
+    );
+    const retryCount = Math.max(0, ...selected.map((item) => item.retryCount));
+    for (const item of selected) item.retryCount = retryCount;
   }
 
   private async reconcileReadyBolt11Items(ready: QueueItem[], error?: unknown): Promise<void> {

--- a/packages/core/test/fixtures/ScriptedMintIssuanceTransport.ts
+++ b/packages/core/test/fixtures/ScriptedMintIssuanceTransport.ts
@@ -1,0 +1,39 @@
+import type { BatchMintPreview, Proof } from '@cashu/cashu-ts';
+import type {
+  MintMethod,
+  MintMethodQuoteSnapshot,
+} from '../../operations/mint/MintMethodHandler.ts';
+
+export type ScriptedStep<T> = { kind: 'return'; value: T } | { kind: 'throw'; error: unknown };
+
+/** Narrow deterministic fixture for Mint Batch submission and NUT-29 quote-check faults. */
+export class ScriptedMintIssuanceTransport {
+  readonly batchSubmissions: BatchMintPreview[] = [];
+  readonly quoteChecks: Array<{ mintUrl: string; method: MintMethod; quoteIds: string[] }> = [];
+
+  constructor(
+    private readonly batchSteps: ScriptedStep<Proof[]>[],
+    private readonly quoteCheckSteps: ScriptedStep<MintMethodQuoteSnapshot[]>[],
+  ) {}
+
+  completeBatchMint = async (preview: BatchMintPreview): Promise<Proof[]> => {
+    this.batchSubmissions.push(preview);
+    return this.runNext(this.batchSteps, 'Mint Batch submission');
+  };
+
+  checkMintQuoteBatch = async (
+    mintUrl: string,
+    method: MintMethod,
+    quoteIds: string[],
+  ): Promise<MintMethodQuoteSnapshot[]> => {
+    this.quoteChecks.push({ mintUrl, method, quoteIds: [...quoteIds] });
+    return this.runNext(this.quoteCheckSteps, 'NUT-29 quote check');
+  };
+
+  private async runNext<T>(steps: ScriptedStep<T>[], boundary: string): Promise<T> {
+    const step = steps.shift();
+    if (!step) throw new Error(`No scripted ${boundary} result remains`);
+    if (step.kind === 'throw') throw step.error;
+    return step.value;
+  }
+}

--- a/packages/core/test/fixtures/ScriptedMintIssuanceTransport.ts
+++ b/packages/core/test/fixtures/ScriptedMintIssuanceTransport.ts
@@ -10,10 +10,12 @@ export type ScriptedStep<T> = { kind: 'return'; value: T } | { kind: 'throw'; er
 export class ScriptedMintIssuanceTransport {
   readonly batchSubmissions: BatchMintPreview[] = [];
   readonly quoteChecks: Array<{ mintUrl: string; method: MintMethod; quoteIds: string[] }> = [];
+  readonly restoreRequests: Array<{ mintUrl: string; attemptId?: string }> = [];
 
   constructor(
     private readonly batchSteps: ScriptedStep<Proof[]>[],
     private readonly quoteCheckSteps: ScriptedStep<MintMethodQuoteSnapshot[]>[],
+    private readonly restoreSteps: ScriptedStep<Proof[]>[] = [],
   ) {}
 
   completeBatchMint = async (preview: BatchMintPreview): Promise<Proof[]> => {
@@ -28,6 +30,15 @@ export class ScriptedMintIssuanceTransport {
   ): Promise<MintMethodQuoteSnapshot[]> => {
     this.quoteChecks.push({ mintUrl, method, quoteIds: [...quoteIds] });
     return this.runNext(this.quoteCheckSteps, 'NUT-29 quote check');
+  };
+
+  restoreExactOutputs = async (
+    mintUrl: string,
+    _outputData: unknown,
+    options: { createdByAttemptId?: string },
+  ): Promise<Proof[]> => {
+    this.restoreRequests.push({ mintUrl, attemptId: options.createdByAttemptId });
+    return this.runNext(this.restoreSteps, 'NUT-09 Restore');
   };
 
   private async runNext<T>(steps: ScriptedStep<T>[], boundary: string): Promise<T> {

--- a/packages/core/test/integration/ScriptedMintIssuanceTransport.test.ts
+++ b/packages/core/test/integration/ScriptedMintIssuanceTransport.test.ts
@@ -1,0 +1,67 @@
+import { Amount, type BatchMintPreview, type Proof } from '@cashu/cashu-ts';
+import { describe, expect, it } from 'bun:test';
+import {
+  HttpResponseError,
+  MintOperationError,
+  NetworkError,
+  ProofValidationError,
+} from '../../models/Error.ts';
+import { mintQuoteFromBolt11Response, mintQuoteToMethodSnapshot } from '../../models/MintQuote.ts';
+import { ScriptedMintIssuanceTransport } from '../fixtures/ScriptedMintIssuanceTransport.ts';
+
+describe('ScriptedMintIssuanceTransport', () => {
+  it('injects the complete deterministic Mint Batch fault vocabulary', async () => {
+    const mintUrl = 'https://mint.test';
+    const proof: Proof = {
+      id: 'keyset-1',
+      amount: Amount.from(20),
+      secret: 'full-proof',
+      C: 'C_full-proof',
+    };
+    const partialProof = { ...proof, amount: Amount.from(10), secret: 'partial-proof' };
+    const quoteObservation = mintQuoteToMethodSnapshot(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: 'quote-1',
+        request: 'lnbc1fixture',
+        amount: Amount.from(20),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'ISSUED',
+      }),
+    );
+    const scripted = new ScriptedMintIssuanceTransport(
+      [
+        { kind: 'return', value: [proof] },
+        { kind: 'throw', error: new MintOperationError(20001, 'structured rejection') },
+        { kind: 'throw', error: new NetworkError('timeout') },
+        { kind: 'throw', error: new NetworkError('disconnect') },
+        { kind: 'throw', error: new HttpResponseError('server failure', 503) },
+        { kind: 'throw', error: new ProofValidationError('malformed response') },
+        { kind: 'throw', error: new ProofValidationError('invalid signature') },
+        { kind: 'return', value: [partialProof] },
+      ],
+      [{ kind: 'return', value: [quoteObservation] }],
+      [
+        { kind: 'return', value: [proof] },
+        { kind: 'return', value: [partialProof] },
+        { kind: 'return', value: [] },
+      ],
+    );
+    const preview = {} as BatchMintPreview;
+
+    await expect(scripted.completeBatchMint(preview)).resolves.toEqual([proof]);
+    await expect(scripted.completeBatchMint(preview)).rejects.toThrow('structured rejection');
+    await expect(scripted.completeBatchMint(preview)).rejects.toThrow('timeout');
+    await expect(scripted.completeBatchMint(preview)).rejects.toThrow('disconnect');
+    await expect(scripted.completeBatchMint(preview)).rejects.toThrow('server failure');
+    await expect(scripted.completeBatchMint(preview)).rejects.toThrow('malformed response');
+    await expect(scripted.completeBatchMint(preview)).rejects.toThrow('invalid signature');
+    await expect(scripted.completeBatchMint(preview)).resolves.toEqual([partialProof]);
+    await expect(scripted.checkMintQuoteBatch(mintUrl, 'bolt11', ['quote-1'])).resolves.toEqual([
+      quoteObservation,
+    ]);
+    await expect(scripted.restoreExactOutputs(mintUrl, {}, {})).resolves.toEqual([proof]);
+    await expect(scripted.restoreExactOutputs(mintUrl, {}, {})).resolves.toEqual([partialProof]);
+    await expect(scripted.restoreExactOutputs(mintUrl, {}, {})).resolves.toEqual([]);
+  });
+});

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -214,9 +214,9 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
   function scriptExactOutputRestore(...steps: ScriptedStep<Proof[]>[]) {
     const scripted = new ScriptedMintIssuanceTransport([], [], steps);
-    (proofService.recoverProofsFromOutputData as Mock<any>).mockImplementation(
-      scripted.restoreExactOutputs,
-    );
+    (
+      proofService.recoverProofsFromOutputData as Mock<ProofService['recoverProofsFromOutputData']>
+    ).mockImplementation(scripted.restoreExactOutputs);
     return scripted;
   }
 

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -1258,11 +1258,11 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(checkMintQuoteBatch).not.toHaveBeenCalled();
   });
 
-  it('selects every ready member of a recovering attempt for the same retry backoff', async () => {
+  it('selects late-enqueued members of a recovering attempt for the same retry backoff', async () => {
     const { operationIds } = await createAmbiguousBatch();
     const failure = new NetworkError('batch recovery unavailable');
     checkMintQuoteBatch.mockRejectedValue(failure);
-    for (const id of operationIds) coordinator.schedule(id);
+    coordinator.schedule(operationIds[0]!);
 
     await expect(coordinator.coordinate()).rejects.toBe(failure);
 

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -1204,6 +1204,31 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(walletBatchMint).toHaveBeenCalledTimes(1);
   });
 
+  it('propagates retryable quote-check failures after preserving batch recovery state', async () => {
+    const { attempt, operationIds } = await createAmbiguousBatch();
+    const networkFailure = new NetworkError('recovery quote check disconnected');
+    checkMintQuoteBatch.mockRejectedValue(networkFailure);
+
+    await expect(coordinator.coordinate(operationIds[0])).rejects.toBe(networkFailure);
+
+    const serverFailure = new HttpResponseError('recovery quote check unavailable', 503);
+    checkMintQuoteBatch.mockRejectedValue(serverFailure);
+    await expect(coordinator.coordinate(operationIds[1])).rejects.toBe(serverFailure);
+
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['executing', 'executing']);
+    await expect(service.canRetryIssuance(operationIds[0])).resolves.toBe(true);
+    expect(checkMintQuoteBatch).toHaveBeenCalledTimes(6);
+  });
+
   it('fails issued members and requeues claimable members for mixed recovery states', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
     await repositories.mintQuoteRepository.setMintQuoteState(
@@ -1424,7 +1449,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
 
     service = createService();
-    await expect(service.finalize(operationId)).resolves.toMatchObject({ state: 'executing' });
+    await expect(service.finalize(operationId)).rejects.toBe(networkFailure);
     await expect(service.finalize(peerOperationId)).resolves.toMatchObject({ state: 'executing' });
     await expect(service.finalize(operationId)).resolves.toMatchObject({ state: 'finalized' });
 

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -1386,6 +1386,33 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(scripted.restoreRequests).toHaveLength(1);
   });
 
+  it('propagates retryable restore failures after preserving batch recovery state', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    await markQuotesIssued(quoteIds);
+    const networkFailure = new NetworkError('restore disconnected');
+    const serverFailure = new HttpResponseError('proof-state check unavailable', 503);
+    const scripted = scriptExactOutputRestore(
+      { kind: 'throw', error: networkFailure },
+      { kind: 'throw', error: serverFailure },
+    );
+
+    await expect(coordinator.coordinate(operationIds[0])).rejects.toBe(networkFailure);
+    await expect(coordinator.coordinate(operationIds[1])).rejects.toBe(serverFailure);
+
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['executing', 'executing']);
+    await expect(service.canRetryIssuance(operationIds[0])).resolves.toBe(true);
+    expect(scripted.restoreRequests).toHaveLength(2);
+  });
+
   it('recovers deterministically across malformed submission and quote-check transport faults', async () => {
     const peerQuoteId = 'quote-scripted-peer';
     const peerOperationId = 'operation-scripted-peer';

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -7,6 +7,7 @@ import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
 import {
   HttpResponseError,
+  MintFetchError,
   MintOperationError,
   NetworkError,
   ProofValidationError,
@@ -55,6 +56,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
   let walletBatchMint: Mock<(preview: BatchMintPreview) => Promise<Proof[]>>;
   let createMintOutputsAtCounter: Mock<ProofService['createMintOutputsAtCounter']>;
   let getMintInfo: Mock<MintService['getMintInfo']>;
+  let checkMintQuote: Mock<MintAdapter['checkMintQuote']>;
   let checkMintQuoteBatch: Mock<MintAdapter['checkMintQuoteBatch']>;
   let nut29BatchLimitCache: Nut29BatchLimitCache;
   let coordinator: MintIssuanceCoordinator;
@@ -351,15 +353,17 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         }),
       ),
     );
+    checkMintQuote = mock(async (_mintUrl, method, requestedQuoteId) => {
+      const quote = await repositories.mintQuoteRepository.getMintQuote(
+        mintUrl,
+        method,
+        requestedQuoteId,
+      );
+      if (!quote) throw new Error(`Missing test quote ${requestedQuoteId}`);
+      return mintQuoteToMethodSnapshot(quote);
+    });
     mintAdapter = {
-      checkMintQuote: mock(async () => ({
-        quote: quoteId,
-        request: 'lnbc1test',
-        amount: Amount.from(10),
-        unit: 'sat',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        state: 'PAID' as const,
-      })),
+      checkMintQuote,
       checkMintQuoteBatch,
     } as unknown as MintAdapter;
 
@@ -1188,9 +1192,10 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       return quote ? [mintQuoteToMethodSnapshot(quote)] : [];
     });
 
-    const result = await coordinator.coordinate(operationIds[1]);
+    await expect(coordinator.coordinate(operationIds[1])).rejects.toThrow(
+      'missing attributable quote observations',
+    );
 
-    expect(result.state).toBe('executing');
     expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
       'recovering',
     );
@@ -1202,6 +1207,70 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       ),
     ).toEqual(['executing', 'executing']);
     expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a partial quote-check transport failure after persisting healthy observations', async () => {
+    const { attempt, operationIds } = await createAmbiguousBatch();
+    const networkFailure = new NetworkError('later isolation branch disconnected');
+    checkMintQuoteBatch.mockImplementation(async (_mintUrl, method, quoteIds) => {
+      if (quoteIds.length > 1) {
+        throw new MintOperationError(11000, 'atomic validation rejection');
+      }
+      if (quoteIds[0] === 'quote-ambiguous-peer') throw networkFailure;
+      const quote = await repositories.mintQuoteRepository.getMintQuote(
+        mintUrl,
+        method,
+        quoteIds[0]!,
+      );
+      return quote ? [mintQuoteToMethodSnapshot(quote)] : [];
+    });
+
+    await expect(coordinator.coordinate(operationIds[0])).rejects.toBe(networkFailure);
+
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
+    expect(checkMintQuoteBatch.mock.calls.map((call) => call[2])).toEqual([
+      [quoteId, 'quote-ambiguous-peer'],
+      [quoteId],
+      ['quote-ambiguous-peer'],
+      ['quote-ambiguous-peer'],
+      ['quote-ambiguous-peer'],
+    ]);
+  });
+
+  it('checks every member when batch recovery falls back to single quote checks', async () => {
+    const { operationIds, recoveredProof } = await createAmbiguousBatch();
+    getMintInfo.mockResolvedValue({
+      ...compatibleMintInfo(),
+      nuts: { ...compatibleMintInfo().nuts, '29': undefined },
+    } as MintInfo);
+    walletBatchMint.mockResolvedValueOnce([recoveredProof]);
+
+    const result = await coordinator.coordinate(operationIds[0]);
+
+    expect(result.state).toBe('finalized');
+    expect(checkMintQuote).toHaveBeenCalledTimes(2);
+    expect(checkMintQuote.mock.calls.map((call) => call[2])).toEqual([
+      quoteId,
+      'quote-ambiguous-peer',
+    ]);
+    expect(checkMintQuoteBatch).not.toHaveBeenCalled();
+  });
+
+  it('selects every ready member of a recovering attempt for the same retry backoff', async () => {
+    const { operationIds } = await createAmbiguousBatch();
+    const failure = new NetworkError('batch recovery unavailable');
+    checkMintQuoteBatch.mockRejectedValue(failure);
+    for (const id of operationIds) coordinator.schedule(id);
+
+    await expect(coordinator.coordinate()).rejects.toBe(failure);
+
+    expect(operationIds.map((id) => coordinator.wasSelectedInLastProcessorTurn(id))).toEqual([
+      true,
+      true,
+    ]);
+    expect(operationIds.map((id) => coordinator.isScheduled(id))).toEqual([false, false]);
   });
 
   it('propagates retryable quote-check failures after preserving batch recovery state', async () => {
@@ -1370,9 +1439,10 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       error: new Error('malformed restore response'),
     });
 
-    const result = await coordinator.coordinate(operationIds[0]);
+    await expect(coordinator.coordinate(operationIds[0])).rejects.toThrow(
+      'malformed restore response',
+    );
 
-    expect(result.state).toBe('executing');
     expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
       'recovering',
     );
@@ -1384,6 +1454,51 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       ),
     ).toEqual(['executing', 'executing']);
     expect(scripted.restoreRequests).toHaveLength(1);
+  });
+
+  it('backs off a non-empty restore result that matches none of the exact outputs', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    await markQuotesIssued(quoteIds);
+    scriptExactOutputRestore({
+      kind: 'return',
+      value: [
+        {
+          id: keysetId,
+          amount: Amount.from(20),
+          secret: 'unattributable-secret',
+          C: 'C_unattributable-secret',
+        },
+      ],
+    });
+
+    await expect(coordinator.coordinate(operationIds[0])).rejects.toThrow(
+      'returned unusable recovered proofs',
+    );
+
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['executing', 'executing']);
+  });
+
+  it('propagates wrapped retryable mint refresh failures before exact-output restoration', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    await markQuotesIssued(quoteIds);
+    const networkFailure = new NetworkError('mint info unavailable');
+    const wrappedFailure = new MintFetchError(mintUrl, undefined, networkFailure);
+    scriptExactOutputRestore({ kind: 'throw', error: wrappedFailure });
+
+    await expect(coordinator.coordinate(operationIds[0])).rejects.toBe(wrappedFailure);
+
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
   });
 
   it('propagates retryable restore failures after preserving batch recovery state', async () => {
@@ -1477,7 +1592,9 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
     service = createService();
     await expect(service.finalize(operationId)).rejects.toBe(networkFailure);
-    await expect(service.finalize(peerOperationId)).resolves.toMatchObject({ state: 'executing' });
+    await expect(service.finalize(peerOperationId)).rejects.toThrow(
+      'scripted malformed quote-check body',
+    );
     await expect(service.finalize(operationId)).resolves.toMatchObject({ state: 'finalized' });
 
     expect(attempt?.state).toBe('recovering');

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -118,6 +118,64 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     });
   }
 
+  async function createAmbiguousBatch(options?: {
+    outputData?: ReturnType<typeof serializeOutputData>;
+    recoveredProof?: Proof;
+  }): Promise<{
+    attempt: MintIssuanceAttempt;
+    operationIds: [string, string];
+    quoteIds: [string, string];
+    outputData: ReturnType<typeof serializeOutputData>;
+    recoveredProof: Proof;
+  }> {
+    const peerQuoteId = 'quote-ambiguous-peer';
+    const peerOperationId = 'operation-ambiguous-peer';
+    const recoveredSecret = 'ambiguous-batch-output';
+    const batchOutputData =
+      options?.outputData ??
+      serializeOutputData({
+        keep: [
+          new OutputData(
+            { amount: Amount.from(20), id: keysetId, B_: `B_${recoveredSecret}` },
+            30n,
+            new TextEncoder().encode(recoveredSecret),
+          ),
+        ],
+        send: [],
+      });
+    const recoveredProof =
+      options?.recoveredProof ??
+      ({
+        id: keysetId,
+        amount: Amount.from(20),
+        secret: recoveredSecret,
+        C: `C_${recoveredSecret}`,
+      } satisfies Proof);
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1ambiguouspeer');
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: batchOutputData.keep.length + batchOutputData.send.length,
+    });
+    walletBatchMint.mockRejectedValueOnce(new NetworkError('connection lost after submission'));
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await expect(coordinator.coordinate()).rejects.toThrow('connection lost after submission');
+
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    if (!attempt) throw new Error('Ambiguous batch attempt was not persisted');
+    return {
+      attempt,
+      operationIds: [operationId, peerOperationId],
+      quoteIds: [quoteId, peerQuoteId],
+      outputData: batchOutputData,
+      recoveredProof,
+    };
+  }
+
   function createService(): MintOperationService {
     const handler = {
       checkPending: mock(async () => ({
@@ -945,33 +1003,8 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
   });
 
   it('preserves an ambiguous Mint Batch without creating fallback attempts', async () => {
-    const peerQuoteId = 'quote-ambiguous-peer';
-    const peerOperationId = 'operation-ambiguous-peer';
-    const ambiguousOutputData = serializeOutputData({
-      keep: [
-        new OutputData(
-          { amount: Amount.from(20), id: keysetId, B_: 'B_ambiguous-batch-output' },
-          30n,
-          new TextEncoder().encode('ambiguous-batch-output'),
-        ),
-      ],
-      send: [],
-    });
-    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1ambiguouspeer');
-    createMintOutputsAtCounter.mockResolvedValueOnce({
-      keysetId,
-      outputData: ambiguousOutputData,
-      counterStart: 0,
-      counterEnd: 1,
-    });
-    walletBatchMint.mockRejectedValueOnce(new NetworkError('connection lost after submission'));
-
-    coordinator.schedule(operationId);
-    coordinator.schedule(peerOperationId);
-    await expect(coordinator.coordinate()).rejects.toThrow('connection lost after submission');
-
-    const attempt =
-      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    const { attempt, operationIds, outputData: ambiguousOutputData } = await createAmbiguousBatch();
+    const peerOperationId = operationIds[1];
     expect(attempt).toMatchObject({
       state: 'recovering',
       memberOperationIds: [operationId, peerOperationId],
@@ -983,12 +1016,311 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect((await repositories.mintOperationRepository.getById(peerOperationId))?.state).toBe(
       'executing',
     );
-    expect(await service.canRetryIssuance(operationId)).toBe(false);
+    expect(await service.canRetryIssuance(operationId)).toBe(true);
     expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
     expect(createMintOutputsAtCounter).toHaveBeenCalledTimes(1);
   });
 
-  it('retries single attempts while deferring ambiguous Mint Batch recovery', async () => {
+  it('resubmits the identical Mint Batch after restart when every member remains claimable', async () => {
+    const { attempt, operationIds, recoveredProof } = await createAmbiguousBatch();
+    const firstPreview = walletBatchMint.mock.calls[0]?.[0];
+    walletBatchMint.mockResolvedValueOnce([recoveredProof]);
+
+    service = createService();
+    const resumed = await service.finalize(operationIds[1]);
+
+    const completedAttempt = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+    const completedOperations = await Promise.all(
+      operationIds.map((id) => repositories.mintOperationRepository.getById(id)),
+    );
+    expect(resumed.state).toBe('finalized');
+    expect(completedAttempt?.state).toBe('succeeded');
+    expect(completedOperations.map((operation) => operation?.state)).toEqual([
+      'finalized',
+      'finalized',
+    ]);
+    expect(walletBatchMint).toHaveBeenCalledTimes(2);
+    expect(walletBatchMint.mock.calls[1]?.[0]).toEqual(firstPreview);
+    expect(createMintOutputsAtCounter).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers the complete exact batch proof set when every member is issued', async () => {
+    const { attempt, operationIds, quoteIds, recoveredProof } = await createAmbiguousBatch();
+    for (const recoveredQuoteId of quoteIds) {
+      await repositories.mintQuoteRepository.setMintQuoteState(
+        mintUrl,
+        'bolt11',
+        recoveredQuoteId,
+        'ISSUED',
+        Date.now(),
+      );
+    }
+    (proofService.recoverProofsFromOutputData as Mock<any>).mockResolvedValueOnce([recoveredProof]);
+
+    const result = await coordinator.coordinate(operationIds[0]);
+
+    expect(result.state).toBe('finalized');
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'succeeded',
+    );
+    expect(
+      await repositories.proofRepository.getProofBySecret(mintUrl, recoveredProof.secret),
+    ).toMatchObject({ state: 'ready', createdByAttemptId: attempt.id });
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the exact batch recoverable when a quote observation is missing', async () => {
+    const { attempt, operationIds } = await createAmbiguousBatch();
+    checkMintQuoteBatch.mockImplementationOnce(async (_mintUrl, method, quoteIds) => {
+      const quote = await repositories.mintQuoteRepository.getMintQuote(
+        mintUrl,
+        method,
+        quoteIds[0]!,
+      );
+      return quote ? [mintQuoteToMethodSnapshot(quote)] : [];
+    });
+
+    const result = await coordinator.coordinate(operationIds[1]);
+
+    expect(result.state).toBe('executing');
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['executing', 'executing']);
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails issued members and requeues claimable members for mixed recovery states', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    await repositories.mintQuoteRepository.setMintQuoteState(
+      mintUrl,
+      'bolt11',
+      quoteIds[0],
+      'ISSUED',
+      Date.now(),
+    );
+
+    const result = await coordinator.coordinate(operationIds[1]);
+
+    const operations = await Promise.all(
+      operationIds.map((id) => repositories.mintOperationRepository.getById(id)),
+    );
+    expect(result.state).toBe('pending');
+    expect(operations[0]).toMatchObject({
+      state: 'failed',
+      attemptId: attempt.id,
+    });
+    expect(operations[1]).toMatchObject({ state: 'pending', attemptId: undefined });
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'failed',
+    );
+    expect(coordinator.isScheduled(operationIds[1])).toBe(true);
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves partial recovered proofs and fails every batch member with one critical error', async () => {
+    const firstSecret = 'partial-batch-output-a';
+    const secondSecret = 'partial-batch-output-b';
+    const partialOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(10), id: keysetId, B_: `B_${firstSecret}` },
+          31n,
+          new TextEncoder().encode(firstSecret),
+        ),
+        new OutputData(
+          { amount: Amount.from(10), id: keysetId, B_: `B_${secondSecret}` },
+          32n,
+          new TextEncoder().encode(secondSecret),
+        ),
+      ],
+      send: [],
+    });
+    const partialProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(10),
+      secret: firstSecret,
+      C: `C_${firstSecret}`,
+    };
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch({
+      outputData: partialOutputData,
+      recoveredProof: partialProof,
+    });
+    for (const recoveredQuoteId of quoteIds) {
+      await repositories.mintQuoteRepository.setMintQuoteState(
+        mintUrl,
+        'bolt11',
+        recoveredQuoteId,
+        'ISSUED',
+        Date.now(),
+      );
+    }
+    (proofService.recoverProofsFromOutputData as Mock<any>).mockResolvedValueOnce([partialProof]);
+
+    await coordinator.coordinate(operationIds[0]);
+
+    const operations = await Promise.all(
+      operationIds.map((id) => repositories.mintOperationRepository.getById(id)),
+    );
+    const errors = operations.map((operation) => operation?.error);
+    expect(operations.map((operation) => operation?.state)).toEqual(['failed', 'failed']);
+    expect(errors[0]).toBe(errors[1]);
+    expect(errors[0]).toContain('partial signing');
+    expect(
+      await repositories.proofRepository.getProofBySecret(mintUrl, partialProof.secret),
+    ).toMatchObject({ state: 'ready', createdByAttemptId: attempt.id });
+    expect(
+      (await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.terminalError?.code,
+    ).toBe('CRITICAL_PARTIAL_SIGNING');
+    await expect(service.canRetryIssuance(operationIds[1])).resolves.toBe(false);
+  });
+
+  it('fails every member when exact-output recovery proves no batch outputs exist', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    for (const recoveredQuoteId of quoteIds) {
+      await repositories.mintQuoteRepository.setMintQuoteState(
+        mintUrl,
+        'bolt11',
+        recoveredQuoteId,
+        'ISSUED',
+        Date.now(),
+      );
+    }
+
+    await coordinator.coordinate(operationIds[0]);
+
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['failed', 'failed']);
+    expect(
+      (await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.terminalError?.code,
+    ).toBe('EXACT_PROOFS_UNRECOVERABLE');
+  });
+
+  it('keeps the batch recoverable when exact-output recovery is unusable', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    for (const recoveredQuoteId of quoteIds) {
+      await repositories.mintQuoteRepository.setMintQuoteState(
+        mintUrl,
+        'bolt11',
+        recoveredQuoteId,
+        'ISSUED',
+        Date.now(),
+      );
+    }
+    (proofService.recoverProofsFromOutputData as Mock<any>).mockRejectedValueOnce(
+      new Error('malformed restore response'),
+    );
+
+    const result = await coordinator.coordinate(operationIds[0]);
+
+    expect(result.state).toBe('executing');
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'recovering',
+    );
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['executing', 'executing']);
+  });
+
+  it('isolates atomic validation rejection while checking an ambiguous batch', async () => {
+    const { operationIds, recoveredProof } = await createAmbiguousBatch();
+    checkMintQuoteBatch.mockImplementation(async (_mintUrl, method, quoteIds) => {
+      if (quoteIds.length > 1) {
+        throw new MintOperationError(11000, 'atomic validation rejection');
+      }
+      const quote = await repositories.mintQuoteRepository.getMintQuote(
+        mintUrl,
+        method,
+        quoteIds[0]!,
+      );
+      return quote ? [mintQuoteToMethodSnapshot(quote)] : [];
+    });
+    walletBatchMint.mockResolvedValueOnce([recoveredProof]);
+
+    const result = await coordinator.coordinate(operationIds[0]);
+
+    expect(result.state).toBe('finalized');
+    expect(checkMintQuoteBatch.mock.calls.map((call) => call[2])).toEqual([
+      [quoteId, 'quote-ambiguous-peer'],
+      [quoteId],
+      ['quote-ambiguous-peer'],
+    ]);
+    expect(walletBatchMint).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent callers recovering different members of one batch', async () => {
+    const { operationIds, recoveredProof } = await createAmbiguousBatch();
+    let releaseCheck!: () => void;
+    let markCheckStarted!: () => void;
+    const checkStarted = new Promise<void>((resolve) => {
+      markCheckStarted = resolve;
+    });
+    checkMintQuoteBatch.mockImplementationOnce(async (_mintUrl, method, quoteIds) => {
+      markCheckStarted();
+      await new Promise<void>((resolve) => {
+        releaseCheck = resolve;
+      });
+      return Promise.all(
+        quoteIds.map(async (requestedQuoteId) => {
+          const quote = await repositories.mintQuoteRepository.getMintQuote(
+            mintUrl,
+            method,
+            requestedQuoteId,
+          );
+          if (!quote) throw new Error(`Missing test quote ${requestedQuoteId}`);
+          return mintQuoteToMethodSnapshot(quote);
+        }),
+      );
+    });
+    walletBatchMint.mockResolvedValueOnce([recoveredProof]);
+
+    const first = coordinator.coordinate(operationIds[0]);
+    await checkStarted;
+    const second = coordinator.coordinate(operationIds[1]);
+    releaseCheck();
+
+    const results = await Promise.all([first, second]);
+    expect(results.map((result) => result.state)).toEqual(['finalized', 'finalized']);
+    expect(checkMintQuoteBatch).toHaveBeenCalledTimes(1);
+    expect(walletBatchMint).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers a crash-persisted submitting batch before making another remote submission', async () => {
+    const { attempt, operationIds, recoveredProof } = await createAmbiguousBatch();
+    await repositories.mintIssuanceAttemptRepository.update({
+      ...attempt,
+      state: 'submitting',
+      updatedAt: Date.now(),
+    });
+    walletBatchMint.mockResolvedValueOnce([recoveredProof]);
+
+    service = createService();
+    const result = await service.finalize(operationIds[0]);
+
+    expect(result.state).toBe('finalized');
+    expect(checkMintQuoteBatch).toHaveBeenCalledTimes(1);
+    expect(walletBatchMint).toHaveBeenCalledTimes(2);
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'succeeded',
+    );
+  });
+
+  it('retries both single attempts and ambiguous Mint Batch recovery', async () => {
     walletMint.mockRejectedValueOnce(new NetworkError('single transport unavailable'));
     await expect(service.execute(operationId)).rejects.toThrow('single transport unavailable');
     await expect(service.canRetryIssuance(operationId)).resolves.toBe(true);
@@ -1043,8 +1375,8 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       recoveryStartedAt: now,
     });
 
-    await expect(service.canRetryIssuance(batchOperationIds[0]!)).resolves.toBe(false);
-    await expect(service.canRetryIssuance(batchOperationIds[1]!)).resolves.toBe(false);
+    await expect(service.canRetryIssuance(batchOperationIds[0]!)).resolves.toBe(true);
+    await expect(service.canRetryIssuance(batchOperationIds[1]!)).resolves.toBe(true);
   });
 
   it('lets an explicit target join its processor-created Mint Batch', async () => {

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -33,7 +33,10 @@ import type { ProofService } from '../../services/ProofService.ts';
 import type { WalletService } from '../../services/WalletService.ts';
 import type { CoreProof, MintInfo } from '../../types.ts';
 import { serializeOutputData } from '../../utils.ts';
-import { ScriptedMintIssuanceTransport } from '../fixtures/ScriptedMintIssuanceTransport.ts';
+import {
+  ScriptedMintIssuanceTransport,
+  type ScriptedStep,
+} from '../fixtures/ScriptedMintIssuanceTransport.ts';
 
 describe('MintOperationService durable single BOLT11 issuance', () => {
   const mintUrl = 'https://mint.test';
@@ -180,6 +183,39 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       outputData: batchOutputData,
       recoveredProof,
     };
+  }
+
+  async function markQuotesIssued(quoteIds: readonly string[]): Promise<void> {
+    for (const issuedQuoteId of quoteIds) {
+      await repositories.mintQuoteRepository.setMintQuoteState(
+        mintUrl,
+        'bolt11',
+        issuedQuoteId,
+        'ISSUED',
+        Date.now(),
+      );
+    }
+  }
+
+  async function setQuoteUnpaid(quoteId: string, expiry: number): Promise<void> {
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteId,
+        request: 'lnbc1ambiguouspeer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'UNPAID',
+      }),
+    );
+  }
+
+  function scriptExactOutputRestore(...steps: ScriptedStep<Proof[]>[]) {
+    const scripted = new ScriptedMintIssuanceTransport([], [], steps);
+    (proofService.recoverProofsFromOutputData as Mock<any>).mockImplementation(
+      scripted.restoreExactOutputs,
+    );
+    return scripted;
   }
 
   function createService(): MintOperationService {
@@ -1125,16 +1161,8 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
   it('recovers the complete exact batch proof set when every member is issued', async () => {
     const { attempt, operationIds, quoteIds, recoveredProof } = await createAmbiguousBatch();
-    for (const recoveredQuoteId of quoteIds) {
-      await repositories.mintQuoteRepository.setMintQuoteState(
-        mintUrl,
-        'bolt11',
-        recoveredQuoteId,
-        'ISSUED',
-        Date.now(),
-      );
-    }
-    (proofService.recoverProofsFromOutputData as Mock<any>).mockResolvedValueOnce([recoveredProof]);
+    await markQuotesIssued(quoteIds);
+    const scripted = scriptExactOutputRestore({ kind: 'return', value: [recoveredProof] });
 
     const result = await coordinator.coordinate(operationIds[0]);
 
@@ -1145,6 +1173,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(
       await repositories.proofRepository.getProofBySecret(mintUrl, recoveredProof.secret),
     ).toMatchObject({ state: 'ready', createdByAttemptId: attempt.id });
+    expect(scripted.restoreRequests).toEqual([{ mintUrl, attemptId: attempt.id }]);
     expect(walletBatchMint).toHaveBeenCalledTimes(1);
   });
 
@@ -1205,16 +1234,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
   it('requeues independently observed PAID and unexpired UNPAID members', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
-    await repositories.mintQuoteRepository.upsertMintQuote(
-      mintQuoteFromBolt11Response(mintUrl, {
-        quote: quoteIds[1],
-        request: 'lnbc1ambiguouspeer',
-        amount: Amount.from(10),
-        unit: 'sat',
-        expiry: Math.floor(Date.now() / 1000) + 3600,
-        state: 'UNPAID',
-      }),
-    );
+    await setQuoteUnpaid(quoteIds[1], Math.floor(Date.now() / 1000) + 3600);
 
     await coordinator.coordinate(operationIds[0]);
 
@@ -1233,16 +1253,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
 
   it('requeues a PAID member while failing an independently observed expired UNPAID member', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
-    await repositories.mintQuoteRepository.upsertMintQuote(
-      mintQuoteFromBolt11Response(mintUrl, {
-        quote: quoteIds[1],
-        request: 'lnbc1ambiguouspeer',
-        amount: Amount.from(10),
-        unit: 'sat',
-        expiry: Math.floor(Date.now() / 1000) - 1,
-        state: 'UNPAID',
-      }),
-    );
+    await setQuoteUnpaid(quoteIds[1], Math.floor(Date.now() / 1000) - 1);
 
     await coordinator.coordinate(operationIds[1]);
 
@@ -1284,16 +1295,8 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       outputData: partialOutputData,
       recoveredProof: partialProof,
     });
-    for (const recoveredQuoteId of quoteIds) {
-      await repositories.mintQuoteRepository.setMintQuoteState(
-        mintUrl,
-        'bolt11',
-        recoveredQuoteId,
-        'ISSUED',
-        Date.now(),
-      );
-    }
-    (proofService.recoverProofsFromOutputData as Mock<any>).mockResolvedValueOnce([partialProof]);
+    await markQuotesIssued(quoteIds);
+    const scripted = scriptExactOutputRestore({ kind: 'return', value: [partialProof] });
 
     await coordinator.coordinate(operationIds[0]);
 
@@ -1310,20 +1313,14 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(
       (await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.terminalError?.code,
     ).toBe('CRITICAL_PARTIAL_SIGNING');
+    expect(scripted.restoreRequests).toHaveLength(1);
     await expect(service.canRetryIssuance(operationIds[1])).resolves.toBe(false);
   });
 
   it('fails every member when exact-output restoration proves no batch outputs exist', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
-    for (const recoveredQuoteId of quoteIds) {
-      await repositories.mintQuoteRepository.setMintQuoteState(
-        mintUrl,
-        'bolt11',
-        recoveredQuoteId,
-        'ISSUED',
-        Date.now(),
-      );
-    }
+    await markQuotesIssued(quoteIds);
+    const scripted = scriptExactOutputRestore({ kind: 'return', value: [] });
 
     await coordinator.coordinate(operationIds[0]);
 
@@ -1337,22 +1334,16 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(
       (await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.terminalError?.code,
     ).toBe('EXACT_PROOFS_UNRECOVERABLE');
+    expect(scripted.restoreRequests).toHaveLength(1);
   });
 
   it('keeps the batch recoverable when exact-output restoration is unusable', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
-    for (const recoveredQuoteId of quoteIds) {
-      await repositories.mintQuoteRepository.setMintQuoteState(
-        mintUrl,
-        'bolt11',
-        recoveredQuoteId,
-        'ISSUED',
-        Date.now(),
-      );
-    }
-    (proofService.recoverProofsFromOutputData as Mock<any>).mockRejectedValueOnce(
-      new Error('malformed restore response'),
-    );
+    await markQuotesIssued(quoteIds);
+    const scripted = scriptExactOutputRestore({
+      kind: 'throw',
+      error: new Error('malformed restore response'),
+    });
 
     const result = await coordinator.coordinate(operationIds[0]);
 
@@ -1367,6 +1358,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         ),
       ),
     ).toEqual(['executing', 'executing']);
+    expect(scripted.restoreRequests).toHaveLength(1);
   });
 
   it('recovers deterministically across malformed submission and quote-check transport faults', async () => {

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -5,7 +5,12 @@ import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
-import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error.ts';
+import {
+  HttpResponseError,
+  MintOperationError,
+  NetworkError,
+  ProofValidationError,
+} from '../../models/Error.ts';
 import {
   getMintQuoteRemoteState,
   mintQuoteFromBolt11Response,
@@ -28,6 +33,7 @@ import type { ProofService } from '../../services/ProofService.ts';
 import type { WalletService } from '../../services/WalletService.ts';
 import type { CoreProof, MintInfo } from '../../types.ts';
 import { serializeOutputData } from '../../utils.ts';
+import { ScriptedMintIssuanceTransport } from '../fixtures/ScriptedMintIssuanceTransport.ts';
 
 describe('MintOperationService durable single BOLT11 issuance', () => {
   const mintUrl = 'https://mint.test';
@@ -579,6 +585,79 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     });
   });
 
+  it('resumes a prepared Mint Batch after a crash before its first submission', async () => {
+    const peerOperationId = 'operation-prepared-peer';
+    const peerQuoteId = 'quote-prepared-peer';
+    const batchSecret = 'prepared-batch-output';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: `B_${batchSecret}` },
+          12n,
+          new TextEncoder().encode(batchSecret),
+        ),
+      ],
+      send: [],
+    });
+    const batchProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: batchSecret,
+      C: `C_${batchSecret}`,
+    };
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1preparedpeer');
+    const attemptId = 'attempt-prepared-restart';
+    const preparedAt = Date.now();
+    await repositories.mintOperationRepository.update({
+      ...pendingOperation(),
+      state: 'executing',
+      attemptId,
+      outputData: batchOutputData,
+    });
+    const peer = await repositories.mintOperationRepository.getById(peerOperationId);
+    await repositories.mintOperationRepository.update({
+      ...peer!,
+      state: 'executing',
+      attemptId,
+      outputData: batchOutputData,
+    } as ExecutingMintOperationRecord<'bolt11'>);
+    await repositories.mintIssuanceAttemptRepository.create({
+      id: attemptId,
+      mintUrl,
+      method: 'bolt11',
+      unit: 'sat',
+      keysetId,
+      state: 'prepared',
+      memberOperationIds: [operationId, peerOperationId],
+      quoteIds: [quoteId, peerQuoteId],
+      quoteAmounts: [Amount.from(10), Amount.from(10)],
+      signingRequirements: [null, null],
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+      request: {
+        kind: 'batch',
+        quoteIds: [quoteId, peerQuoteId],
+        quoteAmounts: [Amount.from(10), Amount.from(10)],
+      },
+      createdAt: preparedAt,
+      updatedAt: preparedAt,
+    });
+
+    const prepared =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+    expect(prepared?.state).toBe('prepared');
+    expect(walletBatchMint).not.toHaveBeenCalled();
+
+    walletBatchMint.mockResolvedValueOnce([batchProof]);
+    service = createService();
+    await expect(service.finalize(peerOperationId)).resolves.toMatchObject({ state: 'finalized' });
+    expect((await repositories.mintIssuanceAttemptRepository.getById(prepared!.id))?.state).toBe(
+      'succeeded',
+    );
+    expect(walletBatchMint).toHaveBeenCalledTimes(1);
+  });
+
   it('requeues a conclusively unissued Mint Batch and succeeds through fresh outputs', async () => {
     const peerQuoteId = 'quote-peer';
     const peerOperationId = 'operation-peer';
@@ -1124,6 +1203,59 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     expect(walletBatchMint).toHaveBeenCalledTimes(1);
   });
 
+  it('requeues independently observed PAID and unexpired UNPAID members', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteIds[1],
+        request: 'lnbc1ambiguouspeer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'UNPAID',
+      }),
+    );
+
+    await coordinator.coordinate(operationIds[0]);
+
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['pending', 'pending']);
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt.id))?.state).toBe(
+      'failed',
+    );
+    expect(operationIds.every((id) => coordinator.isScheduled(id))).toBe(true);
+  });
+
+  it('requeues a PAID member while failing an independently observed expired UNPAID member', async () => {
+    const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteIds[1],
+        request: 'lnbc1ambiguouspeer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) - 1,
+        state: 'UNPAID',
+      }),
+    );
+
+    await coordinator.coordinate(operationIds[1]);
+
+    const operations = await Promise.all(
+      operationIds.map((id) => repositories.mintOperationRepository.getById(id)),
+    );
+    expect(operations[0]).toMatchObject({ state: 'pending', attemptId: undefined });
+    expect(operations[1]).toMatchObject({ state: 'failed', attemptId: attempt.id });
+    expect(operations[1]?.error).toContain('expired before issuance');
+    expect(coordinator.isScheduled(operationIds[0])).toBe(true);
+    expect(coordinator.isScheduled(operationIds[1])).toBe(false);
+  });
+
   it('saves partial recovered proofs and fails every batch member with one critical error', async () => {
     const firstSecret = 'partial-batch-output-a';
     const secondSecret = 'partial-batch-output-b';
@@ -1181,7 +1313,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     await expect(service.canRetryIssuance(operationIds[1])).resolves.toBe(false);
   });
 
-  it('fails every member when exact-output recovery proves no batch outputs exist', async () => {
+  it('fails every member when exact-output restoration proves no batch outputs exist', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
     for (const recoveredQuoteId of quoteIds) {
       await repositories.mintQuoteRepository.setMintQuoteState(
@@ -1207,7 +1339,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     ).toBe('EXACT_PROOFS_UNRECOVERABLE');
   });
 
-  it('keeps the batch recoverable when exact-output recovery is unusable', async () => {
+  it('keeps the batch recoverable when exact-output restoration is unusable', async () => {
     const { attempt, operationIds, quoteIds } = await createAmbiguousBatch();
     for (const recoveredQuoteId of quoteIds) {
       await repositories.mintQuoteRepository.setMintQuoteState(
@@ -1235,6 +1367,83 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         ),
       ),
     ).toEqual(['executing', 'executing']);
+  });
+
+  it('recovers deterministically across malformed submission and quote-check transport faults', async () => {
+    const peerQuoteId = 'quote-scripted-peer';
+    const peerOperationId = 'operation-scripted-peer';
+    const batchSecret = 'scripted-batch-output';
+    const batchOutputData = serializeOutputData({
+      keep: [
+        new OutputData(
+          { amount: Amount.from(20), id: keysetId, B_: `B_${batchSecret}` },
+          41n,
+          new TextEncoder().encode(batchSecret),
+        ),
+      ],
+      send: [],
+    });
+    const batchProof: Proof = {
+      id: keysetId,
+      amount: Amount.from(20),
+      secret: batchSecret,
+      C: `C_${batchSecret}`,
+    };
+    await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1scriptedpeer');
+    const canonicalQuotes = await Promise.all(
+      [quoteId, peerQuoteId].map((id) =>
+        repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', id),
+      ),
+    );
+    const snapshots = canonicalQuotes.map((quote) => mintQuoteToMethodSnapshot(quote!));
+    const networkFailure = new NetworkError('scripted quote-check disconnect');
+    const scripted = new ScriptedMintIssuanceTransport(
+      [
+        {
+          kind: 'return',
+          value: [{ ...batchProof, secret: 'malformed-success-secret' }],
+        },
+        { kind: 'return', value: [batchProof] },
+      ],
+      [
+        { kind: 'throw', error: networkFailure },
+        { kind: 'throw', error: networkFailure },
+        { kind: 'throw', error: networkFailure },
+        {
+          kind: 'throw',
+          error: new ProofValidationError('scripted malformed quote-check body'),
+        },
+        { kind: 'return', value: snapshots },
+      ],
+    );
+    walletBatchMint.mockImplementation(scripted.completeBatchMint);
+    checkMintQuoteBatch.mockImplementation(scripted.checkMintQuoteBatch);
+    createMintOutputsAtCounter.mockResolvedValueOnce({
+      keysetId,
+      outputData: batchOutputData,
+      counterStart: 0,
+      counterEnd: 1,
+    });
+
+    coordinator.schedule(operationId);
+    coordinator.schedule(peerOperationId);
+    await expect(coordinator.coordinate()).rejects.toThrow('exact proof set');
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
+
+    service = createService();
+    await expect(service.finalize(operationId)).resolves.toMatchObject({ state: 'executing' });
+    await expect(service.finalize(peerOperationId)).resolves.toMatchObject({ state: 'executing' });
+    await expect(service.finalize(operationId)).resolves.toMatchObject({ state: 'finalized' });
+
+    expect(attempt?.state).toBe('recovering');
+    expect((await repositories.mintIssuanceAttemptRepository.getById(attempt!.id))?.state).toBe(
+      'succeeded',
+    );
+    expect(scripted.quoteChecks).toHaveLength(5);
+    expect(scripted.batchSubmissions).toHaveLength(2);
+    expect(scripted.batchSubmissions[1]).toEqual(scripted.batchSubmissions[0]);
+    expect(createMintOutputsAtCounter).toHaveBeenCalledTimes(1);
   });
 
   it('isolates atomic validation rejection while checking an ambiguous batch', async () => {

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -277,6 +277,93 @@ describe('MintOperationProcessor', () => {
     }
   });
 
+  it('backs off an attempt peer enqueued while recovery is failing', async () => {
+    const states = new Map<string, 'executing' | 'finalized'>([
+      ['mint-op-recovery', 'executing'],
+      ['mint-op-recovery-peer', 'executing'],
+    ]);
+    const attemptTimes: number[] = [];
+    const coordinateScheduledIssuance = mock(async () => {
+      attemptTimes.push(Date.now());
+      for (const operationId of states.keys()) states.set(operationId, 'finalized');
+    });
+    coordinateScheduledIssuance.mockImplementationOnce(async () => {
+      attemptTimes.push(Date.now());
+      await bus.emit('mint-quote:updated', {
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+        quoteId: 'quote-recovery-peer',
+        quote: mintQuoteFromBolt11Response('https://mint.test', {
+          quote: 'quote-recovery-peer',
+          request: 'lnbc1recoverypeer',
+          amount: Amount.from(10),
+          unit: 'sat',
+          expiry: Math.floor(Date.now() / 1000) + 3600,
+          state: 'PAID',
+        }),
+      });
+      throw new NetworkError('recovery quote check disconnected');
+    });
+    mockMintOperationService = {
+      async getOperationsForQuote(_mintUrl: string, _method: string, quoteId: string) {
+        const operationId = quoteId.replace('quote', 'mint-op');
+        return [
+          {
+            id: operationId,
+            state: states.get(operationId),
+            mintUrl: 'https://mint.test',
+            method: 'bolt11',
+          },
+        ];
+      },
+      scheduleIssuance() {},
+      coordinateScheduledIssuance,
+      async getOperation(operationId: string) {
+        return {
+          id: operationId,
+          state: states.get(operationId),
+          mintUrl: 'https://mint.test',
+          method: 'bolt11',
+        };
+      },
+      async canRetryIssuance() {
+        return true;
+      },
+      wasIssuanceSelectedInLastTurn() {
+        return true;
+      },
+      async claimPendingMintQuotes() {
+        return [];
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: 1,
+        baseRetryDelayMs: TEST_RETRY_DELAY,
+        initialEnqueueDelayMs: 0,
+      },
+    );
+    await processor.start();
+    await bus.emit('mint-op:requeue', {
+      mintUrl: 'https://mint.test',
+      operationId: 'mint-op-recovery',
+      operation: {
+        id: 'mint-op-recovery',
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+      } as CoreEvents['mint-op:requeue']['operation'],
+    });
+
+    await processor.waitForCompletion();
+
+    expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(2);
+    expect(attemptTimes[1]! - attemptTimes[0]!).toBeGreaterThanOrEqual(TEST_RETRY_DELAY - 20);
+  });
+
   it('drains a pending BOLT11 item that the coordinator declines as ineligible', async () => {
     let markRepeated!: () => void;
     const repeated = new Promise<void>((resolve) => {

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -289,6 +289,10 @@ describe('MintOperationProcessor', () => {
     });
     coordinateScheduledIssuance.mockImplementationOnce(async () => {
       attemptTimes.push(Date.now());
+      throw new NetworkError('recovery quote check disconnected before observations');
+    });
+    coordinateScheduledIssuance.mockImplementationOnce(async () => {
+      attemptTimes.push(Date.now());
       await bus.emit('mint-quote:updated', {
         mintUrl: 'https://mint.test',
         method: 'bolt11',
@@ -360,8 +364,8 @@ describe('MintOperationProcessor', () => {
 
     await processor.waitForCompletion();
 
-    expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(2);
-    expect(attemptTimes[1]! - attemptTimes[0]!).toBeGreaterThanOrEqual(TEST_RETRY_DELAY - 20);
+    expect(coordinateScheduledIssuance).toHaveBeenCalledTimes(3);
+    expect(attemptTimes[2]! - attemptTimes[1]!).toBeGreaterThanOrEqual(TEST_RETRY_DELAY * 2 - 20);
   });
 
   it('drains a pending BOLT11 item that the coordinator declines as ineligible', async () => {

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -4,7 +4,12 @@ import { MintOperationProcessor } from '../../services/watchers/MintOperationPro
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { MintOperationService } from '../../operations/mint/MintOperationService';
-import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error';
+import {
+  HttpResponseError,
+  MintFetchError,
+  MintOperationError,
+  NetworkError,
+} from '../../models/Error';
 import { mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 
@@ -851,6 +856,49 @@ describe('MintOperationProcessor', () => {
       expect(secondRetryDelay).toBeGreaterThan(TEST_RETRY_DELAY * 2 - 20);
       expect(secondRetryDelay).toBeLessThan(TEST_RETRY_DELAY * 2 + 100);
     }
+  });
+
+  it('retries transport failures wrapped by mint refresh errors', async () => {
+    const finalize = mock(async (operationId: string) => {
+      finalizeCalls.push(operationId);
+    });
+    finalize.mockImplementationOnce(async () => {
+      throw new MintFetchError(
+        'https://mint.test',
+        undefined,
+        new HttpResponseError('mint info unavailable', 503),
+      );
+    });
+    mockMintOperationService = {
+      finalize,
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: 1,
+        baseRetryDelayMs: 1,
+        maxRetries: 2,
+        initialEnqueueDelayMs: 0,
+      },
+    );
+
+    await processor.start();
+    await bus.emit('mint-op:requeue', {
+      mintUrl: 'https://mint.test',
+      operationId: 'mint-op-wrapped-network',
+      operation: {
+        id: 'mint-op-wrapped-network',
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+      } as CoreEvents['mint-op:requeue']['operation'],
+    });
+    await processor.waitForCompletion();
+
+    expect(finalize).toHaveBeenCalledTimes(2);
+    expect(finalizeCalls).toEqual(['mint-op-wrapped-network']);
   });
 
   it('does not retry mint operation errors', async () => {

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -4,7 +4,7 @@ import { MintOperationProcessor } from '../../services/watchers/MintOperationPro
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { MintOperationService } from '../../operations/mint/MintOperationService';
-import { MintOperationError, NetworkError } from '../../models/Error';
+import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error';
 import { mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 
@@ -789,7 +789,7 @@ describe('MintOperationProcessor', () => {
     expect(finalizeCalls).toEqual(['mint-op-5']);
   });
 
-  it('retries network errors with exponential backoff', async () => {
+  it('retries transient transport errors with exponential backoff', async () => {
     let attemptCount = 0;
     const attemptTimes: number[] = [];
 
@@ -797,9 +797,10 @@ describe('MintOperationProcessor', () => {
       async finalize(operationId: string) {
         attemptCount++;
         attemptTimes.push(Date.now());
-        if (attemptCount <= 2) {
+        if (attemptCount === 1) {
           throw new NetworkError(`network failure for ${operationId}`);
         }
+        if (attemptCount === 2) throw new HttpResponseError('mint unavailable', 503);
         finalizeCalls.push(operationId);
       },
     } as unknown as MintOperationService;

--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -6,7 +6,10 @@ import { ProofService } from '../../services/ProofService.ts';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository.ts';
 import { MemoryCounterRepository } from '../../repositories/memory/MemoryCounterRepository.ts';
 import { CounterService } from '../../services/CounterService.ts';
+import type { KeyRingService } from '../../services/KeyRingService.ts';
+import type { MintService } from '../../services/MintService.ts';
 import { SeedService } from '../../services/SeedService.ts';
+import type { WalletService } from '../../services/WalletService.ts';
 import {
   ProofOperationError,
   ProofValidationError,
@@ -1561,6 +1564,70 @@ describe('ProofService', () => {
       expect(recovered[0]?.C).not.toBe(blindedC_);
     });
 
+    it('rejects indeterminate proof states during exact-output recovery', async () => {
+      const B_ = 'indeterminate-proof-state-output';
+      const serializedOutputData: SerializedOutputData = {
+        keep: [],
+        send: [
+          {
+            blindedMessage: { amount: '1', id: keysetId, B_ },
+            blindingFactor: 'deadbeef',
+            secret: Buffer.from('test-secret').toString('hex'),
+          },
+        ],
+      };
+      OutputData.prototype.toProof = mock(() => ({
+        id: keysetId,
+        amount: Amount.from(1),
+        secret: 'test-secret',
+        C: 'UNBLINDED_C',
+      })) as unknown as typeof OutputData.prototype.toProof;
+      const localMintService = {
+        async ensureUpdatedMint() {
+          return {
+            mint: {},
+            keysets: [{ id: keysetId, unit: 'sat', active: true, keypairs: { '1': 'pubkey-1' } }],
+          };
+        },
+      };
+      const localWalletService = {
+        async getWalletWithActiveKeysetId() {
+          return {
+            wallet: {
+              mint: {
+                async restore() {
+                  return {
+                    outputs: [{ B_, amount: 1, id: keysetId }],
+                    signatures: [{ B_, id: keysetId, amount: Amount.from(1), C_: 'BLINDED_C_' }],
+                  };
+                },
+              },
+              async checkProofsStates() {
+                return [{ state: 'PENDING' }];
+              },
+            },
+          };
+        },
+      };
+      const service = new ProofService(
+        counterService,
+        proofRepo,
+        localWalletService as unknown as WalletService,
+        localMintService as unknown as MintService,
+        keyRingService as unknown as KeyRingService,
+        seedService,
+        undefined,
+        bus,
+      );
+
+      await expect(
+        service.recoverProofsFromOutputData(mintUrl, serializedOutputData, {
+          unit: 'sat',
+          persistRecoveredProofs: false,
+        }),
+      ).rejects.toThrow(ProofValidationError);
+    });
+
     it('rejects restored signatures from a different-unit keyset', async () => {
       const B_ = 'mock_blinded_point_B_';
       const serializedOutputData: SerializedOutputData = {
@@ -1620,9 +1687,9 @@ describe('ProofService', () => {
       const service = new ProofService(
         counterService,
         proofRepo,
-        localWalletService as any,
-        localMintService as any,
-        keyRingService as any,
+        localWalletService as unknown as WalletService,
+        localMintService as unknown as MintService,
+        keyRingService as unknown as KeyRingService,
         seedService,
         undefined,
         bus,
@@ -1676,9 +1743,9 @@ describe('ProofService', () => {
       const service = new ProofService(
         counterService,
         proofRepo,
-        localWalletService as any,
-        localMintService as any,
-        keyRingService as any,
+        localWalletService as unknown as WalletService,
+        localMintService as unknown as MintService,
+        keyRingService as unknown as KeyRingService,
         seedService,
         undefined,
         bus,

--- a/packages/core/test/unit/ProofService.test.ts
+++ b/packages/core/test/unit/ProofService.test.ts
@@ -1636,5 +1636,60 @@ describe('ProofService', () => {
       ).rejects.toThrow(UnitMismatchError);
       expect(toProof).not.toHaveBeenCalled();
     });
+
+    it('rejects an unusable restore response instead of treating it as empty recovery', async () => {
+      const B_ = 'unpaired-blinded-output';
+      const serializedOutputData: SerializedOutputData = {
+        keep: [],
+        send: [
+          {
+            blindedMessage: { amount: '1', id: keysetId, B_ },
+            blindingFactor: 'deadbeef',
+            secret: Buffer.from('test-secret').toString('hex'),
+          },
+        ],
+      };
+      const localMintService = {
+        async ensureUpdatedMint() {
+          return {
+            mint: {},
+            keysets: [{ id: keysetId, unit: 'sat', active: true, keypairs: { '1': 'pubkey-1' } }],
+          };
+        },
+      };
+      const localWalletService = {
+        async getWalletWithActiveKeysetId() {
+          return {
+            wallet: {
+              mint: {
+                async restore() {
+                  return { outputs: [{ B_, amount: 1, id: keysetId }], signatures: [] };
+                },
+              },
+              async checkProofsStates() {
+                throw new Error('proof states must not be checked for an unusable restore');
+              },
+            },
+          };
+        },
+      };
+      const service = new ProofService(
+        counterService,
+        proofRepo,
+        localWalletService as any,
+        localMintService as any,
+        keyRingService as any,
+        seedService,
+        undefined,
+        bus,
+      );
+
+      await expect(
+        service.recoverProofsFromOutputData(mintUrl, serializedOutputData, {
+          unit: 'sat',
+          persistRecoveredProofs: false,
+        }),
+      ).rejects.toThrow(ProofValidationError);
+    });
   });
 });


### PR DESCRIPTION
Parent map: #332
Slice: #342
Implementation PR: #344

This pull request resolves #342.

## Problem

An interrupted or otherwise ambiguous NUT-29 Mint Batch could leave every member executing without a safe way to determine whether to resubmit, recover exact proofs, or return individual quotes to normal grouping. Successful operations must only be reported after Coco owns the complete attributable proof set.

## Summary

- reconcile ambiguous attempts from persisted ordered membership, requests, and outputs using attributable NUT-29 quote observations
- resubmit identical all-claimable attempts, recover all-issued attempts through exact-output NUT-09 Restore, and apply independent rules to mixed canonical states
- validate Restore and proof-state responses before persistence, handle empty and partial recovery safely, and deduplicate concurrent recovery callers
- apply bounded processor backoff to incomplete quote checks, wrapped transport failures, unusable Restore responses, and peers enqueued re-entrantly during recovery
- keep every selected attempt member on the same retry generation so late peers cannot bypass delay or retain extra retry budget
- continue recovery checks across reduced NUT-29 chunks and single-quote fallback until every attempt quote has been attempted
- add deterministic submission, quote-check, and Restore fault injection plus restart, mixed-state, atomic-isolation, partial-signing, concurrency, and retry coverage
- add a core patch changeset; no public API surface changes

## Acceptance criteria

- [x] Preserve executing members and exact ordered attempt reconstruction data after ambiguity.
- [x] Mark attempts recovering and reconcile through attributable batch quote checks.
- [x] Split confirmed validation rejections to isolate invalid singleton checks without fabricated observations.
- [x] Leave attempts recoverable for incomplete or unusable quote-check results.
- [x] Resubmit the identical attempt when every member remains claimable.
- [x] Recover all-issued attempts through exact-output NUT-09 and atomically finalize the complete proof set.
- [x] Fail externally redeemed members and requeue claimable members for issued/claimable mixed states.
- [x] Apply independent canonical rules to other attributable mixed states.
- [x] Fail all members for a valid empty Restore while retaining recoverability for unusable Restore or proof-state responses.
- [x] Save valid partial proofs as ready, fail all members with one critical error, and prevent retries.
- [x] Fail single already-issued operations that lack exact locally recoverable proofs.
- [x] Cover every durable restart boundary and required recovery outcome with deterministic faults.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit` (1,168 passed)
- `bun run --filter='@cashu/coco-core' test -- test/unit/MintIssuanceCoordinator.test.ts test/unit/MintQuoteProcessor.test.ts test/unit/ProofService.test.ts` (113 passed)
- `bun run --filter='@cashu/coco-core' build`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run format:check`
- Standards review: no remaining actionable findings
- Spec review: no remaining actionable findings

The complete core test command was also attempted. Its 1,173 passing tests completed, while four environment-dependent integration cases requiring `MINT_URL`, a local mint on `localhost:3338`, or auth fixtures could not run in this workspace.

## Changeset

- Added `.changeset/recover-ambiguous-mint-batches.md` for `@cashu/coco-core` (patch).
