### PR TITLE
feat(core): add durable BOLT11 mint issuance

### DIFF
--- a/.changeset/durable-mint-issuance-attempt-persistence.md
+++ b/.changeset/durable-mint-issuance-attempt-persistence.md
@@ -1,0 +1,15 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-adapter-tests': patch
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+---
+
+Add immutable Mint Issuance Attempt persistence across every maintained repository adapter.
+
+Attempts retain ordered operation and quote membership with contributed amounts, one aggregate
+serialized output set, legal compare-and-transition lifecycle changes, and transactionally atomic
+participation with counters, Mint Operations, and proofs. Existing operation and proof rows remain
+readable while new rows can retain attempt-level provenance.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,14 @@ waiting on a specific result. Disabling a Background Watcher does not disable ex
 operations for the same domain work.
 _Avoid_: Subscriptions, processors
 
+**Mint Operation**:
+A durable, individually observable intent to claim value from one mint quote.
+_Avoid_: Mint job, quote state
+
+**Mint Issuance Attempt**:
+One atomic mint request that claims one or more Mint Operations and has one aggregate outcome.
+_Avoid_: Mint Operation, request retry
+
 **Restore**:
 The act of reconstructing a wallet's proofs for a mint from the wallet's deterministic secrets and the mint's state. Restore is distinct from operation recovery and does not create a persistent restored state.
 _Avoid_: Recovery, import, restored mint, restored wallet

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "bun scripts/build.ts build",
     "typecheck": "bun scripts/build.ts typecheck",
-    "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
+    "test:coverage:core": "bun run --filter='@cashu/coco-core' build:test-dependencies && bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
     "docs:dev": "vitepress dev packages/docs",
     "docs:build": "vitepress build packages/docs",
     "docs:preview": "vitepress preview packages/docs",

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -58,3 +58,7 @@ instance for every test and for cleaning up via `dispose()`.
   repository set.
 - `runAuthSessionRepositoryContract()` verifies the NUT-21/22 auth session
   persistence contract.
+- `runMintIssuanceAttemptRepositoryContract()` verifies immutable attempt recovery material,
+  ordered membership, legal lifecycle transitions, lookup indexes, and atomic rollback.
+- `runMintIssuanceProvenanceRepositoryContract()` verifies optional attempt links on Mint
+  Operations and proofs while keeping legacy records readable.

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -11,6 +11,7 @@ import {
   type MintQuoteRef,
   type MeltQuoteRef,
   type MintOperation,
+  type PreparedMintIssuanceAttempt,
   type PaymentRequestReceiveAttempt,
   type PaymentRequestReceiveOperation,
   type ReceiveOperation,
@@ -356,6 +357,345 @@ export function createDummyMintOperation(
     outputData: { keep: [], send: [] },
     ...overrides,
   } satisfies PendingMintOperation;
+}
+
+/** Creates stable recovery material for adapter contract fixtures. */
+export function createDummyMintIssuanceAttempt(
+  overrides?: Partial<PreparedMintIssuanceAttempt>,
+): PreparedMintIssuanceAttempt {
+  return {
+    id: 'mint-attempt-1',
+    mintUrl: 'https://mint.test/',
+    unit: 'SAT',
+    state: 'prepared',
+    members: [
+      {
+        operationId: 'mint-op-1',
+        quoteId: 'quote-1',
+        amount: Amount.from(1),
+      },
+      {
+        operationId: 'mint-op-2',
+        quoteId: 'quote-2',
+        amount: Amount.from(2),
+      },
+    ],
+    outputData: {
+      keep: [
+        {
+          blindedMessage: { amount: '3', id: 'keyset-id', B_: 'B_' },
+          blindingFactor: '01',
+          secret: '02',
+        },
+      ],
+      send: [],
+    },
+    createdAt: 1_000,
+    ...overrides,
+  } satisfies PreparedMintIssuanceAttempt;
+}
+
+/** Registers the shared Mint Issuance Attempt persistence contract with a test runner. */
+export async function runMintIssuanceAttemptRepositoryContract(
+  options: ContractOptions,
+  runner: ContractRunner,
+): Promise<void> {
+  const { describe, it, expect } = runner;
+
+  describe('MintIssuanceAttemptRepository contract', () => {
+    it('preserves ordered members and aggregate output data while normalizing identity', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempt = createDummyMintIssuanceAttempt();
+
+        await repositories.mintIssuanceAttemptRepository.create(attempt);
+
+        const stored = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        expect(stored).toBeDefined();
+        expect(stored!.mintUrl).toBe('https://mint.test');
+        expect(stored!.unit).toBe('sat');
+        expect(stored!.members.map((member) => member.operationId).join(',')).toBe(
+          'mint-op-1,mint-op-2',
+        );
+        expect(stored!.members.map((member) => member.quoteId).join(',')).toBe('quote-1,quote-2');
+        expect(stored!.members.map((member) => member.amount.toString()).join(',')).toBe('1,2');
+        expect(JSON.stringify(stored!.outputData)).toBe(JSON.stringify(attempt.outputData));
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('returns the newest retained attempt containing a member operation', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.mintIssuanceAttemptRepository.create(
+          createDummyMintIssuanceAttempt({ id: 'older', createdAt: 1_000 }),
+        );
+        await repositories.mintIssuanceAttemptRepository.create(
+          createDummyMintIssuanceAttempt({
+            id: 'newer',
+            createdAt: 2_000,
+            members: [
+              { operationId: 'mint-op-1', quoteId: 'quote-newer-1', amount: Amount.from(1) },
+              { operationId: 'mint-op-2', quoteId: 'quote-newer-2', amount: Amount.from(2) },
+            ],
+          }),
+        );
+
+        const stored =
+          await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId(
+            'mint-op-1',
+          );
+        const missing =
+          await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('missing');
+
+        expect(stored?.id).toBe('newer');
+        expect(missing).toBe(null);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('lists only incomplete attempts in deterministic order and optionally by mint', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempts = [
+          createDummyMintIssuanceAttempt({ id: 'prepared', createdAt: 3_000 }),
+          createDummyMintIssuanceAttempt({ id: 'submitted', createdAt: 1_000 }),
+          createDummyMintIssuanceAttempt({ id: 'succeeded', createdAt: 2_000 }),
+          createDummyMintIssuanceAttempt({
+            id: 'other-mint',
+            mintUrl: 'https://other-mint.test/',
+            createdAt: 4_000,
+            members: [
+              { operationId: 'other-op-1', quoteId: 'other-quote-1', amount: Amount.from(1) },
+            ],
+          }),
+        ];
+        for (const attempt of attempts) {
+          await repositories.mintIssuanceAttemptRepository.create(attempt);
+        }
+        await repositories.mintIssuanceAttemptRepository.compareAndTransition('submitted', {
+          from: 'prepared',
+          to: 'submitted',
+          submittedAt: 1_100,
+        });
+        await repositories.mintIssuanceAttemptRepository.compareAndTransition('succeeded', {
+          from: 'prepared',
+          to: 'submitted',
+          submittedAt: 2_100,
+        });
+        await repositories.mintIssuanceAttemptRepository.compareAndTransition('succeeded', {
+          from: 'submitted',
+          to: 'succeeded',
+        });
+
+        const all = await repositories.mintIssuanceAttemptRepository.listIncomplete();
+        const mintOnly =
+          await repositories.mintIssuanceAttemptRepository.listIncomplete('https://mint.test/');
+
+        expect(all.map((attempt) => attempt.id).join(',')).toBe('submitted,prepared,other-mint');
+        expect(mintOnly.map((attempt) => attempt.id).join(',')).toBe('submitted,prepared');
+        expect(all[2]?.mintUrl).toBe('https://other-mint.test');
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('compares state while applying only legal lifecycle transitions', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempt = createDummyMintIssuanceAttempt();
+        await repositories.mintIssuanceAttemptRepository.create(attempt);
+
+        const submitted = await repositories.mintIssuanceAttemptRepository.compareAndTransition(
+          attempt.id,
+          { from: 'prepared', to: 'submitted', submittedAt: 1_500 },
+        );
+        const stale = await repositories.mintIssuanceAttemptRepository.compareAndTransition(
+          attempt.id,
+          { from: 'prepared', to: 'submitted', submittedAt: 1_600 },
+        );
+        const failed = await repositories.mintIssuanceAttemptRepository.compareAndTransition(
+          attempt.id,
+          {
+            from: 'submitted',
+            to: 'failed',
+            terminalFailure: {
+              code: 'DEFINITIVE_REJECTION',
+              message: 'Mint rejected before signing',
+              details: { status: 400 },
+            },
+          },
+        );
+
+        const stored = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        expect(submitted).toBe(true);
+        expect(stale).toBe(false);
+        expect(failed).toBe(true);
+        expect(stored?.state).toBe('failed');
+        expect(stored?.submittedAt).toBe(1_500);
+        expect(stored?.terminalFailure?.code).toBe('DEFINITIVE_REJECTION');
+        expect(JSON.stringify(stored?.terminalFailure?.details)).toBe(
+          JSON.stringify({ status: 400 }),
+        );
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('retains immutable recovery material without exposing mutable storage references', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempt = createDummyMintIssuanceAttempt();
+        await repositories.mintIssuanceAttemptRepository.create(attempt);
+
+        attempt.members[0]!.operationId = 'mutated-input';
+        attempt.outputData.keep[0]!.secret = 'mutated-input';
+        const firstRead = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        firstRead!.members[0]!.operationId = 'mutated-read';
+        firstRead!.outputData.keep[0]!.secret = 'mutated-read';
+
+        const stored = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        expect(stored!.members[0]!.operationId).toBe('mint-op-1');
+        expect(stored!.outputData.keep[0]!.secret).toBe('02');
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('rejects lifecycle transitions outside prepared-submitted-terminal', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempt = createDummyMintIssuanceAttempt();
+        await repositories.mintIssuanceAttemptRepository.create(attempt);
+
+        await expectThrows(
+          () =>
+            repositories.mintIssuanceAttemptRepository.compareAndTransition(attempt.id, {
+              from: 'prepared',
+              to: 'succeeded',
+            } as never),
+          expect,
+        );
+
+        const stored = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        expect(stored?.state).toBe('prepared');
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('rolls back attempts with counters, member operations, and proofs atomically', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempt = createDummyMintIssuanceAttempt();
+        const member = createDummyMintOperation({ id: 'mint-op-1', quoteId: 'quote-1' });
+        await repositories.counterRepository.setCounter(attempt.mintUrl, 'keyset-id', 10);
+        await repositories.mintOperationRepository.create(member);
+
+        await expectThrows(async () => {
+          await repositories.withTransaction(async (tx) => {
+            await tx.mintIssuanceAttemptRepository.create(attempt);
+            await tx.mintOperationRepository.update({
+              ...member,
+              state: 'executing',
+              mintIssuanceAttemptId: attempt.id,
+            });
+            await tx.counterRepository.setCounter(attempt.mintUrl, 'keyset-id', 12);
+            await tx.proofRepository.saveProofs(attempt.mintUrl, [
+              createDummyProof({
+                secret: 'rolled-back-proof',
+                createdByMintIssuanceAttemptId: attempt.id,
+              }),
+            ]);
+            throw new Error('rollback issuance preparation');
+          });
+        }, expect);
+
+        const storedAttempt = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        const storedMember = await repositories.mintOperationRepository.getById(member.id);
+        const storedCounter = await repositories.counterRepository.getCounter(
+          attempt.mintUrl,
+          'keyset-id',
+        );
+        const storedProof = await repositories.proofRepository.getProofBySecret(
+          attempt.mintUrl,
+          'rolled-back-proof',
+        );
+        expect(storedAttempt).toBe(null);
+        expect(storedMember?.state).toBe('pending');
+        expect(storedMember?.mintIssuanceAttemptId).toBe(undefined);
+        expect(storedCounter?.counter).toBe(10);
+        expect(storedProof).toBe(null);
+      } finally {
+        await dispose();
+      }
+    });
+  });
+}
+
+/** Registers persistence compatibility for attempt-backed operations and proofs. */
+export async function runMintIssuanceProvenanceRepositoryContract(
+  options: ContractOptions,
+  runner: ContractRunner,
+): Promise<void> {
+  const { describe, it, expect } = runner;
+
+  describe('Mint Issuance provenance repository contract', () => {
+    it('round-trips optional Mint Issuance Attempt identity without changing legacy operations', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.mintOperationRepository.create(
+          createDummyMintOperation({
+            id: 'attempt-backed-operation',
+            quoteId: 'attempt-backed-quote',
+            mintIssuanceAttemptId: 'mint-attempt-1',
+          }),
+        );
+        await repositories.mintOperationRepository.create(
+          createDummyMintOperation({ id: 'legacy-operation', quoteId: 'legacy-quote' }),
+        );
+
+        const attemptBacked = await repositories.mintOperationRepository.getById(
+          'attempt-backed-operation',
+        );
+        const legacy = await repositories.mintOperationRepository.getById('legacy-operation');
+
+        expect(attemptBacked?.mintIssuanceAttemptId).toBe('mint-attempt-1');
+        expect(legacy?.mintIssuanceAttemptId).toBe(undefined);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('round-trips optional attempt-level proof provenance without changing legacy proofs', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.proofRepository.saveProofs('https://mint.test', [
+          createDummyProof({
+            secret: 'attempt-proof',
+            createdByMintIssuanceAttemptId: 'mint-attempt-1',
+          }),
+          createDummyProof({ secret: 'legacy-proof' }),
+        ]);
+
+        const attemptProof = await repositories.proofRepository.getProofBySecret(
+          'https://mint.test',
+          'attempt-proof',
+        );
+        const legacyProof = await repositories.proofRepository.getProofBySecret(
+          'https://mint.test',
+          'legacy-proof',
+        );
+
+        expect(attemptProof?.createdByMintIssuanceAttemptId).toBe('mint-attempt-1');
+        expect(legacyProof?.createdByMintIssuanceAttemptId).toBe(undefined);
+      } finally {
+        await dispose();
+      }
+    });
+  });
 }
 
 type InitMintOperation = Extract<MintOperation, { state: 'init' }>;

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -561,6 +561,44 @@ export async function runMintIssuanceAttemptRepositoryContract(
       }
     });
 
+    it('rejects invalid terminal failure metadata before persistence', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const attempt = createDummyMintIssuanceAttempt();
+        await repositories.mintIssuanceAttemptRepository.create(attempt);
+        await repositories.mintIssuanceAttemptRepository.compareAndTransition(attempt.id, {
+          from: 'prepared',
+          to: 'submitted',
+          submittedAt: 1_500,
+        });
+
+        await expectThrows(
+          () =>
+            repositories.mintIssuanceAttemptRepository.compareAndTransition(attempt.id, {
+              from: 'submitted',
+              to: 'failed',
+              terminalFailure: { message: 'rejected', code: 42 },
+            } as never),
+          expect,
+        );
+        await expectThrows(
+          () =>
+            repositories.mintIssuanceAttemptRepository.compareAndTransition(attempt.id, {
+              from: 'submitted',
+              to: 'failed',
+              terminalFailure: { message: 'rejected', details: [] },
+            } as never),
+          expect,
+        );
+
+        const stored = await repositories.mintIssuanceAttemptRepository.getById(attempt.id);
+        expect(stored?.state).toBe('submitted');
+        expect(stored?.terminalFailure).toBe(undefined);
+      } finally {
+        await dispose();
+      }
+    });
+
     it('retains immutable recovery material without exposing mutable storage references', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -77,6 +77,23 @@ export async function runRepositoryTransactionContract(
       }
     });
 
