### PR TITLE
feat(core): add batch mint quote polling

### DIFF
--- a/.changeset/tidy-nut29-quote-checks.md
+++ b/.changeset/tidy-nut29-quote-checks.md
@@ -2,4 +2,4 @@
 '@cashu/coco-core': patch
 ---
 
-Add batch-aware NUT-29 mint quote checks at the quote lifecycle polling seam.
+Add batch-aware NUT-29 mint quote checks and deterministic Background Watcher batching.

--- a/.changeset/tidy-nut29-quote-checks.md
+++ b/.changeset/tidy-nut29-quote-checks.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Add batch-aware NUT-29 mint quote checks at the quote lifecycle polling seam.

--- a/docs/adr/0006-target-isolate-explicit-quote-checks.md
+++ b/docs/adr/0006-target-isolate-explicit-quote-checks.md
@@ -1,0 +1,17 @@
+# Keep explicit quote checks target-isolated
+
+An Explicit Quote Check is caller-scoped work. It checks only the requested quote through the
+single-quote endpoint and never recruits or waits for Background Watcher interests. An unrelated
+quote therefore cannot make the explicit caller fail.
+
+Background Watchers may batch compatible mint quote checks by normalized mint and Built-in Payment
+Method. When a batch opportunity reports definitive incompatibility, batch-size rejection, a
+malformed response, or validation rejection, Coco marks only that mint-and-method group batch
+unavailable for the current Coco Session. The failed opportunity performs no individual fan-out.
+Later polling turns check one quote at the configured cadence, preserving normal fairness and
+requeueing behavior.
+
+Network failures, authentication interruptions, rate limits, and server failures do not set the
+marker. A successful mint metadata refresh clears the affected mint's markers, and a new Coco
+Session starts without downgrade state. The policy has no recursive splitting, adaptive learned
+limit, internal retry loop, or persisted compatibility state.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -317,7 +317,6 @@ export class Manager {
     });
     this.mintAdapter = new MintAdapter(this.mintRequestProvider);
 
