### PR TITLE
fix(core): preserve paid mint requeue cohorts

### DIFF
--- a/.changeset/cohort-paid-mint-requeue.md
+++ b/.changeset/cohort-paid-mint-requeue.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Resolve the complete eligible paid Mint Operation set before requeueing it so automatic processing
+can preserve processor batching cohorts across asynchronous repository adapters.

--- a/packages/adapter-tests/src/integration.ts
+++ b/packages/adapter-tests/src/integration.ts
@@ -2158,6 +2158,103 @@ export async function runIntegrationTests<TRepositories extends Repositories = R
     });
 
     describe('Watchers and Processors', () => {
+      it('should redeem one processor-selected NUT-29 Mint Batch without duplicate issuance', async () => {
+        const { repositories, dispose } = await createRepositories();
+        try {
+          mgr = await initializeCoco({
+            repo: repositories,
+            seedGetter,
+            logger,
+            processors: {
+              mintOperationProcessor: {
+                disabled: true,
+              },
+            },
+          });
+
+          await mgr.mint.addMint(mintUrl, { trusted: true });
+          const mintInfo = await mgr.mint.getMintInfo(mintUrl);
+          const nut29 = (mintInfo as { nuts?: Record<string, unknown> }).nuts?.['29'];
+          expect(nut29).toBeDefined();
+
+          const operations = await Promise.all([
+            prepareMintOperation(mgr, mintUrl, 21, testUnit),
+            prepareMintOperation(mgr, mintUrl, 34, testUnit),
+          ]);
+          await Promise.all(
+            operations.map((operation) => awaitMintQuoteReadyFromEvents(mgr!, operation)),
+          );
+
+          const operationIds = new Set(operations.map((operation) => operation.id));
+          const finalizedIds = new Set<string>();
+          const allFinalized = new Promise<void>((resolve) => {
+            const off = mgr!.on('mint-op:finalized', ({ operationId }) => {
+              if (!operationIds.has(operationId)) return;
+              finalizedIds.add(operationId);
+              if (finalizedIds.size !== operationIds.size) return;
+              off();
+              resolve();
+            });
+          });
+
+          await mgr.enableMintOperationProcessor({
+            initialEnqueueDelayMs: 0,
+            processIntervalMs: 60_000,
+          });
+          const { requeued } = await mgr.requeuePaidMintQuotes(mintUrl);
+          expect(requeued.slice().sort().join(',')).toBe(
+            operations
+              .map((operation) => operation.quoteId)
+              .sort()
+              .join(','),
+          );
+          await mgr.waitForMintOperationProcessor();
+          await allFinalized;
+
+          const finalized = await Promise.all(
+            operations.map((operation) => mgr!.ops.mint.get(operation.id)),
+          );
+          expect(finalized.map((operation) => operation?.state).join(',')).toBe(
+            'finalized,finalized',
+          );
+          expect(await getMintTotalBalance(mgr, mintUrl, testUnit)).toBe(55);
+
+          const attempts = await repositories.mintIssuanceAttemptRepository.listByMintUrl(mintUrl);
+          const matchesTestOperations = (attempt: (typeof attempts)[number]) =>
+            attempt.memberOperationIds.some((operationId) => operationIds.has(operationId));
+          const matchingAttempts = attempts.filter(matchesTestOperations);
+          expect(matchingAttempts).toHaveLength(1);
+          expect(matchingAttempts[0]!.request.kind).toBe('batch');
+          expect(matchingAttempts[0]!.memberOperationIds.slice().sort().join(',')).toBe(
+            operations
+              .map((operation) => operation.id)
+              .sort()
+              .join(','),
+          );
+          expect(new Set(matchingAttempts[0]!.quoteIds).size).toBe(2);
+
+          const quoteStates = await Promise.all(
+            operations.map((operation) =>
+              mgr!.quotes.mint.get({ mintUrl, quoteId: operation.quoteId }),
+            ),
+          );
+          expect(quoteStates.map((quote) => quote?.state).join(',')).toBe('ISSUED,ISSUED');
+
+          await Promise.all(operations.map((operation) => mgr!.ops.mint.execute(operation.id)));
+          expect(await getMintTotalBalance(mgr, mintUrl, testUnit)).toBe(55);
+          const attemptsAfterReplay =
+            await repositories.mintIssuanceAttemptRepository.listByMintUrl(mintUrl);
+          expect(attemptsAfterReplay.filter(matchesTestOperations)).toHaveLength(1);
+        } finally {
+          if (mgr) {
+            await mgr.pauseSubscriptions();
+            await mgr.dispose();
+            mgr = undefined;
+          }
+          await dispose();
+        }
+      }, 20000);
+
       it('should automatically process paid mint quotes with watcher enabled', async () => {
         const { repositories, dispose } = await createRepositories();
         try {

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -761,24 +761,33 @@ export class Manager {
     return this.logger.child ? this.logger.child({ module: moduleName }) : this.logger;
   }
 
+  /**
+   * Requeues pending operations backed by paid quotes, optionally for one mint.
+   *
+   * Eligibility is resolved for the complete pending set before events are emitted so automatic
+   * processing can consider the eligible operations in one cohort.
+   */
   async requeuePaidMintQuotes(mintUrl?: string): Promise<{ requeued: string[] }> {
     const requeued: string[] = [];
     const pendingOperations = await this.mintOperationService.getPendingOperations();
 
-    for (const operation of pendingOperations) {
-      if (mintUrl && operation.mintUrl !== mintUrl) continue;
+    const eligibleOperations = await Promise.all(
+      pendingOperations.map(async (operation) => {
+        if (mintUrl && operation.mintUrl !== mintUrl) return null;
 
-      const quote = await this.quoteLifecycle.getMintQuote(
-        operation.mintUrl,
-        operation.method,
-        operation.quoteId,
-      );
-      if (!quote || !isStatefulMintQuote(quote) || quote.state !== 'PAID') continue;
+        const quote = await this.quoteLifecycle.getMintQuote(
+          operation.mintUrl,
+          operation.method,
+          operation.quoteId,
+        );
+        if (!quote || !isStatefulMintQuote(quote) || quote.state !== 'PAID') return null;
 
-      const trusted = await this.mintService.isTrustedMint(operation.mintUrl);
-      if (!trusted) {
-        continue;
-      }
+        return (await this.mintService.isTrustedMint(operation.mintUrl)) ? operation : null;
+      }),
+    );
+
+    for (const operation of eligibleOperations) {
+      if (!operation) continue;
 
       await this.eventBus.emit('mint-op:requeue', {
         mintUrl: operation.mintUrl,

--- a/packages/core/test/unit/Manager.test.ts
+++ b/packages/core/test/unit/Manager.test.ts
@@ -1467,29 +1467,54 @@ describe('initializeCoco', () => {
           meltSettlementProcessor: { disabled: true },
         },
       });
-      const operation = makePendingMintOperation('mint-op-paid', 'quote-paid');
-      await repositories.mintOperationRepository.create(operation);
-      await repositories.mintQuoteRepository.upsertMintQuote(
-        mintQuoteFromBolt11Response(operation.mintUrl, {
-          quote: operation.quoteId,
-          request: operation.request,
-          amount: operation.amount,
-          unit: operation.unit,
-          expiry: Math.floor(Date.now() / 1000) + 3600,
-          state: 'PAID',
-        }),
-      );
+      const operations = [
+        makePendingMintOperation('mint-op-paid-a', 'quote-paid-a'),
+        makePendingMintOperation('mint-op-paid-b', 'quote-paid-b'),
+      ];
+      for (const operation of operations) {
+        await repositories.mintOperationRepository.create(operation);
+        await repositories.mintQuoteRepository.upsertMintQuote(
+          mintQuoteFromBolt11Response(operation.mintUrl, {
+            quote: operation.quoteId,
+            request: operation.request,
+            amount: operation.amount,
+            unit: operation.unit,
+            expiry: Math.floor(Date.now() / 1000) + 3600,
+            state: 'PAID',
+          }),
+        );
+      }
 
-      manager['mintService'].isTrustedMint = mock(async () => true);
+      let resolveSecondTrustStarted!: () => void;
+      const secondTrustStarted = new Promise<void>((resolve) => {
+        resolveSecondTrustStarted = resolve;
+      });
+      let releaseSecondTrust!: () => void;
+      const secondTrust = new Promise<void>((resolve) => {
+        releaseSecondTrust = resolve;
+      });
+      let trustChecks = 0;
+      manager['mintService'].isTrustedMint = mock(async () => {
+        trustChecks += 1;
+        if (trustChecks === 2) {
+          resolveSecondTrustStarted();
+          await secondTrust;
+        }
+        return true;
+      });
       const requeuedOperationIds: string[] = [];
       manager.on('mint-op:requeue', ({ operationId }) => {
         requeuedOperationIds.push(operationId);
       });
 
-      const result = await manager.requeuePaidMintQuotes();
+      const resultPromise = manager.requeuePaidMintQuotes();
+      await secondTrustStarted;
+      expect(requeuedOperationIds).toEqual([]);
+      releaseSecondTrust();
+      const result = await resultPromise;
 
-      expect(result.requeued).toEqual([operation.quoteId]);
-      expect(requeuedOperationIds).toEqual([operation.id]);
+      expect(result.requeued).toEqual(operations.map((operation) => operation.quoteId));
+      expect(requeuedOperationIds).toEqual(operations.map((operation) => operation.id));
     });
   });
 

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -5,6 +5,7 @@ import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
 import { mintQuoteGroupKey } from '../../infra/MintQuotePollingKey.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
+import type { Logger } from '../../logging/Logger.ts';
 import {
   HttpResponseError,
   MintFetchError,
@@ -20,9 +21,11 @@ import {
 import { MintScopedLock } from '../../operations/MintScopedLock.ts';
 import { MintIssuanceCoordinator } from '../../operations/mint/MintIssuanceCoordinator.ts';
 import type { MintIssuanceAttempt } from '../../operations/mint/MintIssuanceAttempt.ts';
-import type {
-  ExecutingMintOperationRecord,
-  PendingMintOperationRecord,
+import {
+  toMintOperation,
+  type ExecutingMintOperationRecord,
+  type MintOperation,
+  type PendingMintOperationRecord,
 } from '../../operations/mint/MintOperation.ts';
 import { MintOperationService } from '../../operations/mint/MintOperationService.ts';
 import type { MintMethodHandler } from '../../operations/mint/MintMethodHandler.ts';
@@ -220,7 +223,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     return scripted;
   }
 
-  function createService(): MintOperationService {
+  function createService(logger?: Logger): MintOperationService {
     const handler = {
       checkPending: mock(async () => ({
         observedRemoteState: 'PAID' as const,
@@ -251,6 +254,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       walletService,
       mintAdapter,
       eventBus,
+      logger,
       mintScopedLock,
       nut29BatchLimitCache,
       mintQuotePollingChecker: quoteLifecycle,
@@ -311,7 +315,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     return { operation, attempt };
   }
 
-  beforeEach(async () => {
+  async function resetHarness(): Promise<void> {
     repositories = new MemoryRepositories();
     nut29BatchLimitCache = new Nut29BatchLimitCache();
     eventBus = new EventBus<CoreEvents>();
@@ -387,6 +391,10 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
     );
     await repositories.mintOperationRepository.create(pendingOperation());
     service = createService();
+  }
+
+  beforeEach(async () => {
+    await resetHarness();
   });
 
   it('finalizes through one durable attempt with exact proof provenance', async () => {
@@ -587,6 +595,21 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       secret: batchSecret,
       C: 'C_batch-output-secret',
     };
+    const publicEvents: unknown[] = [];
+    eventBus.on('mint-op:executing', (payload) => {
+      publicEvents.push(payload);
+    });
+    eventBus.on('mint-op:finalized', (payload) => {
+      publicEvents.push(payload);
+    });
+    const logEntries: unknown[] = [];
+    const logger: Logger = {
+      error: (message, ...meta) => logEntries.push({ message, meta }),
+      warn: (message, ...meta) => logEntries.push({ message, meta }),
+      info: (message, ...meta) => logEntries.push({ message, meta }),
+      debug: (message, ...meta) => logEntries.push({ message, meta }),
+    };
+    service = createService(logger);
     await seedPeerOperation(peerQuoteId, peerOperationId, 'lnbc1peer');
     createMintOutputsAtCounter.mockResolvedValueOnce({
       keysetId,
@@ -623,6 +646,10 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
         quote_amounts: [Amount.from(10), Amount.from(10)],
       },
     });
+    const publicSurface = JSON.stringify({ publicEvents, logEntries });
+    expect(publicSurface).not.toContain(batchSecret);
+    expect(publicSurface).not.toContain('outputData');
+    expect(publicSurface).not.toContain('recoveryMaterial');
   });
 
   it('resumes a prepared Mint Batch after a crash before its first submission', async () => {
@@ -2063,6 +2090,201 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       Amount.from(20),
     );
     expect(walletMint).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves public semantics across batching and force-single redemption', async () => {
+    const peers = [
+      {
+        operationId: 'operation-peer-a',
+        quoteId: 'quote-peer-a',
+        request: 'lnbc1peera',
+        createdAtOffset: 1,
+      },
+      {
+        operationId: 'operation-peer-b',
+        quoteId: 'quote-peer-b',
+        request: 'lnbc1peerb',
+        createdAtOffset: 2,
+      },
+    ] as const;
+    const peerOperationIds = peers.map((peer) => peer.operationId);
+    const peerQuoteIds = peers.map((peer) => peer.quoteId);
+
+    const outputFor = (secret: string, amount: number, blindingFactor: bigint) =>
+      serializeOutputData({
+        keep: [
+          new OutputData(
+            { amount: Amount.from(amount), id: keysetId, B_: `B_${secret}` },
+            blindingFactor,
+            new TextEncoder().encode(secret),
+          ),
+        ],
+        send: [],
+      });
+    const proofFor = (secret: string, amount: number): Proof => ({
+      id: keysetId,
+      amount: Amount.from(amount),
+      secret,
+      C: `C_${secret}`,
+    });
+    const normalizePublicOperation = (operation: MintOperation) => ({
+      id: operation.id,
+      state: operation.state,
+      mintUrl: operation.mintUrl,
+      method: operation.method,
+      amount: operation.amount.toNumber(),
+      unit: operation.unit,
+      quoteId: operation.quoteId,
+      error: operation.error,
+      terminalFailure: operation.terminalFailure
+        ? {
+            reason: operation.terminalFailure.reason,
+            code: operation.terminalFailure.code,
+            retryable: operation.terminalFailure.retryable,
+          }
+        : undefined,
+    });
+
+    async function runScenario(forceSingleRedemption: boolean) {
+      await resetHarness();
+      for (const peer of peers) {
+        await seedPeerOperation(peer.quoteId, peer.operationId, peer.request, peer.createdAtOffset);
+      }
+      const readPeerOperations = () =>
+        Promise.all(peerOperationIds.map((id) => repositories.mintOperationRepository.getById(id)));
+
+      const explicit = await service.execute(operationId);
+      const recordsAfterExplicitExecution = await Promise.all(
+        [operationId, ...peerOperationIds].map((id) =>
+          repositories.mintOperationRepository.getById(id),
+        ),
+      );
+      expect(explicit.state).toBe('finalized');
+      expect(recordsAfterExplicitExecution.map((operation) => operation?.state)).toEqual([
+        'finalized',
+        'pending',
+        'pending',
+      ]);
+
+      coordinator.configureProcessorRedemption({ forceSingleRedemption });
+      if (forceSingleRedemption) {
+        for (const [index, secret] of ['single-peer-a', 'single-peer-b'].entries()) {
+          const outputData = outputFor(secret, 10, BigInt(index + 10));
+          createMintOutputsAtCounter.mockImplementationOnce(
+            async (_mint, _intent, counterStart) => ({
+              keysetId,
+              outputData,
+              counterStart,
+              counterEnd: counterStart + 1,
+            }),
+          );
+        }
+        walletMint
+          .mockRejectedValueOnce(new NetworkError('simulated force-single interruption'))
+          .mockResolvedValueOnce([proofFor('single-peer-a', 10)])
+          .mockResolvedValueOnce([proofFor('single-peer-b', 10)]);
+      } else {
+        const batchOutputData = outputFor('paired-batch', 20, 20n);
+        createMintOutputsAtCounter.mockImplementationOnce(async (_mint, _intent, counterStart) => ({
+          keysetId,
+          outputData: batchOutputData,
+          counterStart,
+          counterEnd: counterStart + 1,
+        }));
+        walletBatchMint
+          .mockRejectedValueOnce(new NetworkError('simulated batch interruption'))
+          .mockResolvedValueOnce([proofFor('paired-batch', 20)]);
+      }
+
+      for (const id of peerOperationIds) coordinator.schedule(id);
+      await expect(coordinator.coordinate()).rejects.toThrow('simulated');
+
+      const recordsAtRestart = await readPeerOperations();
+      expect(recordsAtRestart.some((operation) => operation?.state === 'executing')).toBe(true);
+
+      service = createService();
+      service.configureProcessorRedemption({ forceSingleRedemption });
+      await service.finalize(peerOperationIds[0]!);
+      const pendingAfterRecovery = (await readPeerOperations()).filter(
+        (operation) => operation?.state === 'pending',
+      );
+      for (const operation of pendingAfterRecovery) coordinator.schedule(operation!.id);
+      if (pendingAfterRecovery.length > 0) await coordinator.coordinate();
+
+      const operationIds = [operationId, ...peerOperationIds];
+      const records = await Promise.all(
+        operationIds.map((id) => repositories.mintOperationRepository.getById(id)),
+      );
+      const publicOperations = records
+        .map((record) => normalizePublicOperation(toMintOperation(record!)))
+        .sort((left, right) => left.id.localeCompare(right.id));
+      const quoteStates = await Promise.all(
+        [quoteId, ...peerQuoteIds].map(async (id) =>
+          getMintQuoteRemoteState(
+            (await repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', id))!,
+          ),
+        ),
+      );
+      const history: Array<{
+        operationId: string;
+        state: string;
+        quoteId: string;
+        amount: number;
+        unit: string;
+        remoteState?: string;
+      }> = [];
+      for (const entry of await repositories.historyRepository.getPaginatedHistoryEntries(10, 0)) {
+        if (
+          entry.type !== 'mint' ||
+          entry.source !== 'operation' ||
+          !entry.operationId ||
+          !operationIds.includes(entry.operationId)
+        ) {
+          continue;
+        }
+        history.push({
+          operationId: entry.operationId,
+          state: entry.state,
+          quoteId: entry.quoteId,
+          amount: entry.amount.toNumber(),
+          unit: entry.unit,
+          remoteState: entry.remoteState,
+        });
+      }
+      history.sort((left, right) => left.operationId.localeCompare(right.operationId));
+      const attempts = await repositories.mintIssuanceAttemptRepository.listByMintUrl(mintUrl);
+      const issuedQuoteIds = attempts.flatMap((attempt) => attempt.quoteIds);
+      expect(new Set(issuedQuoteIds).size).toBe(3);
+      expect(issuedQuoteIds).toHaveLength(3);
+      const savedProofs = (
+        await Promise.all(
+          attempts.map((attempt) =>
+            repositories.proofRepository.getProofsByAttemptId(mintUrl, attempt.id),
+          ),
+        )
+      ).flat();
+      const walletValue = savedProofs
+        .reduce((total, saved) => total.add(saved.amount), Amount.zero())
+        .toNumber();
+
+      const publicSnapshot = { publicOperations, quoteStates, history, walletValue };
+
+      return {
+        publicSnapshot,
+        statesAfterExplicitExecution: recordsAfterExplicitExecution.map(
+          (operation) => operation?.state,
+        ),
+        requestKinds: attempts.map((attempt) => attempt.request.kind).sort(),
+      };
+    }
+
+    const batched = await runScenario(false);
+    const forcedSingle = await runScenario(true);
+
+    expect(batched.publicSnapshot).toEqual(forcedSingle.publicSnapshot);
+    expect(batched.statesAfterExplicitExecution).toEqual(forcedSingle.statesAfterExplicitExecution);
+    expect(batched.requestKinds).toEqual(['batch', 'single']);
+    expect(forcedSingle.requestKinds).toEqual(['single', 'single', 'single']);
   });
 
   it('normalizes the mint denylist before selecting a processor cohort', async () => {


### PR DESCRIPTION
Implements #343 as the final rollout-evidence slice for #332.

## Summary

- resolve the complete paid/trusted Mint Operation set before emitting requeue events, preserving one processor cohort across asynchronous repository adapters
- add a real FakeWallet NUT-29 integration path proving one processor-selected two-quote batch, public finalization, exact wallet value, issued quote state, and idempotent replay
- add paired batch/force-single recovery coverage comparing public operations, quote states, history, wallet value, target isolation, and durable restart behavior
- assert serialized public events and structured logs omit output/recovery secrets

## Acceptance criteria

- [x] FakeWallet-backed NUT-29 happy path covers two quotes in one processor turn without duplicate issuance
- [x] the pinned mint image is required to advertise NUT-29; CI exercises the real integration path
- [x] batching and forced-single modes have equivalent public outcomes across interrupted/restarted execution
- [x] timing, cross-member event ordering, and proof layout are excluded from semantic comparison
- [x] chunking, immediate explicit checks/redemption, target isolation, and fairness remain covered without performance thresholds
- [x] invalid/unknown watched quotes remain isolated from explicit valid checks
- [x] migration, projection, default-on batching, force-single, denylist, and outputData removal documentation is present on the implementation branch
- [x] public events/logs are checked for recovery-secret leakage
- [x] patch changeset included for the paid-requeue cohort fix
- [x] no benchmark or general-purpose mint infrastructure added

## Validation

- `bun run build`
- `bun run typecheck`
- `bun run --filter='@cashu/coco-core' test:unit` — 1169 passed
- focused Manager and MintIssuanceCoordinator suites — 106 passed
- SQLite3, SQLite Bun, and Expo adapter contracts — 197 passed
- React tests — 49 passed
- `bun run --filter='@cashu/coco-react' lint` — 0 errors, 2 pre-existing warnings
- `bun run docs:build`
- `bun x changeset status --since origin/feat/wayfinder-implementation-332`
- Standards review: pass, no findings
- Spec review: pass, no findings

## Environment notes

The local environment has no Docker command, so the new real FakeWallet test and pinned `cashubtc/mintd:0.17.0-rc.0` NUT-29 assertion are delegated to CI. Playwright browser executables are also unavailable for Ubuntu 26.04 in this environment; browser coverage is delegated to CI.

## Changeset

- `.changeset/cohort-paid-mint-requeue.md` — patch for `@cashu/coco-core`
