### PR TITLE
fix(core): close critical mint batching review gaps

### DIFF
--- a/.changeset/secure-mint-attempt-recovery.md
+++ b/.changeset/secure-mint-attempt-recovery.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Preserve ambiguous mint batch recovery, serialize memory transactions, and redact mint payload
+logs.

--- a/packages/core/infra/RequestRateLimiter.ts
+++ b/packages/core/infra/RequestRateLimiter.ts
@@ -109,11 +109,10 @@ export class RequestRateLimiter {
       body = stringifyJson(requestBody);
     }
 
-    // Log request payload
+    // Mint payloads can contain exact outputs and other recovery material. Log metadata only.
     this.logger?.debug('Mint request', {
       method: init.method || 'GET',
       endpoint,
-      requestBody: requestBody ? stringifyJson(requestBody, 2) : undefined,
     });
 
     let response: Response;
@@ -142,11 +141,10 @@ export class RequestRateLimiter {
         // leave default errorData
       }
 
-      // Log error response
+      // Response bodies can contain recovery material. Log metadata only.
       this.logger?.debug('Mint response error', {
         endpoint,
         status: response.status,
-        errorData: stringifyJson(errorData, 2),
       });
 
       const hasProtocolError =
@@ -175,11 +173,10 @@ export class RequestRateLimiter {
 
     try {
       const responseData = await parseJsonResponse<T>(response);
-      // Log successful response
+      // Response bodies can contain blind signatures and other recovery material.
       this.logger?.debug('Mint response success', {
         endpoint,
         status: response.status,
-        responseData: stringifyJson(responseData, 2),
       });
       return responseData;
     } catch (err) {

--- a/packages/core/operations/mint/MintIssuanceCoordinator.ts
+++ b/packages/core/operations/mint/MintIssuanceCoordinator.ts
@@ -87,6 +87,7 @@ interface ConfirmedBatchRejection {
 
 const CONFIRMED_BATCH_REJECTION_CODE = 'CONFIRMED_BATCH_REJECTION';
 const AUTHENTICATION_ERROR_CODE_MIN = 30_000;
+const OUTPUTS_ALREADY_SIGNED_ERROR_CODE = 11_003;
 const NUT29_BATCH_SIZE_ERROR_CODE = 11_017;
 const MINT_QUOTE_STATE_ERROR_CODES = new Set([20_001, 20_002]);
 const INCOMPATIBLE_ENDPOINT_STATUSES = new Set([404, 405, 501]);
@@ -965,7 +966,11 @@ export class MintIssuanceCoordinator {
     if (error instanceof HttpResponseError && INCOMPATIBLE_ENDPOINT_STATUSES.has(error.status)) {
       return { kind: 'incompatibility', error, httpStatus: error.status };
     }
-    if (!(error instanceof MintOperationError) || error.code >= AUTHENTICATION_ERROR_CODE_MIN) {
+    if (
+      !(error instanceof MintOperationError) ||
+      error.code === OUTPUTS_ALREADY_SIGNED_ERROR_CODE ||
+      error.code >= AUTHENTICATION_ERROR_CODE_MIN
+    ) {
       return null;
     }
     if (error.code === NUT29_BATCH_SIZE_ERROR_CODE) {

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -114,6 +114,7 @@ export class MemoryRepositories implements Repositories {
   receiveOperationRepository: ReceiveOperationRepository;
   paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
+  private transactionTail: Promise<void> = Promise.resolve();
 
   constructor() {
     this.mintRepository = new MemoryMintRepository();
@@ -156,14 +157,25 @@ export class MemoryRepositories implements Repositories {
   }
 
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
-    const snapshots = snapshotMutableContainers(
-      Object.values(this).filter((value): value is object => typeof value === 'object'),
-    );
+    const previousTransaction = this.transactionTail;
+    let releaseTransaction!: () => void;
+    this.transactionTail = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    await previousTransaction;
     try {
-      return await fn(this);
-    } catch (error) {
-      restoreMutableContainers(snapshots);
-      throw error;
+      const snapshots = snapshotMutableContainers(
+        Object.values(this).filter((value): value is object => typeof value === 'object'),
+      );
+      try {
+        return await fn(this);
+      } catch (error) {
+        restoreMutableContainers(snapshots);
+        throw error;
+      }
+    } finally {
+      releaseTransaction();
     }
   }
 }

--- a/packages/core/test/unit/MemoryMintIssuanceAttemptRepository.test.ts
+++ b/packages/core/test/unit/MemoryMintIssuanceAttemptRepository.test.ts
@@ -121,6 +121,39 @@ describe('MemoryMintIssuanceAttemptRepository', () => {
     expect(await repositories.authSessionRepository.getSession('https://mint.test')).toBe(null);
   });
 
+  it('does not erase a concurrent transaction when an earlier transaction rolls back', async () => {
+    const repositories = new MemoryRepositories();
+    let enterFirst!: () => void;
+    let releaseFirst!: () => void;
+    const firstEntered = new Promise<void>((resolve) => {
+      enterFirst = resolve;
+    });
+    const firstRelease = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = repositories
+      .withTransaction(async (tx) => {
+        await tx.counterRepository.setCounter('https://mint.test', 'keyset-1', 1);
+        enterFirst();
+        await firstRelease;
+        throw new Error('roll back first transaction');
+      })
+      .catch((error: unknown) => error);
+
+    await firstEntered;
+    const second = repositories.withTransaction(async (tx) => {
+      await tx.counterRepository.setCounter('https://mint.test', 'keyset-1', 7);
+    });
+    releaseFirst();
+
+    await expect(first).resolves.toBeInstanceOf(Error);
+    await second;
+    expect(
+      (await repositories.counterRepository.getCounter('https://mint.test', 'keyset-1'))?.counter,
+    ).toBe(7);
+  });
+
   it('rejects updates that change exact recovery material', async () => {
     const repositories = new MemoryRepositories();
     const attempt = createAttempt();

--- a/packages/core/test/unit/MintIssuanceCoordinator.test.ts
+++ b/packages/core/test/unit/MintIssuanceCoordinator.test.ts
@@ -135,6 +135,7 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
   async function createAmbiguousBatch(options?: {
     outputData?: ReturnType<typeof serializeOutputData>;
     recoveredProof?: Proof;
+    submissionError?: Error;
   }): Promise<{
     attempt: MintIssuanceAttempt;
     operationIds: [string, string];
@@ -172,11 +173,13 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       counterStart: 0,
       counterEnd: batchOutputData.keep.length + batchOutputData.send.length,
     });
-    walletBatchMint.mockRejectedValueOnce(new NetworkError('connection lost after submission'));
+    const submissionError =
+      options?.submissionError ?? new NetworkError('connection lost after submission');
+    walletBatchMint.mockRejectedValueOnce(submissionError);
 
     coordinator.schedule(operationId);
     coordinator.schedule(peerOperationId);
-    await expect(coordinator.coordinate()).rejects.toThrow('connection lost after submission');
+    await expect(coordinator.coordinate()).rejects.toThrow(submissionError.message);
 
     const attempt =
       await repositories.mintIssuanceAttemptRepository.getByMemberOperationId(operationId);
@@ -1163,6 +1166,31 @@ describe('MintOperationService durable single BOLT11 issuance', () => {
       'executing',
     );
     expect(await service.canRetryIssuance(operationId)).toBe(true);
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+    expect(createMintOutputsAtCounter).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps outputs-already-signed batch errors on exact-attempt recovery', async () => {
+    const {
+      attempt,
+      operationIds,
+      outputData: ambiguousOutputData,
+    } = await createAmbiguousBatch({
+      submissionError: new MintOperationError(11003, 'Outputs already signed'),
+    });
+
+    expect(attempt).toMatchObject({
+      state: 'recovering',
+      memberOperationIds: operationIds,
+      outputData: ambiguousOutputData,
+    });
+    expect(
+      await Promise.all(
+        operationIds.map(
+          async (id) => (await repositories.mintOperationRepository.getById(id))?.state,
+        ),
+      ),
+    ).toEqual(['executing', 'executing']);
     expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
     expect(createMintOutputsAtCounter).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/test/unit/RequestRateLimiter.test.ts
+++ b/packages/core/test/unit/RequestRateLimiter.test.ts
@@ -3,6 +3,7 @@ import { MintOperationError as CashuMintOperationError } from '@cashu/cashu-ts';
 import type { HeadersInit } from 'bun';
 
 import { RequestRateLimiter } from '../../infra/RequestRateLimiter.ts';
+import type { Logger } from '../../logging/Logger.ts';
 import {
   HttpResponseError,
   NetworkError,
@@ -94,6 +95,52 @@ describe('RequestRateLimiter', () => {
     });
 
     expect(result.amount).toBe(9007199254740993n);
+  });
+
+  it('does not log mint request or response bodies', async () => {
+    const logs: unknown[] = [];
+    const logger: Logger = {
+      error: (message, ...meta) => logs.push({ message, meta }),
+      warn: (message, ...meta) => logs.push({ message, meta }),
+      info: (message, ...meta) => logs.push({ message, meta }),
+      debug: (message, ...meta) => logs.push({ message, meta }),
+    };
+    let requestCount = 0;
+    // @ts-ignore
+    globalThis.fetch = async () => {
+      requestCount++;
+      if (requestCount === 1) {
+        return new Response(JSON.stringify({ signatures: [{ C_: 'blind-signature-secret' }] }), {
+          status: 200,
+        });
+      }
+      return new Response(
+        JSON.stringify({ error: 'rejected-sensitive-output', detail: 'do not log me' }),
+        { status: 400 },
+      );
+    };
+
+    const limiter = new RequestRateLimiter({ logger });
+    await limiter.request({
+      endpoint: 'https://mint.test/v1/mint/bolt11',
+      method: 'POST',
+      requestBody: { outputs: [{ B_: 'blinded-output-secret' }] },
+    });
+    await expect(
+      limiter.request({
+        endpoint: 'https://mint.test/v1/mint/bolt11',
+        method: 'POST',
+        requestBody: { outputs: [{ B_: 'second-blinded-output-secret' }] },
+      }),
+    ).rejects.toBeInstanceOf(HttpResponseError);
+
+    const serializedLogs = JSON.stringify(logs);
+    expect(serializedLogs).toContain('https://mint.test/v1/mint/bolt11');
+    expect(serializedLogs).toContain('400');
+    expect(serializedLogs).not.toContain('blinded-output-secret');
+    expect(serializedLogs).not.toContain('blind-signature-secret');
+    expect(serializedLogs).not.toContain('rejected-sensitive-output');
+    expect(serializedLogs).not.toContain('do not log me');
   });
 
   it('throws HttpResponseError with status and message on non-OK responses', async () => {


### PR DESCRIPTION
This pull request fixes the three P1 findings from the review of #344. Lower-priority findings are intentionally out of scope.

## Problem

Mint Batch recovery could abandon exact attempts after an `Outputs already signed` response, overlapping memory transactions could lose a committed write when another transaction rolled back, and transport debug logs exposed complete mint request and response payloads.

## Summary

- keep error `11003` on the ambiguous exact-attempt recovery path
- serialize memory repository transactions so a stale rollback cannot overwrite another commit
- retain request metadata while redacting mint payload bodies from transport logs
- add focused regressions for each P1 finding

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MintIssuanceCoordinator.test.ts test/unit/MemoryMintIssuanceAttemptRepository.test.ts test/unit/RequestRateLimiter.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bunx prettier --check .changeset/secure-mint-attempt-recovery.md packages/core/infra/RequestRateLimiter.ts packages/core/operations/mint/MintIssuanceCoordinator.ts packages/core/repositories/memory/MemoryRepositories.ts packages/core/test/unit/MemoryMintIssuanceAttemptRepository.test.ts packages/core/test/unit/MintIssuanceCoordinator.test.ts packages/core/test/unit/RequestRateLimiter.test.ts`

## Changeset

- adds `.changeset/secure-mint-attempt-recovery.md` for a core patch release
