### PR TITLE
feat(core): issue BOLT11 through durable attempts

### DIFF
--- a/.changeset/durable-mint-issuance-attempt-persistence.md
+++ b/.changeset/durable-mint-issuance-attempt-persistence.md
@@ -7,9 +7,11 @@
 '@cashu/coco-expo-sqlite': patch
 ---
 
-Add immutable Mint Issuance Attempt persistence across every maintained repository adapter.
+Add durable one-member BOLT11 Mint Issuance Attempts and their persistence across every maintained
+repository adapter.
 
 Attempts retain ordered operation and quote membership with contributed amounts, one aggregate
 serialized output set, legal compare-and-transition lifecycle changes, and transactionally atomic
 participation with counters, Mint Operations, and proofs. Existing operation and proof rows remain
-readable while new rows can retain attempt-level provenance.
+readable while eligible unlocked BOLT11 issuance now uses write-ahead submission, validates a
+complete signature vector, and saves proofs with attempt-level provenance.

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -33,6 +33,7 @@ import {
 import { SendOperationService } from './operations/send/SendOperationService';
 import { MeltOperationService } from './operations/melt/MeltOperationService';
 import { MintOperationService } from './operations/mint/MintOperationService';
+import { MintIssuanceEngine } from './operations/mint/MintIssuanceEngine.ts';
 import { ReceiveOperationService } from './operations/receive/ReceiveOperationService';
 import { MintScopedLock } from './operations/MintScopedLock';
 import {
@@ -1002,6 +1003,15 @@ export class Manager {
     const meltOperationRepository = repositories.meltOperationRepository;
 
     const mintOperationLogger = this.getChildLogger('MintOperationService');
+    const mintIssuanceEngine = new MintIssuanceEngine({
+      repositories,
+      proofService,
+      walletService,
+      transport: this.mintAdapter,
+      eventBus: this.eventBus,
+      logger: this.getChildLogger('MintIssuanceEngine'),
+      mintScopedLock,
+    });
     const mintOperationService = new MintOperationService(
       mintHandlerProvider,
       repositories.mintOperationRepository,
@@ -1014,6 +1024,7 @@ export class Manager {
       this.eventBus,
       mintOperationLogger,
       mintScopedLock,
+      mintIssuanceEngine,
     );
     const mintOperationRepository = repositories.mintOperationRepository;
 

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -1025,6 +1025,7 @@ export class Manager {
       mintOperationLogger,
       mintScopedLock,
       mintIssuanceEngine,
+      repositories,
     );
     const mintOperationRepository = repositories.mintOperationRepository;
 

--- a/packages/core/infra/MintAdapter.ts
+++ b/packages/core/infra/MintAdapter.ts
@@ -4,6 +4,8 @@ import {
   type Keys,
   type OutputDataLike,
   type Proof,
+  type SerializedBlindedMessage,
+  type SerializedBlindedSignature,
   type MeltQuoteBolt11Response,
   type MeltQuoteBolt12Response,
   type MeltQuoteOnchainResponse,
@@ -114,6 +116,16 @@ export class MintAdapter {
       requestBody: { quotes: quoteIds },
       ...(Object.keys(headers).length > 0 ? { headers } : {}),
     });
+  }
+
+  /** Submit one ordinary BOLT11 mint request and return its blinded signatures. */
+  async mintBolt11(
+    mintUrl: string,
+    quoteId: string,
+    outputs: SerializedBlindedMessage[],
+  ): Promise<SerializedBlindedSignature[]> {
+    const response = await this.getCashuMint(mintUrl).mintBolt11({ quote: quoteId, outputs });
+    return response.signatures;
   }
 
   // Check current state of a bolt11 melt quote (returns full response including change)

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -59,17 +59,19 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
 
     assertSameUnit(quote.unit, ctx.operation.unit, `Mint quote ${quote.quote}`);
 
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: quote.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
+    const outputData = quote.pubkey
+      ? await ctx.proofService.createOutputsAndIncrementCounters(
+          ctx.operation.mintUrl,
+          {
+            keep: { amount: quote.amount, unit: ctx.operation.unit },
+            send: { amount: Amount.zero(), unit: ctx.operation.unit },
+          },
+          {},
+        )
+      : { keep: [], send: [] };
 
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for mint operation');
+    if (quote.pubkey && outputData.keep.length === 0) {
+      throw new Error('Failed to create deterministic outputs for locked mint operation');
     }
 
     return {

--- a/packages/core/models/Error.ts
+++ b/packages/core/models/Error.ts
@@ -138,3 +138,15 @@ export class QuoteIdentityConflictError extends Error {
     this.methods = [...methods];
   }
 }
+
+/**
+ * Indicates that durable mint issuance could not continue because its persisted state violated
+ * an issuance invariant.
+ */
+export class MintIssuanceError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'MintIssuanceError';
+    (this as unknown as { cause?: unknown }).cause = cause;
+  }
+}

--- a/packages/core/operations/mint/MintIssuanceEngine.ts
+++ b/packages/core/operations/mint/MintIssuanceEngine.ts
@@ -1,0 +1,414 @@
+import {
+  Amount,
+  type SerializedBlindedMessage,
+  type SerializedBlindedSignature,
+} from '@cashu/cashu-ts';
+import type { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+import type { Logger } from '../../logging/Logger.ts';
+import { getMintQuoteAmount, type MintQuote } from '../../models/MintQuote.ts';
+import type { Repositories, RepositoryTransactionScope } from '../../repositories/index.ts';
+import type { ProofService } from '../../services/ProofService.ts';
+import type { WalletService } from '../../services/WalletService.ts';
+import {
+  deserializeOutputData,
+  generateSubId,
+  mapProofToCoreProof,
+  normalizeMintUrl,
+  type SerializedOutputData,
+} from '../../utils.ts';
+import { MintScopedLock } from '../MintScopedLock.ts';
+import type { MintIssuanceAttempt, PreparedMintIssuanceAttempt } from './MintIssuanceAttempt.ts';
+import type {
+  ExecutingMintOperation,
+  FinalizedMintOperation,
+  MintOperation,
+  PendingMintOperation,
+} from './MintOperation.ts';
+
+const emptyOutputData = (): SerializedOutputData => ({ keep: [], send: [] });
+
+export interface MintIssuanceTransport {
+  mintBolt11(
+    mintUrl: string,
+    quoteId: string,
+    outputs: SerializedBlindedMessage[],
+  ): Promise<SerializedBlindedSignature[]>;
+}
+
+interface MintIssuanceEngineOptions {
+  repositories: Repositories;
+  proofService: ProofService;
+  walletService: WalletService;
+  transport: MintIssuanceTransport;
+  eventBus: EventBus<CoreEvents>;
+  logger?: Logger;
+  mintScopedLock?: MintScopedLock;
+}
+
+interface PreparedAttemptResult {
+  attempt: PreparedMintIssuanceAttempt;
+  operation: ExecutingMintOperation<'bolt11'>;
+  keysetId: string;
+  counterEnd: number;
+}
+
+interface FinalizedAttemptResult {
+  operation: FinalizedMintOperation<'bolt11'>;
+  quote: MintQuote<'bolt11'>;
+  proofs: ReturnType<typeof mapProofToCoreProof>;
+}
+
+/**
+ * Deep module for durable mint issuance and one-attempt Operation Recovery.
+ * Callers provide candidates; the module owns selection, persistence, I/O, and finalization.
+ */
+export class MintIssuanceEngine {
+  private readonly repositories: Repositories;
+  private readonly proofService: ProofService;
+  private readonly walletService: WalletService;
+  private readonly transport: MintIssuanceTransport;
+  private readonly eventBus: EventBus<CoreEvents>;
+  private readonly logger?: Logger;
+  private readonly mintScopedLock: MintScopedLock;
+
+  constructor(options: MintIssuanceEngineOptions) {
+    this.repositories = options.repositories;
+    this.proofService = options.proofService;
+    this.walletService = options.walletService;
+    this.transport = options.transport;
+    this.eventBus = options.eventBus;
+    this.logger = options.logger;
+    this.mintScopedLock = options.mintScopedLock ?? new MintScopedLock();
+  }
+
+  async issueCandidates(candidates: MintOperation[]): Promise<MintOperation[]> {
+    for (const candidate of candidates) {
+      const current = await this.repositories.mintOperationRepository.getById(candidate.id);
+      if (!current || !(await this.isEligible(current))) continue;
+
+      return this.runWithMintLock(current.mintUrl, async (events) => {
+        const lockedCurrent = await this.repositories.mintOperationRepository.getById(current.id);
+        if (!lockedCurrent) return [];
+        if (lockedCurrent.state === 'finalized' || lockedCurrent.state === 'failed') {
+          return [lockedCurrent];
+        }
+        if (!(await this.isEligible(lockedCurrent))) return [];
+
+        const prepared = await this.prepareOne(lockedCurrent as PendingMintOperation<'bolt11'>);
+        events.push(() =>
+          this.eventBus.emit('counter:updated', {
+            mintUrl: prepared.attempt.mintUrl,
+            keysetId: prepared.keysetId,
+            counter: prepared.counterEnd,
+          }),
+        );
+        events.push(() =>
+          this.eventBus.emit('mint-op:executing', {
+            mintUrl: prepared.operation.mintUrl,
+            operationId: prepared.operation.id,
+            operation: prepared.operation,
+          }),
+        );
+        const finalized = await this.dispatchPreparedAttempt(prepared.attempt);
+        this.bufferFinalizedEvents(events, finalized);
+        return [finalized.operation];
+      });
+    }
+
+    return [];
+  }
+
+  async recoverAttempt(attempt: MintIssuanceAttempt | string): Promise<MintOperation[]> {
+    const attemptId = typeof attempt === 'string' ? attempt : attempt.id;
+    const current = await this.repositories.mintIssuanceAttemptRepository.getById(attemptId);
+    if (!current) throw new Error(`Mint Issuance Attempt ${attemptId} not found`);
+    if (current.state !== 'prepared') {
+      throw new Error(`Mint Issuance Attempt ${attemptId} requires submitted-attempt recovery`);
+    }
+
+    return this.runWithMintLock(current.mintUrl, async (events) => {
+      const finalized = await this.dispatchPreparedAttempt(current);
+      this.bufferFinalizedEvents(events, finalized);
+      return [finalized.operation];
+    });
+  }
+
+  private async runWithMintLock<T>(
+    mintUrl: string,
+    work: (events: Array<() => Promise<void>>) => Promise<T>,
+  ): Promise<T> {
+    const events: Array<() => Promise<void>> = [];
+    const release = await this.mintScopedLock.acquire(normalizeMintUrl(mintUrl));
+    let result: T | undefined;
+    let failure: unknown;
+    try {
+      result = await work(events);
+    } catch (error) {
+      failure = error;
+    } finally {
+      release();
+    }
+
+    for (const emit of events) {
+      try {
+        await emit();
+      } catch (error) {
+        this.logger?.warn('Mint issuance event listener failed', { error });
+      }
+    }
+
+    if (failure !== undefined) throw failure;
+    return result as T;
+  }
+
+  private async isEligible(operation: MintOperation): Promise<boolean> {
+    if (
+      operation.state !== 'pending' ||
+      operation.method !== 'bolt11' ||
+      operation.mintIssuanceAttemptId ||
+      !operation.amount.greaterThan(Amount.zero())
+    ) {
+      return false;
+    }
+    if (!(await this.repositories.mintRepository.isTrustedMint(operation.mintUrl))) return false;
+
+    const quote = await this.repositories.mintQuoteRepository.getMintQuote(
+      operation.mintUrl,
+      'bolt11',
+      operation.quoteId,
+    );
+    return this.matchesEligibleQuote(operation as PendingMintOperation<'bolt11'>, quote);
+  }
+
+  private matchesEligibleQuote(
+    operation: PendingMintOperation<'bolt11'>,
+    quote: MintQuote | null,
+  ): quote is MintQuote<'bolt11'> {
+    const fixedAmount = quote ? getMintQuoteAmount(quote) : undefined;
+    return Boolean(
+      quote &&
+      quote.method === 'bolt11' &&
+      !quote.reusable &&
+      !quote.pubkey &&
+      quote.state === 'PAID' &&
+      fixedAmount &&
+      fixedAmount.equals(operation.amount) &&
+      quote.unit === operation.unit,
+    );
+  }
+
+  private async prepareOne(
+    candidate: PendingMintOperation<'bolt11'>,
+  ): Promise<PreparedAttemptResult> {
+    const mintUrl = normalizeMintUrl(candidate.mintUrl);
+    const incomplete =
+      await this.repositories.mintIssuanceAttemptRepository.listIncomplete(mintUrl);
+    if (incomplete.length > 0) {
+      throw new Error(
+        `Mint ${mintUrl} already has incomplete Mint Issuance Attempt ${incomplete[0]!.id}`,
+      );
+    }
+
+    const { keysetId } = await this.walletService.getWalletWithActiveKeysetId(
+      mintUrl,
+      candidate.unit,
+    );
+    const storedCounter = await this.repositories.counterRepository.getCounter(mintUrl, keysetId);
+    const counterStart = storedCounter?.counter ?? 0;
+    const outputs = await this.proofService.createMintOutputsAtCounter(
+      mintUrl,
+      { amount: candidate.amount, unit: candidate.unit },
+      counterStart,
+    );
+    if (outputs.keysetId !== keysetId) {
+      throw new Error('Active keyset changed during Mint Issuance Attempt construction');
+    }
+
+    const attemptId = generateSubId();
+    return this.repositories.withTransaction(async (tx) => {
+      const operation = await tx.mintOperationRepository.getById(candidate.id);
+      if (!operation || operation.state !== 'pending' || operation.method !== 'bolt11') {
+        throw new Error(`Mint Operation ${candidate.id} is no longer eligible for issuance`);
+      }
+      if (operation.mintIssuanceAttemptId) {
+        throw new Error(`Mint Operation ${candidate.id} is already attached to an attempt`);
+      }
+      if (!(await tx.mintRepository.isTrustedMint(mintUrl))) {
+        throw new Error(`Mint ${mintUrl} is no longer trusted`);
+      }
+      const quote = await tx.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', operation.quoteId);
+      if (!this.matchesEligibleQuote(operation as PendingMintOperation<'bolt11'>, quote)) {
+        throw new Error(`Mint Operation ${candidate.id} is no longer eligible for issuance`);
+      }
+      const bolt11Operation = operation as PendingMintOperation<'bolt11'>;
+      if ((await tx.mintIssuanceAttemptRepository.listIncomplete(mintUrl)).length > 0) {
+        throw new Error(`Mint ${mintUrl} already has an incomplete Mint Issuance Attempt`);
+      }
+      const counter = await tx.counterRepository.getCounter(mintUrl, keysetId);
+      if ((counter?.counter ?? 0) !== counterStart) {
+        throw new Error('Deterministic counter changed before attempt creation committed');
+      }
+
+      const createdAt = Date.now();
+      const attempt: PreparedMintIssuanceAttempt = {
+        id: attemptId,
+        mintUrl,
+        unit: operation.unit,
+        state: 'prepared',
+        members: [
+          {
+            operationId: bolt11Operation.id,
+            quoteId: bolt11Operation.quoteId,
+            amount: bolt11Operation.amount,
+          },
+        ],
+        outputData: outputs.outputData,
+        createdAt,
+      };
+      const executing: ExecutingMintOperation<'bolt11'> = {
+        ...bolt11Operation,
+        state: 'executing',
+        mintIssuanceAttemptId: attempt.id,
+        outputData: emptyOutputData(),
+        error: undefined,
+        updatedAt: createdAt,
+      };
+      await tx.mintIssuanceAttemptRepository.create(attempt);
+      await tx.mintOperationRepository.update(executing);
+      await tx.counterRepository.setCounter(mintUrl, keysetId, outputs.counterEnd);
+      return {
+        attempt,
+        operation: executing,
+        keysetId,
+        counterEnd: outputs.counterEnd,
+      };
+    });
+  }
+
+  private async dispatchPreparedAttempt(
+    attempt: PreparedMintIssuanceAttempt,
+  ): Promise<FinalizedAttemptResult> {
+    const member = attempt.members[0];
+    if (!member || attempt.members.length !== 1) {
+      throw new Error(`Mint Issuance Attempt ${attempt.id} is not a one-member attempt`);
+    }
+
+    const submittedAt = Date.now();
+    const submitted = await this.repositories.mintIssuanceAttemptRepository.compareAndTransition(
+      attempt.id,
+      { from: 'prepared', to: 'submitted', submittedAt },
+    );
+    if (!submitted) throw new Error(`Mint Issuance Attempt ${attempt.id} is no longer prepared`);
+
+    const outputs = deserializeOutputData(attempt.outputData);
+    if (outputs.send.length > 0 || outputs.keep.length === 0) {
+      throw new Error(`Mint Issuance Attempt ${attempt.id} has invalid aggregate outputs`);
+    }
+    const signatures = await this.transport.mintBolt11(
+      attempt.mintUrl,
+      member.quoteId,
+      outputs.keep.map((output) => output.blindedMessage),
+    );
+    const proofs = await this.proofService.createProofsFromMintSignatures(
+      attempt.mintUrl,
+      attempt.outputData,
+      signatures,
+      attempt.unit,
+    );
+    const coreProofs = mapProofToCoreProof(attempt.mintUrl, 'ready', proofs, {
+      unit: attempt.unit,
+      createdByMintIssuanceAttemptId: attempt.id,
+    });
+
+    return this.repositories.withTransaction(async (tx) =>
+      this.finalizeAttempt(tx, attempt, submittedAt, coreProofs),
+    );
+  }
+
+  private async finalizeAttempt(
+    tx: RepositoryTransactionScope,
+    attempt: PreparedMintIssuanceAttempt,
+    submittedAt: number,
+    coreProofs: ReturnType<typeof mapProofToCoreProof>,
+  ): Promise<FinalizedAttemptResult> {
+    const currentAttempt = await tx.mintIssuanceAttemptRepository.getById(attempt.id);
+    const member = attempt.members[0]!;
+    const operation = await tx.mintOperationRepository.getById(member.operationId);
+    if (currentAttempt?.state !== 'submitted') {
+      throw new Error(`Mint Issuance Attempt ${attempt.id} is no longer submitted`);
+    }
+    if (
+      !operation ||
+      operation.state !== 'executing' ||
+      operation.method !== 'bolt11' ||
+      operation.mintIssuanceAttemptId !== attempt.id
+    ) {
+      throw new Error(`Mint Issuance Attempt ${attempt.id} no longer owns its member`);
+    }
+    const executing = operation as ExecutingMintOperation<'bolt11'>;
+
+    await tx.proofRepository.saveProofs(attempt.mintUrl, coreProofs);
+    await tx.mintQuoteRepository.setMintQuoteState(
+      attempt.mintUrl,
+      'bolt11',
+      member.quoteId,
+      'ISSUED',
+      submittedAt,
+    );
+    const quote = await tx.mintQuoteRepository.getMintQuote(
+      attempt.mintUrl,
+      'bolt11',
+      member.quoteId,
+    );
+    if (!quote || quote.method !== 'bolt11') {
+      throw new Error(`Mint quote ${member.quoteId} disappeared during finalization`);
+    }
+
+    const finalized: FinalizedMintOperation<'bolt11'> = {
+      ...executing,
+      state: 'finalized',
+      outputData: emptyOutputData(),
+      error: undefined,
+      updatedAt: Date.now(),
+    };
+    await tx.mintOperationRepository.update(finalized);
+    const succeeded = await tx.mintIssuanceAttemptRepository.compareAndTransition(attempt.id, {
+      from: 'submitted',
+      to: 'succeeded',
+    });
+    if (!succeeded) throw new Error(`Mint Issuance Attempt ${attempt.id} could not succeed`);
+    return { operation: finalized, quote, proofs: coreProofs };
+  }
+
+  private bufferFinalizedEvents(
+    events: Array<() => Promise<void>>,
+    finalized: FinalizedAttemptResult,
+  ): void {
+    for (const keysetId of new Set(finalized.proofs.map((proof) => proof.id))) {
+      const proofs = finalized.proofs.filter((proof) => proof.id === keysetId);
+      events.push(() =>
+        this.eventBus.emit('proofs:saved', {
+          mintUrl: finalized.operation.mintUrl,
+          keysetId,
+          proofs,
+        }),
+      );
+    }
+    events.push(() =>
+      this.eventBus.emit('mint-quote:updated', {
+        mintUrl: finalized.quote.mintUrl,
+        method: 'bolt11',
+        quoteId: finalized.quote.quoteId,
+        quote: finalized.quote,
+      }),
+    );
+    events.push(() =>
+      this.eventBus.emit('mint-op:finalized', {
+        mintUrl: finalized.operation.mintUrl,
+        operationId: finalized.operation.id,
+        operation: finalized.operation,
+      }),
+    );
+  }
+}

--- a/packages/core/operations/mint/MintIssuanceEngine.ts
+++ b/packages/core/operations/mint/MintIssuanceEngine.ts
@@ -6,6 +6,7 @@ import {
 import type { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { Logger } from '../../logging/Logger.ts';
+import { MintIssuanceError } from '../../models/Error.ts';
 import { getMintQuoteAmount, type MintQuote } from '../../models/MintQuote.ts';
 import type { Repositories, RepositoryTransactionScope } from '../../repositories/index.ts';
 import type { ProofService } from '../../services/ProofService.ts';
@@ -28,6 +29,7 @@ import type {
 
 const emptyOutputData = (): SerializedOutputData => ({ keep: [], send: [] });
 
+/** Narrow transport seam for submitting a prepared BOLT11 issuance request. */
 export interface MintIssuanceTransport {
   mintBolt11(
     mintUrl: string,
@@ -82,6 +84,10 @@ export class MintIssuanceEngine {
     this.mintScopedLock = options.mintScopedLock ?? new MintScopedLock();
   }
 
+  /**
+   * Selects and issues at most one eligible operation from the supplied candidates.
+   * Returns an empty list when none are eligible and owns persistence through finalization.
+   */
   async issueCandidates(candidates: MintOperation[]): Promise<MintOperation[]> {
     for (const candidate of candidates) {
       const current = await this.repositories.mintOperationRepository.getById(candidate.id);
@@ -119,12 +125,18 @@ export class MintIssuanceEngine {
     return [];
   }
 
+  /**
+   * Resumes one prepared attempt through submission and finalization.
+   * Submitted-attempt reconciliation is intentionally handled by the follow-up recovery slice.
+   */
   async recoverAttempt(attempt: MintIssuanceAttempt | string): Promise<MintOperation[]> {
     const attemptId = typeof attempt === 'string' ? attempt : attempt.id;
     const current = await this.repositories.mintIssuanceAttemptRepository.getById(attemptId);
-    if (!current) throw new Error(`Mint Issuance Attempt ${attemptId} not found`);
+    if (!current) throw new MintIssuanceError(`Mint Issuance Attempt ${attemptId} not found`);
     if (current.state !== 'prepared') {
-      throw new Error(`Mint Issuance Attempt ${attemptId} requires submitted-attempt recovery`);
+      throw new MintIssuanceError(
+        `Mint Issuance Attempt ${attemptId} requires submitted-attempt recovery`,
+      );
     }
 
     return this.runWithMintLock(current.mintUrl, async (events) => {
@@ -154,7 +166,10 @@ export class MintIssuanceEngine {
       try {
         await emit();
       } catch (error) {
-        this.logger?.warn('Mint issuance event listener failed', { error });
+        this.logger?.warn('Mint issuance event listener failed', {
+          mintUrl: normalizeMintUrl(mintUrl),
+          error,
+        });
       }
     }
 
@@ -205,7 +220,7 @@ export class MintIssuanceEngine {
     const incomplete =
       await this.repositories.mintIssuanceAttemptRepository.listIncomplete(mintUrl);
     if (incomplete.length > 0) {
-      throw new Error(
+      throw new MintIssuanceError(
         `Mint ${mintUrl} already has incomplete Mint Issuance Attempt ${incomplete[0]!.id}`,
       );
     }
@@ -222,32 +237,44 @@ export class MintIssuanceEngine {
       counterStart,
     );
     if (outputs.keysetId !== keysetId) {
-      throw new Error('Active keyset changed during Mint Issuance Attempt construction');
+      throw new MintIssuanceError(
+        'Active keyset changed during Mint Issuance Attempt construction',
+      );
     }
 
     const attemptId = generateSubId();
     return this.repositories.withTransaction(async (tx) => {
       const operation = await tx.mintOperationRepository.getById(candidate.id);
       if (!operation || operation.state !== 'pending' || operation.method !== 'bolt11') {
-        throw new Error(`Mint Operation ${candidate.id} is no longer eligible for issuance`);
+        throw new MintIssuanceError(
+          `Mint Operation ${candidate.id} is no longer eligible for issuance`,
+        );
       }
       if (operation.mintIssuanceAttemptId) {
-        throw new Error(`Mint Operation ${candidate.id} is already attached to an attempt`);
+        throw new MintIssuanceError(
+          `Mint Operation ${candidate.id} is already attached to an attempt`,
+        );
       }
       if (!(await tx.mintRepository.isTrustedMint(mintUrl))) {
-        throw new Error(`Mint ${mintUrl} is no longer trusted`);
+        throw new MintIssuanceError(`Mint ${mintUrl} is no longer trusted`);
       }
       const quote = await tx.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', operation.quoteId);
       if (!this.matchesEligibleQuote(operation as PendingMintOperation<'bolt11'>, quote)) {
-        throw new Error(`Mint Operation ${candidate.id} is no longer eligible for issuance`);
+        throw new MintIssuanceError(
+          `Mint Operation ${candidate.id} is no longer eligible for issuance`,
+        );
       }
       const bolt11Operation = operation as PendingMintOperation<'bolt11'>;
       if ((await tx.mintIssuanceAttemptRepository.listIncomplete(mintUrl)).length > 0) {
-        throw new Error(`Mint ${mintUrl} already has an incomplete Mint Issuance Attempt`);
+        throw new MintIssuanceError(
+          `Mint ${mintUrl} already has an incomplete Mint Issuance Attempt`,
+        );
       }
       const counter = await tx.counterRepository.getCounter(mintUrl, keysetId);
       if ((counter?.counter ?? 0) !== counterStart) {
-        throw new Error('Deterministic counter changed before attempt creation committed');
+        throw new MintIssuanceError(
+          'Deterministic counter changed before attempt creation committed',
+        );
       }
 
       const createdAt = Date.now();
@@ -291,7 +318,9 @@ export class MintIssuanceEngine {
   ): Promise<FinalizedAttemptResult> {
     const member = attempt.members[0];
     if (!member || attempt.members.length !== 1) {
-      throw new Error(`Mint Issuance Attempt ${attempt.id} is not a one-member attempt`);
+      throw new MintIssuanceError(
+        `Mint Issuance Attempt ${attempt.id} is not a one-member attempt`,
+      );
     }
 
     const submittedAt = Date.now();
@@ -299,11 +328,15 @@ export class MintIssuanceEngine {
       attempt.id,
       { from: 'prepared', to: 'submitted', submittedAt },
     );
-    if (!submitted) throw new Error(`Mint Issuance Attempt ${attempt.id} is no longer prepared`);
+    if (!submitted) {
+      throw new MintIssuanceError(`Mint Issuance Attempt ${attempt.id} is no longer prepared`);
+    }
 
     const outputs = deserializeOutputData(attempt.outputData);
     if (outputs.send.length > 0 || outputs.keep.length === 0) {
-      throw new Error(`Mint Issuance Attempt ${attempt.id} has invalid aggregate outputs`);
+      throw new MintIssuanceError(
+        `Mint Issuance Attempt ${attempt.id} has invalid aggregate outputs`,
+      );
     }
     const signatures = await this.transport.mintBolt11(
       attempt.mintUrl,
@@ -336,7 +369,7 @@ export class MintIssuanceEngine {
     const member = attempt.members[0]!;
     const operation = await tx.mintOperationRepository.getById(member.operationId);
     if (currentAttempt?.state !== 'submitted') {
-      throw new Error(`Mint Issuance Attempt ${attempt.id} is no longer submitted`);
+      throw new MintIssuanceError(`Mint Issuance Attempt ${attempt.id} is no longer submitted`);
     }
     if (
       !operation ||
@@ -344,7 +377,7 @@ export class MintIssuanceEngine {
       operation.method !== 'bolt11' ||
       operation.mintIssuanceAttemptId !== attempt.id
     ) {
-      throw new Error(`Mint Issuance Attempt ${attempt.id} no longer owns its member`);
+      throw new MintIssuanceError(`Mint Issuance Attempt ${attempt.id} no longer owns its member`);
     }
     const executing = operation as ExecutingMintOperation<'bolt11'>;
 
@@ -362,7 +395,7 @@ export class MintIssuanceEngine {
       member.quoteId,
     );
     if (!quote || quote.method !== 'bolt11') {
-      throw new Error(`Mint quote ${member.quoteId} disappeared during finalization`);
+      throw new MintIssuanceError(`Mint quote ${member.quoteId} disappeared during finalization`);
     }
 
     const finalized: FinalizedMintOperation<'bolt11'> = {
@@ -377,7 +410,9 @@ export class MintIssuanceEngine {
       from: 'submitted',
       to: 'succeeded',
     });
-    if (!succeeded) throw new Error(`Mint Issuance Attempt ${attempt.id} could not succeed`);
+    if (!succeeded) {
+      throw new MintIssuanceError(`Mint Issuance Attempt ${attempt.id} could not succeed`);
+    }
     return { operation: finalized, quote, proofs: coreProofs };
   }
 

--- a/packages/core/operations/mint/MintIssuanceEngine.ts
+++ b/packages/core/operations/mint/MintIssuanceEngine.ts
@@ -140,6 +140,9 @@ export class MintIssuanceEngine {
     }
 
     return this.runWithMintLock(current.mintUrl, async (events) => {
+      if (!(await this.repositories.mintRepository.isTrustedMint(current.mintUrl))) {
+        throw new MintIssuanceError(`Mint ${current.mintUrl} is no longer trusted`);
+      }
       const finalized = await this.dispatchPreparedAttempt(current);
       this.bufferFinalizedEvents(events, finalized);
       return [finalized.operation];

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1,5 +1,5 @@
 import { Amount, type Proof } from '@cashu/cashu-ts';
-import type { MintOperationRepository, ProofRepository } from '../../repositories';
+import type { MintOperationRepository, ProofRepository, Repositories } from '../../repositories';
 import type {
   ExecutingMintOperation,
   FailedMintOperation,
@@ -36,6 +36,7 @@ import {
   serializeOutputData,
 } from '../../utils';
 import {
+  MintIssuanceError,
   OperationInProgressError,
   ProofValidationError,
   UnknownMintError,
@@ -74,6 +75,7 @@ export class MintOperationService {
   private readonly eventBus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
   private readonly mintIssuanceEngine?: MintIssuanceEngine;
+  private readonly repositories?: Repositories;
 
   private readonly operationIdLock = new OperationIdLock();
   private recoveryLock: Promise<void> | null = null;
@@ -92,6 +94,7 @@ export class MintOperationService {
     logger?: Logger,
     mintScopedLock?: MintScopedLock,
     mintIssuanceEngine?: MintIssuanceEngine,
+    repositories?: Repositories,
   ) {
     this.handlerProvider = handlerProvider;
     this.mintOperationRepository = mintOperationRepository;
@@ -105,6 +108,7 @@ export class MintOperationService {
     this.logger = logger;
     this.mintScopedLock = mintScopedLock ?? new MintScopedLock();
     this.mintIssuanceEngine = mintIssuanceEngine;
+    this.repositories = repositories;
   }
 
   private buildDeps() {
@@ -390,23 +394,9 @@ export class MintOperationService {
         pendingOp.outputData.keep.length === 0 &&
         pendingOp.outputData.send.length === 0
       ) {
-        const outputData = await this.proofService.createOutputsAndIncrementCounters(
-          pendingOp.mintUrl,
-          {
-            keep: { amount: pendingOp.amount, unit: pendingOp.unit },
-            send: { amount: Amount.zero(), unit: pendingOp.unit },
-          },
-          {},
+        pendingOp = await this.prepareLegacyBolt11Outputs(
+          pendingOp as PendingMintOperation<'bolt11'>,
         );
-        if (outputData.keep.length === 0) {
-          throw new Error('Failed to create deterministic outputs for legacy mint execution');
-        }
-        pendingOp = {
-          ...pendingOp,
-          outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
-          updatedAt: Date.now(),
-        };
-        await this.mintOperationRepository.update(pendingOp);
       }
       const executing: ExecutingMintOperation = {
         ...pendingOp,
@@ -473,6 +463,75 @@ export class MintOperationService {
     } finally {
       releaseLock();
     }
+  }
+
+  private async prepareLegacyBolt11Outputs(
+    operation: PendingMintOperation<'bolt11'>,
+  ): Promise<PendingMintOperation<'bolt11'>> {
+    if (!this.repositories) {
+      throw new Error('Repositories are required to reserve legacy BOLT11 outputs atomically');
+    }
+
+    const mintUrl = normalizeMintUrl(operation.mintUrl);
+    const releaseMintLock = await this.mintScopedLock.acquire(mintUrl);
+    let reservation: {
+      operation: PendingMintOperation<'bolt11'>;
+      counterEnd?: number;
+    };
+    let keysetId: string;
+    try {
+      ({ keysetId } = await this.walletService.getWalletWithActiveKeysetId(
+        mintUrl,
+        operation.unit,
+      ));
+      const storedCounter = await this.repositories.counterRepository.getCounter(mintUrl, keysetId);
+      const counterStart = storedCounter?.counter ?? 0;
+      const outputs = await this.proofService.createMintOutputsAtCounter(
+        mintUrl,
+        { amount: operation.amount, unit: operation.unit },
+        counterStart,
+      );
+      if (outputs.keysetId !== keysetId) {
+        throw new MintIssuanceError(
+          'Active keyset changed during legacy BOLT11 output construction',
+        );
+      }
+
+      reservation = await this.repositories.withTransaction(async (tx) => {
+        const current = await tx.mintOperationRepository.getById(operation.id);
+        if (!current || current.state !== 'pending' || current.method !== 'bolt11') {
+          throw new MintIssuanceError(`Mint Operation ${operation.id} is no longer pending`);
+        }
+        if (current.outputData.keep.length > 0 || current.outputData.send.length > 0) {
+          return { operation: current as PendingMintOperation<'bolt11'> };
+        }
+        const counter = await tx.counterRepository.getCounter(mintUrl, keysetId);
+        if ((counter?.counter ?? 0) !== counterStart) {
+          throw new MintIssuanceError(
+            'Deterministic counter changed before legacy output reservation',
+          );
+        }
+        const updated: PendingMintOperation<'bolt11'> = {
+          ...(current as PendingMintOperation<'bolt11'>),
+          outputData: outputs.outputData,
+          updatedAt: Date.now(),
+        };
+        await tx.mintOperationRepository.update(updated);
+        await tx.counterRepository.setCounter(mintUrl, keysetId, outputs.counterEnd);
+        return { operation: updated, counterEnd: outputs.counterEnd };
+      });
+    } finally {
+      releaseMintLock();
+    }
+
+    if (reservation.counterEnd !== undefined) {
+      await this.eventBus.emit('counter:updated', {
+        mintUrl,
+        keysetId,
+        counter: reservation.counterEnd,
+      });
+    }
+    return reservation.operation;
   }
 
   async finalize(operationId: string): Promise<MintOperation> {

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -29,7 +29,12 @@ import type { ProofService } from '../../services/ProofService';
 import type { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
-import { generateSubId, mapProofToCoreProof, normalizeMintUrl } from '../../utils';
+import {
+  generateSubId,
+  mapProofToCoreProof,
+  normalizeMintUrl,
+  serializeOutputData,
+} from '../../utils';
 import {
   OperationInProgressError,
   ProofValidationError,
@@ -48,6 +53,7 @@ import {
 import { isMintQuoteExpired } from '../../models/MintQuoteExpiry';
 import type { MintQuoteRef } from '../../models/QuoteIdentity';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
+import type { MintIssuanceEngine } from './MintIssuanceEngine.ts';
 
 export interface ClaimMintQuoteOptions {
   autoClaimRemaining?: boolean;
@@ -67,6 +73,7 @@ export class MintOperationService {
   private readonly mintAdapter: MintAdapter;
   private readonly eventBus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
+  private readonly mintIssuanceEngine?: MintIssuanceEngine;
 
   private readonly operationIdLock = new OperationIdLock();
   private recoveryLock: Promise<void> | null = null;
@@ -84,6 +91,7 @@ export class MintOperationService {
     eventBus: EventBus<CoreEvents>,
     logger?: Logger,
     mintScopedLock?: MintScopedLock,
+    mintIssuanceEngine?: MintIssuanceEngine,
   ) {
     this.handlerProvider = handlerProvider;
     this.mintOperationRepository = mintOperationRepository;
@@ -96,6 +104,7 @@ export class MintOperationService {
     this.eventBus = eventBus;
     this.logger = logger;
     this.mintScopedLock = mintScopedLock ?? new MintScopedLock();
+    this.mintIssuanceEngine = mintIssuanceEngine;
   }
 
   private buildDeps() {
@@ -354,6 +363,12 @@ export class MintOperationService {
       }
     }
 
+    if (operation?.state === 'pending' && this.mintIssuanceEngine) {
+      const issued = await this.mintIssuanceEngine.issueCandidates([operation]);
+      const result = issued.find((candidate) => candidate.id === operation.id);
+      if (result) return result;
+    }
+
     return this.executeReadyOperation(operationId);
   }
 
@@ -369,7 +384,30 @@ export class MintOperationService {
         );
       }
 
-      const pendingOp = operation as PendingMintOperation;
+      let pendingOp = operation as PendingMintOperation;
+      if (
+        pendingOp.method === 'bolt11' &&
+        pendingOp.outputData.keep.length === 0 &&
+        pendingOp.outputData.send.length === 0
+      ) {
+        const outputData = await this.proofService.createOutputsAndIncrementCounters(
+          pendingOp.mintUrl,
+          {
+            keep: { amount: pendingOp.amount, unit: pendingOp.unit },
+            send: { amount: Amount.zero(), unit: pendingOp.unit },
+          },
+          {},
+        );
+        if (outputData.keep.length === 0) {
+          throw new Error('Failed to create deterministic outputs for legacy mint execution');
+        }
+        pendingOp = {
+          ...pendingOp,
+          outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
+          updatedAt: Date.now(),
+        };
+        await this.mintOperationRepository.update(pendingOp);
+      }
       const executing: ExecutingMintOperation = {
         ...pendingOp,
         state: 'executing',
@@ -453,6 +491,12 @@ export class MintOperationService {
     }
 
     if (operation.state === 'executing') {
+      if (operation.mintIssuanceAttemptId && this.mintIssuanceEngine) {
+        const recovered = await this.mintIssuanceEngine.recoverAttempt(
+          operation.mintIssuanceAttemptId,
+        );
+        return recovered.find((candidate) => candidate.id === operation.id) ?? operation;
+      }
       await this.recoverExecutingOperation(operation as ExecutingMintOperation);
       const updated = await this.mintOperationRepository.getById(operationId);
       if (updated && isTerminalOperation(updated)) {
@@ -581,6 +625,11 @@ export class MintOperationService {
       }
 
       const executing = current as ExecutingMintOperation;
+
+      if (executing.mintIssuanceAttemptId && this.mintIssuanceEngine) {
+        await this.mintIssuanceEngine.recoverAttempt(executing.mintIssuanceAttemptId);
+        return;
+      }
 
       if (await this.hasSavedOutputs(executing)) {
         await this.finalizeIssuedOperation(executing);

--- a/packages/core/operations/mint/index.ts
+++ b/packages/core/operations/mint/index.ts
@@ -1,3 +1,4 @@
 export * from './MintOperation';
 export * from './MintMethodHandler';
 export * from './MintOperationService';
+export * from './MintIssuanceEngine';

--- a/packages/core/services/ProofService.ts
+++ b/packages/core/services/ProofService.ts
@@ -38,7 +38,12 @@ import {
   normalizeUnitAmount,
   type UnitAmount,
 } from '../amounts.ts';
-import { deserializeOutputData, mapProofToCoreProof, type SerializedOutputData } from '../utils';
+import {
+  deserializeOutputData,
+  mapProofToCoreProof,
+  serializeOutputData,
+  type SerializedOutputData,
+} from '../utils';
 import type { Keyset } from '@core/models/Keyset.ts';
 
 function countBlankOutputsForAmount(amount: Amount): number {
@@ -263,6 +268,111 @@ export class ProofService {
       outputs: data.keep.length + data.send.length,
     });
     return { keep: data.keep, send: data.send, sendAmount, keepAmount };
+  }
+
+  /**
+   * Builds deterministic mint outputs without reserving their counters.
+   * The issuance engine persists the outputs and advances the counter atomically.
+   */
+  async createMintOutputsAtCounter(
+    mintUrl: string,
+    intent: UnitAmount,
+    counterStart: number,
+  ): Promise<{
+    keysetId: string;
+    outputData: SerializedOutputData;
+    counterStart: number;
+    counterEnd: number;
+  }> {
+    if (!Number.isSafeInteger(counterStart) || counterStart < 0) {
+      throw new ProofValidationError('counterStart must be a non-negative safe integer');
+    }
+
+    const { amount, unit } = normalizeUnitAmount(intent);
+    if (amount.isZero()) {
+      throw new ProofValidationError('Mint output amount must be positive');
+    }
+
+    const { keys } = await this.walletService.getWalletWithActiveKeysetId(mintUrl, unit);
+    const seed = await this.seedService.getSeed();
+    const keep = this.outputDataCreator.createDeterministicData(amount, seed, counterStart, keys);
+    if (keep.length === 0) {
+      throw new ProofValidationError('Failed to create deterministic outputs for mint operation');
+    }
+    const aggregateAmount = keep.reduce(
+      (total, output) => total.add(output.blindedMessage.amount),
+      Amount.zero(),
+    );
+    if (!aggregateAmount.equals(amount)) {
+      throw new ProofValidationError(
+        `Mint output aggregate amount ${aggregateAmount} does not match requested amount ${amount}`,
+      );
+    }
+    if (keep.some((output) => output.blindedMessage.id !== keys.id)) {
+      throw new ProofValidationError('Mint output keyset does not match the active keyset');
+    }
+
+    return {
+      keysetId: keys.id,
+      outputData: serializeOutputData({ keep, send: [] }),
+      counterStart,
+      counterEnd: counterStart + keep.length,
+    };
+  }
+
+  /** Converts a complete, positionally matched mint signature vector into proofs. */
+  async createProofsFromMintSignatures(
+    mintUrl: string,
+    outputData: SerializedOutputData,
+    signatures: SerializedBlindedSignature[],
+    unit: string,
+  ): Promise<Proof[]> {
+    const outputs = deserializeOutputData(outputData);
+    const allOutputs = [...outputs.keep, ...outputs.send];
+    if (signatures.length !== allOutputs.length) {
+      throw new ProofValidationError(
+        `Expected ${allOutputs.length} mint signatures, received ${signatures.length}`,
+      );
+    }
+
+    const normalizedUnit = normalizeUnit(unit);
+    const { keysets } = await this.mintService.ensureUpdatedMint(mintUrl);
+    const keysetMap = new Map(keysets.map((keyset) => [keyset.id, keyset]));
+
+    return allOutputs.map((output, index) => {
+      const signature = signatures[index]!;
+      const expected = output.blindedMessage;
+      if (!Amount.from(signature.amount).equals(expected.amount)) {
+        throw new ProofValidationError(`Mint signature ${index} amount does not match its output`);
+      }
+      if (signature.id !== expected.id) {
+        throw new ProofValidationError(`Mint signature ${index} keyset does not match its output`);
+      }
+      if (!signature.dleq?.e || !signature.dleq.s) {
+        throw new ProofValidationError(`Mint signature ${index} is missing required DLEQ data`);
+      }
+
+      const keyset = keysetMap.get(signature.id);
+      if (!keyset) {
+        throw new ProofValidationError(
+          `Mint signature ${index} uses unknown keyset ${signature.id}`,
+        );
+      }
+      assertSameUnit(
+        normalizeUnit(keyset.unit, { defaultUnit: DEFAULT_UNIT }),
+        normalizedUnit,
+        `Mint signature ${index} keyset`,
+      );
+
+      const proof = output.toProof(signature, {
+        id: keyset.id,
+        keys: keyset.keypairs as Keys,
+      });
+      if (!Amount.from(proof.amount).equals(expected.amount) || proof.id !== expected.id) {
+        throw new ProofValidationError(`Mint signature ${index} converted to an invalid proof`);
+      }
+      return proof;
+    });
   }
 
   async saveProofs(mintUrl: string, proofs: CoreProof[]): Promise<void> {

--- a/packages/core/test/fixtures/ScriptedMintIssuanceTransport.ts
+++ b/packages/core/test/fixtures/ScriptedMintIssuanceTransport.ts
@@ -1,0 +1,38 @@
+import type { SerializedBlindedMessage, SerializedBlindedSignature } from '@cashu/cashu-ts';
+import type { MintIssuanceTransport } from '../../operations/mint/MintIssuanceEngine.ts';
+
+export type ScriptedMintIssuanceStep =
+  | { kind: 'return'; signatures: SerializedBlindedSignature[] }
+  | { kind: 'throw'; error: unknown }
+  | {
+      kind: 'run';
+      run: (request: {
+        mintUrl: string;
+        quoteId: string;
+        outputs: SerializedBlindedMessage[];
+      }) => Promise<SerializedBlindedSignature[]>;
+    };
+
+/** Deterministic mint transport adapter for issuance-engine tests. */
+export class ScriptedMintIssuanceTransport implements MintIssuanceTransport {
+  readonly requests: Array<{
+    mintUrl: string;
+    quoteId: string;
+    outputs: SerializedBlindedMessage[];
+  }> = [];
+
+  constructor(private readonly steps: ScriptedMintIssuanceStep[]) {}
+
+  async mintBolt11(
+    mintUrl: string,
+    quoteId: string,
+    outputs: SerializedBlindedMessage[],
+  ): Promise<SerializedBlindedSignature[]> {
+    this.requests.push({ mintUrl, quoteId, outputs });
+    const step = this.steps.shift();
+    if (!step) throw new Error('No scripted BOLT11 mint result remains');
+    if (step.kind === 'throw') throw step.error;
+    if (step.kind === 'run') return step.run({ mintUrl, quoteId, outputs });
+    return step.signatures;
+  }
+}

--- a/packages/core/test/unit/MintIssuanceEngine.test.ts
+++ b/packages/core/test/unit/MintIssuanceEngine.test.ts
@@ -254,6 +254,44 @@ describe('MintIssuanceEngine', () => {
     });
   });
 
+  it('does not recover a prepared attempt after its mint is untrusted', async () => {
+    const transition = Object.getPrototypeOf(repositories.mintIssuanceAttemptRepository)
+      .compareAndTransition as typeof repositories.mintIssuanceAttemptRepository.compareAndTransition;
+    let interruptSubmission = true;
+    repositories.mintIssuanceAttemptRepository.compareAndTransition = async function (
+      attemptId,
+      next,
+    ) {
+      if (interruptSubmission && next.to === 'submitted') {
+        throw new Error('interrupted after prepare commit');
+      }
+      return transition.call(this, attemptId, next);
+    };
+    await expect(
+      makeEngine(new ScriptedMintIssuanceTransport([])).issueCandidates([pendingOperation()]),
+    ).rejects.toThrow('interrupted after prepare commit');
+    const prepared =
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+    expect(prepared?.state).toBe('prepared');
+    interruptSubmission = false;
+    await repositories.mintRepository.setMintTrusted(mintUrl, false);
+    const recoveryTransport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+
+    await expect(makeEngine(recoveryTransport).recoverAttempt(prepared!)).rejects.toThrow(
+      `Mint ${mintUrl} is no longer trusted`,
+    );
+
+    expect(recoveryTransport.requests).toHaveLength(0);
+    expect(
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1'),
+    ).toEqual(prepared);
+    expect((await repositories.mintOperationRepository.getById('mint-op-1'))?.state).toBe(
+      'executing',
+    );
+  });
+
   it.each([
     ['wrong signature count', []],
     ['wrong amount', [{ ...validSignature(), amount: Amount.from(9) }]],

--- a/packages/core/test/unit/MintIssuanceEngine.test.ts
+++ b/packages/core/test/unit/MintIssuanceEngine.test.ts
@@ -1,0 +1,511 @@
+import {
+  Amount,
+  OutputData,
+  type OutputDataLike,
+  type Proof,
+  type SerializedBlindedSignature,
+} from '@cashu/cashu-ts';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+import { mintQuoteFromBolt11Response } from '../../models/MintQuote.ts';
+import { MintScopedLock } from '../../operations/MintScopedLock.ts';
+import { MintIssuanceEngine } from '../../operations/mint/MintIssuanceEngine.ts';
+import type { PendingMintOperation } from '../../operations/mint/MintOperation.ts';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { CounterService } from '../../services/CounterService.ts';
+import { ProofService } from '../../services/ProofService.ts';
+import { SeedService } from '../../services/SeedService.ts';
+import type { WalletService } from '../../services/WalletService.ts';
+import { makeOutputDataCreator } from '../fixtures/OutputDataCreator.ts';
+import { ScriptedMintIssuanceTransport } from '../fixtures/ScriptedMintIssuanceTransport.ts';
+
+describe('MintIssuanceEngine', () => {
+  const mintUrl = 'https://mint.test';
+  const quoteId = 'quote-1';
+  const keysetId = 'keyset-1';
+  const now = 1_000;
+
+  let repositories: MemoryRepositories;
+  let eventBus: EventBus<CoreEvents>;
+  let proofService: ProofService;
+  let walletService: WalletService;
+  let originalToProof: typeof OutputData.prototype.toProof;
+
+  const pendingOperation = (): PendingMintOperation<'bolt11'> => ({
+    id: 'mint-op-1',
+    mintUrl,
+    method: 'bolt11',
+    methodData: {},
+    state: 'pending',
+    quoteId,
+    amount: Amount.from(10),
+    unit: 'sat',
+    request: 'lnbc1test',
+    expiry: 10_000,
+    outputData: { keep: [], send: [] },
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const validSignature = (): SerializedBlindedSignature => ({
+    id: keysetId,
+    amount: Amount.from(10),
+    C_: 'C_1',
+    dleq: { e: '01', s: '02' },
+  });
+
+  function makeEngine(
+    transport: ScriptedMintIssuanceTransport,
+    options: { proofService?: ProofService; mintScopedLock?: MintScopedLock } = {},
+  ): MintIssuanceEngine {
+    return new MintIssuanceEngine({
+      repositories,
+      proofService: options.proofService ?? proofService,
+      walletService,
+      transport,
+      eventBus,
+      mintScopedLock: options.mintScopedLock,
+    });
+  }
+
+  beforeEach(async () => {
+    repositories = new MemoryRepositories();
+    eventBus = new EventBus<CoreEvents>();
+    originalToProof = OutputData.prototype.toProof;
+    OutputData.prototype.toProof = mock(function (): Proof {
+      return {
+        id: keysetId,
+        amount: Amount.from(10),
+        secret: 'secret-0',
+        C: 'C_1',
+        dleq: { e: '01', s: '02', r: '03' },
+      } as Proof;
+    });
+
+    walletService = {
+      async getWalletWithActiveKeysetId() {
+        return { keys: { id: keysetId }, keysetId };
+      },
+    } as never;
+    const mintService = {
+      async ensureUpdatedMint() {
+        return {
+          mint: {},
+          keysets: [
+            {
+              id: keysetId,
+              unit: 'sat',
+              keypairs: {},
+              active: true,
+              feePpk: 0,
+              mintUrl,
+              updatedAt: now,
+            },
+          ],
+        };
+      },
+    };
+    const outputDataCreator = makeOutputDataCreator({
+      createDeterministicData(amount, _seed, counter, keys) {
+        return [
+          new OutputData(
+            { amount: Amount.from(amount), id: keys.id, B_: `B_${counter}` },
+            BigInt(counter + 1),
+            new TextEncoder().encode(`secret-${counter}`),
+          ),
+        ] as OutputDataLike[];
+      },
+    });
+    proofService = new ProofService(
+      new CounterService(repositories.counterRepository),
+      repositories.proofRepository,
+      walletService,
+      mintService as never,
+      {} as never,
+      new SeedService(async () => new Uint8Array(64).fill(7)),
+      undefined,
+      eventBus,
+      outputDataCreator,
+    );
+
+    await repositories.mintRepository.addNewMint({
+      mintUrl,
+      name: 'Test mint',
+      mintInfo: {} as never,
+      trusted: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteId,
+        request: 'lnbc1test',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: 10_000,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create(pendingOperation());
+  });
+
+  afterEach(() => {
+    OutputData.prototype.toProof = originalToProof;
+  });
+
+  it('issues one eligible BOLT11 Mint Operation through one durable attempt', async () => {
+    const transport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+    const engine = makeEngine(transport);
+
+    const issued = await engine.issueCandidates([pendingOperation()]);
+
+    expect(issued).toHaveLength(1);
+    expect(issued[0]?.state).toBe('finalized');
+    const attempts = await repositories.mintIssuanceAttemptRepository.listIncomplete(mintUrl);
+    expect(attempts).toHaveLength(0);
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+    expect(attempt?.state).toBe('succeeded');
+    expect(attempt?.members).toEqual([
+      { operationId: 'mint-op-1', quoteId, amount: Amount.from(10) },
+    ]);
+    expect(transport.requests).toHaveLength(1);
+    expect(transport.requests[0]?.quoteId).toBe(quoteId);
+    expect(transport.requests[0]?.outputs).toHaveLength(1);
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toEqual({
+      mintUrl,
+      keysetId,
+      counter: 1,
+    });
+    const proofs = await repositories.proofRepository.getReadyProofs(mintUrl, { unit: 'sat' });
+    expect(proofs).toHaveLength(1);
+    expect(proofs[0]?.createdByMintIssuanceAttemptId).toBe(attempt?.id);
+    expect(proofs[0]?.createdByOperationId).toBeUndefined();
+  });
+
+  it('marks the attempt submitted before dispatch and preserves ambiguity on transport failure', async () => {
+    const transportError = new Error('connection reset after request write');
+    const transport = new ScriptedMintIssuanceTransport([
+      {
+        kind: 'run',
+        run: async () => {
+          const attempt =
+            await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId(
+              'mint-op-1',
+            );
+          expect(attempt?.state).toBe('submitted');
+          throw transportError;
+        },
+      },
+    ]);
+
+    await expect(makeEngine(transport).issueCandidates([pendingOperation()])).rejects.toBe(
+      transportError,
+    );
+
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+    const operation = await repositories.mintOperationRepository.getById('mint-op-1');
+    expect(attempt?.state).toBe('submitted');
+    expect(operation?.state).toBe('executing');
+    expect(operation?.mintIssuanceAttemptId).toBe(attempt?.id);
+    expect(await repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(0);
+  });
+
+  it('recovers one prepared attempt through the same issuance seam', async () => {
+    const transition = Object.getPrototypeOf(repositories.mintIssuanceAttemptRepository)
+      .compareAndTransition as typeof repositories.mintIssuanceAttemptRepository.compareAndTransition;
+    let interruptSubmission = true;
+    repositories.mintIssuanceAttemptRepository.compareAndTransition = async function (
+      attemptId,
+      next,
+    ) {
+      if (interruptSubmission && next.to === 'submitted') {
+        throw new Error('interrupted after prepare commit');
+      }
+      return transition.call(this, attemptId, next);
+    };
+    const interruptedTransport = new ScriptedMintIssuanceTransport([]);
+    await expect(
+      makeEngine(interruptedTransport).issueCandidates([pendingOperation()]),
+    ).rejects.toThrow('interrupted after prepare commit');
+    const prepared =
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+    expect(prepared?.state).toBe('prepared');
+
+    interruptSubmission = false;
+    const recoveryTransport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+
+    const recovered = await makeEngine(recoveryTransport).recoverAttempt(prepared!);
+
+    expect(recovered[0]?.state).toBe('finalized');
+    expect(recoveryTransport.requests[0]?.outputs[0]?.B_).toBe(
+      prepared?.outputData.keep[0]?.blindedMessage.B_,
+    );
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toEqual({
+      mintUrl,
+      keysetId,
+      counter: 1,
+    });
+  });
+
+  it.each([
+    ['wrong signature count', []],
+    ['wrong amount', [{ ...validSignature(), amount: Amount.from(9) }]],
+    ['wrong keyset', [{ ...validSignature(), id: 'other-keyset' }]],
+    ['missing DLEQ', [{ ...validSignature(), dleq: undefined }]],
+  ] as const)(
+    'keeps a submitted attempt intact for %s',
+    async (_name, signatures: readonly SerializedBlindedSignature[]) => {
+      const transport = new ScriptedMintIssuanceTransport([
+        { kind: 'return', signatures: [...signatures] },
+      ]);
+
+      await expect(makeEngine(transport).issueCandidates([pendingOperation()])).rejects.toThrow();
+
+      const attempt =
+        await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+      expect(attempt?.state).toBe('submitted');
+      expect(await repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(0);
+      expect((await repositories.mintOperationRepository.getById('mint-op-1'))?.state).toBe(
+        'executing',
+      );
+    },
+  );
+
+  it('keeps a submitted attempt intact when proof conversion fails', async () => {
+    OutputData.prototype.toProof = mock(() => {
+      throw new Error('invalid DLEQ proof');
+    });
+    const transport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+
+    await expect(makeEngine(transport).issueCandidates([pendingOperation()])).rejects.toThrow(
+      'invalid DLEQ proof',
+    );
+
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+    expect(attempt?.state).toBe('submitted');
+    expect(await repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(0);
+  });
+
+  it('leaves no durable reservation when local output construction fails', async () => {
+    const constructionError = new Error('output construction failed');
+    const failingProofService = new ProofService(
+      new CounterService(repositories.counterRepository),
+      repositories.proofRepository,
+      walletService,
+      {
+        async ensureUpdatedMint() {
+          return { mint: {}, keysets: [] };
+        },
+      } as never,
+      {} as never,
+      new SeedService(async () => new Uint8Array(64).fill(7)),
+      undefined,
+      eventBus,
+      makeOutputDataCreator({
+        createDeterministicData() {
+          throw constructionError;
+        },
+      }),
+    );
+    const transport = new ScriptedMintIssuanceTransport([]);
+
+    await expect(
+      makeEngine(transport, { proofService: failingProofService }).issueCandidates([
+        pendingOperation(),
+      ]),
+    ).rejects.toBe(constructionError);
+
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+    expect(
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1'),
+    ).toBeNull();
+    expect((await repositories.mintOperationRepository.getById('mint-op-1'))?.state).toBe(
+      'pending',
+    );
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  it('rejects malformed aggregate outputs before reserving counters', async () => {
+    const malformedProofService = new ProofService(
+      new CounterService(repositories.counterRepository),
+      repositories.proofRepository,
+      walletService,
+      {
+        async ensureUpdatedMint() {
+          return { mint: {}, keysets: [] };
+        },
+      } as never,
+      {} as never,
+      new SeedService(async () => new Uint8Array(64).fill(7)),
+      undefined,
+      eventBus,
+      makeOutputDataCreator({
+        createDeterministicData(_amount, _seed, counter, keys) {
+          return [
+            new OutputData(
+              { amount: Amount.from(9), id: keys.id, B_: `B_${counter}` },
+              BigInt(counter + 1),
+              new TextEncoder().encode(`secret-${counter}`),
+            ),
+          ];
+        },
+      }),
+    );
+    const transport = new ScriptedMintIssuanceTransport([]);
+
+    await expect(
+      makeEngine(transport, { proofService: malformedProofService }).issueCandidates([
+        pendingOperation(),
+      ]),
+    ).rejects.toThrow('aggregate amount');
+
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+    expect(
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1'),
+    ).toBeNull();
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  it('rolls proof, quote, operation, and success persistence back atomically', async () => {
+    const transition = repositories.mintIssuanceAttemptRepository.compareAndTransition.bind(
+      repositories.mintIssuanceAttemptRepository,
+    );
+    repositories.mintIssuanceAttemptRepository.compareAndTransition = async (attemptId, next) => {
+      if (next.to === 'succeeded') throw new Error('final commit interrupted');
+      return transition(attemptId, next);
+    };
+    const transport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+
+    await expect(makeEngine(transport).issueCandidates([pendingOperation()])).rejects.toThrow(
+      'final commit interrupted',
+    );
+
+    const attempt =
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1');
+    const quote = await repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', quoteId);
+    expect(attempt?.state).toBe('submitted');
+    expect((await repositories.mintOperationRepository.getById('mint-op-1'))?.state).toBe(
+      'executing',
+    );
+    expect(quote?.state).toBe('PAID');
+    expect(await repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(0);
+  });
+
+  it('does not enter the engine for a NUT-20 locked operation', async () => {
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteId,
+        request: 'lnbc1test',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: 10_000,
+        pubkey: '02'.padEnd(66, '1'),
+        state: 'PAID',
+      }),
+    );
+    const transport = new ScriptedMintIssuanceTransport([]);
+
+    await expect(makeEngine(transport).issueCandidates([pendingOperation()])).resolves.toEqual([]);
+
+    expect(transport.requests).toHaveLength(0);
+    expect(
+      await repositories.mintIssuanceAttemptRepository.getNewestByMemberOperationId('mint-op-1'),
+    ).toBeNull();
+  });
+
+  it('creates at most one attempt from one candidate invocation', async () => {
+    const second = { ...pendingOperation(), id: 'mint-op-2', quoteId: 'quote-2', createdAt: 2_000 };
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: second.quoteId,
+        request: 'lnbc1second',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: 10_000,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create(second);
+    const transport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+
+    const issued = await makeEngine(transport).issueCandidates([pendingOperation(), second]);
+
+    expect(issued.map((operation) => operation.id)).toEqual(['mint-op-1']);
+    expect((await repositories.mintOperationRepository.getById(second.id))?.state).toBe('pending');
+    expect(transport.requests).toHaveLength(1);
+  });
+
+  it('blocks a second attempt while the mint has an incomplete attempt', async () => {
+    const firstTransportError = new Error('ambiguous first submission');
+    const firstTransport = new ScriptedMintIssuanceTransport([
+      { kind: 'throw', error: firstTransportError },
+    ]);
+    await expect(makeEngine(firstTransport).issueCandidates([pendingOperation()])).rejects.toBe(
+      firstTransportError,
+    );
+
+    const second = { ...pendingOperation(), id: 'mint-op-2', quoteId: 'quote-2', createdAt: 2_000 };
+    await repositories.mintQuoteRepository.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: second.quoteId,
+        request: 'lnbc1second',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: 10_000,
+        state: 'PAID',
+      }),
+    );
+    await repositories.mintOperationRepository.create(second);
+    const secondTransport = new ScriptedMintIssuanceTransport([]);
+
+    await expect(makeEngine(secondTransport).issueCandidates([second])).rejects.toThrow(
+      'already has incomplete Mint Issuance Attempt',
+    );
+
+    expect(secondTransport.requests).toHaveLength(0);
+    expect((await repositories.mintOperationRepository.getById(second.id))?.state).toBe('pending');
+  });
+
+  it('emits committed state changes sequentially after releasing the mint lock', async () => {
+    const lock = new MintScopedLock();
+    const observed: string[] = [];
+    eventBus.on('counter:updated', async () => {
+      observed.push('counter');
+    });
+    eventBus.on('mint-op:executing', async () => {
+      const release = await lock.acquire(mintUrl);
+      observed.push('executing');
+      release();
+    });
+    eventBus.on('proofs:saved', async () => {
+      observed.push('proofs');
+    });
+    eventBus.on('mint-quote:updated', async () => {
+      observed.push('quote');
+    });
+    eventBus.on('mint-op:finalized', async () => {
+      observed.push('finalized');
+    });
+    const transport = new ScriptedMintIssuanceTransport([
+      { kind: 'return', signatures: [validSignature()] },
+    ]);
+
+    await makeEngine(transport, { mintScopedLock: lock }).issueCandidates([pendingOperation()]);
+
+    expect(observed).toEqual(['counter', 'executing', 'proofs', 'quote', 'finalized']);
+  });
+});

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -25,6 +25,7 @@ import type { MintHandlerProvider } from '../../infra/handlers/mint';
 import { MemoryMintOperationRepository } from '../../repositories/memory/MemoryMintOperationRepository';
 import { MemoryMintQuoteRepository } from '../../repositories/memory/MemoryMintQuoteRepository';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories';
 import {
   getMintQuoteAvailableAmount,
   mintQuoteFromBolt11Response,
@@ -39,6 +40,8 @@ import type { MintAdapter } from '../../infra/MintAdapter';
 import { serializeOutputData } from '../../utils';
 import type { CoreProof } from '../../types';
 import { QuoteIdentityConflictError } from '../../models/Error';
+import { MintScopedLock } from '../../operations/MintScopedLock.ts';
+import type { Repositories, RepositoryTransactionScope } from '../../repositories/index.ts';
 
 describe('MintOperationService', () => {
   const mintUrl = 'https://mint.test';
@@ -956,6 +959,136 @@ describe('MintOperationService', () => {
     expect(finalizedEvents[0]?.operationId).toBe(finalized?.id);
     expect(finalizedEvents[0]?.operation.state).toBe('finalized');
     expect(failedEvents).toHaveLength(0);
+  });
+
+  it('atomically reserves legacy BOLT11 outputs and emits the counter after lock release', async () => {
+    const repositories = new MemoryRepositories();
+    const operation = {
+      ...makePendingOp('legacy-output-success'),
+      outputData: { keep: [], send: [] },
+    } as PendingMintOperation<'bolt11'>;
+    await repositories.mintOperationRepository.create(operation);
+
+    const outputData = makeSerializedOutputData('legacy-output-success');
+    const fallbackProofService = {
+      createMintOutputsAtCounter: mock(async () => ({
+        keysetId,
+        outputData,
+        counterStart: 0,
+        counterEnd: 1,
+      })),
+    } as unknown as ProofService;
+    const fallbackWalletService = {
+      getWalletWithActiveKeysetId: mock(async () => ({ keysetId })),
+    } as unknown as WalletService;
+    const mintScopedLock = new MintScopedLock();
+    let eventObservedAfterUnlock = false;
+    eventBus.on('counter:updated', async () => {
+      const release = await mintScopedLock.acquire(mintUrl);
+      eventObservedAfterUnlock = true;
+      release();
+    });
+    const fallbackService = new MintOperationService(
+      handlerProvider,
+      repositories.mintOperationRepository,
+      quoteLifecycle,
+      repositories.proofRepository,
+      fallbackProofService,
+      mintService,
+      fallbackWalletService,
+      mintAdapter,
+      eventBus,
+      undefined,
+      mintScopedLock,
+      undefined,
+      repositories,
+    );
+
+    const prepared = await fallbackService['prepareLegacyBolt11Outputs'](operation);
+
+    expect(prepared.outputData).toEqual(outputData);
+    const stored = (await repositories.mintOperationRepository.getById(
+      operation.id,
+    )) as PendingMintOperation;
+    expect(stored.outputData).toEqual(outputData);
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toEqual({
+      mintUrl,
+      keysetId,
+      counter: 1,
+    });
+    expect(eventObservedAfterUnlock).toBe(true);
+  });
+
+  it('rolls back legacy BOLT11 output data when counter reservation fails', async () => {
+    const repositories = new MemoryRepositories();
+    const operation = {
+      ...makePendingOp('legacy-output-rollback'),
+      outputData: { keep: [], send: [] },
+    } as PendingMintOperation<'bolt11'>;
+    await repositories.mintOperationRepository.create(operation);
+
+    const failingRepositories = new Proxy(repositories, {
+      get(target, property, receiver) {
+        if (property !== 'withTransaction') {
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        }
+        return <T>(fn: (tx: RepositoryTransactionScope) => Promise<T>) =>
+          target.withTransaction((tx) =>
+            fn({
+              ...tx,
+              counterRepository: {
+                getCounter: (...args) => tx.counterRepository.getCounter(...args),
+                setCounter: async (...args) => {
+                  await tx.counterRepository.setCounter(...args);
+                  throw new Error('counter persistence failed');
+                },
+              },
+            }),
+          );
+      },
+    }) as Repositories;
+    const fallbackProofService = {
+      createMintOutputsAtCounter: mock(async () => ({
+        keysetId,
+        outputData: makeSerializedOutputData('legacy-output-rollback'),
+        counterStart: 0,
+        counterEnd: 1,
+      })),
+    } as unknown as ProofService;
+    const fallbackWalletService = {
+      getWalletWithActiveKeysetId: mock(async () => ({ keysetId })),
+    } as unknown as WalletService;
+    const counterEvents: Array<CoreEvents['counter:updated']> = [];
+    eventBus.on('counter:updated', (event) => {
+      counterEvents.push(event);
+    });
+    const fallbackService = new MintOperationService(
+      handlerProvider,
+      repositories.mintOperationRepository,
+      quoteLifecycle,
+      repositories.proofRepository,
+      fallbackProofService,
+      mintService,
+      fallbackWalletService,
+      mintAdapter,
+      eventBus,
+      undefined,
+      undefined,
+      undefined,
+      failingRepositories,
+    );
+
+    await expect(fallbackService['prepareLegacyBolt11Outputs'](operation)).rejects.toThrow(
+      'counter persistence failed',
+    );
+
+    const stored = (await repositories.mintOperationRepository.getById(
+      operation.id,
+    )) as PendingMintOperation;
+    expect(stored.outputData).toEqual({ keep: [], send: [] });
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+    expect(counterEvents).toHaveLength(0);
   });
 
   it('finalize is idempotent after finalize', async () => {

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -151,7 +151,11 @@ export function mapProofToCoreProof(
   mintUrl: string,
   state: ProofState,
   proofs: Proof[],
-  options: { unit: string; createdByOperationId?: string },
+  options: {
+    unit: string;
+    createdByOperationId?: string;
+    createdByMintIssuanceAttemptId?: string;
+  },
 ): CoreProof[] {
   const unit = normalizeUnit(options.unit);
   return proofs.map((p) => ({
@@ -160,6 +164,7 @@ export function mapProofToCoreProof(
     unit,
     state,
     createdByOperationId: options?.createdByOperationId,
+    createdByMintIssuanceAttemptId: options?.createdByMintIssuanceAttemptId,
   }));
 }
 


### PR DESCRIPTION
## Summary

- route eligible paid, fixed-amount, unlocked BOLT11 mint operations through one durable one-member issuance attempt
- atomically reserve deterministic outputs and counters before dispatch, validate the complete signature vector, then atomically persist proofs, quote state, operation finalization, and attempt success
- preserve legacy and NUT-20-locked execution behavior, add prepared-attempt recovery, proof provenance, ordered post-lock events, and a narrow issuance transport seam

## Testing

- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' test:unit` (1,134 passed)
- focused issuance/service tests (68 passed)
- `bun run build`
- `bun run format:check`
- full core suite attempted: 1,138 tests passed and 4 integration tests could not run without the external mint/auth test environment (`MINT_URL`/auth configuration and the localhost mint)
- standards review: clean
- spec review: clean

Targets the NUT-29 integration branch from #385.

Closes #378