-    this.subscriptions = this.createSubscriptionManager(webSocketFactory, subscriptions);
     this.originalWatcherConfig = watchers;
     this.originalProcessorConfig = processors;
     if (plugins && plugins.length > 0) {
@@ -350,6 +349,7 @@ export class Manager {
     this.mintOperationService = core.mintOperationService;
     this.mintOperationRepository = core.mintOperationRepository;
     this.proofRepository = repositories.proofRepository;
+    this.subscriptions = this.createSubscriptionManager(webSocketFactory, subscriptions);
     const apis = this.buildApis();
     this.mint = apis.mint;
     this.wallet = apis.wallet;
@@ -820,10 +820,17 @@ export class Manager {
         this.mintAdapter,
         { intervalMs: options.fastPollingIntervalMs },
         wsLogger,
+        this.quoteLifecycle,
       );
       return new SubscriptionManager(polling, this.mintAdapter, wsLogger, options);
     }
-    return new SubscriptionManager(wsFactoryToUse, this.mintAdapter, wsLogger, options);
+    return new SubscriptionManager(
+      wsFactoryToUse,
+      this.mintAdapter,
+      wsLogger,
+      options,
+      this.quoteLifecycle,
+    );
   }
 
   private buildCoreServices(

--- a/packages/core/events/types.ts
+++ b/packages/core/events/types.ts
@@ -20,6 +20,7 @@ import type { CoreProof, ProofState } from '../types';
 export interface CoreEvents {
   'mint:added': { mint: Mint; keysets: Keyset[] };
   'mint:updated': { mint: Mint; keysets: Keyset[] };
+  'mint:metadata-refreshed': { mintUrl: string };
   'mint:trusted': { mintUrl: string };
   'mint:untrusted': { mintUrl: string };
   'counter:updated': Counter;

--- a/packages/core/infra/HybridTransport.ts
+++ b/packages/core/infra/HybridTransport.ts
@@ -7,6 +7,7 @@ import { isMintQuoteExpired } from '../models/MintQuoteExpiry.ts';
 import type { MintAdapter } from './MintAdapter.ts';
 import { WsTransport } from './WsTransport.ts';
 import { PollingTransport } from './PollingTransport.ts';
+import type { MintQuotePollingOperation } from '../quotes/MintQuotePolling.ts';
 
 export interface HybridTransportOptions {
   /** Polling interval while WS is connected (default: 20000ms) */
@@ -49,6 +50,7 @@ export class HybridTransport implements RealTimeTransport {
     mintAdapter: MintAdapter,
     options?: HybridTransportOptions,
     logger?: Logger,
+    mintQuotePolling?: MintQuotePollingOperation,
   ) {
     this.logger = logger;
     this.options = {
@@ -64,6 +66,7 @@ export class HybridTransport implements RealTimeTransport {
       mintAdapter,
       { intervalMs: this.options.slowPollingIntervalMs },
       logger,
+      mintQuotePolling,
     );
   }
 

--- a/packages/core/infra/MintAdapter.ts
+++ b/packages/core/infra/MintAdapter.ts
@@ -84,6 +84,38 @@ export class MintAdapter {
     return (await cashuMint.checkMintQuote(method, quoteId)) as MintMethodQuoteSnapshot<M>;
   }
 
+  /** Send one NUT-29 mint-quote batch check through the shared auth and rate-limit boundary. */
+  async checkMintQuoteBatch(
+    mintUrl: string,
+    method: MintMethod,
+    quoteIds: string[],
+  ): Promise<unknown> {
+    const path = `/v1/mint/quote/${method}/check`;
+    const headers: Record<string, string> = {};
+    const authProvider = this.authProviders.get(mintUrl);
+
+    if (authProvider) {
+      const mintInfo = await this.getCashuMint(mintUrl).getLazyMintInfo();
+      if (mintInfo.requiresBlindAuthToken('POST', path)) {
+        headers['Blind-auth'] = await authProvider.getBlindAuthToken({ method: 'POST', path });
+      }
+      if (mintInfo.requiresClearAuthToken('POST', path)) {
+        const clearAuth = authProvider.ensureCAT
+          ? await authProvider.ensureCAT()
+          : authProvider.getCAT();
+        if (clearAuth) headers['Clear-auth'] = clearAuth;
+      }
+    }
+
+    const request = this.requestProvider.getRequestFn(mintUrl);
+    return request({
+      endpoint: `${mintUrl.replace(/\/$/, '')}${path}`,
+      method: 'POST',
+      requestBody: { quotes: quoteIds },
+      ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    });
+  }
+
   // Check current state of a bolt11 melt quote (returns full response including change)
   async checkMeltQuote(mintUrl: string, quoteId: string): Promise<MeltQuoteBolt11Response> {
     const cashuMint = this.getCashuMint(mintUrl);

--- a/packages/core/infra/PollingTransport.ts
+++ b/packages/core/infra/PollingTransport.ts
@@ -8,6 +8,10 @@ import type {
 } from './SubscriptionProtocol.ts';
 import type { Logger } from '../logging/Logger.ts';
 import type { MintAdapter } from './MintAdapter.ts';
+import { mintQuoteToMethodSnapshot } from '../models/MintQuote.ts';
+import type { MintMethod } from '../operations/mint/MintMethodHandler.ts';
+import type { MintQuotePollingOperation } from '../quotes/MintQuotePolling.ts';
+import { normalizeMintUrl } from '../utils.ts';
 
 type Task = {
   subId?: string; // undefined for proof batch sentinel
@@ -33,6 +37,12 @@ const SUPPORTED_POLLING_KINDS = new Set<SubscriptionKind>([
   'proof_state',
 ]);
 
+const MINT_QUOTE_METHOD_BY_KIND: Partial<Record<SubscriptionKind, MintMethod>> = {
+  bolt11_mint_quote: 'bolt11',
+  bolt12_mint_quote: 'bolt12',
+  onchain_mint_quote: 'onchain',
+};
+
 export interface PollingOptions {
   intervalMs?: number; // minimum interval between requests per mint
 }
@@ -40,6 +50,7 @@ export interface PollingOptions {
 export class PollingTransport implements RealTimeTransport {
   private readonly logger?: Logger;
   private readonly mintAdapter: MintAdapter;
+  private readonly mintQuotePolling?: MintQuotePollingOperation;
   private readonly options: Required<PollingOptions>;
   private readonly listenersByMint = new Map<
     string,
@@ -55,9 +66,15 @@ export class PollingTransport implements RealTimeTransport {
   private readonly unsubscribedByMint = new Map<string, Set<string>>();
   private paused = false;
 
-  constructor(mintAdapter: MintAdapter, options?: PollingOptions, logger?: Logger) {
+  constructor(
+    mintAdapter: MintAdapter,
+    options?: PollingOptions,
+    logger?: Logger,
+    mintQuotePolling?: MintQuotePollingOperation,
+  ) {
     this.logger = logger;
     this.mintAdapter = mintAdapter;
+    this.mintQuotePolling = mintQuotePolling;
     this.options = {
       intervalMs: options?.intervalMs ?? 5000,
     };
@@ -68,6 +85,7 @@ export class PollingTransport implements RealTimeTransport {
     event: 'open' | 'message' | 'error' | 'close',
     handler: (evt: any) => void,
   ): void {
+    mintUrl = normalizeMintUrl(mintUrl);
     let map = this.listenersByMint.get(mintUrl);
     if (!map) {
       map = new Map();
@@ -97,6 +115,7 @@ export class PollingTransport implements RealTimeTransport {
   }
 
   send(mintUrl: string, req: WsRequest): void {
+    mintUrl = normalizeMintUrl(mintUrl);
     if (req.method === 'subscribe') {
       const params = req.params as SubscribeParams;
       const subId = params.subId;
@@ -254,6 +273,7 @@ export class PollingTransport implements RealTimeTransport {
   }
 
   closeMint(mintUrl: string): void {
+    mintUrl = normalizeMintUrl(mintUrl);
     this.schedByMint.delete(mintUrl);
     this.listenersByMint.delete(mintUrl);
     this.proofQueueByMint.delete(mintUrl);
@@ -281,7 +301,7 @@ export class PollingTransport implements RealTimeTransport {
    * If not set, the default interval from constructor options is used.
    */
   setIntervalForMint(mintUrl: string, intervalMs: number): void {
-    this.intervalByMint.set(mintUrl, intervalMs);
+    this.intervalByMint.set(normalizeMintUrl(mintUrl), intervalMs);
   }
 
   /**
@@ -319,22 +339,17 @@ export class PollingTransport implements RealTimeTransport {
 
     s.running = true;
     const task = s.queue.shift()!;
+    let opportunity = [task];
 
     try {
-      await this.performTask(mintUrl, task);
-
-      // Re-enqueue for fairness, but only if not unsubscribed during processing
-      const unsubscribed = this.unsubscribedByMint.get(mintUrl);
-      const wasUnsubscribed = task.subId && unsubscribed?.has(task.subId);
-
-      if (wasUnsubscribed) {
-        // Task was unsubscribed during processing, don't re-enqueue
-        unsubscribed!.delete(task.subId!);
-      } else {
-        s.queue.push(task);
-      }
+      opportunity = await this.selectOpportunity(mintUrl, task, s);
+      await this.performOpportunity(mintUrl, opportunity);
+      this.requeueOpportunity(mintUrl, s, opportunity);
     } catch (err) {
       this.logger?.error('Polling task error', { mintUrl, err });
+      if (this.getMintQuoteMethod(task.kind) && this.mintQuotePolling) {
+        this.requeueOpportunity(mintUrl, s, opportunity);
+      }
     } finally {
       s.nextAllowedAt = Date.now() + this.getIntervalForMint(mintUrl);
       s.running = false;
@@ -343,6 +358,87 @@ export class PollingTransport implements RealTimeTransport {
       setTimeout(() => {
         void this.maybeRun(mintUrl);
       }, delay);
+    }
+  }
+
+  private async selectOpportunity(
+    mintUrl: string,
+    first: Task,
+    scheduler: MintScheduler,
+  ): Promise<Task[]> {
+    const method = this.getMintQuoteMethod(first.kind);
+    if (!method || !this.mintQuotePolling || !first.filter) return [first];
+
+    const advertisedLimit = await this.mintQuotePolling.getMintQuotePollingLimit(mintUrl, method);
+    const limit = Math.max(1, Math.min(100, Math.floor(advertisedLimit)));
+    if (limit === 1) return [first];
+
+    const selected = [first];
+    const selectedQuoteIds = new Set([first.filter]);
+    const remaining: Task[] = [];
+    for (const candidate of scheduler.queue) {
+      const isCompatible = candidate.kind === first.kind && candidate.filter !== undefined;
+      const isSelectedDuplicate = isCompatible && selectedQuoteIds.has(candidate.filter as string);
+      if (isSelectedDuplicate || (isCompatible && selectedQuoteIds.size < limit)) {
+        selected.push(candidate);
+        selectedQuoteIds.add(candidate.filter!);
+      } else {
+        remaining.push(candidate);
+      }
+    }
+    scheduler.queue = remaining;
+    return selected;
+  }
+
+  private requeueOpportunity(mintUrl: string, scheduler: MintScheduler, opportunity: Task[]): void {
+    const unsubscribed = this.unsubscribedByMint.get(mintUrl);
+    const removedSubIds = new Set<string>();
+    for (const task of opportunity) {
+      if (task.subId && unsubscribed?.has(task.subId)) {
+        removedSubIds.add(task.subId);
+      } else {
+        scheduler.queue.push(task);
+      }
+    }
+    for (const subId of removedSubIds) unsubscribed?.delete(subId);
+  }
+
+  private getMintQuoteMethod(kind: Task['kind']): MintMethod | undefined {
+    return MINT_QUOTE_METHOD_BY_KIND[kind];
+  }
+
+  private async performOpportunity(mintUrl: string, opportunity: Task[]): Promise<void> {
+    const first = opportunity[0]!;
+    const method = this.getMintQuoteMethod(first.kind);
+    if (!method || !this.mintQuotePolling) {
+      await this.performTask(mintUrl, first);
+      return;
+    }
+
+    const quoteIds = Array.from(
+      new Set(opportunity.map(({ filter }) => filter).filter((filter) => filter !== undefined)),
+    );
+    const result = await this.mintQuotePolling.checkMintQuotesForPolling(
+      method,
+      quoteIds.map((quoteId) => ({ mintUrl, quoteId })),
+    );
+    const outcomesByQuoteId = new Map(
+      result.outcomes.map((outcome) => [outcome.identity.quoteId, outcome]),
+    );
+    const unsubscribed = this.unsubscribedByMint.get(mintUrl);
+    for (const task of opportunity) {
+      if (!task.subId || !task.filter || unsubscribed?.has(task.subId)) continue;
+      const outcome = outcomesByQuoteId.get(task.filter);
+      if (outcome?.status !== 'updated' || outcome.quote.method !== method) continue;
+      const notification: WsNotification<unknown> = {
+        jsonrpc: '2.0',
+        method: 'subscribe',
+        params: {
+          subId: task.subId,
+          payload: mintQuoteToMethodSnapshot(outcome.quote),
+        },
+      };
+      this.emit(mintUrl, 'message', { data: JSON.stringify(notification) });
     }
   }
 

--- a/packages/core/infra/SubscriptionManager.ts
+++ b/packages/core/infra/SubscriptionManager.ts
@@ -5,6 +5,7 @@ import type { MintAdapter } from './MintAdapter.ts';
 import { PollingTransport } from './PollingTransport.ts';
 import { HybridTransport } from './HybridTransport.ts';
 import { generateSubId } from '../utils.ts';
+import type { MintQuotePollingOperation } from '../quotes/MintQuotePolling.ts';
 
 import type {
   WsRequest,
@@ -45,6 +46,7 @@ export class SubscriptionManager {
   private readonly hasOpenedByMint = new Map<string, boolean>();
   private readonly wsFactory?: WebSocketFactory;
   private readonly mintAdapter: MintAdapter;
+  private readonly mintQuotePolling?: MintQuotePollingOperation;
   private readonly options: Required<SubscriptionManagerOptions>;
   private paused = false;
 
@@ -53,9 +55,11 @@ export class SubscriptionManager {
     mintAdapter: MintAdapter,
     logger?: Logger,
     options?: SubscriptionManagerOptions,
+    mintQuotePolling?: MintQuotePollingOperation,
   ) {
     this.logger = logger;
     this.mintAdapter = mintAdapter;
+    this.mintQuotePolling = mintQuotePolling;
     this.options = {
       slowPollingIntervalMs: options?.slowPollingIntervalMs ?? 20000,
       fastPollingIntervalMs: options?.fastPollingIntervalMs ?? 5000,
@@ -96,6 +100,7 @@ export class SubscriptionManager {
           fastPollingIntervalMs: this.options.fastPollingIntervalMs,
         },
         this.logger,
+        this.mintQuotePolling,
       );
     } else {
       // No wsFactory available, use polling only at fast interval
@@ -103,6 +108,7 @@ export class SubscriptionManager {
         this.mintAdapter,
         { intervalMs: this.options.fastPollingIntervalMs },
         this.logger,
+        this.mintQuotePolling,
       );
     }
     this.transportByMint.set(mintUrl, t);

--- a/packages/core/quotes/MintQuotePolling.ts
+++ b/packages/core/quotes/MintQuotePolling.ts
@@ -1,5 +1,6 @@
 import type { MintQuote } from '../models/MintQuote.ts';
 import type { QuoteIdentity } from '../models/QuoteIdentity.ts';
+import type { MintMethod } from '../operations/mint/MintMethodHandler.ts';
 
 export type MintQuotePollingFailureCategory =
   | 'network'
@@ -33,4 +34,13 @@ export type MintQuotePollingOutcome =
 export interface MintQuotePollingResult {
   outcomes: MintQuotePollingOutcome[];
   responseFailures: MintQuotePollingFailure[];
+}
+
+/** Batch-aware quote lifecycle boundary used by Background Watcher polling. */
+export interface MintQuotePollingOperation {
+  getMintQuotePollingLimit(mintUrl: string, method: MintMethod): Promise<number>;
+  checkMintQuotesForPolling(
+    method: MintMethod,
+    identities: readonly QuoteIdentity[],
+  ): Promise<MintQuotePollingResult>;
 }

--- a/packages/core/quotes/MintQuotePolling.ts
+++ b/packages/core/quotes/MintQuotePolling.ts
@@ -1,0 +1,36 @@
+import type { MintQuote } from '../models/MintQuote.ts';
+import type { QuoteIdentity } from '../models/QuoteIdentity.ts';
+
+export type MintQuotePollingFailureCategory =
+  | 'network'
+  | 'authentication'
+  | 'rate-limit'
+  | 'server'
+  | 'incompatibility'
+  | 'batch-size'
+  | 'malformed-response'
+  | 'validation';
+
+export interface MintQuotePollingFailure {
+  category: MintQuotePollingFailureCategory;
+  error: Error;
+  responseIndex?: number;
+  responseQuoteId?: string;
+}
+
+export type MintQuotePollingOutcome =
+  | {
+      status: 'updated';
+      identity: QuoteIdentity;
+      quote: MintQuote;
+    }
+  | {
+      status: 'failed';
+      identity: QuoteIdentity;
+      failure: MintQuotePollingFailure;
+    };
+
+export interface MintQuotePollingResult {
+  outcomes: MintQuotePollingOutcome[];
+  responseFailures: MintQuotePollingFailure[];
+}

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -65,6 +65,12 @@ const MINT_QUOTE_STATE_RANK: Record<string, number> = {
 };
 
 const BUILT_IN_MINT_METHODS = new Set<MintMethod>(['bolt11', 'bolt12', 'onchain']);
+const DEFINITIVE_BATCH_FAILURE_CATEGORIES = new Set<MintQuotePollingFailure['category']>([
+  'incompatibility',
+  'batch-size',
+  'malformed-response',
+  'validation',
+]);
 
 function isMintQuoteStateDowngrade(
   existing: MintMethodRemoteState,
@@ -84,7 +90,7 @@ function hasReusableSettlementAmounts(snapshot: {
   return snapshot.amount_paid !== undefined && snapshot.amount_issued !== undefined;
 }
 
-function assertMintQuotePollingSnapshotStructure(
+function assertMintQuotePollingSnapshotStructureUnchecked(
   method: MintMethod,
   snapshot: MintMethodQuoteSnapshot,
 ): void {
@@ -131,6 +137,26 @@ function assertMintQuotePollingSnapshotStructure(
     const amount = (snapshot as MintMethodQuoteSnapshot<'bolt12'>).amount;
     if (amount !== undefined && amount !== null) Amount.from(amount as AmountLike);
   }
+}
+
+function assertMintQuotePollingSnapshotStructure(
+  method: MintMethod,
+  snapshot: MintMethodQuoteSnapshot,
+): void {
+  try {
+    assertMintQuotePollingSnapshotStructureUnchecked(method, snapshot);
+  } catch (error) {
+    if (error instanceof ProofValidationError) throw error;
+    const validationError = new ProofValidationError(
+      `${method} mint quote batch observation has invalid amount fields`,
+    );
+    (validationError as Error & { cause?: unknown }).cause = error;
+    throw validationError;
+  }
+}
+
+function isDefinitiveMintQuotePollingValidation(error: Error): boolean {
+  return error instanceof ProofValidationError || error instanceof QuoteIdentityConflictError;
 }
 
 function equalOptionalAmount(
@@ -376,6 +402,7 @@ export class QuoteLifecycle {
   private readonly mintAdapter: MintAdapter;
   private readonly eventBus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
+  private readonly batchUnavailablePollingMethodsByMint = new Map<string, Set<MintMethod>>();
 
   constructor(deps: QuoteLifecycleDeps) {
     this.mintHandlerProvider = deps.mintHandlerProvider;
@@ -389,6 +416,42 @@ export class QuoteLifecycle {
     this.mintAdapter = deps.mintAdapter;
     this.eventBus = deps.eventBus;
     this.logger = deps.logger;
+    this.eventBus.on('mint:metadata-refreshed', ({ mintUrl }) => {
+      this.clearBatchUnavailablePollingGroups(mintUrl);
+    });
+  }
+
+  private isBatchUnavailableForPolling(mintUrl: string, method: MintMethod): boolean {
+    return (
+      this.batchUnavailablePollingMethodsByMint.get(normalizeMintUrl(mintUrl))?.has(method) === true
+    );
+  }
+
+  private markBatchUnavailableForPolling(mintUrl: string, method: MintMethod): void {
+    const normalizedMintUrl = normalizeMintUrl(mintUrl);
+    const unavailableMethods =
+      this.batchUnavailablePollingMethodsByMint.get(normalizedMintUrl) ?? new Set<MintMethod>();
+    if (unavailableMethods.has(method)) return;
+    unavailableMethods.add(method);
+    this.batchUnavailablePollingMethodsByMint.set(normalizedMintUrl, unavailableMethods);
+    this.logger?.warn('Disabling batch mint quote polling for the Coco Session', {
+      mintUrl: normalizedMintUrl,
+      method,
+    });
+  }
+
+  private clearBatchUnavailablePollingGroups(mintUrl: string): void {
+    this.batchUnavailablePollingMethodsByMint.delete(normalizeMintUrl(mintUrl));
+  }
+
+  private recordDefinitiveBatchPollingFailure(
+    mintUrl: string,
+    method: MintMethod,
+    category: MintQuotePollingFailure['category'],
+  ): void {
+    if (DEFINITIVE_BATCH_FAILURE_CATEGORIES.has(category)) {
+      this.markBatchUnavailableForPolling(mintUrl, method);
+    }
   }
 
   private buildDeps() {
@@ -510,6 +573,7 @@ export class QuoteLifecycle {
 
   /** Returns the advertised and safety-capped size for one Background Watcher opportunity. */
   async getMintQuotePollingLimit(mintUrl: string, method: MintMethod): Promise<number> {
+    if (this.isBatchUnavailableForPolling(mintUrl, method)) return 1;
     return this.mintService.getNut29MintQuoteCheckLimit(mintUrl, method);
   }
 
@@ -564,7 +628,9 @@ export class QuoteLifecycle {
 
     let useBatch: boolean;
     try {
-      useBatch = await this.mintService.supportsNut29MintQuoteCheck(mintUrl, method);
+      useBatch =
+        !this.isBatchUnavailableForPolling(mintUrl, method) &&
+        (await this.mintService.supportsNut29MintQuoteCheck(mintUrl, method));
     } catch (error) {
       return failedMintQuotePollingResult(
         normalizedIdentities,
@@ -598,13 +664,14 @@ export class QuoteLifecycle {
             ),
           ];
     } catch (error) {
-      return failedMintQuotePollingResult(
-        normalizedIdentities,
-        classifyMintQuotePollingFailure(error),
-        error,
-      );
+      const category = classifyMintQuotePollingFailure(error);
+      if (useBatch) this.recordDefinitiveBatchPollingFailure(mintUrl, method, category);
+      return failedMintQuotePollingResult(normalizedIdentities, category, error);
     }
     if (!Array.isArray(response)) {
+      if (useBatch) {
+        this.recordDefinitiveBatchPollingFailure(mintUrl, method, 'malformed-response');
+      }
       return failedMintQuotePollingResult(
         normalizedIdentities,
         'malformed-response',
@@ -655,6 +722,7 @@ export class QuoteLifecycle {
       candidates.push({ snapshot: snapshot as MintMethodQuoteSnapshot, responseIndex });
       snapshotsByQuoteId.set(responseQuoteId, candidates);
     }
+    let hasDefinitiveBatchFailure = responseFailures.length > 0;
     const persisted: Array<{
       identity: QuoteIdentity;
       quote: MintQuote;
@@ -665,6 +733,7 @@ export class QuoteLifecycle {
     for (const identity of normalizedIdentities) {
       const candidates = snapshotsByQuoteId.get(identity.quoteId) ?? [];
       if (candidates.length === 0) {
+        hasDefinitiveBatchFailure = true;
         failedByQuoteId.set(identity.quoteId, {
           category: 'malformed-response',
           error: new ProofValidationError(
@@ -679,6 +748,7 @@ export class QuoteLifecycle {
       const invalidCandidates: Array<{
         error: Error;
         responseIndex: number;
+        definitive: boolean;
       }> = [];
       for (const candidate of candidates) {
         try {
@@ -690,14 +760,19 @@ export class QuoteLifecycle {
           );
           validCandidates.push(candidate);
         } catch (error) {
+          const normalizedError = normalizePollingError(error);
           invalidCandidates.push({
-            error: normalizePollingError(error),
+            error: normalizedError,
             responseIndex: candidate.responseIndex,
+            definitive: isDefinitiveMintQuotePollingValidation(normalizedError),
           });
         }
       }
 
       if (validCandidates.length === 0) {
+        if (invalidCandidates.some(({ definitive }) => definitive)) {
+          hasDefinitiveBatchFailure = true;
+        }
         const [firstFailure, ...additionalFailures] = invalidCandidates;
         failedByQuoteId.set(identity.quoteId, {
           category: 'validation',
@@ -722,6 +797,7 @@ export class QuoteLifecycle {
             !areMintQuotePollingSnapshotsEqual(method, firstValid.snapshot, snapshot),
         )
       ) {
+        hasDefinitiveBatchFailure = true;
         failedByQuoteId.set(identity.quoteId, {
           category: 'malformed-response',
           error: new ProofValidationError(
@@ -732,6 +808,9 @@ export class QuoteLifecycle {
         continue;
       }
 
+      if (validCandidates.length > 1 || invalidCandidates.some(({ definitive }) => definitive)) {
+        hasDefinitiveBatchFailure = true;
+      }
       responseFailures.push(
         ...validCandidates.slice(1).map(({ responseIndex }) => ({
           category: 'malformed-response' as const,
@@ -775,7 +854,11 @@ export class QuoteLifecycle {
       if (quote) return { status: 'updated', identity, quote };
       return { status: 'failed', identity, failure: failedByQuoteId.get(identity.quoteId)! };
     });
-    return { outcomes, responseFailures };
+    const result = { outcomes, responseFailures };
+    if (useBatch && hasDefinitiveBatchFailure) {
+      this.markBatchUnavailableForPolling(mintUrl, method);
+    }
+    return result;
   }
 
   private async assertAttributableMintQuotePollingSnapshot(

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -508,6 +508,11 @@ export class QuoteLifecycle {
     return this.mintQuoteRepository.getPendingMintQuotes(method);
   }
 
+  /** Returns the advertised and safety-capped size for one Background Watcher opportunity. */
+  async getMintQuotePollingLimit(mintUrl: string, method: MintMethod): Promise<number> {
+    return this.mintService.getNut29MintQuoteCheckLimit(mintUrl, method);
+  }
+
   /**
    * Checks selected mint quotes through the lifecycle polling seam.
    *

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -90,34 +90,6 @@ function hasReusableSettlementAmounts(snapshot: {
   return snapshot.amount_paid !== undefined && snapshot.amount_issued !== undefined;
 }
 
-function normalizeBolt11MintQuotePollingState(
-  snapshot: MintMethodQuoteSnapshot<'bolt11'>,
-): MintMethodRemoteState<'bolt11'> {
-  const accounting = snapshot as MintMethodQuoteSnapshot<'bolt11'> & {
-    amount_paid?: unknown;
-    amount_issued?: unknown;
-  };
-  const hasAmountPaid = accounting.amount_paid !== undefined;
-  const hasAmountIssued = accounting.amount_issued !== undefined;
-  if (hasAmountPaid !== hasAmountIssued) {
-    throw new ProofValidationError(
-      'BOLT11 mint quote batch observation has incomplete accounting fields',
-    );
-  }
-  if (hasAmountPaid) {
-    const amountPaid = Amount.from(accounting.amount_paid as AmountLike);
-    const amountIssued = Amount.from(accounting.amount_issued as AmountLike);
-    if (amountPaid.lessThan(amountIssued)) {
-      throw new ProofValidationError(
-        'BOLT11 mint quote batch observation has amount_issued greater than amount_paid',
-      );
-    }
-    if (amountPaid.isZero()) return 'UNPAID';
-    return amountPaid.greaterThan(amountIssued) ? 'PAID' : 'ISSUED';
-  }
-  return snapshot.state;
-}
-
 function assertMintQuotePollingSnapshotStructureUnchecked(
   method: MintMethod,
   snapshot: MintMethodQuoteSnapshot,
@@ -140,11 +112,13 @@ function assertMintQuotePollingSnapshotStructureUnchecked(
   if (method === 'bolt11') {
     const bolt11 = snapshot as MintMethodQuoteSnapshot<'bolt11'>;
     const amount = Amount.from(bolt11.amount as AmountLike);
-    const state = normalizeBolt11MintQuotePollingState(bolt11);
-    if (amount.isZero() || (state !== 'UNPAID' && state !== 'PAID' && state !== 'ISSUED')) {
+    if (
+      amount.isZero() ||
+      (bolt11.state !== 'UNPAID' && bolt11.state !== 'PAID' && bolt11.state !== 'ISSUED')
+    ) {
       throw new ProofValidationError('BOLT11 mint quote batch observation is invalid');
     }
-    return { ...bolt11, state };
+    return bolt11;
   }
 
   const reusable = snapshot as

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -90,16 +90,45 @@ function hasReusableSettlementAmounts(snapshot: {
   return snapshot.amount_paid !== undefined && snapshot.amount_issued !== undefined;
 }
 
+function normalizeBolt11MintQuotePollingState(
+  snapshot: MintMethodQuoteSnapshot<'bolt11'>,
+): MintMethodRemoteState<'bolt11'> {
+  const accounting = snapshot as MintMethodQuoteSnapshot<'bolt11'> & {
+    amount_paid?: unknown;
+    amount_issued?: unknown;
+  };
+  const hasAmountPaid = accounting.amount_paid !== undefined;
+  const hasAmountIssued = accounting.amount_issued !== undefined;
+  if (hasAmountPaid !== hasAmountIssued) {
+    throw new ProofValidationError(
+      'BOLT11 mint quote batch observation has incomplete accounting fields',
+    );
+  }
+  if (hasAmountPaid) {
+    const amountPaid = Amount.from(accounting.amount_paid as AmountLike);
+    const amountIssued = Amount.from(accounting.amount_issued as AmountLike);
+    if (amountPaid.lessThan(amountIssued)) {
+      throw new ProofValidationError(
+        'BOLT11 mint quote batch observation has amount_issued greater than amount_paid',
+      );
+    }
+    if (amountPaid.isZero()) return 'UNPAID';
+    return amountPaid.greaterThan(amountIssued) ? 'PAID' : 'ISSUED';
+  }
+  return snapshot.state;
+}
+
 function assertMintQuotePollingSnapshotStructureUnchecked(
   method: MintMethod,
   snapshot: MintMethodQuoteSnapshot,
-): void {
+): MintMethodQuoteSnapshot {
   if (
     typeof snapshot.quote !== 'string' ||
     snapshot.quote.length === 0 ||
     typeof snapshot.request !== 'string' ||
     snapshot.request.length === 0 ||
     typeof snapshot.unit !== 'string' ||
+    snapshot.unit.trim().length === 0 ||
     (snapshot.expiry !== null &&
       snapshot.expiry !== undefined &&
       !Number.isSafeInteger(snapshot.expiry)) ||
@@ -111,13 +140,11 @@ function assertMintQuotePollingSnapshotStructureUnchecked(
   if (method === 'bolt11') {
     const bolt11 = snapshot as MintMethodQuoteSnapshot<'bolt11'>;
     const amount = Amount.from(bolt11.amount as AmountLike);
-    if (
-      amount.isZero() ||
-      (bolt11.state !== 'UNPAID' && bolt11.state !== 'PAID' && bolt11.state !== 'ISSUED')
-    ) {
+    const state = normalizeBolt11MintQuotePollingState(bolt11);
+    if (amount.isZero() || (state !== 'UNPAID' && state !== 'PAID' && state !== 'ISSUED')) {
       throw new ProofValidationError('BOLT11 mint quote batch observation is invalid');
     }
-    return;
+    return { ...bolt11, state };
   }
 
   const reusable = snapshot as
@@ -137,14 +164,15 @@ function assertMintQuotePollingSnapshotStructureUnchecked(
     const amount = (snapshot as MintMethodQuoteSnapshot<'bolt12'>).amount;
     if (amount !== undefined && amount !== null) Amount.from(amount as AmountLike);
   }
+  return snapshot;
 }
 
 function assertMintQuotePollingSnapshotStructure(
   method: MintMethod,
   snapshot: MintMethodQuoteSnapshot,
-): void {
+): MintMethodQuoteSnapshot {
   try {
-    assertMintQuotePollingSnapshotStructureUnchecked(method, snapshot);
+    return assertMintQuotePollingSnapshotStructureUnchecked(method, snapshot);
   } catch (error) {
     if (error instanceof ProofValidationError) throw error;
     const validationError = new ProofValidationError(
@@ -719,7 +747,13 @@ export class QuoteLifecycle {
         continue;
       }
       const candidates = snapshotsByQuoteId.get(responseQuoteId) ?? [];
-      candidates.push({ snapshot: snapshot as MintMethodQuoteSnapshot, responseIndex });
+      candidates.push({
+        snapshot: {
+          ...snapshot,
+          pubkey: (snapshot as { pubkey?: unknown }).pubkey ?? undefined,
+        } as MintMethodQuoteSnapshot,
+        responseIndex,
+      });
       snapshotsByQuoteId.set(responseQuoteId, candidates);
     }
     let hasDefinitiveBatchFailure = responseFailures.length > 0;
@@ -752,13 +786,13 @@ export class QuoteLifecycle {
       }> = [];
       for (const candidate of candidates) {
         try {
-          await this.assertAttributableMintQuotePollingSnapshot(
+          const snapshot = await this.assertAttributableMintQuotePollingSnapshot(
             mintUrl,
             method,
             identity.quoteId,
             candidate.snapshot,
           );
-          validCandidates.push(candidate);
+          validCandidates.push({ ...candidate, snapshot });
         } catch (error) {
           const normalizedError = normalizePollingError(error);
           invalidCandidates.push({
@@ -866,8 +900,8 @@ export class QuoteLifecycle {
     method: MintMethod,
     quoteId: string,
     snapshot: MintMethodQuoteSnapshot,
-  ): Promise<void> {
-    assertMintQuotePollingSnapshotStructure(method, snapshot);
+  ): Promise<MintMethodQuoteSnapshot> {
+    snapshot = assertMintQuotePollingSnapshotStructure(method, snapshot);
     const existing = await this.mintQuoteRepository.getMintQuoteById({ mintUrl, quoteId });
     if (!existing) {
       throw new ProofValidationError(
@@ -897,7 +931,7 @@ export class QuoteLifecycle {
           `Mint quote ${quoteId} batch observation conflicts with canonical amount`,
         );
       }
-      return;
+      return snapshot;
     }
 
     if (existing.method === 'bolt12') {
@@ -914,6 +948,7 @@ export class QuoteLifecycle {
         );
       }
     }
+    return snapshot;
   }
 
   async refreshMintQuote(mintUrl: string, method: MintMethod, quoteId: string): Promise<MintQuote> {

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -25,6 +25,9 @@ import {
 import { meltQuoteToMethodSnapshot, type MeltQuote } from '../models/MeltQuote';
 import { isMintQuoteExpired } from '../models/MintQuoteExpiry';
 import {
+  HttpResponseError,
+  MintOperationError,
+  NetworkError,
   ProofValidationError,
   QuoteIdentityConflictError,
   UnknownMintError,
@@ -49,12 +52,19 @@ import type {
   MintMethodRemoteState,
 } from '../operations/mint/MintMethodHandler';
 import type { MeltQuoteRef, MintQuoteRef, QuoteIdentity } from '../models/QuoteIdentity';
+import type {
+  MintQuotePollingFailure,
+  MintQuotePollingOutcome,
+  MintQuotePollingResult,
+} from './MintQuotePolling.ts';
 
 const MINT_QUOTE_STATE_RANK: Record<string, number> = {
   UNPAID: 0,
   PAID: 1,
   ISSUED: 2,
 };
+
+const BUILT_IN_MINT_METHODS = new Set<MintMethod>(['bolt11', 'bolt12', 'onchain']);
 
 function isMintQuoteStateDowngrade(
   existing: MintMethodRemoteState,
@@ -72,6 +82,152 @@ function hasReusableSettlementAmounts(snapshot: {
   amount_issued?: unknown;
 }): boolean {
   return snapshot.amount_paid !== undefined && snapshot.amount_issued !== undefined;
+}
+
+function assertMintQuotePollingSnapshotStructure(
+  method: MintMethod,
+  snapshot: MintMethodQuoteSnapshot,
+): void {
+  if (
+    typeof snapshot.quote !== 'string' ||
+    snapshot.quote.length === 0 ||
+    typeof snapshot.request !== 'string' ||
+    snapshot.request.length === 0 ||
+    typeof snapshot.unit !== 'string' ||
+    (snapshot.expiry !== null &&
+      snapshot.expiry !== undefined &&
+      !Number.isSafeInteger(snapshot.expiry)) ||
+    (snapshot.pubkey !== undefined && typeof snapshot.pubkey !== 'string')
+  ) {
+    throw new ProofValidationError('Mint quote batch observation has invalid base fields');
+  }
+
+  if (method === 'bolt11') {
+    const bolt11 = snapshot as MintMethodQuoteSnapshot<'bolt11'>;
+    const amount = Amount.from(bolt11.amount as AmountLike);
+    if (
+      amount.isZero() ||
+      (bolt11.state !== 'UNPAID' && bolt11.state !== 'PAID' && bolt11.state !== 'ISSUED')
+    ) {
+      throw new ProofValidationError('BOLT11 mint quote batch observation is invalid');
+    }
+    return;
+  }
+
+  const reusable = snapshot as
+    | MintMethodQuoteSnapshot<'bolt12'>
+    | MintMethodQuoteSnapshot<'onchain'>;
+  if (!hasReusableSettlementAmounts(reusable)) {
+    throw new ProofValidationError(`${method} mint quote batch observation lacks settlement data`);
+  }
+  const amountPaid = Amount.from(reusable.amount_paid);
+  const amountIssued = Amount.from(reusable.amount_issued);
+  if (amountPaid.lessThan(amountIssued)) {
+    throw new ProofValidationError(
+      `${method} mint quote batch observation has amount_issued greater than amount_paid`,
+    );
+  }
+  if (method === 'bolt12') {
+    const amount = (snapshot as MintMethodQuoteSnapshot<'bolt12'>).amount;
+    if (amount !== undefined && amount !== null) Amount.from(amount as AmountLike);
+  }
+}
+
+function equalOptionalAmount(
+  left: AmountLike | null | undefined,
+  right: AmountLike | null | undefined,
+) {
+  if (left == null || right == null) return left == null && right == null;
+  return Amount.from(left).equals(Amount.from(right));
+}
+
+function areMintQuotePollingSnapshotsEqual(
+  method: MintMethod,
+  left: MintMethodQuoteSnapshot,
+  right: MintMethodQuoteSnapshot,
+): boolean {
+  if (
+    left.quote !== right.quote ||
+    left.request !== right.request ||
+    normalizeUnit(left.unit) !== normalizeUnit(right.unit) ||
+    left.expiry !== right.expiry ||
+    left.pubkey !== right.pubkey
+  ) {
+    return false;
+  }
+  if (method === 'bolt11') {
+    const leftBolt11 = left as MintMethodQuoteSnapshot<'bolt11'>;
+    const rightBolt11 = right as MintMethodQuoteSnapshot<'bolt11'>;
+    return (
+      Amount.from(leftBolt11.amount).equals(Amount.from(rightBolt11.amount)) &&
+      leftBolt11.state === rightBolt11.state
+    );
+  }
+
+  const leftReusable = left as
+    | MintMethodQuoteSnapshot<'bolt12'>
+    | MintMethodQuoteSnapshot<'onchain'>;
+  const rightReusable = right as
+    | MintMethodQuoteSnapshot<'bolt12'>
+    | MintMethodQuoteSnapshot<'onchain'>;
+  if (
+    !Amount.from(leftReusable.amount_paid).equals(Amount.from(rightReusable.amount_paid)) ||
+    !Amount.from(leftReusable.amount_issued).equals(Amount.from(rightReusable.amount_issued))
+  ) {
+    return false;
+  }
+  return (
+    method !== 'bolt12' ||
+    equalOptionalAmount(
+      (left as MintMethodQuoteSnapshot<'bolt12'>).amount,
+      (right as MintMethodQuoteSnapshot<'bolt12'>).amount,
+    )
+  );
+}
+
+function normalizePollingError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function classifyMintQuotePollingFailure(error: unknown): MintQuotePollingFailure['category'] {
+  if (error instanceof NetworkError) return 'network';
+  if (error instanceof MintOperationError) {
+    if (error.code === 11_017) return 'batch-size';
+    if (error.code === 31_004) return 'rate-limit';
+    if (error.code >= 30_000) return 'authentication';
+    return 'validation';
+  }
+  if (error instanceof HttpResponseError) {
+    if (error.status >= 200 && error.status < 300) return 'malformed-response';
+    if (error.status === 401 || error.status === 403) return 'authentication';
+    if (error.status === 429) return 'rate-limit';
+    if (error.status === 404 || error.status === 405 || error.status === 501) {
+      return 'incompatibility';
+    }
+    if (error.status >= 500) return 'server';
+  }
+  if (error && typeof error === 'object' && 'cause' in error) {
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause !== undefined && cause !== error) return classifyMintQuotePollingFailure(cause);
+  }
+  if (error instanceof Error && /auth/i.test(error.name)) return 'authentication';
+  return 'validation';
+}
+
+function failedMintQuotePollingResult(
+  identities: readonly QuoteIdentity[],
+  category: MintQuotePollingFailure['category'],
+  error: unknown,
+): MintQuotePollingResult {
+  const normalizedError = normalizePollingError(error);
+  return {
+    outcomes: identities.map((identity) => ({
+      status: 'failed',
+      identity,
+      failure: { category, error: normalizedError },
+    })),
+    responseFailures: [],
+  };
 }
 
 function getRemoteStateChange(
@@ -350,6 +506,326 @@ export class QuoteLifecycle {
 
   getPendingMintQuotes(method?: MintMethod): Promise<MintQuote[]> {
     return this.mintQuoteRepository.getPendingMintQuotes(method);
+  }
+
+  /**
+   * Checks selected mint quotes through the lifecycle polling seam.
+   *
+   * NUT-29 is used when advertised, with identity-based response attribution and
+   * one explicit outcome for every selected quote. Attributable observations are
+   * persisted before any update events are emitted, even when other response
+   * elements are missing, duplicated, extra, malformed, or conflict with canonical
+   * quote data. A single selection falls back to the existing single-quote endpoint
+   * when NUT-29 is unavailable; multiple selections never fan out implicitly.
+   */
+  async checkMintQuotesForPolling(
+    method: MintMethod,
+    identities: readonly QuoteIdentity[],
+  ): Promise<MintQuotePollingResult> {
+    if (identities.length === 0) {
+      return { outcomes: [], responseFailures: [] };
+    }
+
+    const normalizedIdentities = identities.map((identity) => ({
+      mintUrl: normalizeMintUrl(identity.mintUrl),
+      quoteId: identity.quoteId,
+    }));
+    const mintUrl = normalizedIdentities[0]!.mintUrl;
+    const uniqueMintUrls = new Set(normalizedIdentities.map((identity) => identity.mintUrl));
+    const uniqueQuoteIds = new Set(normalizedIdentities.map((identity) => identity.quoteId));
+    if (
+      uniqueMintUrls.size !== 1 ||
+      uniqueQuoteIds.size !== normalizedIdentities.length ||
+      normalizedIdentities.some((identity) => identity.quoteId.length === 0)
+    ) {
+      return failedMintQuotePollingResult(
+        normalizedIdentities,
+        'validation',
+        new ProofValidationError(
+          'Mint quote polling selections require one mint and unique non-empty quote identities',
+        ),
+      );
+    }
+    if (!BUILT_IN_MINT_METHODS.has(method)) {
+      return failedMintQuotePollingResult(
+        normalizedIdentities,
+        'validation',
+        new ProofValidationError(`Unsupported built-in mint quote polling method ${method}`),
+      );
+    }
+    if (!(await this.mintService.isTrustedMint(mintUrl))) {
+      throw new UnknownMintError(`Mint ${mintUrl} is not trusted`);
+    }
+
+    let useBatch: boolean;
+    try {
+      useBatch = await this.mintService.supportsNut29MintQuoteCheck(mintUrl, method);
+    } catch (error) {
+      return failedMintQuotePollingResult(
+        normalizedIdentities,
+        classifyMintQuotePollingFailure(error),
+        error,
+      );
+    }
+    if (!useBatch && normalizedIdentities.length > 1) {
+      return failedMintQuotePollingResult(
+        normalizedIdentities,
+        'incompatibility',
+        new ProofValidationError(
+          `Mint ${mintUrl} does not advertise NUT-29 quote checks for ${method}`,
+        ),
+      );
+    }
+
+    let response: unknown;
+    try {
+      response = useBatch
+        ? await this.mintAdapter.checkMintQuoteBatch(
+            mintUrl,
+            method,
+            normalizedIdentities.map((identity) => identity.quoteId),
+          )
+        : [
+            await this.mintAdapter.checkMintQuote(
+              mintUrl,
+              method,
+              normalizedIdentities[0]!.quoteId,
+            ),
+          ];
+    } catch (error) {
+      return failedMintQuotePollingResult(
+        normalizedIdentities,
+        classifyMintQuotePollingFailure(error),
+        error,
+      );
+    }
+    if (!Array.isArray(response)) {
+      return failedMintQuotePollingResult(
+        normalizedIdentities,
+        'malformed-response',
+        new ProofValidationError('Mint quote batch check returned a non-array response'),
+      );
+    }
+    const snapshots = response;
+    const selectedQuoteIds = new Set(normalizedIdentities.map((identity) => identity.quoteId));
+    const snapshotsByQuoteId = new Map<
+      string,
+      Array<{ snapshot: MintMethodQuoteSnapshot; responseIndex: number }>
+    >();
+    const responseFailures: MintQuotePollingFailure[] = [];
+    for (const [responseIndex, snapshot] of snapshots.entries()) {
+      if (!snapshot || typeof snapshot !== 'object') {
+        responseFailures.push({
+          category: 'malformed-response',
+          error: new ProofValidationError(
+            `Mint quote batch response element ${responseIndex} has no identity`,
+          ),
+          responseIndex,
+        });
+        continue;
+      }
+      const responseQuoteId = (snapshot as { quote?: unknown }).quote;
+      if (typeof responseQuoteId !== 'string' || responseQuoteId.length === 0) {
+        responseFailures.push({
+          category: 'malformed-response',
+          error: new ProofValidationError(
+            `Mint quote batch response element ${responseIndex} has no identity`,
+          ),
+          responseIndex,
+        });
+        continue;
+      }
+      if (!selectedQuoteIds.has(responseQuoteId)) {
+        responseFailures.push({
+          category: 'malformed-response',
+          error: new ProofValidationError(
+            `Mint quote batch response contains unselected quote ${responseQuoteId}`,
+          ),
+          responseIndex,
+          responseQuoteId,
+        });
+        continue;
+      }
+      const candidates = snapshotsByQuoteId.get(responseQuoteId) ?? [];
+      candidates.push({ snapshot: snapshot as MintMethodQuoteSnapshot, responseIndex });
+      snapshotsByQuoteId.set(responseQuoteId, candidates);
+    }
+    const persisted: Array<{
+      identity: QuoteIdentity;
+      quote: MintQuote;
+      remoteStateChanged: boolean;
+    }> = [];
+    const failedByQuoteId = new Map<string, MintQuotePollingFailure>();
+
+    for (const identity of normalizedIdentities) {
+      const candidates = snapshotsByQuoteId.get(identity.quoteId) ?? [];
+      if (candidates.length === 0) {
+        failedByQuoteId.set(identity.quoteId, {
+          category: 'malformed-response',
+          error: new ProofValidationError(
+            `Mint quote batch response is missing quote ${identity.quoteId}`,
+          ),
+          responseQuoteId: identity.quoteId,
+        });
+        continue;
+      }
+
+      const validCandidates: typeof candidates = [];
+      const invalidCandidates: Array<{
+        error: Error;
+        responseIndex: number;
+      }> = [];
+      for (const candidate of candidates) {
+        try {
+          await this.assertAttributableMintQuotePollingSnapshot(
+            mintUrl,
+            method,
+            identity.quoteId,
+            candidate.snapshot,
+          );
+          validCandidates.push(candidate);
+        } catch (error) {
+          invalidCandidates.push({
+            error: normalizePollingError(error),
+            responseIndex: candidate.responseIndex,
+          });
+        }
+      }
+
+      if (validCandidates.length === 0) {
+        const [firstFailure, ...additionalFailures] = invalidCandidates;
+        failedByQuoteId.set(identity.quoteId, {
+          category: 'validation',
+          error: firstFailure!.error,
+          responseQuoteId: identity.quoteId,
+        });
+        responseFailures.push(
+          ...additionalFailures.map(({ error, responseIndex }) => ({
+            category: 'validation' as const,
+            error,
+            responseIndex,
+            responseQuoteId: identity.quoteId,
+          })),
+        );
+        continue;
+      }
+
+      const firstValid = validCandidates[0]!;
+      if (
+        validCandidates.some(
+          ({ snapshot }) =>
+            !areMintQuotePollingSnapshotsEqual(method, firstValid.snapshot, snapshot),
+        )
+      ) {
+        failedByQuoteId.set(identity.quoteId, {
+          category: 'malformed-response',
+          error: new ProofValidationError(
+            `Mint quote batch response contains conflicting duplicates for quote ${identity.quoteId}`,
+          ),
+          responseQuoteId: identity.quoteId,
+        });
+        continue;
+      }
+
+      responseFailures.push(
+        ...validCandidates.slice(1).map(({ responseIndex }) => ({
+          category: 'malformed-response' as const,
+          error: new ProofValidationError(
+            `Mint quote batch response contains duplicate quote ${identity.quoteId}`,
+          ),
+          responseIndex,
+          responseQuoteId: identity.quoteId,
+        })),
+        ...invalidCandidates.map(({ error, responseIndex }) => ({
+          category: 'validation' as const,
+          error,
+          responseIndex,
+          responseQuoteId: identity.quoteId,
+        })),
+      );
+      try {
+        const result = await this.resolveAndPersistMintQuoteSnapshot(
+          mintUrl,
+          method,
+          firstValid.snapshot,
+        );
+        persisted.push({ identity, ...result });
+      } catch (error) {
+        failedByQuoteId.set(identity.quoteId, {
+          category: 'validation',
+          error: normalizePollingError(error),
+          responseQuoteId: identity.quoteId,
+        });
+      }
+    }
+    for (const result of persisted) {
+      await this.emitMintQuoteUpdatedIfNeeded(result.quote, result.remoteStateChanged);
+    }
+
+    const persistedByQuoteId = new Map(
+      persisted.map(({ identity, quote }) => [identity.quoteId, quote]),
+    );
+    const outcomes: MintQuotePollingOutcome[] = normalizedIdentities.map((identity) => {
+      const quote = persistedByQuoteId.get(identity.quoteId);
+      if (quote) return { status: 'updated', identity, quote };
+      return { status: 'failed', identity, failure: failedByQuoteId.get(identity.quoteId)! };
+    });
+    return { outcomes, responseFailures };
+  }
+
+  private async assertAttributableMintQuotePollingSnapshot(
+    mintUrl: string,
+    method: MintMethod,
+    quoteId: string,
+    snapshot: MintMethodQuoteSnapshot,
+  ): Promise<void> {
+    assertMintQuotePollingSnapshotStructure(method, snapshot);
+    const existing = await this.mintQuoteRepository.getMintQuoteById({ mintUrl, quoteId });
+    if (!existing) {
+      throw new ProofValidationError(
+        `Mint quote ${quoteId} batch observation has no canonical quote`,
+      );
+    }
+    if (existing.method !== method) {
+      throw new QuoteIdentityConflictError('mint', mintUrl, quoteId, [method, existing.method]);
+    }
+    if (
+      snapshot.quote !== quoteId ||
+      snapshot.request !== existing.request ||
+      normalizeUnit(snapshot.unit) !== existing.unit ||
+      (snapshot.pubkey ?? undefined) !== (existing.pubkey ?? undefined)
+    ) {
+      throw new ProofValidationError(
+        `Mint quote ${quoteId} batch observation conflicts with canonical identity fields`,
+      );
+    }
+
+    if (existing.method === 'bolt11') {
+      const amount = Amount.from(
+        (snapshot as MintMethodQuoteSnapshot<'bolt11'>).amount as AmountLike,
+      );
+      if (!amount.equals(existing.amount)) {
+        throw new ProofValidationError(
+          `Mint quote ${quoteId} batch observation conflicts with canonical amount`,
+        );
+      }
+      return;
+    }
+
+    if (existing.method === 'bolt12') {
+      const incomingAmount = (snapshot as MintMethodQuoteSnapshot<'bolt12'>).amount;
+      const existingAmount = existing.quoteData.amount;
+      if (
+        (incomingAmount == null) !== (existingAmount === undefined) ||
+        (incomingAmount != null &&
+          existingAmount !== undefined &&
+          !Amount.from(incomingAmount as AmountLike).equals(existingAmount))
+      ) {
+        throw new ProofValidationError(
+          `Mint quote ${quoteId} batch observation conflicts with canonical amount`,
+        );
+      }
+    }
   }
 
   async refreshMintQuote(mintUrl: string, method: MintMethod, quoteId: string): Promise<MintQuote> {

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -18,6 +18,31 @@ import { DEFAULT_UNIT, normalizeUnit, normalizeUnitAmount, type UnitAmount } fro
 
 const MINT_REFRESH_TTL_S = 60 * 5;
 
+function supportsNut29MintQuoteCheckFromInfo(mintInfo: MintInfo, method: string): boolean {
+  const nuts = mintInfo.nuts as unknown;
+  if (!nuts || typeof nuts !== 'object') return false;
+
+  const nut29 = (nuts as Record<string, unknown>)['29'];
+  if (!nut29 || typeof nut29 !== 'object') return false;
+  const methods = (nut29 as { methods?: unknown }).methods;
+  if (methods !== undefined) return Array.isArray(methods) && methods.includes(method);
+
+  const nut4 = (nuts as Record<string, unknown>)['4'];
+  if (!nut4 || typeof nut4 !== 'object' || (nut4 as { disabled?: unknown }).disabled === true) {
+    return false;
+  }
+  const mintMethods = (nut4 as { methods?: unknown }).methods;
+  return (
+    Array.isArray(mintMethods) &&
+    mintMethods.some(
+      (entry) =>
+        entry !== null &&
+        typeof entry === 'object' &&
+        (entry as { method?: unknown }).method === method,
+    )
+  );
+}
+
 export interface MethodUnitCapability {
   supported: boolean;
   disabled: boolean;
@@ -250,28 +275,24 @@ export class MintService {
    */
   async supportsNut29MintQuoteCheck(mintUrl: string, method: string): Promise<boolean> {
     const mintInfo = await this.getMintInfo(normalizeMintUrl(mintUrl));
-    const nuts = mintInfo.nuts as unknown;
-    if (!nuts || typeof nuts !== 'object') return false;
+    return supportsNut29MintQuoteCheckFromInfo(mintInfo, method);
+  }
 
-    const nut29 = (nuts as Record<string, unknown>)['29'];
-    if (!nut29 || typeof nut29 !== 'object') return false;
-    const methods = (nut29 as { methods?: unknown }).methods;
-    if (methods !== undefined) return Array.isArray(methods) && methods.includes(method);
+  /**
+   * Returns the bounded NUT-29 mint quote check limit for one polling group.
+   *
+   * Unsupported methods and malformed advertised limits use one quote per polling
+   * opportunity. An omitted limit uses Coco's protocol safety cap of 100.
+   */
+  async getNut29MintQuoteCheckLimit(mintUrl: string, method: string): Promise<number> {
+    const mintInfo = await this.getMintInfo(normalizeMintUrl(mintUrl));
+    if (!supportsNut29MintQuoteCheckFromInfo(mintInfo, method)) return 1;
 
-    const nut4 = (nuts as Record<string, unknown>)['4'];
-    if (!nut4 || typeof nut4 !== 'object' || (nut4 as { disabled?: unknown }).disabled === true) {
-      return false;
-    }
-    const mintMethods = (nut4 as { methods?: unknown }).methods;
-    return (
-      Array.isArray(mintMethods) &&
-      mintMethods.some(
-        (entry) =>
-          entry !== null &&
-          typeof entry === 'object' &&
-          (entry as { method?: unknown }).method === method,
-      )
-    );
+    const nuts = mintInfo.nuts as unknown as Record<string, unknown>;
+    const maxBatchSize = (nuts['29'] as { max_batch_size?: unknown }).max_batch_size;
+    if (maxBatchSize === undefined) return 100;
+    if (!Number.isSafeInteger(maxBatchSize) || Number(maxBatchSize) < 1) return 1;
+    return Math.min(Number(maxBatchSize), 100);
   }
 
   /**

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -242,6 +242,39 @@ export class MintService {
   }
 
   /**
+   * Returns whether a mint advertises NUT-29 mint quote checks for a payment method.
+   *
+   * When NUT-29 omits its optional method list, enabled NUT-04 method metadata is
+   * used as the source of supported mint methods. Missing or malformed metadata
+   * returns `false`; mint-info refresh failures propagate unchanged.
+   */
+  async supportsNut29MintQuoteCheck(mintUrl: string, method: string): Promise<boolean> {
+    const mintInfo = await this.getMintInfo(normalizeMintUrl(mintUrl));
+    const nuts = mintInfo.nuts as unknown;
+    if (!nuts || typeof nuts !== 'object') return false;
+
+    const nut29 = (nuts as Record<string, unknown>)['29'];
+    if (!nut29 || typeof nut29 !== 'object') return false;
+    const methods = (nut29 as { methods?: unknown }).methods;
+    if (methods !== undefined) return Array.isArray(methods) && methods.includes(method);
+
+    const nut4 = (nuts as Record<string, unknown>)['4'];
+    if (!nut4 || typeof nut4 !== 'object' || (nut4 as { disabled?: unknown }).disabled === true) {
+      return false;
+    }
+    const mintMethods = (nut4 as { methods?: unknown }).methods;
+    return (
+      Array.isArray(mintMethods) &&
+      mintMethods.some(
+        (entry) =>
+          entry !== null &&
+          typeof entry === 'object' &&
+          (entry as { method?: unknown }).method === method,
+      )
+    );
+  }
+
+  /**
    * Requires a mint to advertise a top-level NUT capability.
    *
    * This currently supports NUT-11 checks only. Returns when support is

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -613,6 +613,7 @@ export class MintService {
     mint.mintInfo = mintInfo;
     mint.updatedAt = Math.floor(Date.now() / 1000);
     await this.mintRepo.addOrUpdateMint(mint);
+    await this.eventBus?.emit('mint:metadata-refreshed', { mintUrl: mint.mintUrl });
 
     const repoKeysets = await this.keysetRepo.getKeysetsByMintUrl(mint.mintUrl);
     this.logger?.info('Mint updated', { mintUrl: mint.mintUrl, keysets: repoKeysets.length });

--- a/packages/core/test/unit/HybridTransport.test.ts
+++ b/packages/core/test/unit/HybridTransport.test.ts
@@ -367,9 +367,8 @@ describe('HybridTransport', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 10));
 
-      const originalNow = Date.now;
-      const nowSeconds = Math.floor(originalNow() / 1000);
-      const expiry = nowSeconds + 60;
+      const expiryMs = Date.now() + 100;
+      const expiry = expiryMs / 1000;
       const notification = JSON.stringify({
         jsonrpc: '2.0',
         method: 'subscribe',
@@ -379,17 +378,12 @@ describe('HybridTransport', () => {
         },
       });
 
-      try {
-        Date.now = () => nowSeconds * 1000;
-        mockSocket.triggerMessage(notification);
-        const countAfterFirst = messageHandler.mock.calls.length;
+      mockSocket.triggerMessage(notification);
+      const countAfterFirst = messageHandler.mock.calls.length;
 
-        Date.now = () => (expiry + 1) * 1000;
-        mockSocket.triggerMessage(notification);
-        expect(messageHandler.mock.calls.length).toBe(countAfterFirst + 1);
-      } finally {
-        Date.now = originalNow;
-      }
+      await new Promise((resolve) => setTimeout(resolve, Math.max(0, expiryMs - Date.now() + 1)));
+      mockSocket.triggerMessage(notification);
+      expect(messageHandler.mock.calls.length).toBe(countAfterFirst + 1);
     });
 
     it('should bypass dedupe when no state or complete amount counters are present', async () => {

--- a/packages/core/test/unit/MintAdapter.test.ts
+++ b/packages/core/test/unit/MintAdapter.test.ts
@@ -59,6 +59,7 @@ const onchainMeltQuote = {
 
 type FakeCashuMint = {
   getInfo: ReturnType<typeof mock>;
+  getLazyMintInfo: ReturnType<typeof mock>;
   getKeySets: ReturnType<typeof mock>;
   getKeys: ReturnType<typeof mock>;
   checkMintQuote: ReturnType<typeof mock>;
@@ -88,6 +89,10 @@ describe('MintAdapter', () => {
     adapter = new MintAdapter(requestProvider);
     fakeMint = {
       getInfo: mock(async () => mintInfo),
+      getLazyMintInfo: mock(async () => ({
+        requiresBlindAuthToken: mock(() => false),
+        requiresClearAuthToken: mock(() => false),
+      })),
       getKeySets: mock(async () => keysets),
       getKeys: mock(async () => ({ keysets: [{ keys: { '1': 'pubkey' } }] })),
       checkMintQuote: mock(async () => onchainMintQuote),
@@ -134,6 +139,38 @@ describe('MintAdapter', () => {
 
     expect(fakeMint.getKeys).toHaveBeenCalledWith('keyset-1');
     expect(fakeMint.checkMintQuote).toHaveBeenCalledWith('onchain', 'mint-quote');
+  });
+
+  it('sends NUT-29 quote checks through the shared authenticated request path', async () => {
+    const request = mock(async () => [{ quote: 'quote-1' }, { quote: 'quote-2' }]);
+    requestProvider.getRequestFn = mock(
+      () => request as unknown as ReturnType<MintRequestProvider['getRequestFn']>,
+    );
+    const authProvider = {
+      getBlindAuthToken: mock(async () => 'blind-token'),
+      getCAT: mock(() => 'clear-token'),
+      setCAT: mock(() => undefined),
+    };
+    adapter.setAuthProvider(mintUrl, authProvider);
+    fakeMint.getLazyMintInfo = mock(async () => ({
+      requiresBlindAuthToken: mock(() => true),
+      requiresClearAuthToken: mock(() => true),
+    }));
+    installFakeMint(adapter, fakeMint);
+
+    await expect(
+      adapter.checkMintQuoteBatch(mintUrl, 'bolt11', ['quote-1', 'quote-2']),
+    ).resolves.toEqual([{ quote: 'quote-1' }, { quote: 'quote-2' }]);
+
+    expect(request).toHaveBeenCalledWith({
+      endpoint: `${mintUrl}/v1/mint/quote/bolt11/check`,
+      method: 'POST',
+      requestBody: { quotes: ['quote-1', 'quote-2'] },
+      headers: {
+        'Blind-auth': 'blind-token',
+        'Clear-auth': 'clear-token',
+      },
+    });
   });
 
   it('rejects key lookups that return anything other than one keyset', async () => {

--- a/packages/core/test/unit/MintService.test.ts
+++ b/packages/core/test/unit/MintService.test.ts
@@ -376,6 +376,46 @@ describe('MintService', () => {
       expect(mintCapability.supported).toBe(true);
       expect(meltCapability.supported).toBe(true);
     });
+
+    it('reports NUT-29 mint quote checks for explicitly advertised methods', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '29': { methods: ['bolt11', 'onchain'] },
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.supportsNut29MintQuoteCheck(testMintUrl, 'bolt11')).resolves.toBe(true);
+      await expect(service.supportsNut29MintQuoteCheck(testMintUrl, 'bolt12')).resolves.toBe(false);
+    });
+
+    it('uses enabled NUT-04 methods when NUT-29 omits its method list', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          '4': { methods: [{ method: 'bolt12', unit: 'sat' }], disabled: false },
+          '5': { methods: [], disabled: false },
+          '29': {},
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.supportsNut29MintQuoteCheck(testMintUrl, 'bolt12')).resolves.toBe(true);
+      await expect(service.supportsNut29MintQuoteCheck(testMintUrl, 'bolt11')).resolves.toBe(false);
+    });
+
+    it('rejects malformed NUT-29 metadata and disabled NUT-04 fallback', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          '4': { methods: [{ method: 'bolt11', unit: 'sat' }], disabled: true },
+          '5': { methods: [], disabled: false },
+          '29': true,
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.supportsNut29MintQuoteCheck(testMintUrl, 'bolt11')).resolves.toBe(false);
+    });
   });
 
   describe('method-unit capabilities', () => {

--- a/packages/core/test/unit/MintService.test.ts
+++ b/packages/core/test/unit/MintService.test.ts
@@ -416,6 +416,43 @@ describe('MintService', () => {
 
       await expect(service.supportsNut29MintQuoteCheck(testMintUrl, 'bolt11')).resolves.toBe(false);
     });
+
+    it('bounds the advertised NUT-29 mint quote check limit at 100', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '29': { methods: ['bolt11'], max_batch_size: 250 },
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.getNut29MintQuoteCheckLimit(testMintUrl, 'bolt11')).resolves.toBe(100);
+    });
+
+    it('uses 100 when NUT-29 omits its mint quote check limit', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '29': { methods: ['bolt11'] },
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.getNut29MintQuoteCheckLimit(testMintUrl, 'bolt11')).resolves.toBe(100);
+    });
+
+    it('uses one quote when NUT-29 is unsupported or advertises an invalid limit', async () => {
+      useMintInfo({
+        ...mockMintInfo,
+        nuts: {
+          ...mockMintInfo.nuts,
+          '29': { methods: ['bolt11'], max_batch_size: 0 },
+        },
+      } as unknown as MintInfo);
+
+      await expect(service.getNut29MintQuoteCheckLimit(testMintUrl, 'bolt11')).resolves.toBe(1);
+      await expect(service.getNut29MintQuoteCheckLimit(testMintUrl, 'bolt12')).resolves.toBe(1);
+    });
   });
 
   describe('method-unit capabilities', () => {

--- a/packages/core/test/unit/PollingTransport.test.ts
+++ b/packages/core/test/unit/PollingTransport.test.ts
@@ -1,7 +1,42 @@
+import { Amount } from '@cashu/cashu-ts';
 import { describe, it, expect, beforeEach, mock } from 'bun:test';
 import { PollingTransport } from '../../infra/PollingTransport';
 import type { MintAdapter } from '../../infra/MintAdapter';
 import { NullLogger } from '../../logging';
+import { mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
+import type { QuoteIdentity } from '../../models/QuoteIdentity.ts';
+import type { MintMethod } from '../../operations/mint/MintMethodHandler.ts';
+import type {
+  MintQuotePollingOperation,
+  MintQuotePollingResult,
+} from '../../quotes/MintQuotePolling.ts';
+import { waitFor } from '../waitFor.ts';
+
+function failedPollingResult(mintUrl: string, quoteIds: readonly string[]): MintQuotePollingResult {
+  return {
+    outcomes: quoteIds.map((quoteId) => ({
+      status: 'failed',
+      identity: { mintUrl, quoteId },
+      failure: { category: 'network', error: new Error('offline') },
+    })),
+    responseFailures: [],
+  };
+}
+
+function subscribeToQuotes(
+  transport: PollingTransport,
+  mintUrl: string,
+  method: MintMethod,
+  subId: string,
+  quoteIds: string[],
+): void {
+  transport.send(mintUrl, {
+    jsonrpc: '2.0',
+    method: 'subscribe',
+    params: { kind: `${method}_mint_quote`, subId, filters: quoteIds },
+    id: 1,
+  });
+}
 
 // Mock MintAdapter for testing
 const createMockMintAdapter = (): MintAdapter =>
@@ -253,6 +288,378 @@ describe('PollingTransport subscription kinds', () => {
     expect(scheduler?.queue ?? []).toHaveLength(0);
     expect((adapter.checkMintQuote as any).mock.calls.length).toBe(0);
 
+    transport.closeAll();
+  });
+});
+
+describe('PollingTransport mint quote batching', () => {
+  const mintUrl = 'https://mint.example.com';
+  const mintUrlVariant = 'https://MINT.example.com/';
+
+  it('groups normalized compatible interests deterministically up to the advertised limit', async () => {
+    const calls: Array<{ mintUrl: string; method: MintMethod; quoteIds: string[] }> = [];
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 2),
+      checkMintQuotesForPolling: mock(
+        async (method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push({
+            mintUrl: identities[0]!.mintUrl,
+            method,
+            quoteIds: identities.map(({ quoteId }) => quoteId),
+          });
+          transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    const adapter = createMockMintAdapter();
+    transport = new PollingTransport(adapter, { intervalMs: 1 }, new NullLogger(), polling);
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.pause();
+    subscribeToQuotes(transport, mintUrlVariant, 'bolt11', 'bolt11-sub', [
+      'quote-b',
+      'quote-a',
+      'quote-a',
+      'quote-c',
+    ]);
+    subscribeToQuotes(transport, mintUrl, 'bolt12', 'bolt12-sub', ['quote-z']);
+    transport.resume();
+    await waitFor(() => calls.length === 1);
+
+    expect(calls).toEqual([{ mintUrl, method: 'bolt11', quoteIds: ['quote-b', 'quote-a'] }]);
+    expect(adapter.checkMintQuote).not.toHaveBeenCalled();
+    transport.closeAll();
+  });
+
+  for (const method of ['bolt11', 'bolt12', 'onchain'] as const) {
+    it(`batches advertised ${method} interests`, async () => {
+      const calls: string[][] = [];
+      let transport: PollingTransport;
+      const polling: MintQuotePollingOperation = {
+        getMintQuotePollingLimit: mock(async () => 100),
+        checkMintQuotesForPolling: mock(
+          async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+            calls.push(identities.map(({ quoteId }) => quoteId));
+            transport.pause();
+            return failedPollingResult(
+              mintUrl,
+              identities.map(({ quoteId }) => quoteId),
+            );
+          },
+        ),
+      };
+      transport = new PollingTransport(
+        createMockMintAdapter(),
+        { intervalMs: 1 },
+        new NullLogger(),
+        polling,
+      );
+
+      transport.on(mintUrl, 'message', () => {});
+      transport.pause();
+      subscribeToQuotes(transport, mintUrl, method, `${method}-sub`, ['quote-a', 'quote-b']);
+      transport.resume();
+      await waitFor(() => calls.length === 1);
+
+      expect(calls).toEqual([['quote-a', 'quote-b']]);
+      transport.closeAll();
+    });
+  }
+
+  it('caps observable mint quote polling requests at 100 identities', async () => {
+    const calls: string[][] = [];
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 100),
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push(identities.map(({ quoteId }) => quoteId));
+          transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 1 },
+      new NullLogger(),
+      polling,
+    );
+    const quoteIds = Array.from({ length: 101 }, (_, index) => `quote-${index}`);
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.pause();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'capped-sub', quoteIds);
+    transport.resume();
+    await waitFor(() => calls.length === 1);
+
+    expect(calls[0]).toEqual(quoteIds.slice(0, 100));
+    transport.closeAll();
+  });
+
+  it('ends and requeues the turn when polling-limit resolution fails', async () => {
+    const calls: string[][] = [];
+    const getMintQuotePollingLimit = mock(async () => {
+      if (getMintQuotePollingLimit.mock.calls.length === 1) throw new Error('metadata offline');
+      return 2;
+    });
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit,
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push(identities.map(({ quoteId }) => quoteId));
+          transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 1 },
+      new NullLogger(),
+      polling,
+    );
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.pause();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'retry-sub', ['quote-a', 'quote-b']);
+    transport.resume();
+    await waitFor(() => calls.length === 1);
+
+    expect(getMintQuotePollingLimit).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual([['quote-b', 'quote-a']]);
+    transport.closeAll();
+  });
+
+  it('polls unsupported methods one quote per turn', async () => {
+    const calls: string[][] = [];
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 1),
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push(identities.map(({ quoteId }) => quoteId));
+          if (calls.length === 2) transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 1 },
+      new NullLogger(),
+      polling,
+    );
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.pause();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'single-sub', ['quote-a', 'quote-b']);
+    transport.resume();
+    await waitFor(() => calls.length === 2);
+
+    expect(calls).toEqual([['quote-a'], ['quote-b']]);
+    transport.closeAll();
+  });
+
+  it('rotates requeued interests so every quote retains fair access', async () => {
+    const calls: string[][] = [];
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 2),
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push(identities.map(({ quoteId }) => quoteId));
+          if (calls.length === 3) transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 1 },
+      new NullLogger(),
+      polling,
+    );
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.pause();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'fair-sub', ['quote-a', 'quote-b', 'quote-c']);
+    transport.resume();
+    await waitFor(() => calls.length === 3);
+
+    expect(calls).toEqual([
+      ['quote-a', 'quote-b'],
+      ['quote-c', 'quote-a'],
+      ['quote-b', 'quote-c'],
+    ]);
+    transport.closeAll();
+  });
+
+  it('gives late interests fair access on the next polling turn', async () => {
+    const calls: string[][] = [];
+    let resolveFirst!: () => void;
+    const firstCheck = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 2),
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push(identities.map(({ quoteId }) => quoteId));
+          if (calls.length === 1) await firstCheck;
+          if (calls.length === 2) transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 1 },
+      new NullLogger(),
+      polling,
+    );
+
+    transport.on(mintUrl, 'message', () => {});
+    transport.pause();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'existing-sub', ['quote-a', 'quote-b']);
+    transport.resume();
+    await waitFor(() => calls.length === 1);
+
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'late-sub', ['quote-c']);
+    resolveFirst();
+    await waitFor(() => calls.length === 2);
+
+    expect(calls).toEqual([
+      ['quote-a', 'quote-b'],
+      ['quote-c', 'quote-a'],
+    ]);
+    transport.closeAll();
+  });
+
+  it('keeps the configured interval between requeued polling turns', async () => {
+    const startedAt: number[] = [];
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 1),
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          startedAt.push(Date.now());
+          if (startedAt.length === 2) transport.pause();
+          return failedPollingResult(
+            mintUrl,
+            identities.map(({ quoteId }) => quoteId),
+          );
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 20 },
+      new NullLogger(),
+      polling,
+    );
+
+    transport.on(mintUrl, 'message', () => {});
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'cadence-sub', ['quote-a']);
+    await waitFor(() => startedAt.length === 2);
+
+    expect(startedAt[1]! - startedAt[0]!).toBeGreaterThanOrEqual(18);
+    transport.closeAll();
+  });
+
+  it('removes an in-flight interest without repolling it or corrupting siblings', async () => {
+    const calls: string[][] = [];
+    const messages: Array<{ params?: { subId?: string; payload?: { quote?: string } } }> = [];
+    let resolveFirst!: () => void;
+    const firstCheck = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let transport: PollingTransport;
+    const polling: MintQuotePollingOperation = {
+      getMintQuotePollingLimit: mock(async () => 2),
+      checkMintQuotesForPolling: mock(
+        async (_method: MintMethod, identities: readonly QuoteIdentity[]) => {
+          calls.push(identities.map(({ quoteId }) => quoteId));
+          if (calls.length === 1) await firstCheck;
+          if (calls.length === 2) transport.pause();
+          return {
+            outcomes: identities.map(({ mintUrl: identityMintUrl, quoteId }) => ({
+              status: 'updated' as const,
+              identity: { mintUrl: identityMintUrl, quoteId },
+              quote: mintQuoteFromBolt11Response(identityMintUrl, {
+                quote: quoteId,
+                request: `lnbc1${quoteId}`,
+                amount: Amount.from(10),
+                unit: 'sat',
+                expiry: null,
+                state: 'PAID',
+              }),
+            })),
+            responseFailures: [],
+          };
+        },
+      ),
+    };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 1 },
+      new NullLogger(),
+      polling,
+    );
+
+    transport.on(mintUrl, 'message', (event) => messages.push(JSON.parse(event.data)));
+    transport.pause();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'removed-sub', ['quote-a']);
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'sibling-sub', ['quote-b']);
+    transport.resume();
+    await waitFor(() => calls.length === 1);
+
+    transport.send(mintUrl, {
+      jsonrpc: '2.0',
+      method: 'unsubscribe',
+      params: { subId: 'removed-sub' },
+      id: 2,
+    });
+    resolveFirst();
+    await waitFor(() => calls.length === 2);
+
+    expect(calls).toEqual([['quote-a', 'quote-b'], ['quote-b']]);
+    const notifications = messages.filter(({ params }) => params?.payload?.quote);
+    expect(notifications).toContainEqual(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          subId: 'sibling-sub',
+          payload: expect.objectContaining({ quote: 'quote-b' }),
+        }),
+      }),
+    );
+    expect(
+      notifications.some(
+        ({ params }) => params?.subId === 'removed-sub' || params?.payload?.quote === 'quote-a',
+      ),
+    ).toBe(false);
     transport.closeAll();
   });
 });

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -1,0 +1,622 @@
+import { Amount } from '@cashu/cashu-ts';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+import type { MintAdapter } from '../../infra/MintAdapter.ts';
+import type { MeltHandlerProvider } from '../../infra/handlers/melt/index.ts';
+import type { MintHandlerProvider } from '../../infra/handlers/mint/index.ts';
+import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error.ts';
+import {
+  mintQuoteFromBolt11Response,
+  mintQuoteFromBolt12Response,
+  mintQuoteFromOnchainResponse,
+  type MintQuote,
+} from '../../models/MintQuote.ts';
+import type { ProofRepository } from '../../repositories/index.ts';
+import { MemoryKeysetRepository } from '../../repositories/memory/MemoryKeysetRepository.ts';
+import { MemoryMintQuoteRepository } from '../../repositories/memory/MemoryMintQuoteRepository.ts';
+import { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository.ts';
+import { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
+import { MintService } from '../../services/MintService.ts';
+import type { ProofService } from '../../services/ProofService.ts';
+import type { WalletService } from '../../services/WalletService.ts';
+
+const mintUrl = 'https://mint.test';
+const expiry = Math.floor(Date.now() / 1000) + 3600;
+
+describe('QuoteLifecycle mint quote polling', () => {
+  let eventBus: EventBus<CoreEvents>;
+  let mintAdapter: MintAdapter;
+  let mintQuoteRepository: MemoryMintQuoteRepository;
+  let mintRepository: MemoryMintRepository;
+  let quoteLifecycle: QuoteLifecycle;
+  let fetchRemoteMintQuote: ReturnType<typeof mock>;
+
+  beforeEach(async () => {
+    eventBus = new EventBus<CoreEvents>();
+    mintQuoteRepository = new MemoryMintQuoteRepository();
+    mintAdapter = {
+      checkMintQuoteBatch: mock(async () => []),
+      checkMintQuote: mock(async (_mintUrl: string, _method: string, quoteId: string) => ({
+        quote: quoteId,
+        request: `lnbc1${quoteId}`,
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      })),
+    } as unknown as MintAdapter;
+
+    mintRepository = new MemoryMintRepository();
+    await mintRepository.addOrUpdateMint({
+      mintUrl,
+      name: 'test mint',
+      trusted: true,
+      createdAt: 0,
+      updatedAt: Math.floor(Date.now() / 1000),
+      mintInfo: {
+        nuts: {
+          '4': {
+            methods: [
+              { method: 'bolt11', unit: 'sat' },
+              { method: 'bolt12', unit: 'sat' },
+              { method: 'onchain', unit: 'sat' },
+            ],
+            disabled: false,
+          },
+          '29': { methods: ['bolt11', 'bolt12', 'onchain'], max_batch_size: 100 },
+        },
+      } as never,
+    });
+    const mintService = new MintService(mintRepository, new MemoryKeysetRepository(), mintAdapter);
+    fetchRemoteMintQuote = mock(async ({ quote }: { quote: MintQuote<'bolt11'> }) =>
+      mintQuoteFromBolt11Response(quote.mintUrl, {
+        quote: quote.quoteId,
+        request: quote.request,
+        amount: quote.amount,
+        unit: quote.unit,
+        expiry: quote.expiry,
+        state: 'PAID',
+      }),
+    );
+    const mintHandlerProvider = {
+      get: mock(() => ({ fetchRemoteQuote: fetchRemoteMintQuote })),
+    } as unknown as MintHandlerProvider;
+
+    quoteLifecycle = new QuoteLifecycle({
+      mintHandlerProvider,
+      meltHandlerProvider: {} as MeltHandlerProvider,
+      mintQuoteRepository,
+      meltQuoteRepository: {} as never,
+      proofRepository: {} as ProofRepository,
+      proofService: {} as ProofService,
+      mintService,
+      walletService: {} as WalletService,
+      mintAdapter,
+      eventBus,
+    });
+  });
+
+  async function persistBolt11Quote(quoteId: string): Promise<void> {
+    await mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteId,
+        request: `lnbc1${quoteId}`,
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'UNPAID',
+      }),
+    );
+  }
+
+  async function persistBolt12Quote(quoteId: string): Promise<void> {
+    await mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt12Response(mintUrl, {
+        quote: quoteId,
+        request: `lno1${quoteId}`,
+        amount: Amount.from(12),
+        unit: 'sat',
+        expiry,
+        pubkey: '02'.padEnd(66, '2'),
+        amount_paid: Amount.zero(),
+        amount_issued: Amount.zero(),
+      }),
+    );
+  }
+
+  async function persistOnchainQuote(quoteId: string): Promise<void> {
+    await mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromOnchainResponse(mintUrl, {
+        quote: quoteId,
+        request: `bc1q${quoteId}`,
+        unit: 'sat',
+        expiry,
+        pubkey: '02'.padEnd(66, '3'),
+        amount_paid: Amount.zero(),
+        amount_issued: Amount.zero(),
+      }),
+    );
+  }
+
+  async function setNut29Methods(methods: string[] | undefined): Promise<void> {
+    const mint = await mintRepository.getMintByUrl(mintUrl);
+    if (!mint) throw new Error('Expected test mint');
+    await mintRepository.addOrUpdateMint({
+      ...mint,
+      updatedAt: Math.floor(Date.now() / 1000),
+      mintInfo: {
+        nuts: {
+          '4': {
+            methods: [
+              { method: 'bolt11', unit: 'sat' },
+              { method: 'bolt12', unit: 'sat' },
+              { method: 'onchain', unit: 'sat' },
+            ],
+            disabled: false,
+          },
+          '29': {
+            ...(methods === undefined ? {} : { methods }),
+            max_batch_size: 100,
+          },
+        },
+      } as never,
+    });
+  }
+
+  it('matches reordered BOLT11 observations by identity and persists before events', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-b',
+        request: 'lnbc1quote-b',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+    ]);
+    const persistedDuringEvents: Array<MintQuote | null> = [];
+    eventBus.on('mint-quote:updated', async ({ quote }) => {
+      persistedDuringEvents.push(
+        await mintQuoteRepository.getMintQuote(quote.mintUrl, quote.method, quote.quoteId),
+      );
+    });
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+    ]);
+
+    expect(result.outcomes.map((outcome) => [outcome.identity.quoteId, outcome.status])).toEqual([
+      ['quote-a', 'updated'],
+      ['quote-b', 'updated'],
+    ]);
+    expect(result.responseFailures).toEqual([]);
+    expect(persistedDuringEvents.map((quote) => quote?.method === 'bolt11' && quote.state)).toEqual(
+      ['PAID', 'PAID'],
+    );
+  });
+
+  it('retains attributable observations while reporting missing, duplicate, and extra identities', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    await persistBolt11Quote('quote-c');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+      {
+        quote: 'quote-c',
+        request: 'lnbc1quote-c',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'UNPAID',
+      },
+      {
+        quote: 'quote-c',
+        request: 'lnbc1quote-c',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+      {
+        quote: 'extra-quote',
+        request: 'lnbc1extra',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+      { request: 'identity-less' },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+      { mintUrl, quoteId: 'quote-c' },
+    ]);
+
+    expect(
+      result.outcomes.map((outcome) => [
+        outcome.identity.quoteId,
+        outcome.status,
+        outcome.status === 'failed' ? outcome.failure.category : undefined,
+      ]),
+    ).toEqual([
+      ['quote-a', 'updated', undefined],
+      ['quote-b', 'failed', 'malformed-response'],
+      ['quote-c', 'failed', 'malformed-response'],
+    ]);
+    expect(result.responseFailures.map((failure) => failure.responseQuoteId)).toEqual([
+      'extra-quote',
+      undefined,
+    ]);
+    expect(result.responseFailures.every(({ category }) => category === 'malformed-response')).toBe(
+      true,
+    );
+    await expect(
+      mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote-a'),
+    ).resolves.toMatchObject({ state: 'PAID' });
+    await expect(
+      mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote-b'),
+    ).resolves.toMatchObject({ state: 'UNPAID' });
+    await expect(
+      mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote-c'),
+    ).resolves.toMatchObject({ state: 'UNPAID' });
+  });
+
+  it('retains one attributable observation from identical and partly malformed duplicates', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    const validA = {
+      quote: 'quote-a',
+      request: 'lnbc1quote-a',
+      amount: Amount.from(10),
+      unit: 'sat',
+      expiry,
+      state: 'PAID',
+    };
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      validA,
+      { ...validA },
+      {
+        quote: 'quote-b',
+        request: 'lnbc1quote-b',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+      {
+        quote: 'quote-b',
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+    ]);
+
+    expect(result.outcomes.map((outcome) => outcome.status)).toEqual(['updated', 'updated']);
+    expect(result.responseFailures).toHaveLength(2);
+    expect(result.responseFailures.map((failure) => failure.responseQuoteId)).toEqual([
+      'quote-a',
+      'quote-b',
+    ]);
+    expect(result.responseFailures.map((failure) => failure.category)).toEqual([
+      'malformed-response',
+      'validation',
+    ]);
+  });
+
+  it('normalizes units when identifying equivalent duplicate observations', async () => {
+    await persistBolt11Quote('quote-a');
+    const valid = {
+      quote: 'quote-a',
+      request: 'lnbc1quote-a',
+      amount: Amount.from(10),
+      unit: 'sat',
+      expiry,
+      state: 'PAID',
+    };
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      valid,
+      { ...valid, unit: 'SAT' },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+    ]);
+
+    expect(result.outcomes[0]).toMatchObject({ status: 'updated' });
+    expect(result.responseFailures).toHaveLength(1);
+    expect(result.responseFailures[0]).toMatchObject({
+      category: 'malformed-response',
+      responseQuoteId: 'quote-a',
+    });
+  });
+
+  it('records attributable BOLT12 and on-chain observations', async () => {
+    await persistBolt12Quote('bolt12-quote');
+    await persistOnchainQuote('onchain-quote');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>)
+      .mockResolvedValueOnce([
+        {
+          quote: 'bolt12-quote',
+          request: 'lno1bolt12-quote',
+          amount: Amount.from(12),
+          unit: 'sat',
+          expiry,
+          pubkey: '02'.padEnd(66, '2'),
+          amount_paid: Amount.from(20),
+          amount_issued: Amount.from(8),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          quote: 'onchain-quote',
+          request: 'bc1qonchain-quote',
+          unit: 'sat',
+          expiry,
+          pubkey: '02'.padEnd(66, '3'),
+          amount_paid: Amount.from(30),
+          amount_issued: Amount.from(9),
+        },
+      ]);
+
+    const bolt12 = await quoteLifecycle.checkMintQuotesForPolling('bolt12', [
+      { mintUrl, quoteId: 'bolt12-quote' },
+    ]);
+    const onchain = await quoteLifecycle.checkMintQuotesForPolling('onchain', [
+      { mintUrl, quoteId: 'onchain-quote' },
+    ]);
+
+    expect(bolt12.outcomes[0]?.status).toBe('updated');
+    expect(onchain.outcomes[0]?.status).toBe('updated');
+    const storedBolt12 = await mintQuoteRepository.getMintQuote(mintUrl, 'bolt12', 'bolt12-quote');
+    const storedOnchain = await mintQuoteRepository.getMintQuote(
+      mintUrl,
+      'onchain',
+      'onchain-quote',
+    );
+    expect(storedBolt12?.reusable && storedBolt12.quoteData.amountPaid.toString()).toBe('20');
+    expect(storedOnchain?.reusable && storedOnchain.quoteData.amountPaid.toString()).toBe('30');
+  });
+
+  it('rejects canonical identity conflicts and over-issued reusable observations', async () => {
+    await persistBolt12Quote('bolt12-conflict');
+    await persistOnchainQuote('onchain-over-issued');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>)
+      .mockResolvedValueOnce([
+        {
+          quote: 'bolt12-conflict',
+          request: 'different-request',
+          amount: Amount.from(12),
+          unit: 'sat',
+          expiry,
+          pubkey: '02'.padEnd(66, '2'),
+          amount_paid: Amount.from(20),
+          amount_issued: Amount.from(8),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          quote: 'onchain-over-issued',
+          request: 'bc1qonchain-over-issued',
+          unit: 'sat',
+          expiry,
+          pubkey: '02'.padEnd(66, '3'),
+          amount_paid: Amount.from(10),
+          amount_issued: Amount.from(11),
+        },
+      ]);
+
+    const conflict = await quoteLifecycle.checkMintQuotesForPolling('bolt12', [
+      { mintUrl, quoteId: 'bolt12-conflict' },
+    ]);
+    const overIssued = await quoteLifecycle.checkMintQuotesForPolling('onchain', [
+      { mintUrl, quoteId: 'onchain-over-issued' },
+    ]);
+
+    expect(conflict.outcomes[0]).toMatchObject({
+      status: 'failed',
+      failure: { category: 'validation' },
+    });
+    expect(overIssued.outcomes[0]).toMatchObject({
+      status: 'failed',
+      failure: { category: 'validation' },
+    });
+    const storedConflict = await mintQuoteRepository.getMintQuote(
+      mintUrl,
+      'bolt12',
+      'bolt12-conflict',
+    );
+    const storedOverIssued = await mintQuoteRepository.getMintQuote(
+      mintUrl,
+      'onchain',
+      'onchain-over-issued',
+    );
+    expect(storedConflict?.request).toBe('lno1bolt12-conflict');
+    expect(storedOverIssued?.reusable && storedOverIssued.quoteData.amountIssued.toString()).toBe(
+      '0',
+    );
+  });
+
+  it('classifies request-wide polling failures without losing the original error', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    const cases = [
+      ['network', new NetworkError('offline')],
+      ['authentication', new HttpResponseError('authentication required', 401)],
+      ['authentication', new MintOperationError(30_001, 'blind auth required')],
+      ['rate-limit', new HttpResponseError('slow down', 429)],
+      ['rate-limit', new MintOperationError(31_004, 'BAT mint rate limit exceeded')],
+      ['server', new HttpResponseError('unavailable', 503)],
+      ['incompatibility', new HttpResponseError('not implemented', 405)],
+      ['batch-size', new MintOperationError(11_017, 'batch too large')],
+      ['malformed-response', new HttpResponseError('bad response', 200)],
+      ['validation', new MintOperationError(20_002, 'quote state conflict')],
+    ] as const;
+
+    for (const [category, error] of cases) {
+      (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockRejectedValueOnce(error);
+
+      const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl, quoteId: 'quote-a' },
+        { mintUrl, quoteId: 'quote-b' },
+      ]);
+
+      expect(result.outcomes).toHaveLength(2);
+      for (const outcome of result.outcomes) {
+        expect(outcome.status).toBe('failed');
+        if (outcome.status !== 'failed') throw new Error('Expected a failed polling outcome');
+        expect(outcome.failure.category).toBe(category);
+        expect(outcome.failure.error).toBe(error);
+      }
+      expect(result.responseFailures).toEqual([]);
+    }
+  });
+
+  it('classifies wrapped mint-info refresh failures by their transport cause', async () => {
+    await persistBolt11Quote('quote-a');
+    const mint = await mintRepository.getMintByUrl(mintUrl);
+    if (!mint) throw new Error('Expected test mint');
+    await mintRepository.addOrUpdateMint({ ...mint, updatedAt: 0 });
+    const cases = [
+      ['network', new NetworkError('offline')],
+      ['authentication', new HttpResponseError('authentication required', 401)],
+      ['rate-limit', new HttpResponseError('slow down', 429)],
+      ['server', new HttpResponseError('unavailable', 503)],
+    ] as const;
+
+    for (const [category, cause] of cases) {
+      mintAdapter.fetchMintInfo = mock(async () => {
+        throw cause;
+      });
+
+      const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl, quoteId: 'quote-a' },
+      ]);
+
+      expect(result.outcomes[0]).toMatchObject({
+        status: 'failed',
+        failure: { category },
+      });
+      const outcome = result.outcomes[0]!;
+      if (outcome.status !== 'failed') throw new Error('Expected a failed polling outcome');
+      expect((outcome.failure.error as Error & { cause?: unknown }).cause).toBe(cause);
+    }
+  });
+
+  it('returns malformed-response outcomes when the batch response is not an array', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce({
+      quotes: [],
+    });
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+    ]);
+
+    expect(
+      result.outcomes.map((outcome) =>
+        outcome.status === 'failed' ? outcome.failure.category : outcome.status,
+      ),
+    ).toEqual(['malformed-response', 'malformed-response']);
+    expect(result.responseFailures).toEqual([]);
+  });
+
+  it('uses one single polling check when NUT-29 does not advertise the method', async () => {
+    await persistBolt11Quote('quote-a');
+    await setNut29Methods(['bolt12']);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+    ]);
+
+    expect(result.outcomes[0]?.status).toBe('updated');
+    expect(mintAdapter.checkMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt11', 'quote-a');
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+  });
+
+  it('treats omitted NUT-29 methods as support for NUT-04 methods', async () => {
+    await persistBolt11Quote('quote-a');
+    await setNut29Methods(undefined);
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+    ]);
+
+    expect(result.outcomes[0]?.status).toBe('updated');
+    expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledWith(mintUrl, 'bolt11', ['quote-a']);
+    expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+  });
+
+  it('keeps explicit quote refresh on the existing single-quote handler path', async () => {
+    await persistBolt11Quote('quote-a');
+
+    const refreshed = await quoteLifecycle.refreshMintQuoteById({ mintUrl, quoteId: 'quote-a' });
+
+    expect(refreshed.method === 'bolt11' && refreshed.state).toBe('PAID');
+    expect(fetchRemoteMintQuote).toHaveBeenCalledTimes(1);
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+  });
+
+  it('rejects mixed-mint and duplicate selections before making a polling request', async () => {
+    const selections = [
+      [
+        { mintUrl, quoteId: 'quote-a' },
+        { mintUrl: 'https://other-mint.test', quoteId: 'quote-b' },
+      ],
+      [
+        { mintUrl, quoteId: 'quote-a' },
+        { mintUrl: `${mintUrl}/`, quoteId: 'quote-a' },
+      ],
+    ];
+
+    for (const identities of selections) {
+      const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', identities);
+
+      expect(result.outcomes).toHaveLength(2);
+      expect(
+        result.outcomes.every(
+          (outcome) => outcome.status === 'failed' && outcome.failure.category === 'validation',
+        ),
+      ).toBe(true);
+    }
+    expect(mintAdapter.checkMintQuoteBatch).not.toHaveBeenCalled();
+    expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -427,7 +427,7 @@ describe('QuoteLifecycle mint quote polling', () => {
     expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
   });
 
-  it('derives a BOLT11 polling state from quote accounting when state is omitted', async () => {
+  it('rejects accounting-only BOLT11 polling snapshots without changing canonical state', async () => {
     await persistBolt11Quote('quote-a');
     (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
       {
@@ -447,10 +447,12 @@ describe('QuoteLifecycle mint quote polling', () => {
     ]);
 
     expect(result.outcomes[0]).toMatchObject({
-      status: 'updated',
-      quote: { method: 'bolt11', state: 'PAID' },
+      status: 'failed',
+      failure: { category: 'validation' },
     });
-    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
+    const canonical = await mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote-a');
+    expect(canonical?.state).toBe('UNPAID');
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
   });
 
   it('records attributable BOLT12 and on-chain observations', async () => {

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -3,8 +3,10 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
+import { PollingTransport } from '../../infra/PollingTransport.ts';
 import type { MeltHandlerProvider } from '../../infra/handlers/melt/index.ts';
 import type { MintHandlerProvider } from '../../infra/handlers/mint/index.ts';
+import { NullLogger } from '../../logging/NullLogger.ts';
 import { HttpResponseError, MintOperationError, NetworkError } from '../../models/Error.ts';
 import {
   mintQuoteFromBolt11Response,
@@ -20,6 +22,7 @@ import { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 import { MintService } from '../../services/MintService.ts';
 import type { ProofService } from '../../services/ProofService.ts';
 import type { WalletService } from '../../services/WalletService.ts';
+import { waitFor } from '../waitFor.ts';
 
 const mintUrl = 'https://mint.test';
 const expiry = Math.floor(Date.now() / 1000) + 3600;
@@ -582,6 +585,138 @@ describe('QuoteLifecycle mint quote polling', () => {
     expect(result.outcomes[0]?.status).toBe('updated');
     expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledWith(mintUrl, 'bolt11', ['quote-a']);
     expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+  });
+
+  it('batches Background Watcher requests through the quote lifecycle seam', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-b',
+        request: 'lnbc1quote-b',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+    ]);
+    const notifications: Array<{ params?: { payload?: { quote?: string } } }> = [];
+    const transport = new PollingTransport(
+      mintAdapter,
+      { intervalMs: 5_000 },
+      new NullLogger(),
+      quoteLifecycle,
+    );
+    transport.on(mintUrl, 'message', (event) => notifications.push(JSON.parse(event.data)));
+    transport.pause();
+
+    transport.send(mintUrl, {
+      jsonrpc: '2.0',
+      method: 'subscribe',
+      params: {
+        kind: 'bolt11_mint_quote',
+        subId: 'background-watcher',
+        filters: ['quote-a', 'quote-b'],
+      },
+      id: 1,
+    });
+    transport.resume();
+    await waitFor(() => notifications.some(({ params }) => params?.payload?.quote === 'quote-b'));
+
+    expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledTimes(1);
+    expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledWith(mintUrl, 'bolt11', [
+      'quote-a',
+      'quote-b',
+    ]);
+    expect(
+      notifications
+        .filter(({ params }) => params?.payload?.quote)
+        .map(({ params }) => params!.payload!.quote),
+    ).toEqual(['quote-a', 'quote-b']);
+    transport.closeAll();
+  });
+
+  it('keeps an Explicit Quote Check isolated from an in-flight watcher batch', async () => {
+    await persistBolt11Quote('watcher-a');
+    await persistBolt11Quote('watcher-b');
+    await persistBolt11Quote('explicit');
+    let resolveBatch!: () => void;
+    const batchGate = new Promise<void>((resolve) => {
+      resolveBatch = resolve;
+    });
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockImplementationOnce(
+      async () => {
+        await batchGate;
+        return [
+          {
+            quote: 'watcher-a',
+            request: 'lnbc1watcher-a',
+            amount: Amount.from(10),
+            unit: 'sat',
+            expiry,
+            state: 'PAID',
+          },
+          {
+            quote: 'watcher-b',
+            request: 'lnbc1watcher-b',
+            amount: Amount.from(10),
+            unit: 'sat',
+            expiry,
+            state: 'PAID',
+          },
+        ];
+      },
+    );
+    const notifications: Array<{ params?: { payload?: { quote?: string } } }> = [];
+    const transport = new PollingTransport(
+      mintAdapter,
+      { intervalMs: 5_000 },
+      new NullLogger(),
+      quoteLifecycle,
+    );
+    transport.on(mintUrl, 'message', (event) => notifications.push(JSON.parse(event.data)));
+    transport.pause();
+    transport.send(mintUrl, {
+      jsonrpc: '2.0',
+      method: 'subscribe',
+      params: {
+        kind: 'bolt11_mint_quote',
+        subId: 'background-watcher',
+        filters: ['watcher-a', 'watcher-b'],
+      },
+      id: 1,
+    });
+    transport.resume();
+    await waitFor(
+      () => (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mock.calls.length === 1,
+    );
+
+    let explicitQuote: MintQuote | undefined;
+    let explicitError: unknown;
+    void quoteLifecycle
+      .refreshMintQuoteById({ mintUrl, quoteId: 'explicit' })
+      .then((quote) => {
+        explicitQuote = quote;
+      })
+      .catch((error: unknown) => {
+        explicitError = error;
+      });
+    await waitFor(() => explicitQuote !== undefined || explicitError !== undefined);
+
+    expect(explicitError).toBeUndefined();
+    expect(explicitQuote?.quoteId).toBe('explicit');
+    expect(fetchRemoteMintQuote).toHaveBeenCalledTimes(1);
+    resolveBatch();
+    await waitFor(() => notifications.some(({ params }) => params?.payload?.quote === 'watcher-b'));
+    transport.closeAll();
   });
 
   it('keeps explicit quote refresh on the existing single-quote handler path', async () => {

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -32,6 +32,7 @@ describe('QuoteLifecycle mint quote polling', () => {
   let mintAdapter: MintAdapter;
   let mintQuoteRepository: MemoryMintQuoteRepository;
   let mintRepository: MemoryMintRepository;
+  let mintService: MintService;
   let quoteLifecycle: QuoteLifecycle;
   let fetchRemoteMintQuote: ReturnType<typeof mock>;
 
@@ -71,7 +72,13 @@ describe('QuoteLifecycle mint quote polling', () => {
         },
       } as never,
     });
-    const mintService = new MintService(mintRepository, new MemoryKeysetRepository(), mintAdapter);
+    mintService = new MintService(
+      mintRepository,
+      new MemoryKeysetRepository(),
+      mintAdapter,
+      undefined,
+      eventBus,
+    );
     fetchRemoteMintQuote = mock(async ({ quote }: { quote: MintQuote<'bolt11'> }) =>
       mintQuoteFromBolt11Response(quote.mintUrl, {
         quote: quote.quoteId,
@@ -283,6 +290,7 @@ describe('QuoteLifecycle mint quote polling', () => {
     await expect(
       mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote-c'),
     ).resolves.toMatchObject({ state: 'UNPAID' });
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
   });
 
   it('retains one attributable observation from identical and partly malformed duplicates', async () => {
@@ -330,6 +338,7 @@ describe('QuoteLifecycle mint quote polling', () => {
       'malformed-response',
       'validation',
     ]);
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
   });
 
   it('normalizes units when identifying equivalent duplicate observations', async () => {
@@ -463,6 +472,8 @@ describe('QuoteLifecycle mint quote polling', () => {
     expect(storedOverIssued?.reusable && storedOverIssued.quoteData.amountIssued.toString()).toBe(
       '0',
     );
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt12')).toBe(1);
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'onchain')).toBe(1);
   });
 
   it('classifies request-wide polling failures without losing the original error', async () => {
@@ -497,7 +508,196 @@ describe('QuoteLifecycle mint quote polling', () => {
         expect(outcome.failure.error).toBe(error);
       }
       expect(result.responseFailures).toEqual([]);
+      await eventBus.emit('mint:metadata-refreshed', { mintUrl });
     }
+  });
+
+  for (const [category, error] of [
+    ['incompatibility', new HttpResponseError('not implemented', 405)],
+    ['batch-size', new MintOperationError(11_017, 'batch too large')],
+    ['malformed-response', new HttpResponseError('bad response', 200)],
+    ['validation', new MintOperationError(20_002, 'quote state conflict')],
+  ] as const) {
+    it(`downgrades ${category} failures to one single quote on a later polling turn`, async () => {
+      await persistBolt11Quote('quote-a');
+      await persistBolt11Quote('quote-b');
+      (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockRejectedValueOnce(error);
+
+      const failed = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl: `${mintUrl}/`, quoteId: 'quote-a' },
+        { mintUrl, quoteId: 'quote-b' },
+      ]);
+
+      expect(
+        failed.outcomes.every(
+          (outcome) => outcome.status === 'failed' && outcome.failure.category === category,
+        ),
+      ).toBe(true);
+      expect(await quoteLifecycle.getMintQuotePollingLimit(`${mintUrl}/`, 'bolt11')).toBe(1);
+      expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+
+      const nextTurn = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl, quoteId: 'quote-a' },
+      ]);
+
+      expect(nextTurn.outcomes[0]?.status).toBe('updated');
+      expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledTimes(1);
+      expect(mintAdapter.checkMintQuote).toHaveBeenCalledTimes(1);
+      expect(mintAdapter.checkMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt11', 'quote-a');
+    });
+  }
+
+  for (const [category, error] of [
+    ['network', new NetworkError('offline')],
+    ['authentication', new HttpResponseError('authentication required', 401)],
+    ['rate-limit', new HttpResponseError('slow down', 429)],
+    ['server', new HttpResponseError('unavailable', 503)],
+  ] as const) {
+    it(`keeps ${category} failures eligible for batching on the next polling turn`, async () => {
+      await persistBolt11Quote('quote-a');
+      await persistBolt11Quote('quote-b');
+      (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>)
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce([
+          {
+            quote: 'quote-a',
+            request: 'lnbc1quote-a',
+            amount: Amount.from(10),
+            unit: 'sat',
+            expiry,
+            state: 'PAID',
+          },
+          {
+            quote: 'quote-b',
+            request: 'lnbc1quote-b',
+            amount: Amount.from(10),
+            unit: 'sat',
+            expiry,
+            state: 'PAID',
+          },
+        ]);
+
+      const failed = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl, quoteId: 'quote-a' },
+        { mintUrl, quoteId: 'quote-b' },
+      ]);
+
+      expect(
+        failed.outcomes.every(
+          (outcome) => outcome.status === 'failed' && outcome.failure.category === category,
+        ),
+      ).toBe(true);
+      expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
+
+      const nextTurn = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl, quoteId: 'quote-a' },
+        { mintUrl, quoteId: 'quote-b' },
+      ]);
+
+      expect(nextTurn.outcomes.map(({ status }) => status)).toEqual(['updated', 'updated']);
+      expect(mintAdapter.checkMintQuoteBatch).toHaveBeenCalledTimes(2);
+      expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+    });
+  }
+
+  for (const failureStage of ['canonical read', 'canonical persistence'] as const) {
+    it(`does not downgrade NUT-29 for a local ${failureStage} failure`, async () => {
+      await persistBolt11Quote('quote-a');
+      await persistBolt11Quote('quote-b');
+      (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+        {
+          quote: 'quote-a',
+          request: 'lnbc1quote-a',
+          amount: Amount.from(10),
+          unit: 'sat',
+          expiry,
+          state: 'PAID',
+        },
+        {
+          quote: 'quote-b',
+          request: 'lnbc1quote-b',
+          amount: Amount.from(10),
+          unit: 'sat',
+          expiry,
+          state: 'PAID',
+        },
+      ]);
+      const storageError = new Error('storage unavailable');
+      if (failureStage === 'canonical read') {
+        mintQuoteRepository.getMintQuoteById = mock(async () => {
+          throw storageError;
+        });
+      } else {
+        mintQuoteRepository.upsertMintQuote = mock(async () => {
+          throw storageError;
+        });
+      }
+
+      const failed = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+        { mintUrl, quoteId: 'quote-a' },
+        { mintUrl, quoteId: 'quote-b' },
+      ]);
+
+      expect(failed.outcomes.every(({ status }) => status === 'failed')).toBe(true);
+      expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
+    });
+  }
+
+  it('isolates downgrade state by payment method and clears it after mint metadata updates', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new HttpResponseError('not implemented', 405),
+    );
+
+    await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+    ]);
+
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt12')).toBe(100);
+    const mint = await mintRepository.getMintByUrl(mintUrl);
+    if (!mint) throw new Error('Expected test mint');
+    const otherMintUrl = 'https://other-mint.test';
+    await mintRepository.addOrUpdateMint({ ...mint, mintUrl: otherMintUrl });
+    expect(await quoteLifecycle.getMintQuotePollingLimit(otherMintUrl, 'bolt11')).toBe(100);
+
+    mintAdapter.fetchMintInfo = mock(async () => mint.mintInfo);
+    mintAdapter.fetchKeysets = mock(async () => ({ keysets: [] }));
+    await mintService.updateMintData(mintUrl);
+
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
+  });
+
+  it('does not carry downgrade state into a new Coco Session', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockRejectedValueOnce(
+      new HttpResponseError('not implemented', 405),
+    );
+    await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+    ]);
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
+
+    const nextSession = new QuoteLifecycle({
+      mintHandlerProvider: {
+        get: mock(() => ({ fetchRemoteQuote: fetchRemoteMintQuote })),
+      } as unknown as MintHandlerProvider,
+      meltHandlerProvider: {} as MeltHandlerProvider,
+      mintQuoteRepository,
+      meltQuoteRepository: {} as never,
+      proofRepository: {} as ProofRepository,
+      proofService: {} as ProofService,
+      mintService,
+      walletService: {} as WalletService,
+      mintAdapter,
+      eventBus: new EventBus<CoreEvents>(),
+    });
+
+    expect(await nextSession.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
   });
 
   it('classifies wrapped mint-info refresh failures by their transport cause', async () => {

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -368,6 +368,91 @@ describe('QuoteLifecycle mint quote polling', () => {
     });
   });
 
+  it('accepts a null pubkey for an unlocked polling observation', async () => {
+    await persistBolt11Quote('quote-a');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        pubkey: null,
+        state: 'PAID',
+      },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+    ]);
+
+    expect(result.outcomes[0]).toMatchObject({ status: 'updated' });
+    const outcome = result.outcomes[0]!;
+    if (outcome.status !== 'updated') throw new Error('Expected an updated polling outcome');
+    expect(outcome.quote.pubkey).toBeUndefined();
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
+  });
+
+  it('downgrades batching after a polling observation contains a blank unit', async () => {
+    await persistBolt11Quote('quote-a');
+    await persistBolt11Quote('quote-b');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        unit: '   ',
+        expiry,
+        state: 'PAID',
+      },
+      {
+        quote: 'quote-b',
+        request: 'lnbc1quote-b',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry,
+        state: 'PAID',
+      },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+      { mintUrl, quoteId: 'quote-b' },
+    ]);
+
+    expect(result.outcomes).toMatchObject([
+      { status: 'failed', failure: { category: 'validation' } },
+      { status: 'updated' },
+    ]);
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(1);
+  });
+
+  it('derives a BOLT11 polling state from quote accounting when state is omitted', async () => {
+    await persistBolt11Quote('quote-a');
+    (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>).mockResolvedValueOnce([
+      {
+        quote: 'quote-a',
+        request: 'lnbc1quote-a',
+        amount: Amount.from(10),
+        amount_paid: Amount.from(10),
+        amount_issued: Amount.zero(),
+        updated_at: 1_721_234_567,
+        unit: 'sat',
+        expiry,
+      },
+    ]);
+
+    const result = await quoteLifecycle.checkMintQuotesForPolling('bolt11', [
+      { mintUrl, quoteId: 'quote-a' },
+    ]);
+
+    expect(result.outcomes[0]).toMatchObject({
+      status: 'updated',
+      quote: { method: 'bolt11', state: 'PAID' },
+    });
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt11')).toBe(100);
+  });
+
   it('records attributable BOLT12 and on-chain observations', async () => {
     await persistBolt12Quote('bolt12-quote');
     await persistOnchainQuote('onchain-quote');

--- a/packages/core/test/waitFor.ts
+++ b/packages/core/test/waitFor.ts
@@ -1,0 +1,7 @@
+export async function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for test condition');
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}


### PR DESCRIPTION
## Overview

This is the first implementation PR for #373. It delivers the complete Background Watcher quote-checking track across #374, #375, and #376: a batch-aware quote-lifecycle seam, deterministic watcher batching, and polling-local fallback when a mint's advertised NUT-29 capability is definitively unusable.

Explicit Quote Checks remain immediate, target-isolated, and backed by the existing single-quote endpoint.

## Problem

Coco needs the request-efficiency benefits of NUT-29 background mint-quote checking without recursive splitting, same-turn fan-out, adaptive limits, persistent compatibility policy, or coupling explicit caller-scoped checks to watcher work.

The quote lifecycle must own attribution, validation, canonical persistence, and outcome reporting, while the polling transport must retain predictable cadence, fairness, and requeueing behavior.

## Full PR 1 scope

### Quote-lifecycle batch checking (#374)

- support advertised NUT-29 checks for `bolt11`, `bolt12`, and `onchain`
- match responses by quote identity rather than response position
- return one explicit updated-or-failed outcome for every selected quote
- validate method-specific attributable observations and persist canonical quote state before events
- retain valid attributable observations from partially malformed responses
- distinguish network, authentication, rate-limit, server, incompatibility, batch-size, malformed-response, and validation failures

### Background Watcher batching (#375)

- group compatible interests by normalized mint and Built-in Payment Method
- select deterministically, deduplicate quote identities, and cap requests at the advertised maximum or 100
- preserve polling cadence, fairness, removal, and requeueing behavior
- keep unsupported methods on one quote per polling turn
- perform no internal retry, recursive splitting, or individual fan-out

### Session-scoped capability downgrade (#376)

- mark only the affected mint-and-method group unavailable after definitive incompatibility, batch-size, malformed-response, or validation failures
- do not downgrade for network, authentication, rate-limit, or server failures
- make no same-turn individual requests after a failed batch opportunity
- poll one quote per later turn at the normal interval for downgraded groups
- clear downgrade state when mint metadata changes or a new Coco Session starts
- update or supersede ADR-0006 while preserving Explicit Quote Check isolation

## Progress

- [x] #374 — batch mint-quote checks at the quote-lifecycle seam
- [x] #375 — batch compatible Background Watcher quote interests
- [x] #376 — downgrade broken batch quote checking for the Coco Session

## Out of scope

Durable Mint Issuance Attempts and transparent multi-operation mint batching are delivered by the later PRs in #373.

## Verification

Current branch verification:

- `bun run --filter='@cashu/coco-core' test:unit` — 1,102 passed
- `bun run build`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`

The full core test command was also attempted: 1,103 tests passed, while four environment-dependent integration cases could not complete because the local environment does not provide `MINT_URL`, mint/BAT authentication setup, or the expected mint at `localhost:3338`.

## Changeset

- adds `.changeset/tidy-nut29-quote-checks.md` for a patch release of `@cashu/coco-core`

Closes #374.
Closes #375.
Closes #376.
