### PR TITLE
fix(core): prevent stale mint quote accounting rollback

### DIFF
--- a/.changeset/stale-mint-quote-observations.md
+++ b/.changeset/stale-mint-quote-observations.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Prevent stale or invalid Mint Quote Observations from rolling canonical accounting backward, and
+suppress quote-updated events for ignored or Remote Quote Update Time-only changes.

--- a/.github/workflows/core-integration-tests.yml
+++ b/.github/workflows/core-integration-tests.yml
@@ -41,12 +41,14 @@ jobs:
       - name: Run core custom-unit integration tests
         run: ./scripts/test-integration.sh core --custom-unit usd
 
+      - name: Normalize core integration coverage paths
+        run: sed -i 's|^SF:|SF:packages/core/|' packages/core/coverage/integration/lcov.info
+
       - name: Upload core integration coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: codecov/codecov-action@v7
         with:
-          working-directory: packages/core
-          files: coverage/integration/lcov.info
+          files: packages/core/coverage/integration/lcov.info
           disable_search: true
           fail_ci_if_error: true
           flags: core-integration

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -985,6 +985,8 @@ export class Manager {
       mintAdapter: this.mintAdapter,
       eventBus: this.eventBus,
       logger: quoteLifecycleLogger,
+      withMintQuoteTransaction: (fn) =>
+        repositories.withTransaction(({ mintQuoteRepository }) => fn(mintQuoteRepository)),
     });
     const meltOperationService = new MeltOperationService(
       meltHandlerProvider,

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -17,6 +17,7 @@ import { assertSameUnit } from '@core/amounts';
 import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
 import { Amount, type MintQuoteBolt11Response } from '@cashu/cashu-ts';
 import { mintQuoteFromBolt11Response, type MintQuote } from '../../../models/MintQuote';
+import { mintQuoteObservationFromBolt11Response } from '../../../models/MintQuoteObservationFactory';
 
 export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
   async createQuote(ctx: CreateMintQuoteContext<'bolt11'>): Promise<MintQuote<'bolt11'>> {
@@ -30,7 +31,7 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
       'bolt11',
       ctx.quote.quoteId,
     );
-    return mintQuoteFromBolt11Response(ctx.quote.mintUrl, remoteQuote);
+    return mintQuoteObservationFromBolt11Response(ctx.quote.mintUrl, remoteQuote);
   }
 
   async prepare(

--- a/packages/core/infra/handlers/mint/MintBolt12Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt12Handler.ts
@@ -5,6 +5,7 @@ import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from 
 import { bytesToHex } from '@noble/curves/utils.js';
 import { MintOperationError } from '../../../models/Error';
 import { mintQuoteFromBolt12Response, type MintQuote } from '../../../models/MintQuote';
+import { mintQuoteObservationFromBolt12Response } from '../../../models/MintQuoteObservationFactory';
 import { isMintQuoteExpired } from '../../../models/MintQuoteExpiry';
 import type {
   CreateMintQuoteContext,
@@ -59,7 +60,7 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
       ctx.quote.quoteData.amount,
     );
 
-    return mintQuoteFromBolt12Response(ctx.quote.mintUrl, remoteQuote);
+    return mintQuoteObservationFromBolt12Response(ctx.quote.mintUrl, remoteQuote);
   }
 
   async validateQuoteForPrepare(quote: MintQuote<'bolt12'>): Promise<void> {

--- a/packages/core/infra/handlers/mint/MintOnchainHandler.ts
+++ b/packages/core/infra/handlers/mint/MintOnchainHandler.ts
@@ -13,6 +13,7 @@ import {
   type MintQuote,
   type MintQuoteOnchainResponse,
 } from '../../../models/MintQuote';
+import { mintQuoteObservationFromOnchainResponse } from '../../../models/MintQuoteObservationFactory';
 import { isMintQuoteExpired } from '../../../models/MintQuoteExpiry';
 import type {
   CreateMintQuoteContext,
@@ -54,7 +55,7 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
 
     this.assertQuoteMatchesRequest(remoteQuote, ctx.quote.quoteData.pubkey, ctx.quote.unit);
 
-    return mintQuoteFromOnchainResponse(ctx.quote.mintUrl, remoteQuote);
+    return mintQuoteObservationFromOnchainResponse(ctx.quote.mintUrl, remoteQuote);
   }
 
   async validateQuoteForPrepare(quote: MintQuote<'onchain'>): Promise<void> {

--- a/packages/core/models/MintQuote.ts
+++ b/packages/core/models/MintQuote.ts
@@ -1,11 +1,15 @@
 import {
   Amount,
-  type AmountLike,
   type MintQuoteBolt11Response,
   type MintQuoteBolt12Response,
   type MintQuoteOnchainResponse as CashuMintQuoteOnchainResponse,
 } from '@cashu/cashu-ts';
 import { ProofValidationError } from './Error';
+import {
+  mintQuoteObservationFromBolt11Response,
+  mintQuoteObservationFromBolt12Response,
+  mintQuoteObservationFromOnchainResponse,
+} from './MintQuoteObservationFactory';
 import type {
   MintMethod,
   MintMethodQuoteData,
@@ -129,33 +133,13 @@ export function mintQuoteFromBolt11Response(
   quote: MintQuoteBolt11Response,
   options?: { now?: number },
 ): MintQuote<'bolt11'> {
-  const now = options?.now ?? Date.now();
-  const amount = Amount.from(quote.amount as unknown as AmountLike);
-  const amountPaid = Amount.from(quote.amount_paid);
-  const amountIssued = Amount.from(quote.amount_issued);
-
-  assertValidMintQuoteAccounting(quote.quote, amountPaid, amountIssued);
-  return {
-    mintUrl,
-    method: 'bolt11',
-    quoteId: quote.quote,
-    quote: quote.quote,
-    request: quote.request,
-    unit: quote.unit,
-    amount,
-    expiry: quote.expiry,
-    pubkey: quote.pubkey,
-    state: quote.state,
-    reusable: false,
-    amountPaid,
-    amountIssued,
-    remoteUpdatedAt: quote.updated_at ?? null,
-    quoteData: {
-      amount,
-    },
-    createdAt: now,
-    updatedAt: now,
-  };
+  const canonicalQuote = mintQuoteObservationFromBolt11Response(mintUrl, quote, options);
+  assertValidMintQuoteAccounting(
+    canonicalQuote.quoteId,
+    canonicalQuote.amountPaid,
+    canonicalQuote.amountIssued,
+  );
+  return canonicalQuote;
 }
 
 export function mintQuoteFromOnchainResponse(
@@ -163,29 +147,13 @@ export function mintQuoteFromOnchainResponse(
   quote: CashuMintQuoteOnchainResponse,
   options?: { now?: number },
 ): MintQuote<'onchain'> {
-  const now = options?.now ?? Date.now();
-  const canonicalAmountPaid = Amount.from(quote.amount_paid);
-  const canonicalAmountIssued = Amount.from(quote.amount_issued);
-  assertValidMintQuoteAccounting(quote.quote, canonicalAmountPaid, canonicalAmountIssued);
-  return {
-    mintUrl,
-    method: 'onchain',
-    quoteId: quote.quote,
-    quote: quote.quote,
-    request: quote.request,
-    unit: quote.unit,
-    expiry: quote.expiry,
-    pubkey: quote.pubkey,
-    reusable: true,
-    amountPaid: canonicalAmountPaid,
-    amountIssued: canonicalAmountIssued,
-    remoteUpdatedAt: quote.updated_at ?? null,
-    quoteData: {
-      pubkey: quote.pubkey,
-    },
-    createdAt: now,
-    updatedAt: now,
-  };
+  const canonicalQuote = mintQuoteObservationFromOnchainResponse(mintUrl, quote, options);
+  assertValidMintQuoteAccounting(
+    canonicalQuote.quoteId,
+    canonicalQuote.amountPaid,
+    canonicalQuote.amountIssued,
+  );
+  return canonicalQuote;
 }
 
 export function mintQuoteFromBolt12Response(
@@ -193,32 +161,13 @@ export function mintQuoteFromBolt12Response(
   quote: MintQuoteBolt12Response,
   options?: { now?: number },
 ): MintQuote<'bolt12'> {
-  const now = options?.now ?? Date.now();
-  const amount = quote.amount ? Amount.from(quote.amount as unknown as AmountLike) : undefined;
-  const canonicalAmountPaid = Amount.from(quote.amount_paid);
-  const canonicalAmountIssued = Amount.from(quote.amount_issued);
-  assertValidMintQuoteAccounting(quote.quote, canonicalAmountPaid, canonicalAmountIssued);
-  return {
-    mintUrl,
-    method: 'bolt12',
-    quoteId: quote.quote,
-    quote: quote.quote,
-    request: quote.request,
-    unit: quote.unit,
-    amount,
-    expiry: quote.expiry,
-    pubkey: quote.pubkey,
-    reusable: true,
-    amountPaid: canonicalAmountPaid,
-    amountIssued: canonicalAmountIssued,
-    remoteUpdatedAt: quote.updated_at ?? null,
-    quoteData: {
-      pubkey: quote.pubkey,
-      amount,
-    },
-    createdAt: now,
-    updatedAt: now,
-  };
+  const canonicalQuote = mintQuoteObservationFromBolt12Response(mintUrl, quote, options);
+  assertValidMintQuoteAccounting(
+    canonicalQuote.quoteId,
+    canonicalQuote.amountPaid,
+    canonicalQuote.amountIssued,
+  );
+  return canonicalQuote;
 }
 
 export function mintQuoteToMethodSnapshot<M extends MintMethod>(

--- a/packages/core/models/MintQuoteObservationFactory.ts
+++ b/packages/core/models/MintQuoteObservationFactory.ts
@@ -1,0 +1,91 @@
+import {
+  Amount,
+  type AmountLike,
+  type MintQuoteBolt11Response,
+  type MintQuoteBolt12Response,
+  type MintQuoteOnchainResponse,
+} from '@cashu/cashu-ts';
+import type { MintQuote } from './MintQuote';
+
+/** Maps a normalized BOLT11 response without enforcing canonical accounting invariants. */
+export function mintQuoteObservationFromBolt11Response(
+  mintUrl: string,
+  quote: MintQuoteBolt11Response,
+  options?: { now?: number },
+): MintQuote<'bolt11'> {
+  const now = options?.now ?? Date.now();
+  const amount = Amount.from(quote.amount as unknown as AmountLike);
+  return {
+    mintUrl,
+    method: 'bolt11',
+    quoteId: quote.quote,
+    quote: quote.quote,
+    request: quote.request,
+    unit: quote.unit,
+    amount,
+    expiry: quote.expiry,
+    pubkey: quote.pubkey,
+    state: quote.state,
+    reusable: false,
+    amountPaid: Amount.from(quote.amount_paid),
+    amountIssued: Amount.from(quote.amount_issued),
+    remoteUpdatedAt: quote.updated_at ?? null,
+    quoteData: { amount },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/** Maps a normalized on-chain response without enforcing canonical accounting invariants. */
+export function mintQuoteObservationFromOnchainResponse(
+  mintUrl: string,
+  quote: MintQuoteOnchainResponse,
+  options?: { now?: number },
+): MintQuote<'onchain'> {
+  const now = options?.now ?? Date.now();
+  return {
+    mintUrl,
+    method: 'onchain',
+    quoteId: quote.quote,
+    quote: quote.quote,
+    request: quote.request,
+    unit: quote.unit,
+    expiry: quote.expiry,
+    pubkey: quote.pubkey,
+    reusable: true,
+    amountPaid: Amount.from(quote.amount_paid),
+    amountIssued: Amount.from(quote.amount_issued),
+    remoteUpdatedAt: quote.updated_at ?? null,
+    quoteData: { pubkey: quote.pubkey },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/** Maps a normalized BOLT12 response without enforcing canonical accounting invariants. */
+export function mintQuoteObservationFromBolt12Response(
+  mintUrl: string,
+  quote: MintQuoteBolt12Response,
+  options?: { now?: number },
+): MintQuote<'bolt12'> {
+  const now = options?.now ?? Date.now();
+  const amount = quote.amount ? Amount.from(quote.amount as unknown as AmountLike) : undefined;
+  return {
+    mintUrl,
+    method: 'bolt12',
+    quoteId: quote.quote,
+    quote: quote.quote,
+    request: quote.request,
+    unit: quote.unit,
+    amount,
+    expiry: quote.expiry,
+    pubkey: quote.pubkey,
+    reusable: true,
+    amountPaid: Amount.from(quote.amount_paid),
+    amountIssued: Amount.from(quote.amount_issued),
+    remoteUpdatedAt: quote.updated_at ?? null,
+    quoteData: { pubkey: quote.pubkey, amount },
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/packages/core/quotes/MintQuoteObservation.ts
+++ b/packages/core/quotes/MintQuoteObservation.ts
@@ -1,55 +1,44 @@
-import type { Amount } from '@cashu/cashu-ts';
 import { isStatefulMintQuote, type MintQuote } from '../models/MintQuote';
 
-const MINT_QUOTE_STATE_RANK: Record<string, number> = {
-  UNPAID: 0,
-  PAID: 1,
-  ISSUED: 2,
-};
-
-export type MintQuoteObservationPersistence = 'persist' | 'retain';
-export type MintQuoteObservationMeaningfulChange = 'changed' | 'unchanged';
+export type MintQuoteObservationDisposition =
+  | 'accepted-meaningful-change'
+  | 'accepted-freshness-only'
+  | 'ignored-stale'
+  | 'ignored-conflicting-accounting'
+  | 'ignored-invalid-background'
+  | 'ignored-unchanged';
 
 export interface MintQuoteObservationResolution {
   resolvedQuote: MintQuote;
-  persistence: MintQuoteObservationPersistence;
-  meaningfulChange: MintQuoteObservationMeaningfulChange;
-}
-
-function isMintQuoteStateDowngrade(existing: MintQuote, incoming: MintQuote): boolean {
-  if (!isStatefulMintQuote(existing) || !isStatefulMintQuote(incoming)) return false;
-  return (
-    (MINT_QUOTE_STATE_RANK[incoming.state] ?? 0) < (MINT_QUOTE_STATE_RANK[existing.state] ?? 0)
-  );
-}
-
-function maxAmount(left: Amount, right: Amount): Amount {
-  return left.greaterThan(right) ? left : right;
-}
-
-function mergeReusableSettlement(existing: MintQuote, incoming: MintQuote): MintQuote {
-  if (!existing.reusable || !incoming.reusable) return incoming;
-
-  return {
-    ...incoming,
-    amountPaid: maxAmount(existing.amountPaid, incoming.amountPaid),
-    amountIssued: maxAmount(existing.amountIssued, incoming.amountIssued),
-  } as MintQuote;
+  disposition: MintQuoteObservationDisposition;
 }
 
 function hasMeaningfulChange(existing: MintQuote | null, incoming: MintQuote): boolean {
   if (!existing) return true;
-  if (existing.method !== incoming.method || existing.quoteId !== incoming.quoteId) return true;
-
-  if (isStatefulMintQuote(existing) && isStatefulMintQuote(incoming)) {
-    return existing.state !== incoming.state;
+  if (
+    existing.method !== incoming.method ||
+    existing.quoteId !== incoming.quoteId ||
+    existing.request !== incoming.request ||
+    existing.unit !== incoming.unit ||
+    existing.expiry !== incoming.expiry ||
+    (existing.pubkey ?? null) !== (incoming.pubkey ?? null) ||
+    existing.reusable !== incoming.reusable ||
+    !existing.amountPaid.equals(incoming.amountPaid) ||
+    !existing.amountIssued.equals(incoming.amountIssued)
+  ) {
+    return true;
   }
 
-  if (existing.reusable && incoming.reusable) {
-    return (
-      !existing.amountPaid.equals(incoming.amountPaid) ||
-      !existing.amountIssued.equals(incoming.amountIssued)
-    );
+  if (isStatefulMintQuote(existing) && isStatefulMintQuote(incoming)) {
+    // Until #387, non-terminal BOLT11 state changes still alter canonical claimability.
+    return !existing.amount.equals(incoming.amount) || existing.state !== incoming.state;
+  }
+
+  if (existing.method === 'bolt12' && incoming.method === 'bolt12') {
+    if (existing.amount === undefined || incoming.amount === undefined) {
+      return existing.amount !== incoming.amount;
+    }
+    return !existing.amount.equals(incoming.amount);
   }
 
   return false;
@@ -60,18 +49,63 @@ export function resolveMintQuoteObservation(
   existing: MintQuote | null,
   incoming: MintQuote,
 ): MintQuoteObservationResolution {
-  if (existing && isMintQuoteStateDowngrade(existing, incoming)) {
+  if (incoming.amountIssued.greaterThan(incoming.amountPaid)) {
     return {
-      resolvedQuote: existing,
-      persistence: 'retain',
-      meaningfulChange: 'unchanged',
+      resolvedQuote: existing ?? incoming,
+      disposition: 'ignored-invalid-background',
     };
   }
 
-  const resolvedQuote = existing ? mergeReusableSettlement(existing, incoming) : incoming;
-  return {
-    resolvedQuote,
-    persistence: 'persist',
-    meaningfulChange: hasMeaningfulChange(existing, resolvedQuote) ? 'changed' : 'unchanged',
-  };
+  if (
+    existing &&
+    existing.remoteUpdatedAt !== null &&
+    incoming.remoteUpdatedAt !== null &&
+    incoming.remoteUpdatedAt < existing.remoteUpdatedAt
+  ) {
+    return {
+      resolvedQuote: existing,
+      disposition: 'ignored-stale',
+    };
+  }
+
+  if (
+    existing &&
+    existing.remoteUpdatedAt !== null &&
+    incoming.remoteUpdatedAt !== null &&
+    incoming.remoteUpdatedAt === existing.remoteUpdatedAt &&
+    (!incoming.amountPaid.equals(existing.amountPaid) ||
+      !incoming.amountIssued.equals(existing.amountIssued))
+  ) {
+    return {
+      resolvedQuote: existing,
+      disposition: 'ignored-conflicting-accounting',
+    };
+  }
+
+  if (existing && (existing.remoteUpdatedAt === null || incoming.remoteUpdatedAt === null)) {
+    const hasNewerAccounting = incoming.amountPaid
+      .add(incoming.amountIssued)
+      .greaterThan(existing.amountPaid.add(existing.amountIssued));
+    const hasMonotonicComponents =
+      !incoming.amountPaid.lessThan(existing.amountPaid) &&
+      !incoming.amountIssued.lessThan(existing.amountIssued);
+    if (!hasNewerAccounting || !hasMonotonicComponents) {
+      return {
+        resolvedQuote: existing,
+        disposition: 'ignored-stale',
+      };
+    }
+  }
+
+  const resolvedQuote =
+    existing && existing.remoteUpdatedAt !== null && incoming.remoteUpdatedAt === null
+      ? { ...incoming, remoteUpdatedAt: existing.remoteUpdatedAt }
+      : incoming;
+  if (hasMeaningfulChange(existing, resolvedQuote)) {
+    return { resolvedQuote, disposition: 'accepted-meaningful-change' };
+  }
+  if (existing?.remoteUpdatedAt === resolvedQuote.remoteUpdatedAt) {
+    return { resolvedQuote: existing, disposition: 'ignored-unchanged' };
+  }
+  return { resolvedQuote, disposition: 'accepted-freshness-only' };
 }

--- a/packages/core/quotes/MintQuoteObservation.ts
+++ b/packages/core/quotes/MintQuoteObservation.ts
@@ -1,5 +1,11 @@
 import { isStatefulMintQuote, type MintQuote } from '../models/MintQuote';
 
+const MINT_QUOTE_STATE_RANK = {
+  UNPAID: 0,
+  PAID: 1,
+  ISSUED: 2,
+} as const;
+
 export type MintQuoteObservationDisposition =
   | 'accepted-meaningful-change'
   | 'accepted-freshness-only'
@@ -11,6 +17,21 @@ export type MintQuoteObservationDisposition =
 export interface MintQuoteObservationResolution {
   resolvedQuote: MintQuote;
   disposition: MintQuoteObservationDisposition;
+}
+
+function isMintQuoteStateDowngrade(existing: MintQuote, incoming: MintQuote): boolean {
+  return (
+    isStatefulMintQuote(existing) &&
+    isStatefulMintQuote(incoming) &&
+    MINT_QUOTE_STATE_RANK[incoming.state] < MINT_QUOTE_STATE_RANK[existing.state]
+  );
+}
+
+function hasAccountingComponentDecrease(existing: MintQuote, incoming: MintQuote): boolean {
+  return (
+    incoming.amountPaid.lessThan(existing.amountPaid) ||
+    incoming.amountIssued.lessThan(existing.amountIssued)
+  );
 }
 
 function hasMeaningfulChange(existing: MintQuote | null, incoming: MintQuote): boolean {
@@ -82,14 +103,22 @@ export function resolveMintQuoteObservation(
     };
   }
 
+  if (
+    existing &&
+    (hasAccountingComponentDecrease(existing, incoming) ||
+      isMintQuoteStateDowngrade(existing, incoming))
+  ) {
+    return {
+      resolvedQuote: existing,
+      disposition: 'ignored-stale',
+    };
+  }
+
   if (existing && (existing.remoteUpdatedAt === null || incoming.remoteUpdatedAt === null)) {
     const hasNewerAccounting = incoming.amountPaid
       .add(incoming.amountIssued)
       .greaterThan(existing.amountPaid.add(existing.amountIssued));
-    const hasMonotonicComponents =
-      !incoming.amountPaid.lessThan(existing.amountPaid) &&
-      !incoming.amountIssued.lessThan(existing.amountIssued);
-    if (!hasNewerAccounting || !hasMonotonicComponents) {
+    if (!hasNewerAccounting) {
       return {
         resolvedQuote: existing,
         disposition: 'ignored-stale',

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -1179,19 +1179,26 @@ export class QuoteLifecycle {
     existingQuote: MintQuote | null;
   }> {
     await beforePersist?.(canonicalQuote);
-    const observationKey = [
-      canonicalQuote.mintUrl,
-      canonicalQuote.method,
-      canonicalQuote.quoteId,
-    ].join('::');
+    return this.resolveAndPersistMintQuoteObservationUnderLock(
+      canonicalQuote,
+      () => canonicalQuote,
+    );
+  }
+
+  private async resolveAndPersistMintQuoteObservationUnderLock(
+    ref: MintQuoteRef,
+    buildObservation: (existing: MintQuote | null) => MintQuote,
+  ): Promise<{
+    quote: MintQuote;
+    remoteStateChanged: boolean;
+    existingQuote: MintQuote | null;
+  }> {
+    const observationKey = [ref.mintUrl, ref.method, ref.quoteId].join('::');
     const release = await this.mintQuoteObservationLock.acquire(observationKey);
     try {
       return await this.withMintQuoteTransaction(async (repository) => {
-        const existing = await repository.getMintQuote(
-          canonicalQuote.mintUrl,
-          canonicalQuote.method,
-          canonicalQuote.quoteId,
-        );
+        const existing = await repository.getMintQuote(ref.mintUrl, ref.method, ref.quoteId);
+        const canonicalQuote = buildObservation(existing);
         const resolution = resolveMintQuoteObservation(existing, canonicalQuote);
         this.warnForIgnoredMintQuoteObservation(resolution.disposition, existing, canonicalQuote);
 
@@ -1269,26 +1276,26 @@ export class QuoteLifecycle {
     observedAt = Date.now(),
   ): Promise<MintQuote> {
     await this.ensureMintQuoteRecordForOperation(operation);
-    const existing = await this.mintQuoteRepository.getMintQuote(
-      operation.mintUrl,
-      operation.method,
-      operation.quoteId,
-    );
-    if (!existing) {
-      throw new Error(
-        `Cannot record quote observation: mint quote ${operation.quoteId} for ${operation.method} at ${operation.mintUrl} was not found`,
-      );
-    }
-    if (!isStatefulMintQuote(existing)) return existing;
+    const { quote, remoteStateChanged } = await this.resolveAndPersistMintQuoteObservationUnderLock(
+      operation,
+      (existing) => {
+        if (!existing) {
+          throw new Error(
+            `Cannot record quote observation: mint quote ${operation.quoteId} for ${operation.method} at ${operation.mintUrl} was not found`,
+          );
+        }
+        if (!isStatefulMintQuote(existing)) return existing;
 
-    const { quote, remoteStateChanged } = await this.resolveAndPersistMintQuoteObservation({
-      ...existing,
-      state,
-      amountPaid: state === 'UNPAID' ? Amount.zero() : existing.amount,
-      amountIssued: state === 'ISSUED' ? existing.amount : Amount.zero(),
-      remoteUpdatedAt: null,
-      updatedAt: observedAt,
-    });
+        return {
+          ...existing,
+          state,
+          amountPaid: state === 'UNPAID' ? Amount.zero() : existing.amount,
+          amountIssued: state === 'ISSUED' ? existing.amount : Amount.zero(),
+          remoteUpdatedAt: null,
+          updatedAt: observedAt,
+        };
+      },
+    );
     await this.emitMintQuoteUpdatedIfNeeded(quote, remoteStateChanged);
 
     return quote;

--- a/packages/core/quotes/QuoteLifecycle.ts
+++ b/packages/core/quotes/QuoteLifecycle.ts
@@ -9,7 +9,6 @@ import type { MintHandlerProvider } from '../infra/handlers/mint';
 import type { Logger } from '../logging/Logger';
 import {
   getMintQuoteAmount,
-  getMintQuoteRemoteState,
   mintQuoteFromBolt11Response,
   mintQuoteFromBolt12Response,
   mintQuoteFromOnchainResponse,
@@ -17,6 +16,11 @@ import {
   isStatefulMintQuote,
   type MintQuote,
 } from '../models/MintQuote';
+import {
+  mintQuoteObservationFromBolt11Response,
+  mintQuoteObservationFromBolt12Response,
+  mintQuoteObservationFromOnchainResponse,
+} from '../models/MintQuoteObservationFactory.ts';
 import { meltQuoteToMethodSnapshot, type MeltQuote } from '../models/MeltQuote';
 import { isMintQuoteExpired } from '../models/MintQuoteExpiry';
 import {
@@ -39,6 +43,7 @@ import type {
   MeltMethodQuoteSnapshot,
 } from '../operations/melt/MeltMethodHandler';
 import { normalizeMeltMethodData } from '../operations/melt/MeltMethodHandler';
+import { MintScopedLock } from '../operations/MintScopedLock';
 import type { InitMintOperation, PendingOrLaterOperation } from '../operations/mint/MintOperation';
 import type {
   MintMethod,
@@ -110,13 +115,8 @@ function assertMintQuotePollingSnapshotStructureUnchecked(
       throw new ProofValidationError('BOLT11 mint quote batch observation is invalid');
     }
     if (hasCompleteAccounting) {
-      const amountPaid = Amount.from(bolt11.amount_paid!);
-      const amountIssued = Amount.from(bolt11.amount_issued!);
-      if (amountPaid.lessThan(amountIssued)) {
-        throw new ProofValidationError(
-          'BOLT11 mint quote batch observation has amount_issued greater than amount_paid',
-        );
-      }
+      Amount.from(bolt11.amount_paid!);
+      Amount.from(bolt11.amount_issued!);
     }
     return bolt11;
   }
@@ -127,13 +127,8 @@ function assertMintQuotePollingSnapshotStructureUnchecked(
   if (!hasReusableSettlementAmounts(reusable)) {
     throw new ProofValidationError(`${method} mint quote batch observation lacks settlement data`);
   }
-  const amountPaid = Amount.from(reusable.amount_paid ?? Amount.zero());
-  const amountIssued = Amount.from(reusable.amount_issued ?? Amount.zero());
-  if (amountPaid.lessThan(amountIssued)) {
-    throw new ProofValidationError(
-      `${method} mint quote batch observation has amount_issued greater than amount_paid`,
-    );
-  }
+  Amount.from(reusable.amount_paid ?? Amount.zero());
+  Amount.from(reusable.amount_issued ?? Amount.zero());
   if (method === 'bolt12') {
     const amount = (snapshot as MintMethodQuoteSnapshot<'bolt12'>).amount;
     if (amount !== undefined && amount !== null) Amount.from(amount as AmountLike);
@@ -265,23 +260,6 @@ function failedMintQuotePollingResult(
   };
 }
 
-function getDirectRefreshStateChange(existing: MintQuote, incoming: MintQuote): boolean {
-  if (existing.method !== incoming.method || existing.quoteId !== incoming.quoteId) return true;
-
-  if (existing.method === 'bolt11' && incoming.method === 'bolt11') {
-    return existing.state !== incoming.state;
-  }
-
-  if (existing.reusable && incoming.reusable) {
-    return (
-      !existing.amountPaid.equals(incoming.amountPaid) ||
-      !existing.amountIssued.equals(incoming.amountIssued)
-    );
-  }
-
-  return false;
-}
-
 function serializeMeltChange(change: MeltQuote['change']): NonNullable<MeltQuote['change']> {
   return change ?? [];
 }
@@ -378,6 +356,7 @@ export interface QuoteLifecycleDeps {
   mintAdapter: MintAdapter;
   eventBus: EventBus<CoreEvents>;
   logger?: Logger;
+  withMintQuoteTransaction?: <T>(fn: (repository: MintQuoteRepository) => Promise<T>) => Promise<T>;
 }
 
 export class QuoteLifecycle {
@@ -392,6 +371,10 @@ export class QuoteLifecycle {
   private readonly mintAdapter: MintAdapter;
   private readonly eventBus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
+  private readonly withMintQuoteTransaction: NonNullable<
+    QuoteLifecycleDeps['withMintQuoteTransaction']
+  >;
+  private readonly mintQuoteObservationLock = new MintScopedLock();
   private readonly batchUnavailablePollingMethodsByMint = new Map<string, Set<MintMethod>>();
 
   constructor(deps: QuoteLifecycleDeps) {
@@ -406,6 +389,8 @@ export class QuoteLifecycle {
     this.mintAdapter = deps.mintAdapter;
     this.eventBus = deps.eventBus;
     this.logger = deps.logger;
+    this.withMintQuoteTransaction =
+      deps.withMintQuoteTransaction ?? ((fn) => fn(this.mintQuoteRepository));
     this.eventBus.on('mint:metadata-refreshed', ({ mintUrl }) => {
       this.clearBatchUnavailablePollingGroups(mintUrl);
     });
@@ -463,8 +448,8 @@ export class QuoteLifecycle {
       quote: existingQuote,
     });
 
-    const remoteStateChanged = getDirectRefreshStateChange(existingQuote, refreshed);
-    const quote = await this.persistCanonicalMintQuote(refreshed);
+    const { quote, remoteStateChanged } =
+      await this.resolveAndPersistMintQuoteObservation(refreshed);
     await this.emitMintQuoteUpdatedIfNeeded(quote, remoteStateChanged);
     return quote;
   }
@@ -1020,7 +1005,10 @@ export class QuoteLifecycle {
       normalizedMintUrl,
       method,
       this.normalizeImportedMintQuoteSnapshot(method, quote),
-      (resolvedQuote) => this.assertMintQuoteCapabilities(resolvedQuote),
+      {
+        beforePersist: (resolvedQuote) => this.assertMintQuoteCapabilities(resolvedQuote),
+        validateAccounting: true,
+      },
     );
     await this.emitMintQuoteUpdatedIfNeeded(imported, remoteStateChanged);
     return imported as MintQuote<M>;
@@ -1120,12 +1108,20 @@ export class QuoteLifecycle {
     mintUrl: string,
     method: MintMethod,
     quote: MintMethodQuoteSnapshot,
-    beforePersist?: (quote: MintQuote) => Promise<void>,
+    options: {
+      beforePersist?: (quote: MintQuote) => Promise<void>;
+      validateAccounting?: boolean;
+    } = {},
   ): Promise<{ quote: MintQuote; remoteStateChanged: boolean }> {
-    const canonicalQuote = this.mintQuoteFromSnapshot(mintUrl, method, quote);
+    const canonicalQuote = this.mintQuoteFromSnapshot(
+      mintUrl,
+      method,
+      quote,
+      options.validateAccounting ?? false,
+    );
     const resolution = await this.resolveAndPersistMintQuoteObservation(
       canonicalQuote,
-      beforePersist,
+      options.beforePersist,
     );
     return {
       quote: resolution.quote,
@@ -1137,6 +1133,7 @@ export class QuoteLifecycle {
     mintUrl: string,
     method: MintMethod,
     quote: MintMethodQuoteSnapshot,
+    validateAccounting: boolean,
   ): MintQuote {
     if (method === 'bolt11') {
       const bolt11Quote = quote as MintMethodQuoteSnapshot<'bolt11'>;
@@ -1150,20 +1147,24 @@ export class QuoteLifecycle {
         throw new ProofValidationError('Mint quote ' + bolt11Quote.quote + ' has invalid amount');
       }
 
-      return mintQuoteFromBolt11Response(mintUrl, {
-        ...bolt11Quote,
-        amount,
-      });
+      const response = { ...bolt11Quote, amount };
+      return validateAccounting
+        ? mintQuoteFromBolt11Response(mintUrl, response)
+        : mintQuoteObservationFromBolt11Response(mintUrl, response);
     }
 
     if (method === 'onchain') {
       const onchainQuote = quote as MintMethodQuoteSnapshot<'onchain'>;
-      return mintQuoteFromOnchainResponse(mintUrl, onchainQuote);
+      return validateAccounting
+        ? mintQuoteFromOnchainResponse(mintUrl, onchainQuote)
+        : mintQuoteObservationFromOnchainResponse(mintUrl, onchainQuote);
     }
 
     if (method === 'bolt12') {
       const bolt12Quote = quote as MintMethodQuoteSnapshot<'bolt12'>;
-      return mintQuoteFromBolt12Response(mintUrl, bolt12Quote);
+      return validateAccounting
+        ? mintQuoteFromBolt12Response(mintUrl, bolt12Quote)
+        : mintQuoteObservationFromBolt12Response(mintUrl, bolt12Quote);
     }
 
     throw new Error(`Unsupported mint quote import method ${String(method)}`);
@@ -1177,28 +1178,75 @@ export class QuoteLifecycle {
     remoteStateChanged: boolean;
     existingQuote: MintQuote | null;
   }> {
-    const existing = await this.mintQuoteRepository.getMintQuote(
+    await beforePersist?.(canonicalQuote);
+    const observationKey = [
       canonicalQuote.mintUrl,
       canonicalQuote.method,
       canonicalQuote.quoteId,
-    );
-    const resolution = resolveMintQuoteObservation(existing, canonicalQuote);
-    await beforePersist?.(resolution.resolvedQuote);
+    ].join('::');
+    const release = await this.mintQuoteObservationLock.acquire(observationKey);
+    try {
+      return await this.withMintQuoteTransaction(async (repository) => {
+        const existing = await repository.getMintQuote(
+          canonicalQuote.mintUrl,
+          canonicalQuote.method,
+          canonicalQuote.quoteId,
+        );
+        const resolution = resolveMintQuoteObservation(existing, canonicalQuote);
+        this.warnForIgnoredMintQuoteObservation(resolution.disposition, existing, canonicalQuote);
 
-    if (resolution.persistence === 'retain') {
-      return {
-        quote: resolution.resolvedQuote,
-        remoteStateChanged: resolution.meaningfulChange === 'changed',
-        existingQuote: existing,
-      };
+        if (
+          resolution.disposition === 'ignored-stale' ||
+          resolution.disposition === 'ignored-conflicting-accounting' ||
+          resolution.disposition === 'ignored-invalid-background' ||
+          resolution.disposition === 'ignored-unchanged'
+        ) {
+          return {
+            quote: resolution.resolvedQuote,
+            remoteStateChanged: false,
+            existingQuote: existing,
+          };
+        }
+
+        const persisted = await this.persistCanonicalMintQuote(
+          repository,
+          resolution.resolvedQuote,
+        );
+        return {
+          quote: persisted,
+          remoteStateChanged: resolution.disposition === 'accepted-meaningful-change',
+          existingQuote: existing,
+        };
+      });
+    } finally {
+      release();
     }
+  }
 
-    const persisted = await this.persistCanonicalMintQuote(resolution.resolvedQuote);
-    return {
-      quote: persisted,
-      remoteStateChanged: resolution.meaningfulChange === 'changed',
-      existingQuote: existing,
-    };
+  private warnForIgnoredMintQuoteObservation(
+    disposition: ReturnType<typeof resolveMintQuoteObservation>['disposition'],
+    existing: MintQuote | null,
+    incoming: MintQuote,
+  ): void {
+    const message =
+      disposition === 'ignored-invalid-background'
+        ? 'Ignoring Mint Quote Observation with invalid accounting'
+        : disposition === 'ignored-conflicting-accounting'
+          ? 'Ignoring Mint Quote Observation with conflicting accounting at unchanged Remote Quote Update Time'
+          : null;
+    if (!message) return;
+
+    this.logger?.warn(message, {
+      mintUrl: incoming.mintUrl,
+      method: incoming.method,
+      quoteId: incoming.quoteId,
+      existingRemoteUpdatedAt: existing?.remoteUpdatedAt ?? null,
+      incomingRemoteUpdatedAt: incoming.remoteUpdatedAt,
+      existingAmountPaid: existing?.amountPaid.toString(),
+      existingAmountIssued: existing?.amountIssued.toString(),
+      incomingAmountPaid: incoming.amountPaid.toString(),
+      incomingAmountIssued: incoming.amountIssued.toString(),
+    });
   }
 
   async recordMintQuoteSnapshot(
@@ -1226,28 +1274,22 @@ export class QuoteLifecycle {
       operation.method,
       operation.quoteId,
     );
-    await this.mintQuoteRepository.setMintQuoteState(
-      operation.mintUrl,
-      operation.method,
-      operation.quoteId,
-      state,
-      observedAt,
-    );
-    const quote = await this.mintQuoteRepository.getMintQuote(
-      operation.mintUrl,
-      operation.method,
-      operation.quoteId,
-    );
-    if (!quote) {
+    if (!existing) {
       throw new Error(
         `Cannot record quote observation: mint quote ${operation.quoteId} for ${operation.method} at ${operation.mintUrl} was not found`,
       );
     }
+    if (!isStatefulMintQuote(existing)) return existing;
 
-    await this.emitMintQuoteUpdatedIfNeeded(
-      quote,
-      !existing || getMintQuoteRemoteState(existing) !== getMintQuoteRemoteState(quote),
-    );
+    const { quote, remoteStateChanged } = await this.resolveAndPersistMintQuoteObservation({
+      ...existing,
+      state,
+      amountPaid: state === 'UNPAID' ? Amount.zero() : existing.amount,
+      amountIssued: state === 'ISSUED' ? existing.amount : Amount.zero(),
+      remoteUpdatedAt: null,
+      updatedAt: observedAt,
+    });
+    await this.emitMintQuoteUpdatedIfNeeded(quote, remoteStateChanged);
 
     return quote;
   }
@@ -1441,10 +1483,13 @@ export class QuoteLifecycle {
     return { quote: persisted, remoteQuoteChanged };
   }
 
-  private async persistCanonicalMintQuote(canonicalQuote: MintQuote): Promise<MintQuote> {
-    await this.mintQuoteRepository.upsertMintQuote(canonicalQuote);
+  private async persistCanonicalMintQuote(
+    repository: MintQuoteRepository,
+    canonicalQuote: MintQuote,
+  ): Promise<MintQuote> {
+    await repository.upsertMintQuote(canonicalQuote);
     return (
-      (await this.mintQuoteRepository.getMintQuote(
+      (await repository.getMintQuote(
         canonicalQuote.mintUrl,
         canonicalQuote.method,
         canonicalQuote.quoteId,

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -6,6 +6,7 @@ import type { CoreEvents } from '../../events/types';
 import type { MintAdapter } from '../../infra';
 import { MintBolt12Handler } from '../../infra/handlers/mint/MintBolt12Handler';
 import type { Logger } from '../../logging/Logger';
+import { mintQuoteFromBolt12Response } from '../../models/MintQuote';
 import type { ProofRepository } from '../../repositories';
 import type { KeyRingService } from '../../services/KeyRingService';
 import type { MintService } from '../../services/MintService';
@@ -13,6 +14,7 @@ import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
 import type {
   ExecuteContext,
+  FetchRemoteMintQuoteContext,
   PendingContext,
   PrepareContext,
   RecoverExecutingContext,
@@ -91,6 +93,17 @@ describe('MintBolt12Handler', () => {
     eventBus,
     logger,
     ...overrides,
+  });
+
+  const buildFetchRemoteQuoteContext = (): FetchRemoteMintQuoteContext<'bolt12'> => ({
+    quote: mintQuoteFromBolt12Response(mintUrl, quote()),
+    mintAdapter,
+    proofService,
+    proofRepository,
+    walletService,
+    mintService,
+    eventBus,
+    logger,
   });
 
   const buildPendingContext = (remoteQuote: MintQuoteBolt12Response): PendingContext<'bolt12'> => {
@@ -173,6 +186,22 @@ describe('MintBolt12Handler', () => {
     expect(result.quoteId).toBe(quoteId);
     expect(result.pubkey).toBe(pubkey);
     expect(result.reusable).toBe(true);
+  });
+
+  it('fetches the latest BOLT12 quote through the mint adapter', async () => {
+    const remoteQuote = quote({
+      amount_paid: Amount.from(21),
+      amount_issued: Amount.from(8),
+      updated_at: 20,
+    });
+    (mintAdapter.checkMintQuote as Mock<any>).mockImplementationOnce(async () => remoteQuote);
+
+    const result = await handler.fetchRemoteQuote(buildFetchRemoteQuoteContext());
+
+    expect(mintAdapter.checkMintQuote).toHaveBeenCalledWith(mintUrl, 'bolt12', quoteId);
+    expect(result.amountPaid.equals(Amount.from(21))).toBe(true);
+    expect(result.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(result.remoteUpdatedAt).toBe(20);
   });
 
   it('rejects fixed-amount quotes when the mint omits the response amount', async () => {

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -896,7 +896,7 @@ describe('MintOperationService', () => {
     );
   });
 
-  it('recordMintQuoteSnapshot preserves BOLT11 downgrade protection without emitting', async () => {
+  it('recordMintQuoteSnapshot preserves BOLT11 downgrade protection at a newer update time', async () => {
     await quoteRepo.upsertMintQuote(
       mintQuoteFromBolt11Response(mintUrl, {
         quote: 'quote-snapshot-paid',
@@ -905,6 +905,7 @@ describe('MintOperationService', () => {
         unit: 'sat',
         expiry: Math.floor(Date.now() / 1000) + 3600,
         state: 'PAID',
+        updated_at: 20,
       }),
     );
     const before = await quoteRepo.getMintQuote(mintUrl, 'bolt11', 'quote-snapshot-paid');
@@ -923,6 +924,7 @@ describe('MintOperationService', () => {
         unit: 'sat',
         expiry: Math.floor(Date.now() / 1000) + 7200,
         state: 'UNPAID',
+        updated_at: 21,
       }),
     );
     const stored = await quoteRepo.getMintQuote(mintUrl, 'bolt11', 'quote-snapshot-paid');
@@ -931,6 +933,7 @@ describe('MintOperationService', () => {
     expect(observed.request).toBe('lnbc1canonical');
     expect(stored?.state).toBe('PAID');
     expect(stored?.request).toBe('lnbc1canonical');
+    expect(stored?.remoteUpdatedAt).toBe(20);
     expect(stored?.updatedAt).toBe(before?.updatedAt);
     expect(quoteUpdatedEvents).toHaveLength(0);
   });
@@ -1008,6 +1011,50 @@ describe('MintOperationService', () => {
     expect(stored?.updatedAt).toBe(before?.updatedAt);
     expect(quoteUpdatedEvents).toHaveLength(0);
   });
+
+  for (const accountingDecrease of [
+    { field: 'amount paid', paid: 9, issued: 2 },
+    { field: 'amount issued', paid: 10, issued: 1 },
+  ]) {
+    it(`recordMintQuoteSnapshot ignores newer timestamps with decreased ${accountingDecrease.field}`, async () => {
+      const quoteIdSuffix = accountingDecrease.field.replace(' ', '-');
+      const onchainQuoteId = `onchain-quote-newer-decreased-${quoteIdSuffix}`;
+      await persistOnchainQuote(onchainQuoteId, {
+        paid: Amount.from(10),
+        issued: Amount.from(2),
+        remoteUpdatedAt: 20,
+      });
+      const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+      const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+      eventBus.on('mint-quote:updated', (event) => {
+        quoteUpdatedEvents.push(event);
+      });
+
+      const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+        mintUrl,
+        'onchain',
+        cashuNormalizedOnchainFixture({
+          quote: onchainQuoteId,
+          request: 'bc1qtest',
+          unit: 'sat',
+          expiry: before?.expiry ?? null,
+          pubkey: '02'.padEnd(66, '1'),
+          amount_paid: Amount.from(accountingDecrease.paid),
+          amount_issued: Amount.from(accountingDecrease.issued),
+          updated_at: 21,
+        }),
+      );
+      const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+      expect(observed.amountPaid.toString()).toBe('10');
+      expect(observed.amountIssued.toString()).toBe('2');
+      expect(observed.remoteUpdatedAt).toBe(20);
+      expect(stored?.amountPaid.toString()).toBe('10');
+      expect(stored?.amountIssued.toString()).toBe('2');
+      expect(stored?.updatedAt).toBe(before?.updatedAt);
+      expect(quoteUpdatedEvents).toHaveLength(0);
+    });
+  }
 
   it('recordMintQuoteSnapshot warns and ignores accounting conflicts at an equal update time', async () => {
     const onchainQuoteId = 'onchain-quote-equal-timestamp';

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -2511,6 +2511,67 @@ describe('MintOperationService', () => {
     expect(persistedDuringEvent).toEqual(['PAID']);
   });
 
+  it('recordQuoteObservation applies compatibility state to the latest canonical quote', async () => {
+    const initialExpiry = Math.floor(Date.now() / 1000) + 3600;
+    const newerExpiry = initialExpiry + 3600;
+    await quoteRepo.upsertMintQuote(
+      mintQuoteFromBolt11Response(mintUrl, {
+        quote: quoteId,
+        request: 'lnbc1old',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: initialExpiry,
+        state: 'PAID',
+        updated_at: 20,
+      }),
+    );
+    const pendingOp = {
+      ...makePendingOp('pending-concurrent-compatibility-observation'),
+      request: 'lnbc1old',
+      expiry: initialExpiry,
+    };
+    const newerAtPersist = createDeferred();
+    const releaseNewerPersist = createDeferred();
+    const originalUpsert = quoteRepo.upsertMintQuote.bind(quoteRepo);
+    let delayedNewerSnapshot = false;
+    quoteRepo.upsertMintQuote = mock(async (quote) => {
+      if (!delayedNewerSnapshot && quote.remoteUpdatedAt === 21) {
+        delayedNewerSnapshot = true;
+        newerAtPersist.resolve();
+        await releaseNewerPersist.promise;
+      }
+      return originalUpsert(quote);
+    }) as typeof quoteRepo.upsertMintQuote;
+
+    const newerSnapshot = quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'bolt11',
+      cashuNormalizedBolt11Fixture({
+        quote: quoteId,
+        request: 'lnbc1newer',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: newerExpiry,
+        state: 'PAID',
+        updated_at: 21,
+      }),
+    );
+    await newerAtPersist.promise;
+
+    const compatibilityObservation = quoteLifecycle.recordMintQuoteObservation(pendingOp, 'ISSUED');
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    releaseNewerPersist.resolve();
+
+    await Promise.all([newerSnapshot, compatibilityObservation]);
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'bolt11', quoteId);
+
+    expect(stored?.state).toBe('ISSUED');
+    expect(stored?.amountIssued.toString()).toBe('10');
+    expect(stored?.request).toBe('lnbc1newer');
+    expect(stored?.expiry).toBe(newerExpiry);
+    expect(stored?.remoteUpdatedAt).toBe(21);
+  });
+
   it('recordQuoteObservation ignores stale compatibility-state accounting', async () => {
     await persistQuote();
     const pendingOp = makePendingOp('pending-stale-state-observation');

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -28,6 +28,7 @@ import { MemoryMintOperationRepository } from '../../repositories/memory/MemoryM
 import { MemoryMintQuoteRepository } from '../../repositories/memory/MemoryMintQuoteRepository';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
 import { getMintQuoteAvailableAmount } from '../../models/MintQuote';
+import { mintQuoteObservationFromOnchainResponse } from '../../models/MintQuoteObservationFactory';
 import {
   cashuNormalizedBolt11Fixture,
   cashuNormalizedOnchainFixture,
@@ -40,6 +41,7 @@ import type { MintService } from '../../services/MintService';
 import type { WalletService } from '../../services/WalletService';
 import type { ProofService } from '../../services/ProofService';
 import type { MintAdapter } from '../../infra/MintAdapter';
+import type { Logger } from '../../logging/Logger';
 import { serializeOutputData } from '../../utils';
 import type { CoreProof } from '../../types';
 import { QuoteIdentityConflictError } from '../../models/Error';
@@ -57,6 +59,7 @@ describe('MintOperationService', () => {
   let walletService: WalletService;
   let mintAdapter: MintAdapter;
   let eventBus: EventBus<CoreEvents>;
+  let logger: Logger;
   let handler: MintMethodHandler<'bolt11'>;
   let handlerProvider: MintHandlerProvider;
   let quoteLifecycle: QuoteLifecycle;
@@ -135,7 +138,12 @@ describe('MintOperationService', () => {
 
   const persistOnchainQuote = async (
     quote = 'onchain-quote-1',
-    amounts: { paid?: Amount; issued?: Amount; expiry?: number } = {},
+    amounts: {
+      paid?: Amount;
+      issued?: Amount;
+      expiry?: number;
+      remoteUpdatedAt?: number | null;
+    } = {},
   ): Promise<void> => {
     await quoteRepo.upsertMintQuote(
       mintQuoteFromOnchainResponse(mintUrl, {
@@ -146,6 +154,7 @@ describe('MintOperationService', () => {
         pubkey: '02'.padEnd(66, '1'),
         amount_paid: amounts.paid ?? Amount.zero(),
         amount_issued: amounts.issued ?? Amount.zero(),
+        updated_at: amounts.remoteUpdatedAt ?? null,
       }),
     );
   };
@@ -233,6 +242,12 @@ describe('MintOperationService', () => {
     quoteRepo = new MemoryMintQuoteRepository();
     proofRepo = new MemoryProofRepository();
     eventBus = new EventBus<CoreEvents>();
+    logger = {
+      error: mock(() => {}),
+      warn: mock(() => {}),
+      info: mock(() => {}),
+      debug: mock(() => {}),
+    };
 
     const mockPrepare = mock(async ({ operation }: { operation: InitMintOperation<'bolt11'> }) => {
       return makePendingOp(operation.id) as PendingMintOperation<'bolt11'>;
@@ -340,6 +355,7 @@ describe('MintOperationService', () => {
       walletService,
       mintAdapter,
       eventBus,
+      logger,
     });
 
     service = new MintOperationService(
@@ -757,7 +773,7 @@ describe('MintOperationService', () => {
     expect(persistedDuringEvent).toEqual(['21']);
   });
 
-  it('refreshMintQuote preserves direct BOLT11 replacement semantics', async () => {
+  it('refreshMintQuote ignores a stale direct BOLT11 observation', async () => {
     await quoteRepo.upsertMintQuote(
       mintQuoteFromBolt11Response(mintUrl, {
         quote: 'quote-direct-refresh',
@@ -790,13 +806,12 @@ describe('MintOperationService', () => {
     );
     const stored = await quoteRepo.getMintQuote(mintUrl, 'bolt11', 'quote-direct-refresh');
 
-    expect(refreshed.state).toBe('UNPAID');
-    expect(stored?.state).toBe('UNPAID');
-    expect(quoteUpdatedEvents).toHaveLength(1);
-    expect(quoteUpdatedEvents[0]?.quote.state).toBe('UNPAID');
+    expect(refreshed.state).toBe('PAID');
+    expect(stored?.state).toBe('PAID');
+    expect(quoteUpdatedEvents).toHaveLength(0);
   });
 
-  it('refreshMintQuote preserves direct reusable replacement semantics', async () => {
+  it('refreshMintQuote ignores stale direct reusable accounting', async () => {
     const onchainQuoteId = 'onchain-quote-direct-refresh';
     await persistOnchainQuote(onchainQuoteId, {
       paid: Amount.from(10),
@@ -829,11 +844,56 @@ describe('MintOperationService', () => {
     if (refreshed.method !== 'onchain') throw new Error('Expected onchain quote');
     expect(stored?.method).toBe('onchain');
     if (stored?.method !== 'onchain') throw new Error('Expected stored onchain quote');
-    expect(refreshed.amountPaid.equals(Amount.from(7))).toBe(true);
-    expect(refreshed.amountIssued.equals(Amount.from(5))).toBe(true);
-    expect(stored.amountPaid.equals(Amount.from(7))).toBe(true);
-    expect(stored.amountIssued.equals(Amount.from(5))).toBe(true);
-    expect(quoteUpdatedEvents).toHaveLength(1);
+    expect(refreshed.amountPaid.equals(Amount.from(10))).toBe(true);
+    expect(refreshed.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(stored.amountPaid.equals(Amount.from(10))).toBe(true);
+    expect(stored.amountIssued.equals(Amount.from(8))).toBe(true);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('refreshMintQuote ignores impossible direct reusable accounting', async () => {
+    const onchainQuoteId = 'onchain-quote-invalid-direct-refresh';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const onchainHandler = {
+      ...handler,
+      fetchRemoteQuote: mock(async ({ quote }) =>
+        mintQuoteObservationFromOnchainResponse(
+          quote.mintUrl,
+          cashuNormalizedOnchainFixture({
+            quote: quote.quoteId,
+            request: quote.request,
+            unit: quote.unit,
+            expiry: quote.expiry,
+            pubkey: quote.quoteData.pubkey,
+            amount_paid: Amount.from(9),
+            amount_issued: Amount.from(11),
+            updated_at: 21,
+          }),
+        ),
+      ),
+    } as unknown as MintMethodHandler<'onchain'>;
+    (handlerProvider.get as Mock<any>).mockImplementationOnce(() => onchainHandler);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const refreshed = await quoteLifecycle.refreshMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(refreshed.amountPaid.toString()).toBe('10');
+    expect(stored?.amountIssued.toString()).toBe('2');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Ignoring Mint Quote Observation with invalid accounting',
+      expect.objectContaining({ quoteId: onchainQuoteId }),
+    );
   });
 
   it('recordMintQuoteSnapshot preserves BOLT11 downgrade protection without emitting', async () => {
@@ -910,6 +970,332 @@ describe('MintOperationService', () => {
     expect(stored.amountPaid.equals(Amount.from(10))).toBe(true);
     expect(stored.amountIssued.equals(Amount.from(8))).toBe(true);
     expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('recordMintQuoteSnapshot ignores lower Remote Quote Update Times without emitting', async () => {
+    const onchainQuoteId = 'onchain-quote-lower-timestamp';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qstale',
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 7200,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(12),
+        amount_issued: Amount.from(2),
+        updated_at: 19,
+      }),
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(observed.request).toBe('bc1qtest');
+    expect(observed.amountPaid.toString()).toBe('10');
+    expect(observed.remoteUpdatedAt).toBe(20);
+    expect(stored?.request).toBe('bc1qtest');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('recordMintQuoteSnapshot warns and ignores accounting conflicts at an equal update time', async () => {
+    const onchainQuoteId = 'onchain-quote-equal-timestamp';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: before?.expiry ?? null,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(11),
+        amount_issued: Amount.from(2),
+        updated_at: 20,
+      }),
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(observed.amountPaid.toString()).toBe('10');
+    expect(stored?.amountPaid.toString()).toBe('10');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Ignoring Mint Quote Observation with conflicting accounting at unchanged Remote Quote Update Time',
+      expect.objectContaining({
+        mintUrl,
+        method: 'onchain',
+        quoteId: onchainQuoteId,
+        existingAmountPaid: '10',
+        incomingAmountPaid: '11',
+      }),
+    );
+  });
+
+  it('recordMintQuoteSnapshot accepts a monotonic accounting increase without losing freshness', async () => {
+    const onchainQuoteId = 'onchain-quote-fallback-increase';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(11),
+        amount_issued: Amount.from(2),
+        updated_at: null,
+      }),
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(observed.amountPaid.toString()).toBe('11');
+    expect(stored?.amountPaid.toString()).toBe('11');
+    expect(stored?.remoteUpdatedAt).toBe(20);
+    expect(quoteUpdatedEvents).toHaveLength(1);
+  });
+
+  it('recordMintQuoteSnapshot ignores null-time fallback observations with a component decrease', async () => {
+    const onchainQuoteId = 'onchain-quote-fallback-component-decrease';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: null,
+    });
+    const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: before?.expiry ?? null,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(12),
+        amount_issued: Amount.from(1),
+        updated_at: null,
+      }),
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(stored?.amountPaid.toString()).toBe('10');
+    expect(stored?.amountIssued.toString()).toBe('2');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('recordMintQuoteSnapshot warns and ignores impossible background accounting', async () => {
+    const onchainQuoteId = 'onchain-quote-invalid-background-accounting';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: before?.expiry ?? null,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(9),
+        amount_issued: Amount.from(11),
+        updated_at: 21,
+      }),
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(observed.amountPaid.toString()).toBe('10');
+    expect(stored?.amountIssued.toString()).toBe('2');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Ignoring Mint Quote Observation with invalid accounting',
+      expect.objectContaining({
+        mintUrl,
+        method: 'onchain',
+        quoteId: onchainQuoteId,
+        incomingAmountPaid: '9',
+        incomingAmountIssued: '11',
+      }),
+    );
+  });
+
+  it('recordMintQuoteSnapshot persists timestamp-only freshness without emitting', async () => {
+    const onchainQuoteId = 'onchain-quote-timestamp-only';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const before = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: before?.expiry ?? null,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(10),
+        amount_issued: Amount.from(2),
+        updated_at: 21,
+      }),
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(stored?.remoteUpdatedAt).toBe(21);
+    expect(quoteUpdatedEvents).toHaveLength(0);
+  });
+
+  it('recordMintQuoteSnapshot emits the unchanged event shape for a meaningful quote change', async () => {
+    const onchainQuoteId = 'onchain-quote-meaningful-change';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const nextExpiry = Math.floor(Date.now() / 1000) + 7200;
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const observed = await quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: nextExpiry,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(10),
+        amount_issued: Amount.from(2),
+        updated_at: 21,
+      }),
+    );
+
+    expect(observed.expiry).toBe(nextExpiry);
+    expect(quoteUpdatedEvents).toEqual([
+      {
+        mintUrl,
+        method: 'onchain',
+        quoteId: onchainQuoteId,
+        quote: observed,
+      },
+    ]);
+  });
+
+  it('recordMintQuoteSnapshot serializes concurrent observations before resolving freshness', async () => {
+    const onchainQuoteId = 'onchain-quote-concurrent-observations';
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.from(2),
+      remoteUpdatedAt: 20,
+    });
+    const olderAtPersist = createDeferred();
+    const releaseOlderPersist = createDeferred();
+    const originalUpsert = quoteRepo.upsertMintQuote.bind(quoteRepo);
+    quoteRepo.upsertMintQuote = mock(async (quote) => {
+      if (quote.remoteUpdatedAt === 21) {
+        olderAtPersist.resolve();
+        await releaseOlderPersist.promise;
+      }
+      return originalUpsert(quote);
+    }) as typeof quoteRepo.upsertMintQuote;
+
+    const olderObservation = quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(11),
+        amount_issued: Amount.from(2),
+        updated_at: 21,
+      }),
+    );
+    await olderAtPersist.promise;
+
+    const newerObservation = quoteLifecycle.recordMintQuoteSnapshot(
+      mintUrl,
+      'onchain',
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(12),
+        amount_issued: Amount.from(2),
+        updated_at: 22,
+      }),
+    );
+    await Promise.resolve();
+    releaseOlderPersist.resolve();
+
+    await Promise.all([olderObservation, newerObservation]);
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(stored?.remoteUpdatedAt).toBe(22);
+    expect(stored?.amountPaid.toString()).toBe('12');
   });
 
   it('prepare fails before creating an operation when the quote is missing', async () => {
@@ -2076,6 +2462,29 @@ describe('MintOperationService', () => {
 
     expect(quote.state).toBe('PAID');
     expect(persistedDuringEvent).toEqual(['PAID']);
+  });
+
+  it('recordQuoteObservation ignores stale compatibility-state accounting', async () => {
+    await persistQuote();
+    const pendingOp = makePendingOp('pending-stale-state-observation');
+    await operationRepo.create(pendingOp);
+    const before = await quoteRepo.getMintQuote(mintUrl, 'bolt11', quoteId);
+    const quoteUpdatedEvents: Array<CoreEvents['mint-quote:updated']> = [];
+    eventBus.on('mint-quote:updated', (event) => {
+      quoteUpdatedEvents.push(event);
+    });
+
+    const quote = await quoteLifecycle.recordMintQuoteObservation(
+      pendingOp,
+      'UNPAID',
+      Date.now() + 1,
+    );
+    const stored = await quoteRepo.getMintQuote(mintUrl, 'bolt11', quoteId);
+
+    expect(quote.state).toBe('PAID');
+    expect(stored?.state).toBe('PAID');
+    expect(stored?.updatedAt).toBe(before?.updatedAt);
+    expect(quoteUpdatedEvents).toHaveLength(0);
   });
 
   it('does not mirror canonical quote updates into pending operations', async () => {

--- a/packages/core/test/unit/MintQuoteObservation.test.ts
+++ b/packages/core/test/unit/MintQuoteObservation.test.ts
@@ -1,0 +1,103 @@
+import { Amount } from '@cashu/cashu-ts';
+import { describe, expect, it } from 'bun:test';
+import { resolveMintQuoteObservation } from '../../quotes/MintQuoteObservation';
+import {
+  mintQuoteFromBolt11Fixture,
+  mintQuoteFromBolt12Fixture,
+  mintQuoteFromOnchainFixture,
+} from '../normalizedMintQuoteFixtures';
+
+describe('resolveMintQuoteObservation', () => {
+  const mintUrl = 'https://mint.test';
+  const expiry = Math.floor(Date.now() / 1000) + 3600;
+
+  it('classifies a forward BOLT11 state transition as meaningful', () => {
+    const existing = mintQuoteFromBolt11Fixture(mintUrl, {
+      quote: 'bolt11-state-change',
+      request: 'lnbc1test',
+      amount: Amount.from(10),
+      unit: 'sat',
+      expiry,
+      state: 'PAID',
+      updated_at: 20,
+    });
+    const incoming = {
+      ...existing,
+      state: 'ISSUED' as const,
+      remoteUpdatedAt: 21,
+    };
+
+    const resolution = resolveMintQuoteObservation(existing, incoming);
+
+    expect(resolution.disposition).toBe('accepted-meaningful-change');
+    expect(resolution.resolvedQuote).toBe(incoming);
+  });
+
+  it('classifies freshness-only changes for amountless BOLT12 quotes', () => {
+    const existing = mintQuoteFromBolt12Fixture(mintUrl, {
+      quote: 'bolt12-freshness',
+      request: 'lno1test',
+      method: 'bolt12',
+      amount: null,
+      unit: 'sat',
+      expiry,
+      pubkey: '02'.padEnd(66, '1'),
+      amount_paid: Amount.zero(),
+      amount_issued: Amount.zero(),
+      updated_at: 20,
+    });
+    const incoming = { ...existing, remoteUpdatedAt: 21 };
+
+    const resolution = resolveMintQuoteObservation(existing, incoming);
+
+    expect(resolution.disposition).toBe('accepted-freshness-only');
+    expect(resolution.resolvedQuote).toBe(incoming);
+  });
+
+  it('classifies BOLT12 amount changes as meaningful', () => {
+    const existing = mintQuoteFromBolt12Fixture(mintUrl, {
+      quote: 'bolt12-amount-change',
+      request: 'lno1test',
+      method: 'bolt12',
+      amount: Amount.from(10),
+      unit: 'sat',
+      expiry,
+      pubkey: '02'.padEnd(66, '2'),
+      amount_paid: Amount.zero(),
+      amount_issued: Amount.zero(),
+      updated_at: 20,
+    });
+    const amount = Amount.from(20);
+    const incoming = {
+      ...existing,
+      amount,
+      quoteData: { ...existing.quoteData, amount },
+      remoteUpdatedAt: 21,
+    };
+
+    const resolution = resolveMintQuoteObservation(existing, incoming);
+
+    expect(resolution.disposition).toBe('accepted-meaningful-change');
+    expect(resolution.resolvedQuote).toBe(incoming);
+  });
+
+  it('ignores an unchanged observation at the same freshness timestamp', () => {
+    const existing = mintQuoteFromOnchainFixture(mintUrl, {
+      quote: 'onchain-unchanged',
+      request: 'bc1qtest',
+      method: 'onchain',
+      unit: 'sat',
+      expiry,
+      pubkey: '02'.padEnd(66, '3'),
+      amount_paid: Amount.from(10),
+      amount_issued: Amount.from(2),
+      updated_at: 20,
+    });
+    const incoming = { ...existing };
+
+    const resolution = resolveMintQuoteObservation(existing, incoming);
+
+    expect(resolution.disposition).toBe('ignored-unchanged');
+    expect(resolution.resolvedQuote).toBe(existing);
+  });
+});

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -478,7 +478,7 @@ describe('QuoteLifecycle mint quote polling', () => {
     expect(storedOnchain?.reusable && storedOnchain.amountPaid.toString()).toBe('30');
   });
 
-  it('rejects canonical identity conflicts and over-issued reusable observations', async () => {
+  it('rejects identity conflicts but ignores over-issued accounting without downgrading', async () => {
     await persistBolt12Quote('bolt12-conflict');
     await persistOnchainQuote('onchain-over-issued');
     (mintAdapter.checkMintQuoteBatch as ReturnType<typeof mock>)
@@ -517,10 +517,7 @@ describe('QuoteLifecycle mint quote polling', () => {
       status: 'failed',
       failure: { category: 'validation' },
     });
-    expect(overIssued.outcomes[0]).toMatchObject({
-      status: 'failed',
-      failure: { category: 'validation' },
-    });
+    expect(overIssued.outcomes[0]).toMatchObject({ status: 'updated' });
     const storedConflict = await mintQuoteRepository.getMintQuote(
       mintUrl,
       'bolt12',
@@ -534,7 +531,7 @@ describe('QuoteLifecycle mint quote polling', () => {
     expect(storedConflict?.request).toBe('lno1bolt12-conflict');
     expect(storedOverIssued?.reusable && storedOverIssued.amountIssued.toString()).toBe('0');
     expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'bolt12')).toBe(1);
-    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'onchain')).toBe(1);
+    expect(await quoteLifecycle.getMintQuotePollingLimit(mintUrl, 'onchain')).toBe(100);
   });
 
   it('classifies request-wide polling failures without losing the original error', async () => {


### PR DESCRIPTION
This pull request applies the canonical Mint Quote Observation freshness policy at the quote persistence boundary.

Stale, conflicting, or invalid background observations could previously overwrite canonical accounting or emit updates that unnecessarily woke Mint Operation processing.

- Add explicit dispositions for meaningful, freshness-only, stale, conflicting, invalid, and unchanged observations.
- Serialize read/resolve/write handling per quote and execute it within repository transactions.
- Keep background observations non-destructive while preserving strict validation for explicit imports.
- Persist Remote Quote Update Time-only changes without emitting `mint-quote:updated`.
- Preserve event payloads, NUT-29 attribution, polling fallback behavior, claimability semantics, and melt quote behavior.
- Add focused and concurrency regression coverage.
- Add a patch changeset for `@cashu/coco-core`.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit` — 1,136 tests passed
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
- SQLite, Expo SQLite, and SQL storage contract tests
- Standards and Spec reviews completed with no findings

Live-mint integration tests require `MINT_URL`. IndexedDB browser tests are gated by unavailable host browser libraries.

This pull request resolves #300.