### PR TITLE
fix(react): serialize local storage seed initialization

### DIFF
--- a/.changeset/lock-local-storage-seeds.md
+++ b/.changeset/lock-local-storage-seeds.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-react': patch
+---
+
+Serialize localStorage seed initialization across same-origin browser contexts with the Web Locks
+API, preventing concurrent first-run tabs from caching different wallet seeds.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -60,7 +60,10 @@ export function App() {
 
 `localStorageSeedGetter()` stores a generated browser seed under
 `COCO_REACT_SEED` by default. Pass `localStorageSeedGetter({ storageKey })` to
-use a different localStorage key.
+use a different localStorage key. The helper requires the Web Locks API so seed
+initialization is serialized across same-origin browser contexts. Call it from a
+secure browser context (HTTPS or localhost), and provide another `seedGetter` in
+environments without `window.navigator.locks`.
 
 If your application already owns the manager lifecycle, pass an initialized
 manager instead:

--- a/packages/react/src/lib/utils/localStorageSeedGetter.test.ts
+++ b/packages/react/src/lib/utils/localStorageSeedGetter.test.ts
@@ -50,8 +50,37 @@ const installLocalStorageMock = () => {
   });
 };
 
+const installWebLocksMock = () => {
+  let lockTail = Promise.resolve();
+  const request = vi.fn(
+    async <T>(name: string, callback: (lock: Lock) => Promise<T> | T): Promise<T> => {
+      const previousLock = lockTail;
+      let releaseLock: () => void = () => undefined;
+      lockTail = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+      });
+
+      await previousLock;
+
+      try {
+        return await callback({ name, mode: 'exclusive' } as Lock);
+      } finally {
+        releaseLock();
+      }
+    },
+  );
+
+  Object.defineProperty(window.navigator, 'locks', {
+    configurable: true,
+    value: { request },
+  });
+
+  return request;
+};
+
 beforeEach(() => {
   installLocalStorageMock();
+  installWebLocksMock();
 });
 
 afterEach(() => {
@@ -70,6 +99,44 @@ describe('localStorageSeedGetter', () => {
     expect(getRandomValues).toHaveBeenCalledTimes(1);
   });
 
+  it('converges concurrent initializers on the same persisted seed', async () => {
+    const generatedSeeds = [makeSeed(31), makeSeed(37)];
+    const getRandomValues = vi
+      .spyOn(window.crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(array: T): T => {
+        if (!(array instanceof Uint8Array)) {
+          throw new Error('expected Uint8Array');
+        }
+
+        const seed = generatedSeeds.shift();
+        if (!seed) {
+          throw new Error('unexpected random request');
+        }
+
+        array.set(seed);
+        return array;
+      });
+
+    const firstGetter = localStorageSeedGetter();
+    const secondGetter = localStorageSeedGetter();
+    let secondPromise: Promise<Uint8Array> | null = null;
+
+    vi.mocked(window.localStorage.getItem).mockImplementationOnce(() => {
+      secondPromise = secondGetter();
+      return null;
+    });
+
+    const firstSeed = await firstGetter();
+    if (!secondPromise) {
+      throw new Error('second initializer did not run');
+    }
+    const secondSeed = await secondPromise;
+
+    expect(firstSeed).toEqual(secondSeed);
+    expect(window.localStorage.getItem('COCO_REACT_SEED')).toBe(encodeSeed(firstSeed));
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+  });
+
   it('uses a custom storage key', async () => {
     const seed = makeSeed(3);
     mockRandomValues(seed);
@@ -78,6 +145,21 @@ describe('localStorageSeedGetter', () => {
     await expect(seedGetter()).resolves.toEqual(seed);
     expect(window.localStorage.getItem('MY_COCO_SEED')).toBe(encodeSeed(seed));
     expect(window.localStorage.getItem('COCO_REACT_SEED')).toBeNull();
+  });
+
+  it('fails before generating a seed when Web Locks are unavailable', async () => {
+    const getRandomValues = mockRandomValues(makeSeed(5));
+    Object.defineProperty(window.navigator, 'locks', {
+      configurable: true,
+      value: undefined,
+    });
+    const seedGetter = localStorageSeedGetter();
+
+    await expect(seedGetter()).rejects.toThrow(
+      'localStorageSeedGetter requires window.navigator.locks.',
+    );
+    expect(getRandomValues).not.toHaveBeenCalled();
+    expect(window.localStorage.setItem).not.toHaveBeenCalled();
   });
 
   it('reads an existing seed from localStorage', async () => {

--- a/packages/react/src/lib/utils/localStorageSeedGetter.ts
+++ b/packages/react/src/lib/utils/localStorageSeedGetter.ts
@@ -1,5 +1,6 @@
 const DEFAULT_STORAGE_KEY = 'COCO_REACT_SEED';
 const SEED_LENGTH_BYTES = 64;
+const SEED_LOCK_PREFIX = 'cashu:coco-react:local-storage-seed:';
 
 export type LocalStorageSeedGetterConfig = {
   storageKey?: string;
@@ -16,6 +17,10 @@ const getBrowserWindow = (): Window & typeof globalThis => {
 
   if (!window.crypto?.getRandomValues) {
     throw new Error('localStorageSeedGetter requires window.crypto.getRandomValues.');
+  }
+
+  if (!window.navigator?.locks) {
+    throw new Error('localStorageSeedGetter requires window.navigator.locks.');
   }
 
   return window;
@@ -61,6 +66,7 @@ const createSeed = (browserWindow: Window & typeof globalThis): Uint8Array => {
  */
 export const localStorageSeedGetter = (config: LocalStorageSeedGetterConfig = {}) => {
   const storageKey = config.storageKey ?? DEFAULT_STORAGE_KEY;
+  const lockName = `${SEED_LOCK_PREFIX}${storageKey}`;
   let cachedSeed: Uint8Array | null = null;
 
   return async (): Promise<Uint8Array> => {
@@ -69,17 +75,24 @@ export const localStorageSeedGetter = (config: LocalStorageSeedGetterConfig = {}
     }
 
     const browserWindow = getBrowserWindow();
-    const storedSeed = browserWindow.localStorage.getItem(storageKey);
 
-    if (storedSeed) {
-      cachedSeed = decodeSeed(storedSeed, browserWindow);
-      return new Uint8Array(cachedSeed);
-    }
+    return browserWindow.navigator.locks.request(lockName, async () => {
+      if (cachedSeed) {
+        return new Uint8Array(cachedSeed);
+      }
 
-    const generatedSeed = createSeed(browserWindow);
-    browserWindow.localStorage.setItem(storageKey, encodeSeed(generatedSeed, browserWindow));
-    cachedSeed = generatedSeed;
+      const storedSeed = browserWindow.localStorage.getItem(storageKey);
 
-    return new Uint8Array(generatedSeed);
+      if (storedSeed) {
+        cachedSeed = decodeSeed(storedSeed, browserWindow);
+        return new Uint8Array(cachedSeed);
+      }
+
+      const generatedSeed = createSeed(browserWindow);
+      browserWindow.localStorage.setItem(storageKey, encodeSeed(generatedSeed, browserWindow));
+      cachedSeed = generatedSeed;
+
+      return new Uint8Array(generatedSeed);
+    });
   };
 };


### PR DESCRIPTION
## Problem

`localStorageSeedGetter()` initialized a missing seed with a non-atomic localStorage read-generate-write sequence. Concurrent first-run tabs could each cache a different seed even though only the last seed written remained recoverable from storage.

## Summary

- serialize seed initialization across same-origin browser contexts with an origin-scoped Web Lock
- fail before generating or writing when Web Locks are unavailable
- document the secure-context requirement and add a patch changeset
- add deterministic regression coverage for concurrent initializers and unsupported environments

## Verification

- `bun run --filter='@cashu/coco-react' test` (50 tests passed)
- `bun run --filter='@cashu/coco-react' typecheck`
- `bun run --filter='@cashu/coco-react' lint` (passes with two existing warnings)
- `bun run --filter='@cashu/coco-react' build`
- `bunx prettier --check packages/react/src/lib/utils/localStorageSeedGetter.ts packages/react/src/lib/utils/localStorageSeedGetter.test.ts packages/react/README.md .changeset/lock-local-storage-seeds.md`

This issue was found by Project Loupe