+    it('rolls nested transactions into the parent transaction', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.withTransaction(async (outer) => {
+          await outer.mintRepository.addOrUpdateMint(createDummyMint());
+          await outer.withTransaction(async (inner) => {
+            await inner.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
+          });
+        });
+
+        expect(await repositories.mintRepository.getAllMints()).toHaveLength(1);
+        expect(await repositories.proofRepository.getAllReadyProofs()).toHaveLength(1);
+      } finally {
+        await dispose();
+      }
+    });
+
     if (options.testConcurrentRootOperationIsolation) {
       it('does not include concurrent root repository writes in active transactions', async () => {
         const { repositories, dispose } = await options.createRepositories();

--- a/packages/core/adapter.ts
+++ b/packages/core/adapter.ts
@@ -9,6 +9,7 @@ export type {
   MeltOperationRepository,
   MeltQuoteRepository,
   MintOperationRepository,
+  MintIssuanceAttemptRepository,
   MintQuoteRepository,
   MintRepository,
   PaymentRequestReceiveAttemptRepository,
@@ -59,6 +60,15 @@ export type {
   MintMethodRemoteState,
   MintOperation,
   MintOperationState,
+  MintIssuanceAttempt,
+  MintIssuanceAttemptFailure,
+  MintIssuanceAttemptMember,
+  MintIssuanceAttemptState,
+  MintIssuanceAttemptTransition,
+  PreparedMintIssuanceAttempt,
+  SubmittedMintIssuanceAttempt,
+  SucceededMintIssuanceAttempt,
+  FailedMintIssuanceAttempt,
   PaymentRequestReceiveAttempt,
   PaymentRequestReceiveAttemptState,
   PaymentRequestReceiveOperation,
@@ -70,6 +80,14 @@ export type {
   SendMethodData,
   SendOperation,
   SendOperationState,
+} from './operations/index.ts';
+export {
+  applyMintIssuanceAttemptTransition,
+  INCOMPLETE_MINT_ISSUANCE_ATTEMPT_STATES,
+  normalizeMintIssuanceAttempt,
+  parseMintIssuanceAttemptFailure,
+  parseMintIssuanceAttemptMembers,
+  parseMintIssuanceAttemptOutputData,
 } from './operations/index.ts';
 export type { MeltMethodRemoteState } from './operations/melt/MeltMethodHandler.ts';
 export { normalizeMeltMethodData } from './operations/index.ts';

--- a/packages/core/operations/index.ts
+++ b/packages/core/operations/index.ts
@@ -4,6 +4,25 @@ export { normalizeMeltMethodData } from './melt/MeltMethodHandler.ts';
 export { MeltOperationService } from './melt/MeltOperationService.ts';
 export type { MintOperation, MintOperationState } from './mint/MintOperation.ts';
 export type {
+  FailedMintIssuanceAttempt,
+  MintIssuanceAttempt,
+  MintIssuanceAttemptFailure,
+  MintIssuanceAttemptMember,
+  MintIssuanceAttemptState,
+  MintIssuanceAttemptTransition,
+  PreparedMintIssuanceAttempt,
+  SubmittedMintIssuanceAttempt,
+  SucceededMintIssuanceAttempt,
+} from './mint/MintIssuanceAttempt.ts';
+export {
+  applyMintIssuanceAttemptTransition,
+  INCOMPLETE_MINT_ISSUANCE_ATTEMPT_STATES,
+  normalizeMintIssuanceAttempt,
+  parseMintIssuanceAttemptFailure,
+  parseMintIssuanceAttemptMembers,
+  parseMintIssuanceAttemptOutputData,
+} from './mint/MintIssuanceAttempt.ts';
+export type {
   MintMethod,
   MintMethodData,
   MintMethodRemoteState,

--- a/packages/core/operations/mint/MintIssuanceAttempt.ts
+++ b/packages/core/operations/mint/MintIssuanceAttempt.ts
@@ -1,0 +1,300 @@
+import { Amount } from '@cashu/cashu-ts';
+import { normalizeUnit } from '../../amounts.ts';
+import { normalizeMintUrl, type SerializedOutputData } from '../../utils.ts';
+
+/** One Mint Operation's contribution to an atomic Mint Issuance Attempt. */
+export interface MintIssuanceAttemptMember {
+  operationId: string;
+  quoteId: string;
+  amount: Amount;
+}
+
+/** Structured metadata retained for a terminally failed attempt. */
+export interface MintIssuanceAttemptFailure {
+  message: string;
+  code?: string;
+  details?: Record<string, unknown>;
+}
+
+interface MintIssuanceAttemptBase {
+  id: string;
+  mintUrl: string;
+  unit: string;
+  members: MintIssuanceAttemptMember[];
+  outputData: SerializedOutputData;
+  createdAt: number;
+}
+
+/** Recovery material that has been persisted but is definitely unsent. */
+export interface PreparedMintIssuanceAttempt extends MintIssuanceAttemptBase {
+  state: 'prepared';
+  submittedAt?: never;
+  terminalFailure?: never;
+}
+
+/** Recovery material for a request that may have reached the mint. */
+export interface SubmittedMintIssuanceAttempt extends MintIssuanceAttemptBase {
+  state: 'submitted';
+  submittedAt: number;
+  terminalFailure?: never;
+}
+
+/** Retained recovery material for a completely finalized issuance request. */
+export interface SucceededMintIssuanceAttempt extends MintIssuanceAttemptBase {
+  state: 'succeeded';
+  submittedAt: number;
+  terminalFailure?: never;
+}
+
+/** Retained recovery material for a definitive pre-signing rejection. */
+export interface FailedMintIssuanceAttempt extends MintIssuanceAttemptBase {
+  state: 'failed';
+  submittedAt: number;
+  terminalFailure: MintIssuanceAttemptFailure;
+}
+
+/** Durable lifecycle record for one exact aggregate mint issuance request. */
+export type MintIssuanceAttempt =
+  | PreparedMintIssuanceAttempt
+  | SubmittedMintIssuanceAttempt
+  | SucceededMintIssuanceAttempt
+  | FailedMintIssuanceAttempt;
+
+/** Legal persisted lifecycle states for a Mint Issuance Attempt. */
+export type MintIssuanceAttemptState = MintIssuanceAttempt['state'];
+
+/** The only legal compare-and-transition state changes. */
+export type MintIssuanceAttemptTransition =
+  | { from: 'prepared'; to: 'submitted'; submittedAt: number }
+  | { from: 'submitted'; to: 'succeeded' }
+  | {
+      from: 'submitted';
+      to: 'failed';
+      terminalFailure: MintIssuanceAttemptFailure;
+    };
+
+/** States whose exact request may still need submission or recovery. */
+export const INCOMPLETE_MINT_ISSUANCE_ATTEMPT_STATES = [
+  'prepared',
+  'submitted',
+] as const satisfies readonly MintIssuanceAttempt['state'][];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+/** Defensively parses persisted ordered membership data. */
+export function parseMintIssuanceAttemptMembers(value: unknown): MintIssuanceAttemptMember[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Mint issuance attempt members must be an array');
+  }
+  return normalizeMembers(
+    value.map((member, index) => {
+      if (!isRecord(member)) {
+        throw new Error(`Mint issuance attempt member ${index} must be an object`);
+      }
+      if (typeof member.amount !== 'string' && typeof member.amount !== 'number') {
+        throw new Error(`Mint issuance attempt member ${index} amount is invalid`);
+      }
+      return {
+        operationId: requireString(member.operationId, `Mint issuance attempt member ${index} id`),
+        quoteId: requireString(member.quoteId, `Mint issuance attempt member ${index} quote id`),
+        amount: Amount.from(member.amount),
+      };
+    }),
+  );
+}
+
+/** Defensively parses persisted aggregate output recovery material. */
+export function parseMintIssuanceAttemptOutputData(value: unknown): SerializedOutputData {
+  if (!isRecord(value) || !Array.isArray(value.keep) || !Array.isArray(value.send)) {
+    throw new Error('Mint issuance attempt output data must contain keep and send arrays');
+  }
+
+  const parseOutputs = (outputs: unknown[], group: string): SerializedOutputData['keep'] =>
+    outputs.map((output, index) => {
+      if (!isRecord(output) || !isRecord(output.blindedMessage)) {
+        throw new Error(`Mint issuance attempt ${group} output ${index} must be an object`);
+      }
+      const amount = output.blindedMessage.amount;
+      if (typeof amount !== 'string' && typeof amount !== 'number') {
+        throw new Error(`Mint issuance attempt ${group} output ${index} amount is invalid`);
+      }
+      Amount.from(amount);
+      const blindingFactor = requireString(
+        output.blindingFactor,
+        `Mint issuance attempt ${group} output ${index} blinding factor`,
+      );
+      BigInt(`0x${blindingFactor}`);
+      const secret = requireString(
+        output.secret,
+        `Mint issuance attempt ${group} output ${index} secret`,
+      );
+      if (!/^(?:[0-9a-fA-F]{2})+$/.test(secret)) {
+        throw new Error(`Mint issuance attempt ${group} output ${index} secret must be hex`);
+      }
+      if (output.ephemeralE !== undefined && typeof output.ephemeralE !== 'string') {
+        throw new Error(`Mint issuance attempt ${group} output ${index} ephemeral E is invalid`);
+      }
+      return {
+        blindedMessage: {
+          amount,
+          id: requireString(
+            output.blindedMessage.id,
+            `Mint issuance attempt ${group} output ${index} keyset id`,
+          ),
+          B_: requireString(
+            output.blindedMessage.B_,
+            `Mint issuance attempt ${group} output ${index} blinded message`,
+          ),
+        },
+        blindingFactor,
+        secret,
+        ...(output.ephemeralE === undefined ? {} : { ephemeralE: output.ephemeralE }),
+      };
+    });
+
+  return {
+    keep: parseOutputs(value.keep, 'keep'),
+    send: parseOutputs(value.send, 'send'),
+  };
+}
+
+/** Defensively parses optional metadata for a terminally failed attempt. */
+export function parseMintIssuanceAttemptFailure(value: unknown): MintIssuanceAttemptFailure {
+  if (!isRecord(value)) {
+    throw new Error('Mint issuance attempt terminal failure must be an object');
+  }
+  if (value.code !== undefined && typeof value.code !== 'string') {
+    throw new Error('Mint issuance attempt terminal failure code must be a string');
+  }
+  if (value.details !== undefined && !isRecord(value.details)) {
+    throw new Error('Mint issuance attempt terminal failure details must be an object');
+  }
+  return {
+    message: requireString(value.message, 'Mint issuance attempt terminal failure message'),
+    ...(value.code === undefined ? {} : { code: value.code }),
+    ...(value.details === undefined ? {} : { details: value.details }),
+  };
+}
+
+function cloneOutputData(outputData: SerializedOutputData): SerializedOutputData {
+  return {
+    keep: outputData.keep.map((output) => ({
+      ...output,
+      blindedMessage: { ...output.blindedMessage },
+    })),
+    send: outputData.send.map((output) => ({
+      ...output,
+      blindedMessage: { ...output.blindedMessage },
+    })),
+  };
+}
+
+function cloneFailure(failure: MintIssuanceAttemptFailure): MintIssuanceAttemptFailure {
+  return {
+    ...failure,
+    details: failure.details
+      ? (JSON.parse(JSON.stringify(failure.details)) as Record<string, unknown>)
+      : undefined,
+  };
+}
+
+function requireNonEmpty(value: string, field: string): void {
+  if (value.trim().length === 0) throw new Error(`${field} must not be empty`);
+}
+
+function normalizeMembers(members: MintIssuanceAttemptMember[]): MintIssuanceAttemptMember[] {
+  if (members.length === 0) throw new Error('Mint issuance attempt members must not be empty');
+
+  const operationIds = new Set<string>();
+  const quoteIds = new Set<string>();
+  return members.map((member) => {
+    requireNonEmpty(member.operationId, 'Mint issuance attempt member operationId');
+    requireNonEmpty(member.quoteId, 'Mint issuance attempt member quoteId');
+    if (operationIds.has(member.operationId)) {
+      throw new Error(`Duplicate Mint Operation member: ${member.operationId}`);
+    }
+    if (quoteIds.has(member.quoteId)) {
+      throw new Error(`Duplicate mint quote member: ${member.quoteId}`);
+    }
+    operationIds.add(member.operationId);
+    quoteIds.add(member.quoteId);
+
+    const amount = Amount.from(member.amount);
+    if (amount.isZero()) {
+      throw new Error('Mint issuance attempt member amount must be positive');
+    }
+    return { operationId: member.operationId, quoteId: member.quoteId, amount };
+  });
+}
+
+/** Validates, normalizes, and defensively clones an adapter-facing attempt record. */
+export function normalizeMintIssuanceAttempt(attempt: MintIssuanceAttempt): MintIssuanceAttempt {
+  requireNonEmpty(attempt.id, 'Mint issuance attempt id');
+  if (!Number.isFinite(attempt.createdAt)) {
+    throw new Error('Mint issuance attempt createdAt must be finite');
+  }
+
+  const base = {
+    id: attempt.id,
+    mintUrl: normalizeMintUrl(attempt.mintUrl),
+    unit: normalizeUnit(attempt.unit),
+    members: normalizeMembers(attempt.members),
+    outputData: cloneOutputData(attempt.outputData),
+    createdAt: attempt.createdAt,
+  };
+
+  if (attempt.state === 'prepared') return { ...base, state: 'prepared' };
+  if (!Number.isFinite(attempt.submittedAt)) {
+    throw new Error('Submitted Mint issuance attempt submittedAt must be finite');
+  }
+  if (attempt.state === 'failed') {
+    requireNonEmpty(attempt.terminalFailure.message, 'Mint issuance attempt failure message');
+    return {
+      ...base,
+      state: 'failed',
+      submittedAt: attempt.submittedAt,
+      terminalFailure: cloneFailure(attempt.terminalFailure),
+    };
+  }
+  return { ...base, state: attempt.state, submittedAt: attempt.submittedAt };
+}
+
+/** Applies a legal transition, or returns null when the compare state does not match. */
+export function applyMintIssuanceAttemptTransition(
+  attempt: MintIssuanceAttempt,
+  transition: MintIssuanceAttemptTransition,
+): MintIssuanceAttempt | null {
+  if (attempt.state !== transition.from) return null;
+
+  if (transition.from === 'prepared' && transition.to === 'submitted') {
+    return normalizeMintIssuanceAttempt({
+      ...attempt,
+      state: 'submitted',
+      submittedAt: transition.submittedAt,
+    });
+  }
+  if (attempt.state !== 'submitted') {
+    throw new Error('Illegal Mint issuance attempt transition');
+  }
+  if (transition.from === 'submitted' && transition.to === 'succeeded') {
+    return normalizeMintIssuanceAttempt({ ...attempt, state: 'succeeded' });
+  }
+  if (transition.from === 'submitted' && transition.to === 'failed') {
+    return normalizeMintIssuanceAttempt({
+      ...attempt,
+      state: 'failed',
+      terminalFailure: transition.terminalFailure,
+    });
+  }
+
+  throw new Error(`Illegal Mint issuance attempt transition`);
+}

--- a/packages/core/operations/mint/MintIssuanceAttempt.ts
+++ b/packages/core/operations/mint/MintIssuanceAttempt.ts
@@ -178,8 +178,10 @@ export function parseMintIssuanceAttemptFailure(value: unknown): MintIssuanceAtt
   if (value.details !== undefined && !isRecord(value.details)) {
     throw new Error('Mint issuance attempt terminal failure details must be an object');
   }
+  const message = requireString(value.message, 'Mint issuance attempt terminal failure message');
+  requireNonEmpty(message, 'Mint issuance attempt failure message');
   return {
-    message: requireString(value.message, 'Mint issuance attempt terminal failure message'),
+    message,
     ...(value.code === undefined ? {} : { code: value.code }),
     ...(value.details === undefined ? {} : { details: value.details }),
   };
@@ -244,12 +246,12 @@ export function normalizeMintIssuanceAttempt(attempt: MintIssuanceAttempt): Mint
     throw new Error('Submitted Mint issuance attempt submittedAt must be finite');
   }
   if (attempt.state === 'failed') {
-    requireNonEmpty(attempt.terminalFailure.message, 'Mint issuance attempt failure message');
+    const terminalFailure = parseMintIssuanceAttemptFailure(attempt.terminalFailure);
     return {
       ...base,
       state: 'failed',
       submittedAt: attempt.submittedAt,
-      terminalFailure: cloneFailure(attempt.terminalFailure),
+      terminalFailure: cloneFailure(terminalFailure),
     };
   }
   return { ...base, state: attempt.state, submittedAt: attempt.submittedAt };

--- a/packages/core/operations/mint/MintIssuanceAttempt.ts
+++ b/packages/core/operations/mint/MintIssuanceAttempt.ts
@@ -185,19 +185,6 @@ export function parseMintIssuanceAttemptFailure(value: unknown): MintIssuanceAtt
   };
 }
 
-function cloneOutputData(outputData: SerializedOutputData): SerializedOutputData {
-  return {
-    keep: outputData.keep.map((output) => ({
-      ...output,
-      blindedMessage: { ...output.blindedMessage },
-    })),
-    send: outputData.send.map((output) => ({
-      ...output,
-      blindedMessage: { ...output.blindedMessage },
-    })),
-  };
-}
-
 function cloneFailure(failure: MintIssuanceAttemptFailure): MintIssuanceAttemptFailure {
   return {
     ...failure,
@@ -248,7 +235,7 @@ export function normalizeMintIssuanceAttempt(attempt: MintIssuanceAttempt): Mint
     mintUrl: normalizeMintUrl(attempt.mintUrl),
     unit: normalizeUnit(attempt.unit),
     members: normalizeMembers(attempt.members),
-    outputData: cloneOutputData(attempt.outputData),
+    outputData: parseMintIssuanceAttemptOutputData(attempt.outputData),
     createdAt: attempt.createdAt,
   };
 

--- a/packages/core/operations/mint/MintOperation.ts
+++ b/packages/core/operations/mint/MintOperation.ts
@@ -26,6 +26,8 @@ interface MintOperationBase<M extends MintMethod = MintMethod> extends MintMetho
   updatedAt: number;
   error?: string;
   terminalFailure?: MintOperationFailure;
+  /** Durable attempt currently or historically responsible for this operation's issuance. */
+  mintIssuanceAttemptId?: string;
 }
 
 export interface MintOperationFailure {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,9 +47,9 @@
     "build": "tsdown",
     "build:test-dependencies": "bun run build && bun run --cwd ../adapter-tests build",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
+    "test": "bun run build:test-dependencies && bun test",
     "test:unit": "bun run build:test-dependencies && bun test test/unit",
-    "test:integration": "bun test test/integration",
+    "test:integration": "bun run build:test-dependencies && bun test test/integration",
     "prepublishOnly": "bun run build"
   },
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,9 +45,10 @@
   },
   "scripts": {
     "build": "tsdown",
+    "build:test-dependencies": "bun run build && bun run --cwd ../adapter-tests build",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "test:unit": "bun test test/unit",
+    "test:unit": "bun run build:test-dependencies && bun test test/unit",
     "test:integration": "bun test test/integration",
     "prepublishOnly": "bun run build"
   },

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -386,11 +386,13 @@ interface RepositoriesBase {
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
 }
 
-export interface Repositories extends RepositoriesBase {
-  init(): Promise<void>;
+/** Repositories bound to one transaction; nested calls roll into that transaction. */
+export interface RepositoryTransactionScope extends RepositoriesBase {
   withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
 }
 
-export type RepositoryTransactionScope = RepositoriesBase;
+export interface Repositories extends RepositoryTransactionScope {
+  init(): Promise<void>;
+}
 
 export * from './memory';

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -7,6 +7,11 @@ import type { QuoteIdentity } from '@core/models/QuoteIdentity';
 import type { MeltOperation, MeltOperationState } from '@core/operations/melt/MeltOperation';
 import type { MintOperation, MintOperationState } from '@core/operations/mint/MintOperation';
 import type {
+  MintIssuanceAttempt,
+  MintIssuanceAttemptTransition,
+  PreparedMintIssuanceAttempt,
+} from '@core/operations/mint/MintIssuanceAttempt';
+import type {
   ReceiveOperation,
   ReceiveOperationState,
 } from '../operations/receive/ReceiveOperation';
@@ -298,6 +303,15 @@ export interface MintOperationRepository {
   delete(id: string): Promise<void>;
 }
 
+/** Persists immutable recovery material for atomic mint issuance requests. */
+export interface MintIssuanceAttemptRepository {
+  create(attempt: PreparedMintIssuanceAttempt): Promise<void>;
+  getById(id: string): Promise<MintIssuanceAttempt | null>;
+  getNewestByMemberOperationId(operationId: string): Promise<MintIssuanceAttempt | null>;
+  listIncomplete(mintUrl?: string): Promise<MintIssuanceAttempt[]>;
+  compareAndTransition(id: string, transition: MintIssuanceAttemptTransition): Promise<boolean>;
+}
+
 export interface ReceiveOperationRepository {
   /** Create a new receive operation */
   create(operation: ReceiveOperation): Promise<void>;
@@ -366,6 +380,7 @@ interface RepositoriesBase {
   meltOperationRepository: MeltOperationRepository;
   authSessionRepository: AuthSessionRepository;
   mintOperationRepository: MintOperationRepository;
+  mintIssuanceAttemptRepository: MintIssuanceAttemptRepository;
   receiveOperationRepository: ReceiveOperationRepository;
   paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;

--- a/packages/core/repositories/memory/MemoryMintIssuanceAttemptRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintIssuanceAttemptRepository.ts
@@ -1,0 +1,64 @@
+import type { MintIssuanceAttemptRepository } from '..';
+import {
+  applyMintIssuanceAttemptTransition,
+  INCOMPLETE_MINT_ISSUANCE_ATTEMPT_STATES,
+  normalizeMintIssuanceAttempt,
+  type MintIssuanceAttempt,
+  type MintIssuanceAttemptTransition,
+  type PreparedMintIssuanceAttempt,
+} from '../../operations/mint/MintIssuanceAttempt.ts';
+import { normalizeMintUrl } from '../../utils.ts';
+
+/** In-memory persistence for immutable Mint Issuance Attempt recovery records. */
+export class MemoryMintIssuanceAttemptRepository implements MintIssuanceAttemptRepository {
+  private attempts = new Map<string, MintIssuanceAttempt>();
+
+  async create(input: PreparedMintIssuanceAttempt): Promise<void> {
+    if (this.attempts.has(input.id)) {
+      throw new Error(`Mint issuance attempt already exists: ${input.id}`);
+    }
+    const attempt = normalizeMintIssuanceAttempt(input);
+    if (attempt.state !== 'prepared') {
+      throw new Error('Mint issuance attempts must be created in prepared state');
+    }
+    this.attempts.set(attempt.id, attempt);
+  }
+
+  async getById(id: string): Promise<MintIssuanceAttempt | null> {
+    const attempt = this.attempts.get(id);
+    return attempt ? normalizeMintIssuanceAttempt(attempt) : null;
+  }
+
+  async getNewestByMemberOperationId(operationId: string): Promise<MintIssuanceAttempt | null> {
+    const newest = Array.from(this.attempts.values())
+      .filter((attempt) => attempt.members.some((member) => member.operationId === operationId))
+      .sort((a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id))[0];
+    return newest ? normalizeMintIssuanceAttempt(newest) : null;
+  }
+
+  async listIncomplete(mintUrl?: string): Promise<MintIssuanceAttempt[]> {
+    const normalizedMintUrl = mintUrl ? normalizeMintUrl(mintUrl) : undefined;
+    return Array.from(this.attempts.values())
+      .filter(
+        (attempt) =>
+          INCOMPLETE_MINT_ISSUANCE_ATTEMPT_STATES.includes(
+            attempt.state as (typeof INCOMPLETE_MINT_ISSUANCE_ATTEMPT_STATES)[number],
+          ) &&
+          (!normalizedMintUrl || attempt.mintUrl === normalizedMintUrl),
+      )
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+      .map(normalizeMintIssuanceAttempt);
+  }
+
+  async compareAndTransition(
+    id: string,
+    transition: MintIssuanceAttemptTransition,
+  ): Promise<boolean> {
+    const existing = this.attempts.get(id);
+    if (!existing) return false;
+    const transitioned = applyMintIssuanceAttemptTransition(existing, transition);
+    if (!transitioned) return false;
+    this.attempts.set(id, transitioned);
+    return true;
+  }
+}

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -14,6 +14,7 @@ import type {
   RepositoryTransactionScope,
   SendOperationRepository,
   MintOperationRepository,
+  MintIssuanceAttemptRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
   ReceiveOperationRepository,
@@ -31,11 +32,72 @@ import { MemoryMintRepository } from './MemoryMintRepository';
 import { MemoryProofRepository } from './MemoryProofRepository';
 import { MemorySendOperationRepository } from './MemorySendOperationRepository';
 import { MemoryMintOperationRepository } from './MemoryMintOperationRepository';
+import { MemoryMintIssuanceAttemptRepository } from './MemoryMintIssuanceAttemptRepository';
 import { MemoryReceiveOperationRepository } from './MemoryReceiveOperationRepository';
 import {
   MemoryPaymentRequestReceiveAttemptRepository,
   MemoryPaymentRequestReceiveOperationRepository,
 } from './MemoryPaymentRequestReceiveRepository';
+
+type MutableContainer = Map<unknown, unknown> | unknown[];
+
+interface MutableContainerSnapshot {
+  repository: object;
+  property: string;
+  value: MutableContainer;
+}
+
+/** Deeply clones repository state while retaining domain-object prototypes and shared references. */
+function cloneTransactionValue<T>(value: T, seen = new Map<object, unknown>()): T {
+  if (typeof value !== 'object' || value === null) return value;
+  const known = seen.get(value);
+  if (known) return known as T;
+  if (value instanceof Uint8Array) return value.slice() as T;
+  if (value instanceof Map) {
+    const clone = new Map();
+    seen.set(value, clone);
+    for (const [key, item] of value) {
+      clone.set(cloneTransactionValue(key, seen), cloneTransactionValue(item, seen));
+    }
+    return clone as T;
+  }
+  if (Array.isArray(value)) {
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    clone.push(...value.map((item) => cloneTransactionValue(item, seen)));
+    return clone as T;
+  }
+  const clone = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
+  seen.set(value, clone);
+  for (const [key, item] of Object.entries(value)) {
+    clone[key] = cloneTransactionValue(item, seen);
+  }
+  return clone as T;
+}
+
+/** Captures repository-owned mutable containers before entering a memory transaction. */
+function snapshotMutableContainers(repositories: object[]): MutableContainerSnapshot[] {
+  const snapshots: MutableContainerSnapshot[] = [];
+  for (const repository of new Set(repositories)) {
+    for (const [property, value] of Object.entries(repository)) {
+      if (value instanceof Map || Array.isArray(value)) {
+        snapshots.push({
+          repository,
+          property,
+          value: cloneTransactionValue(value),
+        });
+      }
+    }
+  }
+  return snapshots;
+}
+
+/** Restores repository-owned mutable containers when a memory transaction rolls back. */
+function restoreMutableContainers(snapshots: MutableContainerSnapshot[]): void {
+  for (const snapshot of snapshots) {
+    Reflect.set(snapshot.repository, snapshot.property, cloneTransactionValue(snapshot.value));
+  }
+}
 
 export class MemoryRepositories implements Repositories {
   mintRepository: MintRepository;
@@ -51,47 +113,155 @@ export class MemoryRepositories implements Repositories {
   meltOperationRepository: MeltOperationRepository;
   authSessionRepository: AuthSessionRepository;
   mintOperationRepository: MintOperationRepository;
+  mintIssuanceAttemptRepository: MintIssuanceAttemptRepository;
   receiveOperationRepository: ReceiveOperationRepository;
   paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
+  private readonly transactionScope: RepositoryTransactionScope;
+  private transactionTail: Promise<void> = Promise.resolve();
+  private activeOperations = 0;
+  private operationsDrained: Promise<void> = Promise.resolve();
+  private releaseOperationsDrained?: () => void;
 
   constructor() {
-    this.mintRepository = new MemoryMintRepository();
-    this.keyRingRepository = new MemoryKeyRingRepository();
-    this.counterRepository = new MemoryCounterRepository();
-    this.keysetRepository = new MemoryKeysetRepository();
-    this.proofRepository = new MemoryProofRepository();
+    const mintRepository = new MemoryMintRepository();
+    const keyRingRepository = new MemoryKeyRingRepository();
+    const counterRepository = new MemoryCounterRepository();
+    const keysetRepository = new MemoryKeysetRepository();
+    const proofRepository = new MemoryProofRepository();
     const sendOperationRepository = new MemorySendOperationRepository();
     const meltOperationRepository = new MemoryMeltOperationRepository();
     const mintOperationRepository = new MemoryMintOperationRepository();
     const receiveOperationRepository = new MemoryReceiveOperationRepository();
-
-    this.sendOperationRepository = sendOperationRepository;
-    this.meltOperationRepository = meltOperationRepository;
-    this.mintOperationRepository = mintOperationRepository;
-    this.receiveOperationRepository = receiveOperationRepository;
-    this.mintQuoteRepository = new MemoryMintQuoteRepository();
-    this.legacyMintQuoteRepository = new MemoryLegacyMintQuoteRepository();
-    this.meltQuoteRepository = new MemoryMeltQuoteRepository();
-    this.historyRepository = new MemoryHistoryRepository({
+    const mintIssuanceAttemptRepository = new MemoryMintIssuanceAttemptRepository();
+    const mintQuoteRepository = new MemoryMintQuoteRepository();
+    const legacyMintQuoteRepository = new MemoryLegacyMintQuoteRepository();
+    const meltQuoteRepository = new MemoryMeltQuoteRepository();
+    const historyRepository = new MemoryHistoryRepository({
       sendOperationRepository,
       meltOperationRepository,
       mintOperationRepository,
-      mintQuoteRepository: this.mintQuoteRepository,
+      mintQuoteRepository,
       receiveOperationRepository,
     });
-    this.authSessionRepository = new MemoryAuthSessionRepository();
-    this.paymentRequestReceiveOperationRepository =
+    const authSessionRepository = new MemoryAuthSessionRepository();
+    const paymentRequestReceiveOperationRepository =
       new MemoryPaymentRequestReceiveOperationRepository();
-    this.paymentRequestReceiveAttemptRepository =
+    const paymentRequestReceiveAttemptRepository =
       new MemoryPaymentRequestReceiveAttemptRepository();
+
+    this.transactionScope = {
+      mintRepository,
+      keyRingRepository,
+      counterRepository,
+      keysetRepository,
+      proofRepository,
+      mintQuoteRepository,
+      legacyMintQuoteRepository,
+      meltQuoteRepository,
+      historyRepository,
+      sendOperationRepository,
+      meltOperationRepository,
+      authSessionRepository,
+      mintOperationRepository,
+      mintIssuanceAttemptRepository,
+      receiveOperationRepository,
+      paymentRequestReceiveOperationRepository,
+      paymentRequestReceiveAttemptRepository,
+    };
+
+    this.mintRepository = this.serializeRepository(mintRepository);
+    this.keyRingRepository = this.serializeRepository(keyRingRepository);
+    this.counterRepository = this.serializeRepository(counterRepository);
+    this.keysetRepository = this.serializeRepository(keysetRepository);
+    this.proofRepository = this.serializeRepository(proofRepository);
+    this.mintQuoteRepository = this.serializeRepository(mintQuoteRepository);
+    this.legacyMintQuoteRepository = this.serializeRepository(legacyMintQuoteRepository);
+    this.meltQuoteRepository = this.serializeRepository(meltQuoteRepository);
+    this.historyRepository = this.serializeRepository(historyRepository);
+    this.sendOperationRepository = this.serializeRepository(sendOperationRepository);
+    this.meltOperationRepository = this.serializeRepository(meltOperationRepository);
+    this.authSessionRepository = this.serializeRepository(authSessionRepository);
+    this.mintOperationRepository = this.serializeRepository(mintOperationRepository);
+    this.mintIssuanceAttemptRepository = this.serializeRepository(mintIssuanceAttemptRepository);
+    this.receiveOperationRepository = this.serializeRepository(receiveOperationRepository);
+    this.paymentRequestReceiveOperationRepository = this.serializeRepository(
+      paymentRequestReceiveOperationRepository,
+    );
+    this.paymentRequestReceiveAttemptRepository = this.serializeRepository(
+      paymentRequestReceiveAttemptRepository,
+    );
   }
 
   async init(): Promise<void> {
     // No-op: Memory repositories don't require initialization
   }
 
+  /**
+   * Serializes memory transactions and restores repository containers when a callback fails.
+   * Root repository calls wait for an active transaction so they cannot leak into its snapshot.
+   */
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
-    return fn(this);
+    const previousTransaction = this.transactionTail;
+    let releaseTransaction!: () => void;
+    const currentTransaction = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    this.transactionTail = previousTransaction.then(() => currentTransaction);
+
+    await previousTransaction;
+    await this.operationsDrained;
+    try {
+      const snapshots = snapshotMutableContainers(
+        Object.values(this.transactionScope).filter(
+          (value): value is object => typeof value === 'object',
+        ),
+      );
+      try {
+        return await fn(this.transactionScope);
+      } catch (error) {
+        restoreMutableContainers(snapshots);
+        throw error;
+      }
+    } finally {
+      releaseTransaction();
+    }
+  }
+
+  /** Wraps root repositories so calls wait for any active memory transaction. */
+  private serializeRepository<T extends object>(repository: T): T {
+    return new Proxy(repository, {
+      get: (target, property, receiver) => {
+        const value = Reflect.get(target, property, receiver);
+        if (typeof value !== 'function') return value;
+        return (...args: unknown[]) =>
+          this.runRepositoryOperation(() => Reflect.apply(value, target, args) as unknown);
+      },
+    });
+  }
+
+  /** Tracks root operations so a transaction can snapshot only after prior calls drain. */
+  private async runRepositoryOperation<T>(fn: () => T | Promise<T>): Promise<T> {
+    while (true) {
+      const transaction = this.transactionTail;
+      await transaction;
+      if (transaction === this.transactionTail) break;
+    }
+
+    if (this.activeOperations === 0) {
+      this.operationsDrained = new Promise<void>((resolve) => {
+        this.releaseOperationsDrained = resolve;
+      });
+    }
+    this.activeOperations += 1;
+    try {
+      return await fn();
+    } finally {
+      this.activeOperations -= 1;
+      if (this.activeOperations === 0) {
+        this.releaseOperationsDrained?.();
+        this.releaseOperationsDrained = undefined;
+      }
+    }
   }
 }

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -150,7 +150,7 @@ export class MemoryRepositories implements Repositories {
     const paymentRequestReceiveAttemptRepository =
       new MemoryPaymentRequestReceiveAttemptRepository();
 
-    this.transactionScope = {
+    const transactionScope: RepositoryTransactionScope = {
       mintRepository,
       keyRingRepository,
       counterRepository,
@@ -168,7 +168,9 @@ export class MemoryRepositories implements Repositories {
       receiveOperationRepository,
       paymentRequestReceiveOperationRepository,
       paymentRequestReceiveAttemptRepository,
+      withTransaction: (fn) => fn(transactionScope),
     };
+    this.transactionScope = transactionScope;
 
     this.mintRepository = this.serializeRepository(mintRepository);
     this.keyRingRepository = this.serializeRepository(keyRingRepository);
@@ -200,6 +202,7 @@ export class MemoryRepositories implements Repositories {
   /**
    * Serializes memory transactions and restores repository containers when a callback fails.
    * Root repository calls wait for an active transaction so they cannot leak into its snapshot.
+   * Calls through the callback's transaction scope roll into the active transaction.
    */
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
     const previousTransaction = this.transactionTail;

--- a/packages/core/repositories/memory/index.ts
+++ b/packages/core/repositories/memory/index.ts
@@ -13,5 +13,6 @@ export * from './MemorySendOperationRepository';
 export * from './MemoryMeltOperationRepository';
 export * from './MemoryMeltQuoteRepository';
 export * from './MemoryMintOperationRepository';
+export * from './MemoryMintIssuanceAttemptRepository';
 export * from './MemoryReceiveOperationRepository';
 export * from './MemoryPaymentRequestReceiveRepository';

--- a/packages/core/test/unit/MemoryMintIssuanceAttemptRepository.test.ts
+++ b/packages/core/test/unit/MemoryMintIssuanceAttemptRepository.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  runMintIssuanceAttemptRepositoryContract,
+  runMintIssuanceProvenanceRepositoryContract,
+  runRepositoryTransactionContract,
+} from '@cashu/coco-adapter-tests';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+
+async function createRepositories() {
+  const repositories = new MemoryRepositories();
+  await repositories.init();
+  return {
+    repositories,
+    dispose: async () => {},
+  };
+}
+
+runMintIssuanceAttemptRepositoryContract({ createRepositories }, { describe, it, expect });
+runMintIssuanceProvenanceRepositoryContract({ createRepositories }, { describe, it, expect });
+runRepositoryTransactionContract(
+  { createRepositories, testConcurrentRootOperationIsolation: true },
+  { describe, it, expect },
+);

--- a/packages/core/test/unit/MintIssuanceAttempt.test.ts
+++ b/packages/core/test/unit/MintIssuanceAttempt.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
+import { Amount } from '@cashu/cashu-ts';
 import {
+  normalizeMintIssuanceAttempt,
   parseMintIssuanceAttemptFailure,
   parseMintIssuanceAttemptMembers,
   parseMintIssuanceAttemptOutputData,
@@ -25,5 +27,28 @@ describe('Mint Issuance Attempt persisted recovery material', () => {
     expect(() =>
       parseMintIssuanceAttemptFailure({ message: 'rejected', details: ['not', 'an', 'object'] }),
     ).toThrow('details must be an object');
+  });
+
+  it('rejects invalid output recovery material before persistence', () => {
+    expect(() =>
+      normalizeMintIssuanceAttempt({
+        id: 'attempt-1',
+        mintUrl: 'https://mint.test',
+        unit: 'sat',
+        state: 'prepared',
+        members: [{ operationId: 'operation-1', quoteId: 'quote-1', amount: Amount.from(1) }],
+        outputData: {
+          keep: [
+            {
+              blindedMessage: { amount: '1', id: 'keyset', B_: 'B_' },
+              blindingFactor: '01',
+              secret: 'not-hex',
+            },
+          ],
+          send: [],
+        },
+        createdAt: 1,
+      }),
+    ).toThrow('secret must be hex');
   });
 });

--- a/packages/core/test/unit/MintIssuanceAttempt.test.ts
+++ b/packages/core/test/unit/MintIssuanceAttempt.test.ts
@@ -51,4 +51,30 @@ describe('Mint Issuance Attempt persisted recovery material', () => {
       }),
     ).toThrow('secret must be hex');
   });
+
+  it('rejects invalid terminal failure metadata before persistence', () => {
+    const failedAttempt = {
+      id: 'attempt-1',
+      mintUrl: 'https://mint.test',
+      unit: 'sat',
+      state: 'failed',
+      members: [{ operationId: 'operation-1', quoteId: 'quote-1', amount: Amount.from(1) }],
+      outputData: { keep: [], send: [] },
+      createdAt: 1,
+      submittedAt: 2,
+    } as const;
+
+    expect(() =>
+      normalizeMintIssuanceAttempt({
+        ...failedAttempt,
+        terminalFailure: { message: 'rejected', code: 42 },
+      } as never),
+    ).toThrow('code must be a string');
+    expect(() =>
+      normalizeMintIssuanceAttempt({
+        ...failedAttempt,
+        terminalFailure: { message: 'rejected', details: [] },
+      } as never),
+    ).toThrow('details must be an object');
+  });
 });

--- a/packages/core/test/unit/MintIssuanceAttempt.test.ts
+++ b/packages/core/test/unit/MintIssuanceAttempt.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  parseMintIssuanceAttemptFailure,
+  parseMintIssuanceAttemptMembers,
+  parseMintIssuanceAttemptOutputData,
+} from '../../operations/mint/MintIssuanceAttempt.ts';
+
+describe('Mint Issuance Attempt persisted recovery material', () => {
+  it('rejects malformed members, outputs, and terminal failure metadata', () => {
+    expect(() =>
+      parseMintIssuanceAttemptMembers([{ operationId: 'op', quoteId: 'quote' }]),
+    ).toThrow('amount is invalid');
+    expect(() =>
+      parseMintIssuanceAttemptOutputData({
+        keep: [
+          {
+            blindedMessage: { amount: '1', id: 'keyset', B_: 'B_' },
+            blindingFactor: '01',
+            secret: 'not-hex',
+          },
+        ],
+        send: [],
+      }),
+    ).toThrow('secret must be hex');
+    expect(() =>
+      parseMintIssuanceAttemptFailure({ message: 'rejected', details: ['not', 'an', 'object'] }),
+    ).toThrow('details must be an object');
+  });
+});

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -57,4 +57,7 @@ export interface CoreProof extends Proof {
    * Used for auditing and rollback purposes.
    */
   createdByOperationId?: string;
+
+  /** Mint Issuance Attempt that produced this proof as part of an aggregate output set. */
+  createdByMintIssuanceAttemptId?: string;
 }

--- a/packages/expo-sqlite/src/index.ts
+++ b/packages/expo-sqlite/src/index.ts
@@ -21,6 +21,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: Repositories['meltOperationRepository'];
   readonly authSessionRepository: Repositories['authSessionRepository'];
   readonly mintOperationRepository: Repositories['mintOperationRepository'];
+  readonly mintIssuanceAttemptRepository: Repositories['mintIssuanceAttemptRepository'];
   readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
   readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
   readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
@@ -44,6 +45,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = this.repositories.meltOperationRepository;
     this.authSessionRepository = this.repositories.authSessionRepository;
     this.mintOperationRepository = this.repositories.mintOperationRepository;
+    this.mintIssuanceAttemptRepository = this.repositories.mintIssuanceAttemptRepository;
     this.receiveOperationRepository = this.repositories.receiveOperationRepository;
     this.paymentRequestReceiveOperationRepository =
       this.repositories.paymentRequestReceiveOperationRepository;

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -5,6 +5,8 @@ import {
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
+  runMintIssuanceAttemptRepositoryContract,
+  runMintIssuanceProvenanceRepositoryContract,
   runPaymentRequestReceiveRepositoryContract,
   runReceiveOperationRepositoryContract,
   runSendOperationRepositoryContract,
@@ -163,6 +165,10 @@ runAuthSessionRepositoryContract({ createRepositories }, { describe, it, expect 
 runProofRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runMintOperationRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceAttemptRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceProvenanceRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runReceiveOperationRepositoryContract({ createRepositories }, { describe, it, expect });
 

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -124,6 +124,8 @@ export class IndexedDbRepositories implements Repositories {
         paymentRequestReceiveAttemptRepository: new IdbPaymentRequestReceiveAttemptRepository(
           scopedDb,
         ),
+        withTransaction: (nestedFn) =>
+          scopedDb.runTransaction('rw', stores, () => nestedFn(scopedRepositories)),
       };
       return fn(scopedRepositories);
     });

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -12,6 +12,7 @@ import type {
   MeltOperationRepository,
   AuthSessionRepository,
   MintOperationRepository,
+  MintIssuanceAttemptRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
   ReceiveOperationRepository,
@@ -32,6 +33,7 @@ import { IdbSendOperationRepository } from './repositories/SendOperationReposito
 import { IdbMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { IdbAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { IdbMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { IdbMintIssuanceAttemptRepository } from './repositories/MintIssuanceAttemptRepository.ts';
 import { IdbReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 import {
   IdbPaymentRequestReceiveAttemptRepository,
@@ -54,6 +56,7 @@ export class IndexedDbRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintIssuanceAttemptRepository: MintIssuanceAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -75,6 +78,7 @@ export class IndexedDbRepositories implements Repositories {
     this.meltOperationRepository = new IdbMeltOperationRepository(this.db);
     this.authSessionRepository = new IdbAuthSessionRepository(this.db);
     this.mintOperationRepository = new IdbMintOperationRepository(this.db);
+    this.mintIssuanceAttemptRepository = new IdbMintIssuanceAttemptRepository(this.db);
     this.receiveOperationRepository = new IdbReceiveOperationRepository(this.db);
     this.paymentRequestReceiveOperationRepository = new IdbPaymentRequestReceiveOperationRepository(
       this.db,
@@ -112,6 +116,7 @@ export class IndexedDbRepositories implements Repositories {
         meltOperationRepository: new IdbMeltOperationRepository(scopedDb),
         authSessionRepository: new IdbAuthSessionRepository(scopedDb),
         mintOperationRepository: new IdbMintOperationRepository(scopedDb),
+        mintIssuanceAttemptRepository: new IdbMintIssuanceAttemptRepository(scopedDb),
         receiveOperationRepository: new IdbReceiveOperationRepository(scopedDb),
         paymentRequestReceiveOperationRepository: new IdbPaymentRequestReceiveOperationRepository(
           scopedDb,
@@ -141,6 +146,7 @@ export {
   IdbMeltOperationRepository,
   IdbAuthSessionRepository,
   IdbMintOperationRepository,
+  IdbMintIssuanceAttemptRepository,
   IdbReceiveOperationRepository,
   IdbPaymentRequestReceiveOperationRepository,
   IdbPaymentRequestReceiveAttemptRepository,

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -145,6 +145,7 @@ export interface ProofRow {
   createdAt: number;
   usedByOperationId?: string | null;
   createdByOperationId?: string | null;
+  createdByMintIssuanceAttemptId?: string | null;
 }
 
 export interface MintQuoteRow {
@@ -325,4 +326,19 @@ export interface MintOperationRow {
   lastObservedRemoteStateAt?: number | null;
   terminalFailureJson?: string | null;
   outputDataJson?: string | null;
+  mintIssuanceAttemptId?: string | null;
+}
+
+export interface MintIssuanceAttemptRow {
+  id: string;
+  mintUrl: string;
+  unit: string;
+  state: 'prepared' | 'submitted' | 'succeeded' | 'failed';
+  membersJson: string;
+  /** Indexed adapter projection; the domain record remains the ordered members array. */
+  memberOperationIds: string[];
+  outputDataJson: string;
+  createdAt: number;
+  submittedAt?: number | null;
+  terminalFailureJson?: string | null;
 }

--- a/packages/indexeddb/src/lib/schema.ts
+++ b/packages/indexeddb/src/lib/schema.ts
@@ -1076,4 +1076,30 @@ export async function ensureSchema(db: IdbDb): Promise<void> {
     coco_cashu_payment_request_receive_attempts:
       '&id, requestOperationId, requestId, state, &[requestOperationId+payloadHash], [requestId+payloadHash], &transportMessageId, &receiveOperationId',
   });
+
+  // Version 32: Immutable Mint Issuance Attempts and attempt-level provenance.
+  db.version(32).stores({
+    coco_cashu_mints: '&mintUrl, name, updatedAt, trusted',
+    coco_cashu_keysets: '&[mintUrl+id], mintUrl, id, updatedAt, unit',
+    coco_cashu_counters: '&[mintUrl+keysetId]',
+    coco_cashu_proofs:
+      '&[mintUrl+secret], [mintUrl+state], [mintUrl+unit+state], [mintUrl+id+state], [mintUrl+id+unit+state], [mintUrl+unit+id+state], [unit+state], state, mintUrl, unit, id, usedByOperationId, createdByOperationId',
+    coco_cashu_mint_quotes: '&[mintUrl+quote], state, mintUrl',
+    coco_cashu_canonical_mint_quotes:
+      '&[mintUrl+method+quoteId], &[mintUrl+quoteId], state, mintUrl, method',
+    coco_cashu_melt_quotes: '&[mintUrl+method+quoteId], &[mintUrl+quoteId], state, mintUrl, method',
+    coco_cashu_history:
+      '++id, mintUrl, type, createdAt, [mintUrl+quoteId+type], [mintUrl+operationId]',
+    coco_cashu_keypairs: '&publicKey, createdAt, derivationIndex',
+    coco_cashu_send_operations: '&id, state, mintUrl, createdAt',
+    coco_cashu_melt_operations: '&id, state, mintUrl, createdAt, [mintUrl+quoteId]',
+    coco_cashu_receive_operations: '&id, state, mintUrl, createdAt',
+    coco_cashu_auth_sessions: '&mintUrl',
+    coco_cashu_mint_operations:
+      '&id, state, mintUrl, createdAt, [mintUrl+quoteId], [mintUrl+method+quoteId]',
+    coco_cashu_payment_request_receive_operations: '&id, state, requestId',
+    coco_cashu_payment_request_receive_attempts:
+      '&id, requestOperationId, requestId, state, &[requestOperationId+payloadHash], [requestId+payloadHash], &transportMessageId, &receiveOperationId',
+    coco_cashu_mint_issuance_attempts: '&id, state, mintUrl, createdAt, *memberOperationIds',
+  });
 }

--- a/packages/indexeddb/src/repositories/MintIssuanceAttemptRepository.ts
+++ b/packages/indexeddb/src/repositories/MintIssuanceAttemptRepository.ts
@@ -1,0 +1,152 @@
+import {
+  normalizeMintIssuanceAttempt,
+  normalizeMintUrl,
+  parseMintIssuanceAttemptFailure,
+  parseMintIssuanceAttemptMembers,
+  parseMintIssuanceAttemptOutputData,
+  serializeAmount,
+  type MintIssuanceAttempt,
+  type MintIssuanceAttemptRepository,
+  type MintIssuanceAttemptTransition,
+  type PreparedMintIssuanceAttempt,
+} from '@cashu/coco-core/adapter';
+import type { IdbDb, MintIssuanceAttemptRow } from '../lib/db.ts';
+
+function attemptToRow(attempt: MintIssuanceAttempt): MintIssuanceAttemptRow {
+  return {
+    id: attempt.id,
+    mintUrl: attempt.mintUrl,
+    unit: attempt.unit,
+    state: attempt.state,
+    membersJson: JSON.stringify(
+      attempt.members.map((member) => ({
+        operationId: member.operationId,
+        quoteId: member.quoteId,
+        amount: serializeAmount(member.amount),
+      })),
+    ),
+    memberOperationIds: attempt.members.map((member) => member.operationId),
+    outputDataJson: JSON.stringify(attempt.outputData),
+    createdAt: attempt.createdAt,
+    submittedAt: attempt.submittedAt ?? null,
+    terminalFailureJson: attempt.terminalFailure ? JSON.stringify(attempt.terminalFailure) : null,
+  };
+}
+
+function rowToAttempt(row: MintIssuanceAttemptRow): MintIssuanceAttempt {
+  const base = {
+    id: row.id,
+    mintUrl: row.mintUrl,
+    unit: row.unit,
+    members: parseMintIssuanceAttemptMembers(JSON.parse(row.membersJson)),
+    outputData: parseMintIssuanceAttemptOutputData(JSON.parse(row.outputDataJson)),
+    createdAt: row.createdAt,
+  };
+
+  if (row.state === 'prepared') {
+    return normalizeMintIssuanceAttempt({ ...base, state: 'prepared' });
+  }
+  if (row.submittedAt == null) {
+    throw new Error(`Mint issuance attempt ${row.id} is missing submittedAt`);
+  }
+  if (row.state === 'failed') {
+    if (!row.terminalFailureJson) {
+      throw new Error(`Failed Mint issuance attempt ${row.id} is missing terminal failure`);
+    }
+    return normalizeMintIssuanceAttempt({
+      ...base,
+      state: 'failed',
+      submittedAt: row.submittedAt,
+      terminalFailure: parseMintIssuanceAttemptFailure(JSON.parse(row.terminalFailureJson)),
+    });
+  }
+  return normalizeMintIssuanceAttempt({
+    ...base,
+    state: row.state,
+    submittedAt: row.submittedAt,
+  });
+}
+
+/** IndexedDB persistence for immutable Mint Issuance Attempt recovery records. */
+export class IdbMintIssuanceAttemptRepository implements MintIssuanceAttemptRepository {
+  constructor(private readonly db: IdbDb) {}
+
+  async create(input: PreparedMintIssuanceAttempt): Promise<void> {
+    const attempt = normalizeMintIssuanceAttempt(input);
+    if (attempt.state !== 'prepared') {
+      throw new Error('Mint issuance attempts must be created in prepared state');
+    }
+    await this.db.runTransaction('rw', ['coco_cashu_mint_issuance_attempts'], async (tx) => {
+      const table = tx.table('coco_cashu_mint_issuance_attempts');
+      if (await table.get(attempt.id)) {
+        throw new Error(`Mint issuance attempt already exists: ${attempt.id}`);
+      }
+      await table.add(attemptToRow(attempt));
+    });
+  }
+
+  async getById(id: string): Promise<MintIssuanceAttempt | null> {
+    const row = (await this.db.table('coco_cashu_mint_issuance_attempts').get(id)) as
+      | MintIssuanceAttemptRow
+      | undefined;
+    return row ? rowToAttempt(row) : null;
+  }
+
+  async getNewestByMemberOperationId(operationId: string): Promise<MintIssuanceAttempt | null> {
+    const rows = (await this.db
+      .table('coco_cashu_mint_issuance_attempts')
+      .where('memberOperationIds')
+      .equals(operationId)
+      .toArray()) as MintIssuanceAttemptRow[];
+    rows.sort((a, b) => b.createdAt - a.createdAt || b.id.localeCompare(a.id));
+    return rows[0] ? rowToAttempt(rows[0]) : null;
+  }
+
+  async listIncomplete(mintUrl?: string): Promise<MintIssuanceAttempt[]> {
+    const normalizedMintUrl = mintUrl ? normalizeMintUrl(mintUrl) : undefined;
+    const rows = (await this.db
+      .table('coco_cashu_mint_issuance_attempts')
+      .where('state')
+      .anyOf(['prepared', 'submitted'])
+      .toArray()) as MintIssuanceAttemptRow[];
+    return rows
+      .filter((row) => !normalizedMintUrl || row.mintUrl === normalizedMintUrl)
+      .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id))
+      .map(rowToAttempt);
+  }
+
+  async compareAndTransition(
+    id: string,
+    transition: MintIssuanceAttemptTransition,
+  ): Promise<boolean> {
+    return this.db.runTransaction('rw', ['coco_cashu_mint_issuance_attempts'], async (tx) => {
+      const table = tx.table('coco_cashu_mint_issuance_attempts');
+      const row = (await table.get(id)) as MintIssuanceAttemptRow | undefined;
+      if (!row || row.state !== transition.from) return false;
+
+      if (transition.from === 'prepared' && transition.to === 'submitted') {
+        if (!Number.isFinite(transition.submittedAt)) {
+          throw new Error('Submitted Mint issuance attempt submittedAt must be finite');
+        }
+        await table.put({ ...row, state: 'submitted', submittedAt: transition.submittedAt });
+        return true;
+      }
+      if (transition.from === 'submitted' && transition.to === 'succeeded') {
+        await table.put({ ...row, state: 'succeeded' });
+        return true;
+      }
+      if (transition.from === 'submitted' && transition.to === 'failed') {
+        if (transition.terminalFailure.message.trim().length === 0) {
+          throw new Error('Mint issuance attempt failure message must not be empty');
+        }
+        await table.put({
+          ...row,
+          state: 'failed',
+          terminalFailureJson: JSON.stringify(transition.terminalFailure),
+        });
+        return true;
+      }
+      throw new Error('Illegal Mint issuance attempt transition');
+    });
+  }
+}

--- a/packages/indexeddb/src/repositories/MintIssuanceAttemptRepository.ts
+++ b/packages/indexeddb/src/repositories/MintIssuanceAttemptRepository.ts
@@ -136,13 +136,11 @@ export class IdbMintIssuanceAttemptRepository implements MintIssuanceAttemptRepo
         return true;
       }
       if (transition.from === 'submitted' && transition.to === 'failed') {
-        if (transition.terminalFailure.message.trim().length === 0) {
-          throw new Error('Mint issuance attempt failure message must not be empty');
-        }
+        const terminalFailure = parseMintIssuanceAttemptFailure(transition.terminalFailure);
         await table.put({
           ...row,
           state: 'failed',
-          terminalFailureJson: JSON.stringify(transition.terminalFailure),
+          terminalFailureJson: JSON.stringify(terminalFailure),
         });
         return true;
       }

--- a/packages/indexeddb/src/repositories/MintOperationRepository.ts
+++ b/packages/indexeddb/src/repositories/MintOperationRepository.ts
@@ -41,6 +41,7 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     ...(row.terminalFailureJson
       ? { terminalFailure: JSON.parse(row.terminalFailureJson) as MintOperationFailure }
       : {}),
+    ...(row.mintIssuanceAttemptId ? { mintIssuanceAttemptId: row.mintIssuanceAttemptId } : {}),
   };
 
   const intent = {
@@ -91,6 +92,7 @@ const operationToRow = (operation: MintOperation): MintOperationRow => {
         ? JSON.stringify(operation.terminalFailure)
         : null,
       outputDataJson: null,
+      mintIssuanceAttemptId: operation.mintIssuanceAttemptId ?? null,
     };
   }
 
@@ -115,6 +117,7 @@ const operationToRow = (operation: MintOperation): MintOperationRow => {
       ? JSON.stringify(operation.terminalFailure)
       : null,
     outputDataJson: JSON.stringify(operation.outputData),
+    mintIssuanceAttemptId: operation.mintIssuanceAttemptId ?? null,
   };
 };
 

--- a/packages/indexeddb/src/repositories/ProofRepository.ts
+++ b/packages/indexeddb/src/repositories/ProofRepository.ts
@@ -45,6 +45,9 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByMintIssuanceAttemptId
+      ? { createdByMintIssuanceAttemptId: r.createdByMintIssuanceAttemptId }
+      : {}),
   };
 }
 
@@ -84,6 +87,7 @@ export class IdbProofRepository implements ProofRepository {
           createdAt: now,
           usedByOperationId: p.usedByOperationId ?? null,
           createdByOperationId: p.createdByOperationId ?? null,
+          createdByMintIssuanceAttemptId: p.createdByMintIssuanceAttemptId ?? null,
         };
         await table.put(row);
       }

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -4,6 +4,8 @@ import {
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
+  runMintIssuanceAttemptRepositoryContract,
+  runMintIssuanceProvenanceRepositoryContract,
   runPaymentRequestReceiveRepositoryContract,
   runReceiveOperationRepositoryContract,
   runSendOperationRepositoryContract,
@@ -46,6 +48,10 @@ runAuthSessionRepositoryContract({ createRepositories }, { describe, it, expect 
 runProofRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runMintOperationRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceAttemptRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceProvenanceRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runReceiveOperationRepositoryContract({ createRepositories }, { describe, it, expect });
 

--- a/packages/sql-storage/src/index.ts
+++ b/packages/sql-storage/src/index.ts
@@ -36,6 +36,7 @@ export {
   SqliteMeltOperationRepository,
   SqliteAuthSessionRepository,
   SqliteMintOperationRepository,
+  SqliteMintIssuanceAttemptRepository,
   SqliteReceiveOperationRepository,
   SqlitePaymentRequestReceiveOperationRepository,
   SqlitePaymentRequestReceiveAttemptRepository,

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -14,6 +14,7 @@ import type {
   MeltOperationRepository,
   AuthSessionRepository,
   MintOperationRepository,
+  MintIssuanceAttemptRepository,
   ReceiveOperationRepository,
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
@@ -33,6 +34,7 @@ import { SqliteSendOperationRepository } from './repositories/SendOperationRepos
 import { SqliteMeltOperationRepository } from './repositories/MeltOperationRepository.ts';
 import { SqliteAuthSessionRepository } from './repositories/AuthSessionRepository.ts';
 import { SqliteMintOperationRepository } from './repositories/MintOperationRepository.ts';
+import { SqliteMintIssuanceAttemptRepository } from './repositories/MintIssuanceAttemptRepository.ts';
 import { SqliteReceiveOperationRepository } from './repositories/ReceiveOperationRepository.ts';
 import {
   SqlitePaymentRequestReceiveAttemptRepository,
@@ -58,6 +60,7 @@ function createRepositoryScope(database: SqlDatabase): RepositoryTransactionScop
     meltOperationRepository: new SqliteMeltOperationRepository(database),
     authSessionRepository: new SqliteAuthSessionRepository(database),
     mintOperationRepository: new SqliteMintOperationRepository(database),
+    mintIssuanceAttemptRepository: new SqliteMintIssuanceAttemptRepository(database),
     receiveOperationRepository: new SqliteReceiveOperationRepository(database),
     paymentRequestReceiveOperationRepository: new SqlitePaymentRequestReceiveOperationRepository(
       database,
@@ -82,6 +85,7 @@ export class SqlStorageRepositories implements Repositories {
   readonly meltOperationRepository: MeltOperationRepository;
   readonly authSessionRepository: AuthSessionRepository;
   readonly mintOperationRepository: MintOperationRepository;
+  readonly mintIssuanceAttemptRepository: MintIssuanceAttemptRepository;
   readonly receiveOperationRepository: ReceiveOperationRepository;
   readonly paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   readonly paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
@@ -103,6 +107,7 @@ export class SqlStorageRepositories implements Repositories {
     this.meltOperationRepository = repositories.meltOperationRepository;
     this.authSessionRepository = repositories.authSessionRepository;
     this.mintOperationRepository = repositories.mintOperationRepository;
+    this.mintIssuanceAttemptRepository = repositories.mintIssuanceAttemptRepository;
     this.receiveOperationRepository = repositories.receiveOperationRepository;
     this.paymentRequestReceiveOperationRepository =
       repositories.paymentRequestReceiveOperationRepository;
@@ -133,6 +138,7 @@ export {
   SqliteMeltOperationRepository,
   SqliteAuthSessionRepository,
   SqliteMintOperationRepository,
+  SqliteMintIssuanceAttemptRepository,
   SqliteReceiveOperationRepository,
   SqlitePaymentRequestReceiveOperationRepository,
   SqlitePaymentRequestReceiveAttemptRepository,

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -68,6 +68,8 @@ function createRepositoryScope(database: SqlDatabase): RepositoryTransactionScop
     paymentRequestReceiveAttemptRepository: new SqlitePaymentRequestReceiveAttemptRepository(
       database,
     ),
+    withTransaction: (fn) =>
+      database.transaction((transactionDatabase) => fn(createRepositoryScope(transactionDatabase))),
   };
 }
 

--- a/packages/sql-storage/src/repositories/MintIssuanceAttemptRepository.ts
+++ b/packages/sql-storage/src/repositories/MintIssuanceAttemptRepository.ts
@@ -1,0 +1,196 @@
+import {
+  deserializeAmount,
+  normalizeMintIssuanceAttempt,
+  normalizeMintUrl,
+  parseMintIssuanceAttemptFailure,
+  parseMintIssuanceAttemptOutputData,
+  serializeAmount,
+  type MintIssuanceAttempt,
+  type MintIssuanceAttemptRepository,
+  type MintIssuanceAttemptState,
+  type MintIssuanceAttemptTransition,
+  type PreparedMintIssuanceAttempt,
+} from '@cashu/coco-core/adapter';
+import type { SqlDatabase, SqlValue } from '../index.ts';
+
+interface AttemptRow {
+  id: string;
+  mintUrl: string;
+  unit: string;
+  state: MintIssuanceAttemptState;
+  outputDataJson: string;
+  createdAt: number;
+  submittedAt: number | null;
+  terminalFailureJson: string | null;
+}
+
+interface MemberRow {
+  operationId: string;
+  quoteId: string;
+  amount: string | number;
+}
+
+function rowToAttempt(row: AttemptRow, members: MemberRow[]): MintIssuanceAttempt {
+  const base = {
+    id: row.id,
+    mintUrl: row.mintUrl,
+    unit: row.unit,
+    members: members.map((member) => ({
+      operationId: member.operationId,
+      quoteId: member.quoteId,
+      amount: deserializeAmount(member.amount),
+    })),
+    outputData: parseMintIssuanceAttemptOutputData(JSON.parse(row.outputDataJson)),
+    createdAt: row.createdAt,
+  };
+
+  if (row.state === 'prepared') {
+    return normalizeMintIssuanceAttempt({ ...base, state: 'prepared' });
+  }
+  if (row.submittedAt === null) {
+    throw new Error(`Mint issuance attempt ${row.id} is missing submittedAt`);
+  }
+  if (row.state === 'failed') {
+    if (!row.terminalFailureJson) {
+      throw new Error(`Failed Mint issuance attempt ${row.id} is missing terminal failure`);
+    }
+    return normalizeMintIssuanceAttempt({
+      ...base,
+      state: 'failed',
+      submittedAt: row.submittedAt,
+      terminalFailure: parseMintIssuanceAttemptFailure(JSON.parse(row.terminalFailureJson)),
+    });
+  }
+  return normalizeMintIssuanceAttempt({
+    ...base,
+    state: row.state,
+    submittedAt: row.submittedAt,
+  });
+}
+
+/** Shared SQL persistence for immutable Mint Issuance Attempt recovery records. */
+export class SqliteMintIssuanceAttemptRepository implements MintIssuanceAttemptRepository {
+  constructor(private readonly db: SqlDatabase) {}
+
+  async create(input: PreparedMintIssuanceAttempt): Promise<void> {
+    const attempt = normalizeMintIssuanceAttempt(input);
+    if (attempt.state !== 'prepared') {
+      throw new Error('Mint issuance attempts must be created in prepared state');
+    }
+
+    await this.db.transaction(async (tx) => {
+      await tx.run(
+        `INSERT INTO coco_cashu_mint_issuance_attempts
+          (id, mintUrl, unit, state, outputDataJson, createdAt, submittedAt, terminalFailureJson)
+         VALUES (?, ?, ?, 'prepared', ?, ?, NULL, NULL)`,
+        [
+          attempt.id,
+          attempt.mintUrl,
+          attempt.unit,
+          JSON.stringify(attempt.outputData),
+          attempt.createdAt,
+        ],
+      );
+      for (const [position, member] of attempt.members.entries()) {
+        await tx.run(
+          `INSERT INTO coco_cashu_mint_issuance_attempt_members
+            (attemptId, position, operationId, quoteId, amount)
+           VALUES (?, ?, ?, ?, ?)`,
+          [
+            attempt.id,
+            position,
+            member.operationId,
+            member.quoteId,
+            serializeAmount(member.amount),
+          ],
+        );
+      }
+    });
+  }
+
+  async getById(id: string): Promise<MintIssuanceAttempt | null> {
+    const row = await this.db.get<AttemptRow>(
+      'SELECT * FROM coco_cashu_mint_issuance_attempts WHERE id = ? LIMIT 1',
+      [id],
+    );
+    return row ? rowToAttempt(row, await this.getMembers(row.id)) : null;
+  }
+
+  async getNewestByMemberOperationId(operationId: string): Promise<MintIssuanceAttempt | null> {
+    const row = await this.db.get<AttemptRow>(
+      `SELECT attempts.* FROM coco_cashu_mint_issuance_attempts attempts
+       JOIN coco_cashu_mint_issuance_attempt_members members ON members.attemptId = attempts.id
+       WHERE members.operationId = ?
+       ORDER BY attempts.createdAt DESC, attempts.id DESC
+       LIMIT 1`,
+      [operationId],
+    );
+    return row ? rowToAttempt(row, await this.getMembers(row.id)) : null;
+  }
+
+  async listIncomplete(mintUrl?: string): Promise<MintIssuanceAttempt[]> {
+    const params: SqlValue[] = [];
+    let where = "state IN ('prepared', 'submitted')";
+    if (mintUrl) {
+      where += ' AND mintUrl = ?';
+      params.push(normalizeMintUrl(mintUrl));
+    }
+    const rows = await this.db.all<AttemptRow>(
+      `SELECT * FROM coco_cashu_mint_issuance_attempts
+       WHERE ${where}
+       ORDER BY createdAt ASC, id ASC`,
+      params,
+    );
+    return Promise.all(rows.map(async (row) => rowToAttempt(row, await this.getMembers(row.id))));
+  }
+
+  async compareAndTransition(
+    id: string,
+    transition: MintIssuanceAttemptTransition,
+  ): Promise<boolean> {
+    if (transition.from === 'prepared' && transition.to === 'submitted') {
+      if (!Number.isFinite(transition.submittedAt)) {
+        throw new Error('Submitted Mint issuance attempt submittedAt must be finite');
+      }
+      const result = await this.db.run(
+        `UPDATE coco_cashu_mint_issuance_attempts
+         SET state = 'submitted', submittedAt = ?
+         WHERE id = ? AND state = 'prepared'`,
+        [transition.submittedAt, id],
+      );
+      return result.changes === 1;
+    }
+    if (transition.from === 'submitted' && transition.to === 'succeeded') {
+      const result = await this.db.run(
+        `UPDATE coco_cashu_mint_issuance_attempts
+         SET state = 'succeeded'
+         WHERE id = ? AND state = 'submitted'`,
+        [id],
+      );
+      return result.changes === 1;
+    }
+    if (transition.from === 'submitted' && transition.to === 'failed') {
+      if (transition.terminalFailure.message.trim().length === 0) {
+        throw new Error('Mint issuance attempt failure message must not be empty');
+      }
+      const result = await this.db.run(
+        `UPDATE coco_cashu_mint_issuance_attempts
+         SET state = 'failed', terminalFailureJson = ?
+         WHERE id = ? AND state = 'submitted'`,
+        [JSON.stringify(transition.terminalFailure), id],
+      );
+      return result.changes === 1;
+    }
+    throw new Error('Illegal Mint issuance attempt transition');
+  }
+
+  private async getMembers(attemptId: string): Promise<MemberRow[]> {
+    return this.db.all<MemberRow>(
+      `SELECT operationId, quoteId, amount
+       FROM coco_cashu_mint_issuance_attempt_members
+       WHERE attemptId = ?
+       ORDER BY position ASC`,
+      [attemptId],
+    );
+  }
+}

--- a/packages/sql-storage/src/repositories/MintIssuanceAttemptRepository.ts
+++ b/packages/sql-storage/src/repositories/MintIssuanceAttemptRepository.ts
@@ -170,14 +170,12 @@ export class SqliteMintIssuanceAttemptRepository implements MintIssuanceAttemptR
       return result.changes === 1;
     }
     if (transition.from === 'submitted' && transition.to === 'failed') {
-      if (transition.terminalFailure.message.trim().length === 0) {
-        throw new Error('Mint issuance attempt failure message must not be empty');
-      }
+      const terminalFailure = parseMintIssuanceAttemptFailure(transition.terminalFailure);
       const result = await this.db.run(
         `UPDATE coco_cashu_mint_issuance_attempts
          SET state = 'failed', terminalFailureJson = ?
          WHERE id = ? AND state = 'submitted'`,
-        [JSON.stringify(transition.terminalFailure), id],
+        [JSON.stringify(terminalFailure), id],
       );
       return result.changes === 1;
     }

--- a/packages/sql-storage/src/repositories/MintOperationRepository.ts
+++ b/packages/sql-storage/src/repositories/MintOperationRepository.ts
@@ -28,6 +28,7 @@ interface MintOperationRow {
   lastObservedRemoteStateAt: number | null;
   terminalFailureJson: string | null;
   outputDataJson: string | null;
+  mintIssuanceAttemptId: string | null;
 }
 
 const persistedStates = ['pending', 'executing', 'finalized', 'failed'] as const;
@@ -63,6 +64,7 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     ...(row.terminalFailureJson
       ? { terminalFailure: JSON.parse(row.terminalFailureJson) as MintOperationFailure }
       : {}),
+    ...(row.mintIssuanceAttemptId ? { mintIssuanceAttemptId: row.mintIssuanceAttemptId } : {}),
   };
 
   const intent = {
@@ -116,6 +118,7 @@ const operationToParams = (operation: MintOperation): SqlValue[] => {
       null,
       operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
       null,
+      operation.mintIssuanceAttemptId ?? null,
     ];
   }
 
@@ -138,6 +141,7 @@ const operationToParams = (operation: MintOperation): SqlValue[] => {
     null,
     operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
     JSON.stringify(operation.outputData),
+    operation.mintIssuanceAttemptId ?? null,
   ];
 };
 
@@ -160,8 +164,8 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
     const params = operationToParams(operation);
     await this.db.run(
       `INSERT INTO coco_cashu_mint_operations
-        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, mintUrl, quoteId, state, createdAt, updatedAt, error, method, methodDataJson, amount, unit, request, expiry, pubkey, lastObservedRemoteState, lastObservedRemoteStateAt, terminalFailureJson, outputDataJson, mintIssuanceAttemptId)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       params,
     );
   }
@@ -180,7 +184,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
     if (operation.state === 'init') {
       await this.db.run(
         `UPDATE coco_cashu_mint_operations
-         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?
+         SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, terminalFailureJson = ?, mintIssuanceAttemptId = ?
          WHERE id = ?`,
         [
           operation.quoteId,
@@ -192,6 +196,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
           serializeAmount(operation.amount),
           operation.unit,
           operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
+          operation.mintIssuanceAttemptId ?? null,
           operation.id,
         ],
       );
@@ -200,7 +205,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
 
     await this.db.run(
       `UPDATE coco_cashu_mint_operations
-       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?
+       SET quoteId = ?, state = ?, updatedAt = ?, error = ?, method = ?, methodDataJson = ?, amount = ?, unit = ?, request = ?, expiry = ?, pubkey = ?, lastObservedRemoteState = ?, lastObservedRemoteStateAt = ?, terminalFailureJson = ?, outputDataJson = ?, mintIssuanceAttemptId = ?
        WHERE id = ?`,
       [
         operation.quoteId,
@@ -218,6 +223,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
         null,
         operation.terminalFailure ? JSON.stringify(operation.terminalFailure) : null,
         JSON.stringify(operation.outputData),
+        operation.mintIssuanceAttemptId ?? null,
         operation.id,
       ],
     );

--- a/packages/sql-storage/src/repositories/ProofRepository.ts
+++ b/packages/sql-storage/src/repositories/ProofRepository.ts
@@ -23,12 +23,13 @@ interface ProofRow {
   state: ProofState;
   usedByOperationId: string | null;
   createdByOperationId: string | null;
+  createdByMintIssuanceAttemptId: string | null;
 }
 
 const MAX_PROOF_SECRET_LOOKUP_BATCH_SIZE = 900;
 
 const PROOF_COLUMNS =
-  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId';
+  'mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, usedByOperationId, createdByOperationId, createdByMintIssuanceAttemptId';
 
 function normalizeProofUnit(proof: CoreProof): string {
   return normalizeUnit((proof as { unit?: string }).unit);
@@ -68,6 +69,9 @@ function rowToProof(r: ProofRow): CoreProof {
     state: r.state,
     ...(r.usedByOperationId ? { usedByOperationId: r.usedByOperationId } : {}),
     ...(r.createdByOperationId ? { createdByOperationId: r.createdByOperationId } : {}),
+    ...(r.createdByMintIssuanceAttemptId
+      ? { createdByMintIssuanceAttemptId: r.createdByMintIssuanceAttemptId }
+      : {}),
   };
 }
 
@@ -95,7 +99,7 @@ export class SqliteProofRepository implements ProofRepository {
         }
       }
       const insertSql =
-        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+        'INSERT INTO coco_cashu_proofs (mintUrl, id, unit, amount, secret, C, dleqJson, witnessJson, state, createdAt, usedByOperationId, createdByOperationId, createdByMintIssuanceAttemptId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
       for (const p of normalizedProofs) {
         const dleqJson = p.dleq ? JSON.stringify(p.dleq) : null;
         const witnessJson = p.witness ? JSON.stringify(p.witness) : null;
@@ -112,6 +116,7 @@ export class SqliteProofRepository implements ProofRepository {
           now,
           p.usedByOperationId ?? null,
           p.createdByOperationId ?? null,
+          p.createdByMintIssuanceAttemptId ?? null,
         ]);
       }
     });

--- a/packages/sql-storage/src/schema.ts
+++ b/packages/sql-storage/src/schema.ts
@@ -1446,6 +1446,42 @@ const MIGRATIONS: readonly Migration[] = [
         ON coco_cashu_melt_quotes(mintUrl, quoteId);
     `,
   },
+  {
+    id: '037_mint_issuance_attempts',
+    sql: `
+      CREATE TABLE coco_cashu_mint_issuance_attempts (
+        id TEXT PRIMARY KEY,
+        mintUrl TEXT NOT NULL,
+        unit TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('prepared','submitted','succeeded','failed')),
+        outputDataJson TEXT NOT NULL,
+        createdAt INTEGER NOT NULL,
+        submittedAt INTEGER,
+        terminalFailureJson TEXT
+      );
+
+      CREATE INDEX idx_coco_cashu_mint_issuance_attempts_incomplete
+        ON coco_cashu_mint_issuance_attempts(state, mintUrl, createdAt);
+
+      CREATE TABLE coco_cashu_mint_issuance_attempt_members (
+        attemptId TEXT NOT NULL,
+        position INTEGER NOT NULL,
+        operationId TEXT NOT NULL,
+        quoteId TEXT NOT NULL,
+        amount TEXT NOT NULL,
+        PRIMARY KEY (attemptId, position),
+        UNIQUE (attemptId, operationId),
+        UNIQUE (attemptId, quoteId),
+        FOREIGN KEY (attemptId) REFERENCES coco_cashu_mint_issuance_attempts(id)
+      );
+
+      CREATE INDEX idx_coco_cashu_mint_issuance_attempt_members_operation
+        ON coco_cashu_mint_issuance_attempt_members(operationId, attemptId);
+
+      ALTER TABLE coco_cashu_mint_operations ADD COLUMN mintIssuanceAttemptId TEXT;
+      ALTER TABLE coco_cashu_proofs ADD COLUMN createdByMintIssuanceAttemptId TEXT;
+    `,
+  },
 ];
 
 // Export for testing

--- a/packages/sql-storage/src/test/schema.test.ts
+++ b/packages/sql-storage/src/test/schema.test.ts
@@ -43,6 +43,7 @@ const EXPECTED_MIGRATION_IDS = [
   '034_clean_unquoted_mint_operations',
   '035_duplicate_quote_ids',
   '036_quote_identity_unique_indexes',
+  '037_mint_issuance_attempts',
 ] as const;
 
 const RECEIVE_OPERATIONS_SQL = `
@@ -181,6 +182,66 @@ describe('shared SQL schema migrations', () => {
       [...EXPECTED_MIGRATION_IDS, '012_receive_operations', '013_send_operations_method'].sort(),
     );
   });
+
+  itWithDatabase(
+    'adds attempt persistence without rewriting legacy operations or proofs',
+    async (db) => {
+      await ensureSchemaUpTo(db, '037_mint_issuance_attempts');
+      await db.run(
+        `INSERT INTO coco_cashu_mint_operations
+        (id, mintUrl, quoteId, state, createdAt, updatedAt, method, methodDataJson, amount, unit)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          'legacy-mint-op',
+          'https://mint.test',
+          'legacy-quote',
+          'init',
+          1,
+          2,
+          'bolt11',
+          '{}',
+          '1',
+          'sat',
+        ],
+      );
+      await db.run(
+        `INSERT INTO coco_cashu_proofs
+        (mintUrl, id, unit, amount, secret, C, state, createdAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        ['https://mint.test', 'keyset-id', 'sat', '1', 'legacy-secret', 'C', 'ready', 1],
+      );
+
+      await ensureSchemaUpTo(db);
+
+      const operation = await db.get<{ id: string; mintIssuanceAttemptId: string | null }>(
+        'SELECT id, mintIssuanceAttemptId FROM coco_cashu_mint_operations WHERE id = ?',
+        ['legacy-mint-op'],
+      );
+      const proof = await db.get<{
+        secret: string;
+        createdByMintIssuanceAttemptId: string | null;
+      }>(
+        `SELECT secret, createdByMintIssuanceAttemptId
+       FROM coco_cashu_proofs WHERE mintUrl = ? AND secret = ?`,
+        ['https://mint.test', 'legacy-secret'],
+      );
+      const attemptTables = await db.all<{ name: string }>(
+        `SELECT name FROM sqlite_master
+       WHERE type = 'table' AND name LIKE 'coco_cashu_mint_issuance_attempt%'
+       ORDER BY name`,
+      );
+
+      expect(operation).toEqual({ id: 'legacy-mint-op', mintIssuanceAttemptId: null });
+      expect(proof).toEqual({
+        secret: 'legacy-secret',
+        createdByMintIssuanceAttemptId: null,
+      });
+      expect(attemptTables.map((row) => row.name)).toEqual([
+        'coco_cashu_mint_issuance_attempt_members',
+        'coco_cashu_mint_issuance_attempts',
+      ]);
+    },
+  );
 
   itWithDatabase('upgrades mint operations to allow failed state persistence', async (db) => {
     await ensureSchemaUpTo(db, '020_mint_operations_failed_state');

--- a/packages/sqlite-bun/src/index.ts
+++ b/packages/sqlite-bun/src/index.ts
@@ -21,6 +21,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: Repositories['meltOperationRepository'];
   readonly authSessionRepository: Repositories['authSessionRepository'];
   readonly mintOperationRepository: Repositories['mintOperationRepository'];
+  readonly mintIssuanceAttemptRepository: Repositories['mintIssuanceAttemptRepository'];
   readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
   readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
   readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
@@ -44,6 +45,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = this.repositories.meltOperationRepository;
     this.authSessionRepository = this.repositories.authSessionRepository;
     this.mintOperationRepository = this.repositories.mintOperationRepository;
+    this.mintIssuanceAttemptRepository = this.repositories.mintIssuanceAttemptRepository;
     this.receiveOperationRepository = this.repositories.receiveOperationRepository;
     this.paymentRequestReceiveOperationRepository =
       this.repositories.paymentRequestReceiveOperationRepository;

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -5,6 +5,8 @@ import {
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
+  runMintIssuanceAttemptRepositoryContract,
+  runMintIssuanceProvenanceRepositoryContract,
   runPaymentRequestReceiveRepositoryContract,
   runReceiveOperationRepositoryContract,
   runSendOperationRepositoryContract,
@@ -55,6 +57,10 @@ runAuthSessionRepositoryContract({ createRepositories }, { describe, it, expect 
 runProofRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runMintOperationRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceAttemptRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceProvenanceRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runReceiveOperationRepositoryContract({ createRepositories }, { describe, it, expect });
 

--- a/packages/sqlite3/src/index.ts
+++ b/packages/sqlite3/src/index.ts
@@ -21,6 +21,7 @@ export class SqliteRepositories implements Repositories {
   readonly meltOperationRepository: Repositories['meltOperationRepository'];
   readonly authSessionRepository: Repositories['authSessionRepository'];
   readonly mintOperationRepository: Repositories['mintOperationRepository'];
+  readonly mintIssuanceAttemptRepository: Repositories['mintIssuanceAttemptRepository'];
   readonly receiveOperationRepository: Repositories['receiveOperationRepository'];
   readonly paymentRequestReceiveOperationRepository: Repositories['paymentRequestReceiveOperationRepository'];
   readonly paymentRequestReceiveAttemptRepository: Repositories['paymentRequestReceiveAttemptRepository'];
@@ -44,6 +45,7 @@ export class SqliteRepositories implements Repositories {
     this.meltOperationRepository = this.repositories.meltOperationRepository;
     this.authSessionRepository = this.repositories.authSessionRepository;
     this.mintOperationRepository = this.repositories.mintOperationRepository;
+    this.mintIssuanceAttemptRepository = this.repositories.mintIssuanceAttemptRepository;
     this.receiveOperationRepository = this.repositories.receiveOperationRepository;
     this.paymentRequestReceiveOperationRepository =
       this.repositories.paymentRequestReceiveOperationRepository;

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -5,6 +5,8 @@ import {
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
+  runMintIssuanceAttemptRepositoryContract,
+  runMintIssuanceProvenanceRepositoryContract,
   runPaymentRequestReceiveRepositoryContract,
   runReceiveOperationRepositoryContract,
   runSendOperationRepositoryContract,
@@ -55,6 +57,10 @@ runAuthSessionRepositoryContract({ createRepositories }, { describe, it, expect 
 runProofRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runMintOperationRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceAttemptRepositoryContract({ createRepositories }, { describe, it, expect });
+
+runMintIssuanceProvenanceRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runReceiveOperationRepositoryContract({ createRepositories }, { describe, it, expect });
 


### PR DESCRIPTION
## Summary

This draft is PR2 of #373. It adds one durable Mint Issuance Attempt model for eligible one-member BOLT11 issuance without introducing transparent multi-operation batching yet.

The completed foundation retains exact aggregate recovery material across every storage adapter. The remaining PR2 slices will route eligible issuance through that record and recover interrupted requests by exact replay and NUT-09 Restore.

## PR2 scope

- [x] #377 — persist immutable Mint Issuance Attempts, ordered membership, and attempt-level provenance across memory, SQL, IndexedDB, and package wrappers
- [ ] #378 — issue eligible one-member BOLT11 Mint Operations through the durable issuance engine
- [ ] #379 — recover prepared and submitted attempts while preserving ambiguous outcomes

## Why

Coco needs crash-safe BOLT11 issuance before transparent batching can be added. Persisting exact outputs, submission state, member identity, counters, operations, and proof provenance atomically prevents retries from inventing replacement recovery material or reporting success without proofs.

## Compatibility

The adapter repository contract expands with `mintIssuanceAttemptRepository`. SQL adds migration 037 and IndexedDB advances to schema version 32. Legacy Mint Operation and proof records remain readable.

## Verification

- `bun run build`
- `bun run typecheck`
- Core unit suite: 1,114 passed
- Focused issuance-attempt tests: 13 passed
- SQLite-Bun contract: 65 passed
- SQLite3 contract: 65 passed
- Expo SQLite contract: 67 passed
- IndexedDB Chromium contract: 58 passed
- SQL migration tests: 26 passed

## Changeset

Added `.changeset/durable-mint-issuance-attempt-persistence.md`.

Closes #377.
Closes #378.
Closes #379.