### PR TITLE
refactor(core): centralize mint quote observation resolution

### DIFF
--- a/packages/core/quotes/MintQuoteObservation.ts
+++ b/packages/core/quotes/MintQuoteObservation.ts
@@ -1,0 +1,80 @@
+import type { Amount } from '@cashu/cashu-ts';
+import { isStatefulMintQuote, type MintQuote } from '../models/MintQuote';
+
+const MINT_QUOTE_STATE_RANK: Record<string, number> = {
+  UNPAID: 0,
+  PAID: 1,
+  ISSUED: 2,
+};
+
+export type MintQuoteObservationPersistence = 'persist' | 'retain';
+export type MintQuoteObservationMeaningfulChange = 'changed' | 'unchanged';
+
+export interface MintQuoteObservationResolution {
+  resolvedQuote: MintQuote;
+  persistence: MintQuoteObservationPersistence;
+  meaningfulChange: MintQuoteObservationMeaningfulChange;
+}
+
+function isMintQuoteStateDowngrade(existing: MintQuote, incoming: MintQuote): boolean {
+  if (!isStatefulMintQuote(existing) || !isStatefulMintQuote(incoming)) return false;
+  return (
+    (MINT_QUOTE_STATE_RANK[incoming.state] ?? 0) < (MINT_QUOTE_STATE_RANK[existing.state] ?? 0)
+  );
+}
+
+function maxAmount(left: Amount, right: Amount): Amount {
+  return left.greaterThan(right) ? left : right;
+}
+
+function mergeReusableSettlement(existing: MintQuote, incoming: MintQuote): MintQuote {
+  if (!existing.reusable || !incoming.reusable) return incoming;
+
+  return {
+    ...incoming,
+    quoteData: {
+      ...incoming.quoteData,
+      amountPaid: maxAmount(existing.quoteData.amountPaid, incoming.quoteData.amountPaid),
+      amountIssued: maxAmount(existing.quoteData.amountIssued, incoming.quoteData.amountIssued),
+    },
+  } as MintQuote;
+}
+
+function hasMeaningfulChange(existing: MintQuote | null, incoming: MintQuote): boolean {
+  if (!existing) return true;
+  if (existing.method !== incoming.method || existing.quoteId !== incoming.quoteId) return true;
+
+  if (isStatefulMintQuote(existing) && isStatefulMintQuote(incoming)) {
+    return existing.state !== incoming.state;
+  }
+
+  if (existing.reusable && incoming.reusable) {
+    return (
+      !existing.quoteData.amountPaid.equals(incoming.quoteData.amountPaid) ||
+      !existing.quoteData.amountIssued.equals(incoming.quoteData.amountIssued)
+    );
+  }
+
+  return false;
+}
+
+/** Resolves one canonical Mint Quote Observation without performing lifecycle side effects. */
+export function resolveMintQuoteObservation(
+  existing: MintQuote | null,
+  incoming: MintQuote,
+): MintQuoteObservationResolution {
+  if (existing && isMintQuoteStateDowngrade(existing, incoming)) {
+    return {
+      resolvedQuote: existing,
+      persistence: 'retain',
+      meaningfulChange: 'unchanged',
+    };
+  }
+
+  const resolvedQuote = existing ? mergeReusableSettlement(existing, incoming) : incoming;
+  return {
+    resolvedQuote,
+    persistence: 'persist',
+    meaningfulChange: hasMeaningfulChange(existing, resolvedQuote) ? 'changed' : 'unchanged',
+  };
+}

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -57,12 +57,7 @@ import type {
   MintQuotePollingOutcome,
   MintQuotePollingResult,
 } from './MintQuotePolling.ts';
-
-const MINT_QUOTE_STATE_RANK: Record<string, number> = {
-  UNPAID: 0,
-  PAID: 1,
-  ISSUED: 2,
-};
+import { resolveMintQuoteObservation } from './MintQuoteObservation.ts';
 
 const BUILT_IN_MINT_METHODS = new Set<MintMethod>(['bolt11', 'bolt12', 'onchain']);
 const DEFINITIVE_BATCH_FAILURE_CATEGORIES = new Set<MintQuotePollingFailure['category']>([
@@ -72,22 +67,10 @@ const DEFINITIVE_BATCH_FAILURE_CATEGORIES = new Set<MintQuotePollingFailure['cat
   'validation',
 ]);
 
-function isMintQuoteStateDowngrade(
-  existing: MintMethodRemoteState,
-  incoming: MintMethodRemoteState,
-): boolean {
-  return (MINT_QUOTE_STATE_RANK[incoming] ?? 0) < (MINT_QUOTE_STATE_RANK[existing] ?? 0);
-}
-
-function maxAmount(left: Amount, right: Amount): Amount {
-  return left.greaterThan(right) ? left : right;
-}
-
-function hasReusableSettlementAmounts(snapshot: {
-  amount_paid?: unknown;
-  amount_issued?: unknown;
-}): boolean {
-  return snapshot.amount_paid !== undefined && snapshot.amount_issued !== undefined;
+function hasReusableSettlementAmounts(snapshot: unknown): boolean {
+  if (!snapshot || typeof snapshot !== 'object') return false;
+  const settlement = snapshot as { amount_paid?: unknown; amount_issued?: unknown };
+  return settlement.amount_paid !== undefined && settlement.amount_issued !== undefined;
 }
 
 function assertMintQuotePollingSnapshotStructureUnchecked(
@@ -258,37 +241,18 @@ function failedMintQuotePollingResult(
   };
 }
 
-function getRemoteStateChange(
-  existing: MintQuote | null,
-  incoming: MintQuote,
-  rawSnapshot?: MintMethodQuoteSnapshot,
-): boolean {
-  if (!existing) {
-    return true;
-  }
-
-  if (existing.method !== incoming.method || existing.quoteId !== incoming.quoteId) {
-    return true;
-  }
+function getDirectRefreshStateChange(existing: MintQuote, incoming: MintQuote): boolean {
+  if (existing.method !== incoming.method || existing.quoteId !== incoming.quoteId) return true;
 
   if (existing.method === 'bolt11' && incoming.method === 'bolt11') {
     return existing.state !== incoming.state;
   }
 
   if (existing.reusable && incoming.reusable) {
-    const snapshot = rawSnapshot as
-      | (MintMethodQuoteSnapshot<'onchain'> | MintMethodQuoteSnapshot<'bolt12'>)
-      | undefined;
-    if (!snapshot || hasReusableSettlementAmounts(snapshot)) {
-      return (
-        !existing.quoteData.amountPaid.equals(incoming.quoteData.amountPaid) ||
-        !existing.quoteData.amountIssued.equals(incoming.quoteData.amountIssued)
-      );
-    }
-
-    const existingState = (existing as { state?: unknown }).state;
-    const incomingState = (rawSnapshot as { state?: unknown }).state;
-    return incomingState !== undefined && existingState !== incomingState;
+    return (
+      !existing.quoteData.amountPaid.equals(incoming.quoteData.amountPaid) ||
+      !existing.quoteData.amountIssued.equals(incoming.quoteData.amountIssued)
+    );
   }
 
   return false;
@@ -475,7 +439,7 @@ export class QuoteLifecycle {
       quote: existingQuote,
     });
 
-    const remoteStateChanged = getRemoteStateChange(existingQuote, refreshed);
+    const remoteStateChanged = getDirectRefreshStateChange(existingQuote, refreshed);
     const quote = await this.persistCanonicalMintQuote(refreshed);
     await this.emitMintQuoteUpdatedIfNeeded(quote, remoteStateChanged);
     return quote;
@@ -1044,8 +1008,29 @@ export class QuoteLifecycle {
     quote: MintMethodQuoteSnapshot,
     beforePersist?: (quote: MintQuote) => Promise<void>,
   ): Promise<{ quote: MintQuote; remoteStateChanged: boolean }> {
-    let canonicalQuote: MintQuote;
+    const canonicalQuote = this.mintQuoteFromSnapshot(mintUrl, method, quote);
+    const { existingQuote, ...result } = await this.resolveAndPersistMintQuoteObservation(
+      canonicalQuote,
+      beforePersist,
+    );
 
+    if (existingQuote?.reusable && !hasReusableSettlementAmounts(quote)) {
+      const existingState = (existingQuote as { state?: unknown }).state;
+      const incomingState = (quote as { state?: unknown }).state;
+      return {
+        ...result,
+        remoteStateChanged: incomingState !== undefined && existingState !== incomingState,
+      };
+    }
+
+    return result;
+  }
+
+  private mintQuoteFromSnapshot(
+    mintUrl: string,
+    method: MintMethod,
+    quote: MintMethodQuoteSnapshot,
+  ): MintQuote {
     if (method === 'bolt11') {
       const bolt11Quote = quote as MintMethodQuoteSnapshot<'bolt11'>;
       const rawAmount = (bolt11Quote as { amount?: unknown }).amount;
@@ -1058,63 +1043,63 @@ export class QuoteLifecycle {
         throw new ProofValidationError('Mint quote ' + bolt11Quote.quote + ' has invalid amount');
       }
 
-      canonicalQuote = mintQuoteFromBolt11Response(mintUrl, {
+      return mintQuoteFromBolt11Response(mintUrl, {
         ...bolt11Quote,
         amount,
       } as MintQuoteBolt11Response);
-    } else if (method === 'onchain') {
+    }
+
+    if (method === 'onchain') {
       const onchainQuote = quote as MintMethodQuoteSnapshot<'onchain'>;
-      canonicalQuote = mintQuoteFromOnchainResponse(mintUrl, {
+      return mintQuoteFromOnchainResponse(mintUrl, {
         ...onchainQuote,
         amount_paid: onchainQuote.amount_paid ?? Amount.zero(),
         amount_issued: onchainQuote.amount_issued ?? Amount.zero(),
       });
-    } else if (method === 'bolt12') {
+    }
+
+    if (method === 'bolt12') {
       const bolt12Quote = quote as MintMethodQuoteSnapshot<'bolt12'>;
-      canonicalQuote = mintQuoteFromBolt12Response(mintUrl, {
+      return mintQuoteFromBolt12Response(mintUrl, {
         ...bolt12Quote,
         amount_paid: bolt12Quote.amount_paid ?? Amount.zero(),
         amount_issued: bolt12Quote.amount_issued ?? Amount.zero(),
       } as MintQuoteBolt12Response);
-    } else {
-      throw new Error(`Unsupported mint quote import method ${String(method)}`);
     }
 
+    throw new Error(`Unsupported mint quote import method ${String(method)}`);
+  }
+
+  private async resolveAndPersistMintQuoteObservation(
+    canonicalQuote: MintQuote,
+    beforePersist?: (quote: MintQuote) => Promise<void>,
+  ): Promise<{
+    quote: MintQuote;
+    remoteStateChanged: boolean;
+    existingQuote: MintQuote | null;
+  }> {
     const existing = await this.mintQuoteRepository.getMintQuote(
       canonicalQuote.mintUrl,
       canonicalQuote.method,
       canonicalQuote.quoteId,
     );
-    if (
-      existing &&
-      isStatefulMintQuote(existing) &&
-      isStatefulMintQuote(canonicalQuote) &&
-      isMintQuoteStateDowngrade(existing.state, canonicalQuote.state)
-    ) {
-      await beforePersist?.(existing);
+    const resolution = resolveMintQuoteObservation(existing, canonicalQuote);
+    await beforePersist?.(resolution.resolvedQuote);
+
+    if (resolution.persistence === 'retain') {
       return {
-        quote: existing,
-        remoteStateChanged: false,
-      };
-    }
-    if (existing?.reusable && canonicalQuote.reusable) {
-      canonicalQuote = {
-        ...canonicalQuote,
-        quoteData: {
-          ...canonicalQuote.quoteData,
-          amountPaid: maxAmount(existing.quoteData.amountPaid, canonicalQuote.quoteData.amountPaid),
-          amountIssued: maxAmount(
-            existing.quoteData.amountIssued,
-            canonicalQuote.quoteData.amountIssued,
-          ),
-        },
+        quote: resolution.resolvedQuote,
+        remoteStateChanged: resolution.meaningfulChange === 'changed',
+        existingQuote: existing,
       };
     }
 
-    const remoteStateChanged = getRemoteStateChange(existing, canonicalQuote, quote);
-    await beforePersist?.(canonicalQuote);
-    const persisted = await this.persistCanonicalMintQuote(canonicalQuote);
-    return { quote: persisted, remoteStateChanged };
+    const persisted = await this.persistCanonicalMintQuote(resolution.resolvedQuote);
+    return {
+      quote: persisted,
+      remoteStateChanged: resolution.meaningfulChange === 'changed',
+      existingQuote: existing,
+    };
   }
 
   async recordMintQuoteSnapshot(

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -18,6 +18,7 @@ import type {
 import type {
   MintExecutionResult,
   MintMethodHandler,
+  MintMethodQuoteSnapshot,
   PendingMintCheckResult,
   RecoverExecutingResult,
 } from '../../operations/mint/MintMethodHandler';
@@ -741,6 +742,190 @@ describe('MintOperationService', () => {
     expect(refreshed.quoteData.amountIssued.equals(Amount.from(8))).toBe(true);
     expect(getMintQuoteAvailableAmount(refreshed).equals(Amount.from(13))).toBe(true);
     expect(persistedDuringEvent).toEqual(['21']);
+  });
+
+  it('refreshMintQuote preserves direct BOLT11 replacement semantics', async () => {
+    await quoteRepo.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: 'quote-direct-refresh',
+        request: 'lnbc1direct',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    (handler.fetchRemoteQuote as Mock<any>).mockImplementationOnce(async ({ quote }: any) =>
+      mintQuoteFromBolt11Response(quote.mintUrl, {
+        quote: quote.quoteId,
+        request: quote.request,
+        amount: quote.amount,
+        unit: quote.unit,
+        expiry: quote.expiry,
+        state: 'UNPAID',
+      }),
+    );
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const refreshed = await quoteLifecycle.refreshMintQuote(
+      mintUrl,
+      'bolt11',
+      'quote-direct-refresh',
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'bolt11', 'quote-direct-refresh');
+
+    expect(refreshed.state).toBe('UNPAID');
+    expect(stored?.state).toBe('UNPAID');
+    expect(quoteUpdatedEvents).toHaveLength(1);
+    expect(quoteUpdatedEvents[0]?.quote.state).toBe('UNPAID');
+  });
+
+  it('refreshMintQuote preserves direct reusable replacement semantics', async () => {
+    const onchainQuoteId = 'onchain-quote-direct-refresh';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(8),
+    });
+    const onchainHandler = {
+      ...handler,
+      fetchRemoteQuote: mock(async ({ quote }) =>
+        mintQuoteFromOnchainResponse(quote.mintUrl, {
+          quote: quote.quoteId,
+          request: quote.request,
+          unit: quote.unit,
+          expiry: quote.expiry,
+          pubkey: quote.quoteData.pubkey,
+          amount_paid: Amount.from(7),
+          amount_issued: Amount.from(5),
+        }),
+      ),
+    } as unknown as MintMethodHandler<'onchain'>;
+    (handlerProvider.get as Mock<any>).mockImplementationOnce(() => onchainHandler);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const refreshed = await quoteLifecycle.refreshMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(refreshed.method).toBe('onchain');
+    if (refreshed.method !== 'onchain') throw new Error('Expected onchain quote');
+    expect(stored?.method).toBe('onchain');
+    if (stored?.method !== 'onchain') throw new Error('Expected stored onchain quote');
+    expect(refreshed.quoteData.amountPaid.equals(Amount.from(7))).toBe(true);
+    expect(refreshed.quoteData.amountIssued.equals(Amount.from(5))).toBe(true);
+    expect(stored.quoteData.amountPaid.equals(Amount.from(7))).toBe(true);
+    expect(stored.quoteData.amountIssued.equals(Amount.from(5))).toBe(true);
+    expect(quoteUpdatedEvents).toHaveLength(1);
+  });
+
+  it('recordMintQuoteSnapshot preserves BOLT11 downgrade protection without emitting', async () => {
+    await quoteRepo.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: 'quote-snapshot-paid',
+        request: 'lnbc1canonical',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        state: 'PAID',
+      }),
+    );
+    const before = await quoteRepo.getMintQuote(mintUrl, 'bolt11', 'quote-snapshot-paid');
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(mintUrl, 'bolt11', {
+      quote: 'quote-snapshot-paid',
+      request: 'lnbc1stale',
+      amount: Amount.from(10),
+      unit: 'sat',
+      expiry: Math.floor(Date.now() / 1000) + 7200,
+      state: 'UNPAID',
+    });
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'bolt11', 'quote-snapshot-paid');
+
+    expect(observed.state).toBe('PAID');
+    expect(observed.request).toBe('lnbc1canonical');
+    expect(stored?.state).toBe('PAID');
+    expect(stored?.request).toBe('lnbc1canonical');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('recordMintQuoteSnapshot preserves reusable accounting without emitting', async () => {
+    const onchainQuoteId = 'onchain-quote-stale-snapshot';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(8),
+    });
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(mintUrl, 'onchain', {
+      quote: onchainQuoteId,
+      request: 'bc1qtest',
+      unit: 'sat',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      pubkey: '02'.padEnd(66, '1'),
+      amount_paid: Amount.from(7),
+      amount_issued: Amount.from(5),
+    });
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(observed.method).toBe('onchain');
+    if (observed.method !== 'onchain') throw new Error('Expected onchain quote');
+    expect(stored?.method).toBe('onchain');
+    if (stored?.method !== 'onchain') throw new Error('Expected stored onchain quote');
+    expect(observed.quoteData.amountPaid.equals(Amount.from(10))).toBe(true);
+    expect(observed.quoteData.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(stored.quoteData.amountPaid.equals(Amount.from(10))).toBe(true);
+    expect(stored.quoteData.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('recordMintQuoteSnapshot preserves partial reusable snapshot event semantics', async () => {
+    const onchainQuoteId = 'onchain-quote-partial-snapshot';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(8),
+    });
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+    const partialSnapshot = {
+      quote: onchainQuoteId,
+      request: 'bc1qtest',
+      unit: 'sat',
+      expiry: Math.floor(Date.now() / 1000) + 3600,
+      pubkey: '02'.padEnd(66, '1'),
+      amount_paid: Amount.from(12),
+    } as MintMethodQuoteSnapshot<'onchain'>;
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      partialSnapshot,
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(observed.method).toBe('onchain');
+    if (observed.method !== 'onchain') throw new Error('Expected onchain quote');
+    expect(stored?.method).toBe('onchain');
+    if (stored?.method !== 'onchain') throw new Error('Expected stored onchain quote');
+    expect(observed.quoteData.amountPaid.equals(Amount.from(12))).toBe(true);
+    expect(observed.quoteData.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(stored.quoteData.amountPaid.equals(Amount.from(12))).toBe(true);
+    expect(stored.quoteData.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(quoteUpdatedEvents).toHaveLength(0);
   });
 
   it('prepare fails before creating an operation when the quote is missing', async () => {


### PR DESCRIPTION
## Description

This pull request extracts canonical Mint Quote Observation resolution into a focused internal module.

This pull request resolves #297.

## Problem

Downgrade protection, reusable accounting merging, persistence disposition, and meaningful-change detection were interleaved with snapshot conversion and lifecycle side effects, making later NUT-04 accounting changes harder to isolate.

## Summary

- Add a pure resolver returning the resolved quote and persistence/change dispositions.
- Keep conversion, validation, repository writes, legacy compatibility, and event emission in Quote Lifecycle.
- Add lifecycle regression coverage for BOLT11, reusable, direct-refresh, and partial-snapshot semantics.
- Leave melt quote behavior and public interfaces unchanged.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/QuoteLifecyclePolling.test.ts test/unit/MintOperationService.test.ts test/unit/MintQuoteProcessor.test.ts` — 100 passed
- `bun run --filter='@cashu/coco-core' test:unit` — 1,107 passed
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- Prettier and `git diff --check`

## Changeset

Not added: this is an internal, behavior-preserving refactor with no public or persisted-data change.