### PR TITLE
fix: allocate key derivation indexes atomically

### DIFF
--- a/.changeset/atomic-key-allocation.md
+++ b/.changeset/atomic-key-allocation.md
@@ -8,10 +8,10 @@
 '@cashu/coco-indexeddb': patch
 ---
 
-Atomically reserve purpose-scoped key derivation indexes before key generation so concurrent P2PK
-and NUT-20 mint-quote calls cannot reuse deterministic keys. Add durable SQL and IndexedDB
-high-water migrations, permanent gap semantics, cross-instance adapter contracts, and explicit
+Atomically derive and persist purpose-scoped keypairs with their durable high-water marks so
+concurrent P2PK and NUT-20 mint-quote calls cannot reuse deterministic keys. Add SQL and IndexedDB
+high-water migrations, rollback-safe cross-instance adapter contracts, and explicit
 derivation-index exhaustion errors.
 
-Custom repository adapters must replace `getLastDerivationIndex` with the required root-only
-`KeyRingAllocationRepository.reserveNextDerivationIndex` capability.
+Custom repository adapters must replace `getLastDerivationIndex` with the required
+`KeyRingRepository.deriveAndPersistKeyPair` transaction boundary.

--- a/.changeset/atomic-key-allocation.md
+++ b/.changeset/atomic-key-allocation.md
@@ -1,0 +1,17 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-adapter-tests': minor
+'@cashu/coco-sql-storage': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-indexeddb': patch
+---
+
+Atomically reserve purpose-scoped key derivation indexes before key generation so concurrent P2PK
+and NUT-20 mint-quote calls cannot reuse deterministic keys. Add durable SQL and IndexedDB
+high-water migrations, permanent gap semantics, cross-instance adapter contracts, and explicit
+derivation-index exhaustion errors.
+
+Custom repository adapters must replace `getLastDerivationIndex` with the required root-only
+`KeyRingAllocationRepository.reserveNextDerivationIndex` capability.

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0",
         "@cashu/coco-sql-storage": "1.0.0",
+        "@types/node": "^25.0.9",
       },
       "peerDependencies": {
         "@cashu/cashu-ts": "5.0.0-rc.4",
@@ -127,6 +128,7 @@
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0",
         "@cashu/coco-sql-storage": "1.0.0",
+        "@types/node": "^25.0.9",
       },
       "peerDependencies": {
         "@cashu/cashu-ts": "5.0.0-rc.4",
@@ -144,6 +146,7 @@
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0",
         "@cashu/coco-sql-storage": "1.0.0",
+        "@types/node": "^25.0.9",
         "vitest": "^2.1.9",
       },
       "peerDependencies": {

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -18,6 +18,7 @@ contract suites into your test runner:
 import { describe, it, expect } from 'bun:test';
 import {
   runRepositoryTransactionContract,
+  runKeyRingAllocationRepositoryContract,
   runAuthSessionRepositoryContract,
 } from '@cashu/coco-adapter-tests';
 import { MyAdapterRepositories } from './src';
@@ -49,6 +50,15 @@ runAuthSessionRepositoryContract(
   },
   { describe, it, expect },
 );
+
+runKeyRingAllocationRepositoryContract(
+  {
+    createRepositories: createFreshRepositories,
+    // Returns { first, second, dispose } using one physical store and independent roots.
+    createSharedRepositories: createTwoRootsForOneStore,
+  },
+  { describe, it, expect },
+);
 ```
 
 The factory is responsible for providing a fresh, isolated repositories
@@ -56,5 +66,8 @@ instance for every test and for cleaning up via `dispose()`.
 
 - `runRepositoryTransactionContract()` verifies transactional behavior across the
   repository set.
+- `runKeyRingAllocationRepositoryContract()` verifies purpose isolation, concurrency,
+  permanent gaps, exhaustion, and—when `createSharedRepositories` is supplied—coordination
+  between independent roots sharing one physical store.
 - `runAuthSessionRepositoryContract()` verifies the NUT-21/22 auth session
   persistence contract.

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -18,7 +18,7 @@ contract suites into your test runner:
 import { describe, it, expect } from 'bun:test';
 import {
   runRepositoryTransactionContract,
-  runKeyRingAllocationRepositoryContract,
+  runKeyRingDerivationRepositoryContract,
   runAuthSessionRepositoryContract,
 } from '@cashu/coco-adapter-tests';
 import { MyAdapterRepositories } from './src';
@@ -51,7 +51,7 @@ runAuthSessionRepositoryContract(
   { describe, it, expect },
 );
 
-runKeyRingAllocationRepositoryContract(
+runKeyRingDerivationRepositoryContract(
   {
     createRepositories: createFreshRepositories,
     // Returns { first, second, dispose } using one physical store and independent roots.
@@ -66,8 +66,9 @@ instance for every test and for cleaning up via `dispose()`.
 
 - `runRepositoryTransactionContract()` verifies transactional behavior across the
   repository set.
-- `runKeyRingAllocationRepositoryContract()` verifies purpose isolation, concurrency,
-  permanent gaps, exhaustion, and—when `createSharedRepositories` is supplied—coordination
-  between independent roots sharing one physical store.
+- `runKeyRingDerivationRepositoryContract()` verifies purpose isolation, concurrency,
+  transactional rollback, committed-key deletion behavior, exhaustion, and—when
+  `createSharedRepositories` is supplied—coordination between independent roots sharing one
+  physical store.
 - `runAuthSessionRepositoryContract()` verifies the NUT-21/22 auth session
   persistence contract.

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -16,6 +16,8 @@ import {
   type ReceiveOperation,
   type SendOperation,
   type AuthSession,
+  type KeypairPurpose,
+  DerivationIndexExhaustedError,
   QuoteIdentityConflictError,
 } from '@cashu/coco-core/adapter';
 
@@ -28,6 +30,159 @@ type ContractOptions<TRepositories extends Repositories = Repositories> = {
   createRepositories: TransactionFactory<TRepositories>;
   testConcurrentRootOperationIsolation?: boolean;
 };
+
+export type KeyRingAllocationContractOptions<TRepositories extends Repositories = Repositories> = {
+  createRepositories: TransactionFactory<TRepositories>;
+  createSharedRepositories?: () => Promise<{
+    first: TRepositories;
+    second: TRepositories;
+    dispose(): Promise<void>;
+  }>;
+};
+
+function sortedIndexes(indexes: number[]): number[] {
+  return [...indexes].sort((left, right) => left - right);
+}
+
+function expectExactIndexRange(
+  indexes: number[],
+  start: number,
+  count: number,
+  expect: Expectation,
+): void {
+  const expected = Array.from({ length: count }, (_, offset) => start + offset);
+  expect(indexes.length).toBe(count);
+  expect(new Set(indexes).size).toBe(count);
+  expect(JSON.stringify(sortedIndexes(indexes))).toBe(JSON.stringify(expected));
+}
+
+function derivedKeypair(publicKeyHex: string, derivationIndex: number, purpose: KeypairPurpose) {
+  return {
+    publicKeyHex,
+    secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
+    derivationIndex,
+    purpose,
+  } as const;
+}
+
+export function runKeyRingAllocationRepositoryContract(
+  options: KeyRingAllocationContractOptions,
+  runner: ContractRunner,
+): void {
+  const { describe, it, expect } = runner;
+
+  describe('keyring derivation allocation contract', () => {
+    it('starts each purpose at zero and advances independently', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const p2pk = await Promise.all([
+          repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+          repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+          repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+        ]);
+        const quote = await Promise.all([
+          repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+        ]);
+
+        expectExactIndexRange(p2pk, 0, 3, expect);
+        expectExactIndexRange(quote, 0, 3, expect);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('continues above existing persisted keypairs', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.keyRingRepository.setPersistedKeyPair(
+          derivedKeypair('02' + '07'.repeat(32), 7, 'p2pk'),
+        );
+        const next = await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
+        expect(next).toBe(8);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('allocates one exact sequence under one-root concurrency', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const indexes = await Promise.all(
+          Array.from({ length: 50 }, () =>
+            repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          ),
+        );
+        expectExactIndexRange(indexes, 0, 50, expect);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('does not recycle abandoned or deleted allocations', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const abandoned = await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
+        expect(abandoned).toBe(0);
+        const persistedIndex =
+          await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
+        const keypair = derivedKeypair('02' + '08'.repeat(32), persistedIndex, 'p2pk');
+        await repositories.keyRingRepository.setPersistedKeyPair(keypair);
+        await repositories.keyRingRepository.deletePersistedKeyPair(keypair.publicKeyHex, 'p2pk');
+        expect(await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).toBe(2);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('fails explicitly without advancing beyond the maximum child index', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        await repositories.keyRingRepository.setPersistedKeyPair(
+          derivedKeypair('02' + '09'.repeat(32), 0x7fffffff, 'nut20_mint_quote'),
+        );
+        await expectThrowsNamed(
+          () => repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          DerivationIndexExhaustedError.name,
+          expect,
+        );
+        await expectThrowsNamed(
+          () => repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          DerivationIndexExhaustedError.name,
+          expect,
+        );
+      } finally {
+        await dispose();
+      }
+    });
+
+    if (options.createSharedRepositories) {
+      it('coordinates independent roots sharing one physical store', async () => {
+        const { first, second, dispose } = await options.createSharedRepositories!();
+        try {
+          const indexes = await Promise.all([
+            ...Array.from({ length: 50 }, () =>
+              first.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+            ),
+            ...Array.from({ length: 50 }, () =>
+              second.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+            ),
+          ]);
+          expectExactIndexRange(indexes, 0, 100, expect);
+
+          const p2pk = await Promise.all([
+            first.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+            second.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+          ]);
+          expectExactIndexRange(p2pk, 0, 2, expect);
+        } finally {
+          await dispose();
+        }
+      });
+    }
+  });
+}
 
 export async function runRepositoryTransactionContract(
   options: ContractOptions,
@@ -167,6 +322,20 @@ async function expectThrowsError(
     thrown = error;
   }
   expect(thrown instanceof errorClass).toBe(true);
+}
+
+async function expectThrowsNamed(
+  fn: () => Promise<unknown>,
+  errorName: string,
+  expect: Expectation,
+) {
+  let thrown: unknown;
+  try {
+    await fn();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown instanceof Error ? thrown.name : undefined).toBe(errorName);
 }
 
 function createDeferred<T = void>() {

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -17,6 +17,7 @@ import {
   type SendOperation,
   type AuthSession,
   type KeypairPurpose,
+  type KeyRingRepository,
   DerivationIndexExhaustedError,
   QuoteIdentityConflictError,
 } from '@cashu/coco-core/adapter';
@@ -31,7 +32,7 @@ type ContractOptions<TRepositories extends Repositories = Repositories> = {
   testConcurrentRootOperationIsolation?: boolean;
 };
 
-export type KeyRingAllocationContractOptions<TRepositories extends Repositories = Repositories> = {
+export type KeyRingDerivationContractOptions<TRepositories extends Repositories = Repositories> = {
   createRepositories: TransactionFactory<TRepositories>;
   createSharedRepositories?: () => Promise<{
     first: TRepositories;
@@ -56,38 +57,53 @@ function expectExactIndexRange(
   expect(JSON.stringify(sortedIndexes(indexes))).toBe(JSON.stringify(expected));
 }
 
-function derivedKeypair(publicKeyHex: string, derivationIndex: number, purpose: KeypairPurpose) {
+function derivedKeypair(derivationIndex: number, purpose: KeypairPurpose) {
+  const prefix = purpose === 'p2pk' ? '02' : '03';
   return {
-    publicKeyHex,
+    publicKeyHex: prefix + derivationIndex.toString(16).padStart(64, '0'),
     secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
     derivationIndex,
     purpose,
   } as const;
 }
 
-export function runKeyRingAllocationRepositoryContract(
-  options: KeyRingAllocationContractOptions,
+function deriveNext(repository: KeyRingRepository, purpose: KeypairPurpose) {
+  return repository.deriveAndPersistKeyPair(purpose, (index) => derivedKeypair(index, purpose));
+}
+
+export function runKeyRingDerivationRepositoryContract(
+  options: KeyRingDerivationContractOptions,
   runner: ContractRunner,
 ): void {
   const { describe, it, expect } = runner;
 
-  describe('keyring derivation allocation contract', () => {
+  describe('keyring derivation persistence contract', () => {
     it('starts each purpose at zero and advances independently', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {
         const p2pk = await Promise.all([
-          repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
-          repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
-          repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+          deriveNext(repositories.keyRingRepository, 'p2pk'),
+          deriveNext(repositories.keyRingRepository, 'p2pk'),
+          deriveNext(repositories.keyRingRepository, 'p2pk'),
         ]);
         const quote = await Promise.all([
-          repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
-          repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
-          repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
+          deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
+          deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
         ]);
 
-        expectExactIndexRange(p2pk, 0, 3, expect);
-        expectExactIndexRange(quote, 0, 3, expect);
+        expectExactIndexRange(
+          p2pk.map((key) => key.derivationIndex!),
+          0,
+          3,
+          expect,
+        );
+        expectExactIndexRange(
+          quote.map((key) => key.derivationIndex!),
+          0,
+          3,
+          expect,
+        );
       } finally {
         await dispose();
       }
@@ -96,11 +112,9 @@ export function runKeyRingAllocationRepositoryContract(
     it('continues above existing persisted keypairs', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {
-        await repositories.keyRingRepository.setPersistedKeyPair(
-          derivedKeypair('02' + '07'.repeat(32), 7, 'p2pk'),
-        );
-        const next = await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
-        expect(next).toBe(8);
+        await repositories.keyRingRepository.setPersistedKeyPair(derivedKeypair(7, 'p2pk'));
+        const next = await deriveNext(repositories.keyRingRepository, 'p2pk');
+        expect(next.derivationIndex).toBe(8);
       } finally {
         await dispose();
       }
@@ -111,26 +125,35 @@ export function runKeyRingAllocationRepositoryContract(
       try {
         const indexes = await Promise.all(
           Array.from({ length: 50 }, () =>
-            repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+            deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
           ),
         );
-        expectExactIndexRange(indexes, 0, 50, expect);
+        expectExactIndexRange(
+          indexes.map((key) => key.derivationIndex!),
+          0,
+          50,
+          expect,
+        );
       } finally {
         await dispose();
       }
     });
 
-    it('does not recycle abandoned or deleted allocations', async () => {
+    it('rolls back an unexposed index but does not recycle a deleted committed key', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {
-        const abandoned = await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
-        expect(abandoned).toBe(0);
-        const persistedIndex =
-          await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
-        const keypair = derivedKeypair('02' + '08'.repeat(32), persistedIndex, 'p2pk');
-        await repositories.keyRingRepository.setPersistedKeyPair(keypair);
+        await expectThrowsNamed(
+          () =>
+            repositories.keyRingRepository.deriveAndPersistKeyPair('p2pk', () => {
+              throw new Error('derivation failed');
+            }),
+          Error.name,
+          expect,
+        );
+        const keypair = await deriveNext(repositories.keyRingRepository, 'p2pk');
+        expect(keypair.derivationIndex).toBe(0);
         await repositories.keyRingRepository.deletePersistedKeyPair(keypair.publicKeyHex, 'p2pk');
-        expect(await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).toBe(2);
+        expect((await deriveNext(repositories.keyRingRepository, 'p2pk')).derivationIndex).toBe(1);
       } finally {
         await dispose();
       }
@@ -140,15 +163,15 @@ export function runKeyRingAllocationRepositoryContract(
       const { repositories, dispose } = await options.createRepositories();
       try {
         await repositories.keyRingRepository.setPersistedKeyPair(
-          derivedKeypair('02' + '09'.repeat(32), 0x7fffffff, 'nut20_mint_quote'),
+          derivedKeypair(0x7fffffff, 'nut20_mint_quote'),
         );
         await expectThrowsNamed(
-          () => repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          () => deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
           DerivationIndexExhaustedError.name,
           expect,
         );
         await expectThrowsNamed(
-          () => repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+          () => deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
           DerivationIndexExhaustedError.name,
           expect,
         );
@@ -163,19 +186,29 @@ export function runKeyRingAllocationRepositoryContract(
         try {
           const indexes = await Promise.all([
             ...Array.from({ length: 50 }, () =>
-              first.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+              deriveNext(first.keyRingRepository, 'nut20_mint_quote'),
             ),
             ...Array.from({ length: 50 }, () =>
-              second.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+              deriveNext(second.keyRingRepository, 'nut20_mint_quote'),
             ),
           ]);
-          expectExactIndexRange(indexes, 0, 100, expect);
+          expectExactIndexRange(
+            indexes.map((key) => key.derivationIndex!),
+            0,
+            100,
+            expect,
+          );
 
           const p2pk = await Promise.all([
-            first.keyRingRepository.reserveNextDerivationIndex('p2pk'),
-            second.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+            deriveNext(first.keyRingRepository, 'p2pk'),
+            deriveNext(second.keyRingRepository, 'p2pk'),
           ]);
-          expectExactIndexRange(p2pk, 0, 2, expect);
+          expectExactIndexRange(
+            p2pk.map((key) => key.derivationIndex!),
+            0,
+            2,
+            expect,
+          );
         } finally {
           await dispose();
         }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -220,6 +220,7 @@ import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
 - `MintQuoteRepository`
 - `HistoryRepository`
 - `KeyRingRepository`
+- `KeyRingAllocationRepository`
 - `AuthSessionRepository`
 - `SendOperationRepository`
 - `MeltOperationRepository`
@@ -227,6 +228,13 @@ import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
 - `ReceiveOperationRepository`
 
 The package root exports `MemoryRepositories` as an in-memory test/example repository bundle.
+
+`Repositories.keyRingRepository` implements `KeyRingAllocationRepository`. Its
+`reserveNextDerivationIndex(purpose)` method must permanently commit a unique, purpose-scoped
+derivation index before resolving. Transaction callbacks intentionally expose only
+`KeyRingRepository`; allocation must not be nested in a caller transaction that could later roll
+back. See the [storage adapter contract](../docs/pages/storage-adapters.md) for persistence and
+backup requirements.
 
 ## Public API surface
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -220,7 +220,6 @@ import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
 - `MintQuoteRepository`
 - `HistoryRepository`
 - `KeyRingRepository`
-- `KeyRingAllocationRepository`
 - `AuthSessionRepository`
 - `SendOperationRepository`
 - `MeltOperationRepository`
@@ -229,12 +228,11 @@ import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
 
 The package root exports `MemoryRepositories` as an in-memory test/example repository bundle.
 
-`Repositories.keyRingRepository` implements `KeyRingAllocationRepository`. Its
-`reserveNextDerivationIndex(purpose)` method must permanently commit a unique, purpose-scoped
-derivation index before resolving. Transaction callbacks intentionally expose only
-`KeyRingRepository`; allocation must not be nested in a caller transaction that could later roll
-back. See the [storage adapter contract](../docs/pages/storage-adapters.md) for persistence and
-backup requirements.
+`KeyRingRepository.deriveAndPersistKeyPair(purpose, derive)` selects the next purpose-scoped
+derivation index, invokes the synchronous derivation callback, and atomically commits the keypair
+with its durable high-water mark. It returns the keypair only after commit. See the
+[storage adapter contract](../docs/pages/storage-adapters.md) for transaction and backup
+requirements.
 
 ## Public API surface
 

--- a/packages/core/adapter.ts
+++ b/packages/core/adapter.ts
@@ -3,7 +3,6 @@ export type {
   CounterRepository,
   HistoryProjectionRepository,
   HistoryRepository,
-  KeyRingAllocationRepository,
   KeyRingRepository,
   KeysetRepository,
   LegacyMintQuoteRepository,

--- a/packages/core/adapter.ts
+++ b/packages/core/adapter.ts
@@ -3,6 +3,7 @@ export type {
   CounterRepository,
   HistoryProjectionRepository,
   HistoryRepository,
+  KeyRingAllocationRepository,
   KeyRingRepository,
   KeysetRepository,
   LegacyMintQuoteRepository,
@@ -51,6 +52,7 @@ export {
   operationHistoryId,
   parseHistoryEntryId,
   projectLegacyHistoryRow,
+  DerivationIndexExhaustedError,
   QuoteIdentityConflictError,
 } from './models/index.ts';
 export type {

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -41,8 +41,6 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     if (shouldLock) {
       await ctx.mintService.assertNutSupported(ctx.mintUrl, 20, 'locked BOLT11 mint quote');
     }
-    // TODO: Reserve mint-quote derivation indexes atomically in the upstream key service;
-    // concurrent quote creation can otherwise reuse the same derived key.
     const lockPubkey =
       shouldLock && !ownedPubkey
         ? (await this.keyRingService.generateMintQuoteKeyPair()).publicKeyHex

--- a/packages/core/models/Error.ts
+++ b/packages/core/models/Error.ts
@@ -1,3 +1,5 @@
+import type { KeypairPurpose } from './Keypair.ts';
+
 export { HttpResponseError, MintOperationError, NetworkError } from '@cashu/cashu-ts';
 
 export class UnknownMintError extends Error {
@@ -50,6 +52,16 @@ export class MintQuoteKeyError extends Error {
     super(message);
     this.name = 'MintQuoteKeyError';
     (this as unknown as { cause?: unknown }).cause = cause;
+  }
+}
+
+export class DerivationIndexExhaustedError extends Error {
+  readonly purpose: KeypairPurpose;
+
+  constructor(purpose: KeypairPurpose) {
+    super(`No derivation indexes remain for keypair purpose ${purpose}`);
+    this.name = 'DerivationIndexExhaustedError';
+    this.purpose = purpose;
   }
 }
 

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -206,7 +206,21 @@ export interface KeyRingRepository {
   deletePersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<void>;
   getAllPersistedKeyPairs(purpose?: KeypairPurpose): Promise<Keypair[]>;
   getLatestKeyPair(purpose?: KeypairPurpose): Promise<Keypair | null>;
-  getLastDerivationIndex(purpose?: KeypairPurpose): Promise<number>;
+}
+
+/**
+ * Root keyring repository capability for permanently consuming derivation indexes.
+ *
+ * This capability is deliberately absent from {@link RepositoryTransactionScope}: an allocation
+ * must commit independently so that a later caller rollback cannot make its index reusable.
+ */
+export interface KeyRingAllocationRepository extends KeyRingRepository {
+  /**
+   * Permanently consume and return the next derivation index for `purpose`.
+   *
+   * The returned promise must resolve only after the allocation transaction has committed.
+   */
+  reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number>;
 }
 
 export interface HistoryProjectionRepository {
@@ -374,6 +388,7 @@ interface RepositoriesBase {
 }
 
 export interface Repositories extends RepositoriesBase {
+  keyRingRepository: KeyRingAllocationRepository;
   init(): Promise<void>;
   withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
 }

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -206,21 +206,17 @@ export interface KeyRingRepository {
   deletePersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<void>;
   getAllPersistedKeyPairs(purpose?: KeypairPurpose): Promise<Keypair[]>;
   getLatestKeyPair(purpose?: KeypairPurpose): Promise<Keypair | null>;
-}
-
-/**
- * Root keyring repository capability for permanently consuming derivation indexes.
- *
- * This capability is deliberately absent from {@link RepositoryTransactionScope}: an allocation
- * must commit independently so that a later caller rollback cannot make its index reusable.
- */
-export interface KeyRingAllocationRepository extends KeyRingRepository {
   /**
-   * Permanently consume and return the next derivation index for `purpose`.
+   * Derive and persist the next keypair for `purpose` atomically with its durable high-water mark.
    *
-   * The returned promise must resolve only after the allocation transaction has committed.
+   * Implementations invoke `derive` synchronously inside a writer transaction and resolve only
+   * after both the returned keypair and the high-water mark have committed. If derivation,
+   * persistence, or commit fails, neither value may remain persisted.
    */
-  reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number>;
+  deriveAndPersistKeyPair(
+    purpose: KeypairPurpose,
+    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+  ): Promise<Keypair>;
 }
 
 export interface HistoryProjectionRepository {
@@ -388,11 +384,12 @@ interface RepositoriesBase {
 }
 
 export interface Repositories extends RepositoriesBase {
-  keyRingRepository: KeyRingAllocationRepository;
   init(): Promise<void>;
   withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
 }
 
-export type RepositoryTransactionScope = RepositoriesBase;
+export type RepositoryTransactionScope = Omit<RepositoriesBase, 'keyRingRepository'> & {
+  keyRingRepository: Omit<KeyRingRepository, 'deriveAndPersistKeyPair'>;
+};
 
 export * from './memory';

--- a/packages/core/repositories/memory/MemoryKeyRingRepository.ts
+++ b/packages/core/repositories/memory/MemoryKeyRingRepository.ts
@@ -1,14 +1,14 @@
 import type { Keypair, KeypairPurpose } from '../../models/Keypair';
 import { DerivationIndexExhaustedError } from '../../models/Error.ts';
-import type { KeyRingAllocationRepository } from '..';
+import type { KeyRingRepository } from '..';
 
 const DEFAULT_KEYPAIR_PURPOSE: KeypairPurpose = 'p2pk';
 const MAX_DERIVATION_INDEX = 0x7fffffff;
 
-export class MemoryKeyRingRepository implements KeyRingAllocationRepository {
+export class MemoryKeyRingRepository implements KeyRingRepository {
   private keyPairs: Map<string, Keypair> = new Map();
   private insertionOrder: string[] = [];
-  private lastAllocatedIndexes: Map<KeypairPurpose, number> = new Map();
+  private highWaterMarks: Map<KeypairPurpose, number> = new Map();
 
   async getPersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<Keypair | null> {
     const keyPair = this.keyPairs.get(publicKey) ?? null;
@@ -17,6 +17,10 @@ export class MemoryKeyRingRepository implements KeyRingAllocationRepository {
   }
 
   async setPersistedKeyPair(keyPair: Keypair): Promise<void> {
+    this.persistKeyPair(keyPair);
+  }
+
+  private persistKeyPair(keyPair: Keypair): void {
     if (!this.keyPairs.has(keyPair.publicKeyHex)) {
       this.insertionOrder.push(keyPair.publicKeyHex);
     }
@@ -66,7 +70,10 @@ export class MemoryKeyRingRepository implements KeyRingAllocationRepository {
     return null;
   }
 
-  reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+  async deriveAndPersistKeyPair(
+    purpose: KeypairPurpose,
+    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+  ): Promise<Keypair> {
     let greatestStoredIndex = -1;
     for (const keypair of this.keyPairs.values()) {
       if ((keypair.purpose ?? DEFAULT_KEYPAIR_PURPOSE) !== purpose) continue;
@@ -75,14 +82,17 @@ export class MemoryKeyRingRepository implements KeyRingAllocationRepository {
       }
     }
 
-    const lastAllocatedIndex = this.lastAllocatedIndexes.get(purpose) ?? -1;
-    const baseIndex = Math.max(lastAllocatedIndex, greatestStoredIndex);
+    const highWaterMark = this.highWaterMarks.get(purpose) ?? -1;
+    const baseIndex = Math.max(highWaterMark, greatestStoredIndex);
     if (baseIndex >= MAX_DERIVATION_INDEX) {
-      return Promise.reject(new DerivationIndexExhaustedError(purpose));
+      throw new DerivationIndexExhaustedError(purpose);
     }
 
     const nextIndex = baseIndex + 1;
-    this.lastAllocatedIndexes.set(purpose, nextIndex);
-    return Promise.resolve(nextIndex);
+    const keyPair = { ...derive(nextIndex), derivationIndex: nextIndex, purpose };
+
+    this.persistKeyPair(keyPair);
+    this.highWaterMarks.set(purpose, nextIndex);
+    return keyPair;
   }
 }

--- a/packages/core/repositories/memory/MemoryKeyRingRepository.ts
+++ b/packages/core/repositories/memory/MemoryKeyRingRepository.ts
@@ -1,11 +1,14 @@
 import type { Keypair, KeypairPurpose } from '../../models/Keypair';
-import type { KeyRingRepository } from '..';
+import { DerivationIndexExhaustedError } from '../../models/Error.ts';
+import type { KeyRingAllocationRepository } from '..';
 
 const DEFAULT_KEYPAIR_PURPOSE: KeypairPurpose = 'p2pk';
+const MAX_DERIVATION_INDEX = 0x7fffffff;
 
-export class MemoryKeyRingRepository implements KeyRingRepository {
+export class MemoryKeyRingRepository implements KeyRingAllocationRepository {
   private keyPairs: Map<string, Keypair> = new Map();
   private insertionOrder: string[] = [];
+  private lastAllocatedIndexes: Map<KeypairPurpose, number> = new Map();
 
   async getPersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<Keypair | null> {
     const keyPair = this.keyPairs.get(publicKey) ?? null;
@@ -63,14 +66,23 @@ export class MemoryKeyRingRepository implements KeyRingRepository {
     return null;
   }
 
-  async getLastDerivationIndex(purpose?: KeypairPurpose): Promise<number> {
-    let maxIndex = -1;
+  reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+    let greatestStoredIndex = -1;
     for (const keypair of this.keyPairs.values()) {
-      if (purpose && (keypair.purpose ?? DEFAULT_KEYPAIR_PURPOSE) !== purpose) continue;
-      if (keypair.derivationIndex != null && keypair.derivationIndex > maxIndex) {
-        maxIndex = keypair.derivationIndex;
+      if ((keypair.purpose ?? DEFAULT_KEYPAIR_PURPOSE) !== purpose) continue;
+      if (keypair.derivationIndex != null && keypair.derivationIndex > greatestStoredIndex) {
+        greatestStoredIndex = keypair.derivationIndex;
       }
     }
-    return maxIndex;
+
+    const lastAllocatedIndex = this.lastAllocatedIndexes.get(purpose) ?? -1;
+    const baseIndex = Math.max(lastAllocatedIndex, greatestStoredIndex);
+    if (baseIndex >= MAX_DERIVATION_INDEX) {
+      return Promise.reject(new DerivationIndexExhaustedError(purpose));
+    }
+
+    const nextIndex = baseIndex + 1;
+    this.lastAllocatedIndexes.set(purpose, nextIndex);
+    return Promise.resolve(nextIndex);
   }
 }

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -2,7 +2,7 @@ import type {
   AuthSessionRepository,
   CounterRepository,
   HistoryProjectionRepository,
-  KeyRingRepository,
+  KeyRingAllocationRepository,
   KeysetRepository,
   LegacyMintQuoteRepository,
   MeltQuoteRepository,
@@ -39,7 +39,7 @@ import {
 
 export class MemoryRepositories implements Repositories {
   mintRepository: MintRepository;
-  keyRingRepository: KeyRingRepository;
+  keyRingRepository: KeyRingAllocationRepository;
   counterRepository: CounterRepository;
   keysetRepository: KeysetRepository;
   proofRepository: ProofRepository;

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -2,7 +2,7 @@ import type {
   AuthSessionRepository,
   CounterRepository,
   HistoryProjectionRepository,
-  KeyRingAllocationRepository,
+  KeyRingRepository,
   KeysetRepository,
   LegacyMintQuoteRepository,
   MeltQuoteRepository,
@@ -39,7 +39,7 @@ import {
 
 export class MemoryRepositories implements Repositories {
   mintRepository: MintRepository;
-  keyRingRepository: KeyRingAllocationRepository;
+  keyRingRepository: KeyRingRepository;
   counterRepository: CounterRepository;
   keysetRepository: KeysetRepository;
   proofRepository: ProofRepository;

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -1,6 +1,6 @@
 import type { Proof } from '@cashu/cashu-ts';
 import type { Logger } from '@core/logging';
-import type { KeyRingAllocationRepository } from '@core/repositories';
+import type { KeyRingRepository } from '@core/repositories';
 import type { Keypair, KeypairPurpose } from '@core/models/Keypair';
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
@@ -15,13 +15,9 @@ export class KeyRingService {
   };
 
   private readonly logger?: Logger;
-  private readonly keyRingRepository: KeyRingAllocationRepository;
+  private readonly keyRingRepository: KeyRingRepository;
   private readonly seedService: SeedService;
-  constructor(
-    keyRingRepository: KeyRingAllocationRepository,
-    seedService: SeedService,
-    logger?: Logger,
-  ) {
+  constructor(keyRingRepository: KeyRingRepository, seedService: SeedService, logger?: Logger) {
     this.keyRingRepository = keyRingRepository;
     this.logger = logger;
     this.seedService = seedService;
@@ -49,30 +45,29 @@ export class KeyRingService {
     },
   ): Promise<{ publicKeyHex: string } | Keypair> {
     this.logger?.debug('Generating new key pair');
-    const nextDerivationIndex = await this.keyRingRepository.reserveNextDerivationIndex(purpose);
     const seed = await this.seedService.getSeed();
     const hdKey = HDKey.fromMasterSeed(seed);
     const derivationPurpose = KeyRingService.DERIVATION_PURPOSES[purpose];
-    const derivationPath = `m/129373'/${derivationPurpose}'/0'/0'/${nextDerivationIndex}`;
-    const { privateKey: secretKey } = hdKey.derive(derivationPath);
-    if (!secretKey) {
-      throw new Error('Failed to derive secret key');
-    }
-    const publicKeyHex =
-      purpose === 'nut20_mint_quote'
-        ? this.getCompressedPublicKeyHex(secretKey)
-        : this.getPublicKeyHex(secretKey);
-    await this.keyRingRepository.setPersistedKeyPair({
-      publicKeyHex,
-      secretKey,
-      derivationIndex: nextDerivationIndex,
+    const keyPair = await this.keyRingRepository.deriveAndPersistKeyPair(
       purpose,
-    });
-    this.logger?.debug('New key pair generated', { publicKeyHex });
+      (derivationIndex) => {
+        const derivationPath = `m/129373'/${derivationPurpose}'/0'/0'/${derivationIndex}`;
+        const { privateKey: secretKey } = hdKey.derive(derivationPath);
+        if (!secretKey) {
+          throw new Error('Failed to derive secret key');
+        }
+        const publicKeyHex =
+          purpose === 'nut20_mint_quote'
+            ? this.getCompressedPublicKeyHex(secretKey)
+            : this.getPublicKeyHex(secretKey);
+        return { publicKeyHex, secretKey };
+      },
+    );
+    this.logger?.debug('New key pair generated', { publicKeyHex: keyPair.publicKeyHex });
     if (options?.dumpSecretKey) {
-      return { publicKeyHex, secretKey, derivationIndex: nextDerivationIndex, purpose };
+      return keyPair;
     }
-    return { publicKeyHex };
+    return { publicKeyHex: keyPair.publicKeyHex };
   }
 
   async addKeyPair(secretKey: Uint8Array): Promise<Keypair> {

--- a/packages/core/services/KeyRingService.ts
+++ b/packages/core/services/KeyRingService.ts
@@ -1,6 +1,6 @@
 import type { Proof } from '@cashu/cashu-ts';
 import type { Logger } from '@core/logging';
-import type { KeyRingRepository } from '@core/repositories';
+import type { KeyRingAllocationRepository } from '@core/repositories';
 import type { Keypair, KeypairPurpose } from '@core/models/Keypair';
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import { bytesToHex } from '@noble/curves/utils.js';
@@ -15,9 +15,13 @@ export class KeyRingService {
   };
 
   private readonly logger?: Logger;
-  private readonly keyRingRepository: KeyRingRepository;
+  private readonly keyRingRepository: KeyRingAllocationRepository;
   private readonly seedService: SeedService;
-  constructor(keyRingRepository: KeyRingRepository, seedService: SeedService, logger?: Logger) {
+  constructor(
+    keyRingRepository: KeyRingAllocationRepository,
+    seedService: SeedService,
+    logger?: Logger,
+  ) {
     this.keyRingRepository = keyRingRepository;
     this.logger = logger;
     this.seedService = seedService;
@@ -45,8 +49,7 @@ export class KeyRingService {
     },
   ): Promise<{ publicKeyHex: string } | Keypair> {
     this.logger?.debug('Generating new key pair');
-    const lastDerivationIndex = await this.keyRingRepository.getLastDerivationIndex(purpose);
-    const nextDerivationIndex = lastDerivationIndex + 1;
+    const nextDerivationIndex = await this.keyRingRepository.reserveNextDerivationIndex(purpose);
     const seed = await this.seedService.getSeed();
     const hdKey = HDKey.fromMasterSeed(seed);
     const derivationPurpose = KeyRingService.DERIVATION_PURPOSES[purpose];

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -3,9 +3,11 @@ import { describe, it, beforeEach, expect } from 'bun:test';
 import { KeyRingService } from '../../services/KeyRingService.ts';
 import { SeedService } from '../../services/SeedService.ts';
 import { MemoryKeyRingRepository } from '../../repositories/memory/MemoryKeyRingRepository.ts';
+import { DerivationIndexExhaustedError } from '../../models/Error.ts';
 import { bytesToHex } from '@noble/curves/utils.js';
 import { schnorr, secp256k1 } from '@noble/curves/secp256k1.js';
 import type { Proof } from '@cashu/cashu-ts';
+import type { Keypair, KeypairPurpose } from '../../models/Keypair.ts';
 
 // Mock seed for deterministic testing
 const MOCK_SEED = new Uint8Array(64);
@@ -126,6 +128,169 @@ describe('KeyRingService', () => {
       expect(quoteKey.publicKeyHex).toBe(
         bytesToHex(secp256k1.getPublicKey(quoteKey.secretKey, true)),
       );
+    });
+
+    it('atomically generates distinct mint quote keys for concurrent calls', async () => {
+      const keyPairs = await Promise.all(
+        Array.from({ length: 32 }, () => service.generateMintQuoteKeyPair()),
+      );
+
+      expect(new Set(keyPairs.map((keyPair) => keyPair.derivationIndex)).size).toBe(32);
+      expect(new Set(keyPairs.map((keyPair) => keyPair.publicKeyHex)).size).toBe(32);
+      expect(new Set(keyPairs.map((keyPair) => bytesToHex(keyPair.secretKey))).size).toBe(32);
+      expect(keyPairs.map((keyPair) => keyPair.derivationIndex).sort((a, b) => a! - b!)).toEqual(
+        Array.from({ length: 32 }, (_, index) => index),
+      );
+      expect(await repo.getAllPersistedKeyPairs('nut20_mint_quote')).toHaveLength(32);
+    });
+
+    it('coordinates concurrent services sharing one repository', async () => {
+      const secondService = new KeyRingService(repo, new SeedService(async () => MOCK_SEED));
+      const keyPairs = await Promise.all([
+        ...Array.from({ length: 16 }, () => service.generateMintQuoteKeyPair()),
+        ...Array.from({ length: 16 }, () => secondService.generateMintQuoteKeyPair()),
+      ]);
+
+      expect(new Set(keyPairs.map((keyPair) => keyPair.derivationIndex)).size).toBe(32);
+      expect(new Set(keyPairs.map((keyPair) => keyPair.publicKeyHex)).size).toBe(32);
+      expect(keyPairs.map((keyPair) => keyPair.derivationIndex).sort((a, b) => a! - b!)).toEqual(
+        Array.from({ length: 32 }, (_, index) => index),
+      );
+    });
+
+    it('keeps concurrent P2PK and mint quote allocation sequences independent', async () => {
+      const [p2pkKeys, quoteKeys] = await Promise.all([
+        Promise.all(
+          Array.from({ length: 16 }, () => service.generateNewKeyPair({ dumpSecretKey: true })),
+        ),
+        Promise.all(Array.from({ length: 16 }, () => service.generateMintQuoteKeyPair())),
+      ]);
+
+      const expectedIndexes = Array.from({ length: 16 }, (_, index) => index);
+      expect(p2pkKeys.map((key) => key.derivationIndex).sort((a, b) => a! - b!)).toEqual(
+        expectedIndexes,
+      );
+      expect(quoteKeys.map((key) => key.derivationIndex).sort((a, b) => a! - b!)).toEqual(
+        expectedIndexes,
+      );
+      expect(new Set([...p2pkKeys, ...quoteKeys].map((keyPair) => keyPair.publicKeyHex)).size).toBe(
+        32,
+      );
+    });
+
+    it('does not consume an index when allocation fails before commit', async () => {
+      class FailBeforeAllocationRepository extends MemoryKeyRingRepository {
+        private failNextAllocation = true;
+
+        override reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+          if (this.failNextAllocation) {
+            this.failNextAllocation = false;
+            return Promise.reject(new Error('allocation failed'));
+          }
+          return super.reserveNextDerivationIndex(purpose);
+        }
+      }
+
+      const failingRepository = new FailBeforeAllocationRepository();
+      const failingService = new KeyRingService(failingRepository, seedService);
+
+      await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow('allocation failed');
+      await expect(failingService.generateMintQuoteKeyPair()).resolves.toMatchObject({
+        derivationIndex: 0,
+      });
+    });
+
+    it('leaves a permanent gap when seed loading fails after allocation', async () => {
+      let failNextSeed = true;
+      const failingSeedService = new SeedService(async () => {
+        if (failNextSeed) {
+          failNextSeed = false;
+          throw new Error('seed unavailable');
+        }
+        return MOCK_SEED;
+      });
+      const failingService = new KeyRingService(repo, failingSeedService);
+
+      await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow('seed unavailable');
+      expect(await repo.getAllPersistedKeyPairs('nut20_mint_quote')).toEqual([]);
+      await expect(failingService.generateMintQuoteKeyPair()).resolves.toMatchObject({
+        derivationIndex: 1,
+      });
+    });
+
+    it('leaves a permanent gap when key persistence fails after allocation', async () => {
+      class FailFirstPersistenceRepository extends MemoryKeyRingRepository {
+        private failNextPersistence = true;
+
+        override async setPersistedKeyPair(keyPair: Keypair): Promise<void> {
+          if (this.failNextPersistence) {
+            this.failNextPersistence = false;
+            throw new Error('key persistence failed');
+          }
+          await super.setPersistedKeyPair(keyPair);
+        }
+      }
+
+      const failingRepository = new FailFirstPersistenceRepository();
+      const failingService = new KeyRingService(failingRepository, seedService);
+
+      await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow(
+        'key persistence failed',
+      );
+      expect(await failingRepository.getAllPersistedKeyPairs('nut20_mint_quote')).toEqual([]);
+      await expect(failingService.generateMintQuoteKeyPair()).resolves.toMatchObject({
+        derivationIndex: 1,
+      });
+    });
+
+    it('does not resolve generation before the keypair is persisted', async () => {
+      let releasePersistence!: () => void;
+      let reportPersistenceStarted!: () => void;
+      const persistenceGate = new Promise<void>((resolve) => {
+        releasePersistence = resolve;
+      });
+      const persistenceStarted = new Promise<void>((resolve) => {
+        reportPersistenceStarted = resolve;
+      });
+
+      class BlockingPersistenceRepository extends MemoryKeyRingRepository {
+        override async setPersistedKeyPair(keyPair: Keypair): Promise<void> {
+          reportPersistenceStarted();
+          await persistenceGate;
+          await super.setPersistedKeyPair(keyPair);
+        }
+      }
+
+      const blockingRepository = new BlockingPersistenceRepository();
+      const blockingService = new KeyRingService(blockingRepository, seedService);
+      let generationSettled = false;
+      const generation = blockingService.generateMintQuoteKeyPair().then((keyPair) => {
+        generationSettled = true;
+        return keyPair;
+      });
+
+      await persistenceStarted;
+      await Promise.resolve();
+      expect(generationSettled).toBe(false);
+
+      releasePersistence();
+      const keyPair = await generation;
+      expect(
+        await blockingRepository.getPersistedKeyPair(keyPair.publicKeyHex, 'nut20_mint_quote'),
+      ).not.toBeNull();
+    });
+
+    it('fails explicitly when the derivation index space is exhausted', async () => {
+      await repo.setPersistedKeyPair({
+        publicKeyHex: '02' + '01'.repeat(32),
+        secretKey: new Uint8Array(32).fill(1),
+        derivationIndex: 0x7fffffff,
+        purpose: 'nut20_mint_quote',
+      });
+
+      const allocation = repo.reserveNextDerivationIndex('nut20_mint_quote');
+      await expect(allocation).rejects.toBeInstanceOf(DerivationIndexExhaustedError);
+      await expect(repo.reserveNextDerivationIndex('p2pk')).resolves.toBe(0);
     });
 
     it('keeps mint quote keys out of user-facing key queries and removal', async () => {
@@ -318,6 +483,9 @@ describe('KeyRingService', () => {
 
       const latest = await service.getLatestKeyPair();
       expect(latest).toBeNull();
+
+      const next = await service.generateNewKeyPair({ dumpSecretKey: true });
+      expect(next.derivationIndex).toBe(1);
     });
   });
 

--- a/packages/core/test/unit/KeyRingService.test.ts
+++ b/packages/core/test/unit/KeyRingService.test.ts
@@ -178,29 +178,32 @@ describe('KeyRingService', () => {
       );
     });
 
-    it('does not consume an index when allocation fails before commit', async () => {
-      class FailBeforeAllocationRepository extends MemoryKeyRingRepository {
-        private failNextAllocation = true;
+    it('does not expose or consume an index when atomic persistence fails', async () => {
+      class FailBeforeCommitRepository extends MemoryKeyRingRepository {
+        private failNextCommit = true;
 
-        override reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
-          if (this.failNextAllocation) {
-            this.failNextAllocation = false;
-            return Promise.reject(new Error('allocation failed'));
+        override deriveAndPersistKeyPair(
+          purpose: KeypairPurpose,
+          derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+        ): Promise<Keypair> {
+          if (this.failNextCommit) {
+            this.failNextCommit = false;
+            return Promise.reject(new Error('commit failed'));
           }
-          return super.reserveNextDerivationIndex(purpose);
+          return super.deriveAndPersistKeyPair(purpose, derive);
         }
       }
 
-      const failingRepository = new FailBeforeAllocationRepository();
+      const failingRepository = new FailBeforeCommitRepository();
       const failingService = new KeyRingService(failingRepository, seedService);
 
-      await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow('allocation failed');
+      await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow('commit failed');
       await expect(failingService.generateMintQuoteKeyPair()).resolves.toMatchObject({
         derivationIndex: 0,
       });
     });
 
-    it('leaves a permanent gap when seed loading fails after allocation', async () => {
+    it('loads the seed before allocating a derivation index', async () => {
       let failNextSeed = true;
       const failingSeedService = new SeedService(async () => {
         if (failNextSeed) {
@@ -214,36 +217,11 @@ describe('KeyRingService', () => {
       await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow('seed unavailable');
       expect(await repo.getAllPersistedKeyPairs('nut20_mint_quote')).toEqual([]);
       await expect(failingService.generateMintQuoteKeyPair()).resolves.toMatchObject({
-        derivationIndex: 1,
+        derivationIndex: 0,
       });
     });
 
-    it('leaves a permanent gap when key persistence fails after allocation', async () => {
-      class FailFirstPersistenceRepository extends MemoryKeyRingRepository {
-        private failNextPersistence = true;
-
-        override async setPersistedKeyPair(keyPair: Keypair): Promise<void> {
-          if (this.failNextPersistence) {
-            this.failNextPersistence = false;
-            throw new Error('key persistence failed');
-          }
-          await super.setPersistedKeyPair(keyPair);
-        }
-      }
-
-      const failingRepository = new FailFirstPersistenceRepository();
-      const failingService = new KeyRingService(failingRepository, seedService);
-
-      await expect(failingService.generateMintQuoteKeyPair()).rejects.toThrow(
-        'key persistence failed',
-      );
-      expect(await failingRepository.getAllPersistedKeyPairs('nut20_mint_quote')).toEqual([]);
-      await expect(failingService.generateMintQuoteKeyPair()).resolves.toMatchObject({
-        derivationIndex: 1,
-      });
-    });
-
-    it('does not resolve generation before the keypair is persisted', async () => {
+    it('does not return the keypair before the repository commit completes', async () => {
       let releasePersistence!: () => void;
       let reportPersistenceStarted!: () => void;
       const persistenceGate = new Promise<void>((resolve) => {
@@ -254,10 +232,14 @@ describe('KeyRingService', () => {
       });
 
       class BlockingPersistenceRepository extends MemoryKeyRingRepository {
-        override async setPersistedKeyPair(keyPair: Keypair): Promise<void> {
+        override async deriveAndPersistKeyPair(
+          purpose: KeypairPurpose,
+          derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+        ): Promise<Keypair> {
+          const keyPair = await super.deriveAndPersistKeyPair(purpose, derive);
           reportPersistenceStarted();
           await persistenceGate;
-          await super.setPersistedKeyPair(keyPair);
+          return keyPair;
         }
       }
 
@@ -288,9 +270,12 @@ describe('KeyRingService', () => {
         purpose: 'nut20_mint_quote',
       });
 
-      const allocation = repo.reserveNextDerivationIndex('nut20_mint_quote');
-      await expect(allocation).rejects.toBeInstanceOf(DerivationIndexExhaustedError);
-      await expect(repo.reserveNextDerivationIndex('p2pk')).resolves.toBe(0);
+      await expect(service.generateMintQuoteKeyPair()).rejects.toBeInstanceOf(
+        DerivationIndexExhaustedError,
+      );
+      await expect(service.generateNewKeyPair({ dumpSecretKey: true })).resolves.toMatchObject({
+        derivationIndex: 0,
+      });
     });
 
     it('keeps mint quote keys out of user-facing key queries and removal', async () => {

--- a/packages/core/test/unit/MemoryKeyRingRepository.test.ts
+++ b/packages/core/test/unit/MemoryKeyRingRepository.test.ts
@@ -1,18 +1,75 @@
 import { describe, expect, it } from 'bun:test';
-import { runKeyRingAllocationRepositoryContract } from '@cashu/coco-adapter-tests';
+import { DerivationIndexExhaustedError } from '../../models/Error.ts';
+import type { KeypairPurpose } from '../../models/Keypair.ts';
 import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
 import type { RepositoryTransactionScope } from '../../repositories/index.ts';
 
-async function createRepositories() {
-  const repositories = new MemoryRepositories();
-  await repositories.init();
+const MAX_DERIVATION_INDEX = 0x7fffffff;
+
+function derivedKeypair(publicKeyHex: string, derivationIndex: number, purpose: KeypairPurpose) {
   return {
-    repositories,
-    dispose: async () => {},
+    publicKeyHex,
+    secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
+    derivationIndex,
+    purpose,
   };
 }
 
-runKeyRingAllocationRepositoryContract({ createRepositories }, { describe, it, expect });
+describe('MemoryKeyRingRepository derivation allocation', () => {
+  it('allocates exact concurrent sequences independently for each purpose', async () => {
+    const repositories = new MemoryRepositories();
+    const p2pk = await Promise.all(
+      Array.from({ length: 50 }, () =>
+        repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
+      ),
+    );
+    const mintQuote = await Promise.all(
+      Array.from({ length: 50 }, () =>
+        repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+      ),
+    );
+
+    expect(p2pk.sort((left, right) => left - right)).toEqual(
+      Array.from({ length: 50 }, (_, index) => index),
+    );
+    expect(mintQuote.sort((left, right) => left - right)).toEqual(
+      Array.from({ length: 50 }, (_, index) => index),
+    );
+  });
+
+  it('continues above persisted indexes and never recycles gaps or deleted keys', async () => {
+    const repositories = new MemoryRepositories();
+    await repositories.keyRingRepository.setPersistedKeyPair(
+      derivedKeypair('02' + '07'.repeat(32), 7, 'p2pk'),
+    );
+
+    await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
+      8,
+    );
+    const persistedIndex = await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
+    const persisted = derivedKeypair('02' + '08'.repeat(32), persistedIndex, 'p2pk');
+    await repositories.keyRingRepository.setPersistedKeyPair(persisted);
+    await repositories.keyRingRepository.deletePersistedKeyPair(persisted.publicKeyHex, 'p2pk');
+
+    await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
+      10,
+    );
+  });
+
+  it('fails explicitly without advancing beyond the maximum child index', async () => {
+    const repositories = new MemoryRepositories();
+    await repositories.keyRingRepository.setPersistedKeyPair(
+      derivedKeypair('02' + '09'.repeat(32), MAX_DERIVATION_INDEX, 'nut20_mint_quote'),
+    );
+
+    await expect(
+      repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+    ).rejects.toBeInstanceOf(DerivationIndexExhaustedError);
+    await expect(
+      repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+    ).rejects.toBeInstanceOf(DerivationIndexExhaustedError);
+  });
+});
 
 function assertAllocationIsRootOnly(scope: RepositoryTransactionScope): void {
   // @ts-expect-error Irreversible allocation must not be available inside a caller transaction.

--- a/packages/core/test/unit/MemoryKeyRingRepository.test.ts
+++ b/packages/core/test/unit/MemoryKeyRingRepository.test.ts
@@ -6,74 +6,85 @@ import type { RepositoryTransactionScope } from '../../repositories/index.ts';
 
 const MAX_DERIVATION_INDEX = 0x7fffffff;
 
-function derivedKeypair(publicKeyHex: string, derivationIndex: number, purpose: KeypairPurpose) {
+function derivedKeypair(derivationIndex: number, purpose: KeypairPurpose) {
+  const prefix = purpose === 'p2pk' ? '02' : '03';
   return {
-    publicKeyHex,
+    publicKeyHex: prefix + derivationIndex.toString(16).padStart(64, '0'),
     secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
     derivationIndex,
     purpose,
   };
 }
 
-describe('MemoryKeyRingRepository derivation allocation', () => {
+function deriveNext(repository: MemoryRepositories['keyRingRepository'], purpose: KeypairPurpose) {
+  return repository.deriveAndPersistKeyPair(purpose, (index) => derivedKeypair(index, purpose));
+}
+
+describe('MemoryKeyRingRepository derivation persistence', () => {
   it('allocates exact concurrent sequences independently for each purpose', async () => {
     const repositories = new MemoryRepositories();
     const p2pk = await Promise.all(
-      Array.from({ length: 50 }, () =>
-        repositories.keyRingRepository.reserveNextDerivationIndex('p2pk'),
-      ),
+      Array.from({ length: 50 }, () => deriveNext(repositories.keyRingRepository, 'p2pk')),
     );
     const mintQuote = await Promise.all(
       Array.from({ length: 50 }, () =>
-        repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+        deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
       ),
     );
 
-    expect(p2pk.sort((left, right) => left - right)).toEqual(
+    expect(p2pk.map((key) => key.derivationIndex).sort((left, right) => left! - right!)).toEqual(
       Array.from({ length: 50 }, (_, index) => index),
     );
-    expect(mintQuote.sort((left, right) => left - right)).toEqual(
-      Array.from({ length: 50 }, (_, index) => index),
-    );
+    expect(
+      mintQuote.map((key) => key.derivationIndex).sort((left, right) => left! - right!),
+    ).toEqual(Array.from({ length: 50 }, (_, index) => index));
   });
 
   it('continues above persisted indexes and never recycles gaps or deleted keys', async () => {
     const repositories = new MemoryRepositories();
-    await repositories.keyRingRepository.setPersistedKeyPair(
-      derivedKeypair('02' + '07'.repeat(32), 7, 'p2pk'),
-    );
+    await repositories.keyRingRepository.setPersistedKeyPair(derivedKeypair(7, 'p2pk'));
 
-    await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
-      8,
-    );
-    const persistedIndex = await repositories.keyRingRepository.reserveNextDerivationIndex('p2pk');
-    const persisted = derivedKeypair('02' + '08'.repeat(32), persistedIndex, 'p2pk');
-    await repositories.keyRingRepository.setPersistedKeyPair(persisted);
+    const persisted = await deriveNext(repositories.keyRingRepository, 'p2pk');
+    expect(persisted.derivationIndex).toBe(8);
     await repositories.keyRingRepository.deletePersistedKeyPair(persisted.publicKeyHex, 'p2pk');
 
-    await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
-      10,
-    );
+    await expect(deriveNext(repositories.keyRingRepository, 'p2pk')).resolves.toMatchObject({
+      derivationIndex: 9,
+    });
+  });
+
+  it('reuses an unexposed index after derivation fails', async () => {
+    const repositories = new MemoryRepositories();
+    await expect(
+      repositories.keyRingRepository.deriveAndPersistKeyPair('p2pk', () => {
+        throw new Error('derivation failed');
+      }),
+    ).rejects.toThrow('derivation failed');
+
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([]);
+    await expect(deriveNext(repositories.keyRingRepository, 'p2pk')).resolves.toMatchObject({
+      derivationIndex: 0,
+    });
   });
 
   it('fails explicitly without advancing beyond the maximum child index', async () => {
     const repositories = new MemoryRepositories();
     await repositories.keyRingRepository.setPersistedKeyPair(
-      derivedKeypair('02' + '09'.repeat(32), MAX_DERIVATION_INDEX, 'nut20_mint_quote'),
+      derivedKeypair(MAX_DERIVATION_INDEX, 'nut20_mint_quote'),
     );
 
     await expect(
-      repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+      deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
     ).rejects.toBeInstanceOf(DerivationIndexExhaustedError);
     await expect(
-      repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+      deriveNext(repositories.keyRingRepository, 'nut20_mint_quote'),
     ).rejects.toBeInstanceOf(DerivationIndexExhaustedError);
   });
 });
 
-function assertAllocationIsRootOnly(scope: RepositoryTransactionScope): void {
-  // @ts-expect-error Irreversible allocation must not be available inside a caller transaction.
-  void scope.keyRingRepository.reserveNextDerivationIndex;
+function assertAtomicDerivationIsRootOnly(scope: RepositoryTransactionScope): void {
+  // @ts-expect-error A generated key must not be exposed before its own transaction commits.
+  void scope.keyRingRepository.deriveAndPersistKeyPair;
 }
 
-void assertAllocationIsRootOnly;
+void assertAtomicDerivationIsRootOnly;

--- a/packages/core/test/unit/MemoryKeyRingRepository.test.ts
+++ b/packages/core/test/unit/MemoryKeyRingRepository.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { runKeyRingAllocationRepositoryContract } from '@cashu/coco-adapter-tests';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import type { RepositoryTransactionScope } from '../../repositories/index.ts';
+
+async function createRepositories() {
+  const repositories = new MemoryRepositories();
+  await repositories.init();
+  return {
+    repositories,
+    dispose: async () => {},
+  };
+}
+
+runKeyRingAllocationRepositoryContract({ createRepositories }, { describe, it, expect });
+
+function assertAllocationIsRootOnly(scope: RepositoryTransactionScope): void {
+  // @ts-expect-error Irreversible allocation must not be available inside a caller transaction.
+  void scope.keyRingRepository.reserveNextDerivationIndex;
+}
+
+void assertAllocationIsRootOnly;

--- a/packages/docs/pages/keyring.md
+++ b/packages/docs/pages/keyring.md
@@ -36,14 +36,15 @@ The secret key is sensitive cryptographic material. When setting `dumpSecretKey:
 
 #### Atomic derivation allocation
 
-Coco reserves each derivation index in storage before loading the seed and deriving the key. The
-allocation sequence is independent for P2PK keys and NUT-20 mint-quote keys, and built-in durable
-adapters coordinate sessions that share the same database. Concurrent generation therefore cannot
-select the same index or deterministic key.
+Coco loads the seed first, then asks the storage adapter to derive and persist the next key inside
+one writer transaction. The transaction commits the generated keypair and its purpose-scoped
+high-water mark together, and the key is returned only after commit. Built-in durable adapters
+coordinate sessions that share the same database, so concurrent generation cannot select the same
+index or deterministic key.
 
-An index remains consumed if seed access, derivation, or key persistence fails after reservation.
-This can leave intentional gaps in the sequence; gaps are safe and are never filled later. Removing
-a generated keypair also does not make its index reusable.
+If seed access, derivation, persistence, or commit fails, no key is exposed and the transaction does
+not consume the index. Removing a successfully generated keypair does not lower the durable
+high-water mark, so its committed index is never reused.
 
 ### Importing Existing Keypairs
 
@@ -176,8 +177,8 @@ private keys and NUT-20 mint-quote private keys.
 See [Storage Adapters](./storage-adapters.md#security) for the storage security model and guidance
 on protecting wallet data.
 
-Derivation allocation metadata and keypairs form one backup unit. Restoring only keypairs without
-the allocation metadata is unsupported. Deleting the complete database or restoring an old
+Derivation high-water metadata and keypairs form one backup unit. Restoring only keypairs without
+the high-water metadata is unsupported. Deleting the complete database or restoring an old
 snapshot resets allocation history to that state and can reproduce keys derived after the snapshot
 when the same seed is reused.
 

--- a/packages/docs/pages/keyring.md
+++ b/packages/docs/pages/keyring.md
@@ -34,6 +34,17 @@ console.log('Secret key:', keypair.secretKey); // Uint8Array(32)
 The secret key is sensitive cryptographic material. When setting `dumpSecretKey: true`, ensure you handle the key securely and clear it from memory when no longer needed.
 :::
 
+#### Atomic derivation allocation
+
+Coco reserves each derivation index in storage before loading the seed and deriving the key. The
+allocation sequence is independent for P2PK keys and NUT-20 mint-quote keys, and built-in durable
+adapters coordinate sessions that share the same database. Concurrent generation therefore cannot
+select the same index or deterministic key.
+
+An index remains consumed if seed access, derivation, or key persistence fails after reservation.
+This can leave intentional gaps in the sequence; gaps are safe and are never filled later. Removing
+a generated keypair also does not make its index reusable.
+
 ### Importing Existing Keypairs
 
 You can import external keypairs by providing a 32-byte secret key:
@@ -139,6 +150,7 @@ interface Keypair {
   publicKeyHex: string; // The public key as a hex string
   secretKey: Uint8Array; // The 32-byte secret key
   derivationIndex?: number; // BIP32 derivation index (if generated)
+  purpose?: 'p2pk' | 'nut20_mint_quote'; // Independent derivation branch
 }
 
 // KeyRing API methods
@@ -163,6 +175,11 @@ private keys and NUT-20 mint-quote private keys.
 
 See [Storage Adapters](./storage-adapters.md#security) for the storage security model and guidance
 on protecting wallet data.
+
+Derivation allocation metadata and keypairs form one backup unit. Restoring only keypairs without
+the allocation metadata is unsupported. Deleting the complete database or restoring an old
+snapshot resets allocation history to that state and can reproduce keys derived after the snapshot
+when the same seed is reused.
 
 ## Error Handling
 

--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -30,32 +30,38 @@ Concrete core services, operation service classes, handler providers, transport
 internals, and individual memory repository classes are not part of the
 app-facing root API.
 
-## Atomic key derivation allocation
+## Atomic key derivation persistence
 
-The root `Repositories.keyRingRepository` implements `KeyRingAllocationRepository`:
+`KeyRingRepository` owns the transaction boundary for generated keys:
 
 ```ts
-interface KeyRingAllocationRepository extends KeyRingRepository {
-  reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number>;
+interface KeyRingRepository {
+  deriveAndPersistKeyPair(
+    purpose: KeypairPurpose,
+    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+  ): Promise<Keypair>;
 }
 ```
 
-This method must atomically select and persist an index greater than both the purpose's durable
-high-water mark and every stored keypair index for that purpose. Its promise resolves only after
-that allocation commits. A committed index is permanent even when later seed access, key
-derivation, or key persistence fails, so gaps are expected and must not be recycled.
+The caller loads the seed before invoking this method. The repository then starts a writer
+transaction, selects an index greater than both the purpose's durable high-water mark and every
+stored keypair index, synchronously derives the key, and commits the keypair and high-water mark
+together. The promise resolves with the keypair only after commit.
 
-Allocation is deliberately unavailable on `RepositoryTransactionScope`. Implement it as an
-independent top-level storage transaction; nesting it in a caller transaction would allow a later
-rollback to reuse an index. A process-local mutex or optional read/increment/write fallback does
-not satisfy the contract because it cannot coordinate independent processes, database connections,
-or browser tabs.
+If derivation, persistence, or commit fails, neither the keypair nor the high-water mark may remain
+persisted. Reusing that index is safe because the key was never returned. Once a keypair commits,
+deleting it must not lower the high-water mark or make its index reusable. A process-local mutex
+alone does not satisfy the contract because it cannot coordinate independent processes, database
+connections, or browser tabs.
+
+Call this root repository method directly; it is omitted from `RepositoryTransactionScope` so its
+result cannot be exposed before a surrounding caller transaction commits.
 
 The Memory adapter guarantees this behavior only for callers sharing one repository object. SQL
-adapters use a native writer transaction, and IndexedDB uses one `readwrite` transaction covering
-the keypair and allocation stores. Adapter authors can run
-`runKeyRingAllocationRepositoryContract` from `@cashu/coco-adapter-tests` to verify the required
-sequences, gaps, bounds, and shared-storage behavior.
+adapters use an immediate/exclusive writer transaction, and IndexedDB uses one `readwrite`
+transaction covering the keypair and allocation stores. Adapter authors can run
+`runKeyRingDerivationRepositoryContract` from `@cashu/coco-adapter-tests` to verify rollback,
+purpose isolation, bounds, deletion behavior, and shared-storage coordination.
 
 ## Security
 
@@ -68,7 +74,7 @@ encryption at rest should use an encrypted database, encrypted filesystem or pla
 a custom `Repositories` implementation that provides the required protection. Ensure that the
 chosen protection also covers database journals and backups.
 
-Back up and restore keypairs and key-derivation allocation metadata together. A full database
+Back up and restore keypairs and key-derivation high-water metadata together. A full database
 deletion intentionally starts a new local allocation namespace. Restoring a historical snapshot can
 reproduce deterministic keys created after that snapshot when the same Wallet Seed is reused;
 applications must avoid exposing post-snapshot quote keys or rotate to a new seed/allocation

--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -30,6 +30,33 @@ Concrete core services, operation service classes, handler providers, transport
 internals, and individual memory repository classes are not part of the
 app-facing root API.
 
+## Atomic key derivation allocation
+
+The root `Repositories.keyRingRepository` implements `KeyRingAllocationRepository`:
+
+```ts
+interface KeyRingAllocationRepository extends KeyRingRepository {
+  reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number>;
+}
+```
+
+This method must atomically select and persist an index greater than both the purpose's durable
+high-water mark and every stored keypair index for that purpose. Its promise resolves only after
+that allocation commits. A committed index is permanent even when later seed access, key
+derivation, or key persistence fails, so gaps are expected and must not be recycled.
+
+Allocation is deliberately unavailable on `RepositoryTransactionScope`. Implement it as an
+independent top-level storage transaction; nesting it in a caller transaction would allow a later
+rollback to reuse an index. A process-local mutex or optional read/increment/write fallback does
+not satisfy the contract because it cannot coordinate independent processes, database connections,
+or browser tabs.
+
+The Memory adapter guarantees this behavior only for callers sharing one repository object. SQL
+adapters use a native writer transaction, and IndexedDB uses one `readwrite` transaction covering
+the keypair and allocation stores. Adapter authors can run
+`runKeyRingAllocationRepositoryContract` from `@cashu/coco-adapter-tests` to verify the required
+sequences, gaps, bounds, and shared-storage behavior.
+
 ## Security
 
 Coco's built-in storage adapters do not encrypt wallet data at rest. Stored data can include
@@ -40,6 +67,12 @@ The embedding application is responsible for storage protection. Applications th
 encryption at rest should use an encrypted database, encrypted filesystem or platform storage, or
 a custom `Repositories` implementation that provides the required protection. Ensure that the
 chosen protection also covers database journals and backups.
+
+Back up and restore keypairs and key-derivation allocation metadata together. A full database
+deletion intentionally starts a new local allocation namespace. Restoring a historical snapshot can
+reproduce deterministic keys created after that snapshot when the same Wallet Seed is reused;
+applications must avoid exposing post-snapshot quote keys or rotate to a new seed/allocation
+namespace.
 
 ## SQLite adapter public API
 

--- a/packages/expo-sqlite/package.json
+++ b/packages/expo-sqlite/package.json
@@ -16,7 +16,8 @@
   ],
   "devDependencies": {
     "@cashu/coco-adapter-tests": "1.0.0",
-    "@cashu/coco-sql-storage": "1.0.0"
+    "@cashu/coco-sql-storage": "1.0.0",
+    "@types/node": "^25.0.9"
   },
   "exports": {
     ".": {

--- a/packages/expo-sqlite/src/db.ts
+++ b/packages/expo-sqlite/src/db.ts
@@ -1,7 +1,12 @@
 // Minimal promise-based wrapper for expo-sqlite's async API
 // Consumers pass an already opened database instance
 import type { SQLiteDatabase } from 'expo-sqlite';
-import type { SqlDatabase, SqlParams, SqlRunResult } from '@cashu/coco-sql-storage';
+import type {
+  SqlDatabase,
+  SqlParams,
+  SqlRunResult,
+  SqlTransactionOptions,
+} from '@cashu/coco-sql-storage';
 
 type ExpoSqliteRunResult = SqlRunResult & {
   readonly lastID: number;
@@ -156,7 +161,10 @@ export class ExpoSqliteDb implements SqlDatabase {
    * @returns Promise that resolves with the return value of fn
    * @throws Re-throws any error from fn after rolling back the transaction
    */
-  async transaction<T>(fn: (tx: ExpoSqliteDb) => Promise<T>): Promise<T> {
+  async transaction<T>(
+    fn: (tx: ExpoSqliteDb) => Promise<T>,
+    options?: SqlTransactionOptions,
+  ): Promise<T> {
     const { root } = this;
 
     // NESTED TRANSACTION DETECTION:
@@ -197,6 +205,29 @@ export class ExpoSqliteDb implements SqlDatabase {
       root.currentScope = scopeToken;
       root.scopeDepth = 1;
 
+      const runManualTransaction = async (beginStatement: string): Promise<T> => {
+        const scopedDb = new ExpoSqliteDb(root, scopeToken);
+        await dbAny.execAsync(beginStatement);
+        try {
+          const result = await fn(scopedDb);
+          await dbAny.execAsync('COMMIT');
+          return result;
+        } catch (error) {
+          try {
+            await dbAny.execAsync('ROLLBACK');
+          } catch {
+            // Ignore rollback errors so the original transaction error is preserved.
+          }
+          throw error;
+        }
+      };
+
+      // Expo's transaction helpers always issue deferred BEGIN statements. Use the underlying
+      // connection directly when the caller needs the writer lock before its first read.
+      if (options?.mode === 'immediate') {
+        return await runManualTransaction('BEGIN IMMEDIATE');
+      }
+
       // Prefer exclusive transactions when available. Expo documents withTransactionAsync as
       // interruptible by other async queries, so transaction-scoped operations must use txn.
       if (typeof dbAny.withExclusiveTransactionAsync === 'function' && !isWebRuntime()) {
@@ -216,24 +247,8 @@ export class ExpoSqliteDb implements SqlDatabase {
         return result;
       }
 
-      // Fallback to manual BEGIN/COMMIT for older versions
-      const scopedDb = new ExpoSqliteDb(root, scopeToken);
-      await dbAny.execAsync('BEGIN');
-      try {
-        // Execute user code within the transaction
-        const res = await fn(scopedDb);
-        // Success - commit the transaction
-        await dbAny.execAsync('COMMIT');
-        return res;
-      } catch (error) {
-        // Error - rollback the transaction
-        try {
-          await dbAny.execAsync('ROLLBACK');
-        } catch {
-          // Ignore rollback errors (e.g., if transaction already rolled back)
-        }
-        throw error;
-      }
+      // Fallback for older Expo versions without transaction helpers.
+      return await runManualTransaction('BEGIN');
     } finally {
       // CLEANUP: Always clear the current scope and release the queue
       // This allows the next queued transaction to proceed

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   runRepositoryTransactionContract,
-  runKeyRingAllocationRepositoryContract,
+  runKeyRingDerivationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -96,6 +96,12 @@ class WebExpoSqliteDatabaseShim extends BunExpoSqliteDatabaseShim {
 class NativeExpoSqliteDatabaseShim extends BunExpoSqliteDatabaseShim {
   exclusiveTransactionCalls = 0;
   transactionCalls = 0;
+  executedSql: string[] = [];
+
+  override async execAsync(sql: string): Promise<void> {
+    this.executedSql.push(sql);
+    await super.execAsync(sql);
+  }
 
   async withExclusiveTransactionAsync(fn: (txn: BunExpoSqliteDatabaseShim) => Promise<void>) {
     this.exclusiveTransactionCalls++;
@@ -190,7 +196,7 @@ runRepositoryTransactionContract(
   { describe, it, expect },
 );
 
-runKeyRingAllocationRepositoryContract(
+runKeyRingDerivationRepositoryContract(
   { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );
@@ -264,6 +270,30 @@ describe('expo-sqlite native transaction compatibility', () => {
       expect(database.exclusiveTransactionCalls).toBe(1);
       expect(database.transactionCalls).toBe(0);
       await expect(repositories.mintRepository.getAllMints()).resolves.toHaveLength(1);
+    } finally {
+      await database.closeAsync();
+    }
+  });
+
+  it('uses BEGIN IMMEDIATE before reading when immediate mode is requested', async () => {
+    const database = new NativeExpoSqliteDatabaseShim();
+    const wrappedDatabase = new ExpoSqliteDb({
+      database: database as unknown as SqliteRepositoriesOptions['database'],
+    });
+
+    try {
+      await wrappedDatabase.transaction(
+        async (transaction) => {
+          await expect(transaction.get<{ value: number }>('SELECT 1 AS value')).resolves.toEqual({
+            value: 1,
+          });
+        },
+        { mode: 'immediate' },
+      );
+
+      expect(database.executedSql).toEqual(['BEGIN IMMEDIATE', 'COMMIT']);
+      expect(database.exclusiveTransactionCalls).toBe(0);
+      expect(database.transactionCalls).toBe(0);
     } finally {
       await database.closeAsync();
     }

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'bun:test';
 import { Database } from 'bun:sqlite';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   runRepositoryTransactionContract,
+  runKeyRingAllocationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -132,6 +136,33 @@ async function createRepositories() {
   } as const;
 }
 
+async function createSharedRepositories() {
+  const directory = await mkdtemp(join(tmpdir(), 'coco-expo-sqlite-keyring-'));
+  const filename = join(directory, 'wallet.sqlite');
+  const firstDatabase = new NativeExpoSqliteDatabaseShim(filename);
+  const secondDatabase = new NativeExpoSqliteDatabaseShim(filename);
+  const first = new Repositories({
+    database: firstDatabase as unknown as SqliteRepositoriesOptions['database'],
+  });
+  const second = new Repositories({
+    database: secondDatabase as unknown as SqliteRepositoriesOptions['database'],
+  });
+  await first.init();
+  await second.init();
+  await firstDatabase.execAsync('PRAGMA busy_timeout = 10');
+  await secondDatabase.execAsync('PRAGMA busy_timeout = 10');
+
+  return {
+    first,
+    second,
+    dispose: async () => {
+      await firstDatabase.closeAsync();
+      await secondDatabase.closeAsync();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
 runSqlDatabaseContract(
   {
     createDatabase() {
@@ -156,6 +187,11 @@ runRepositoryTransactionContract(
     createRepositories,
     testConcurrentRootOperationIsolation: true,
   },
+  { describe, it, expect },
+);
+
+runKeyRingAllocationRepositoryContract(
+  { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );
 

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -2,7 +2,7 @@ import type {
   Repositories,
   MintRepository,
   KeysetRepository,
-  KeyRingRepository,
+  KeyRingAllocationRepository,
   CounterRepository,
   ProofRepository,
   MeltQuoteRepository,
@@ -42,7 +42,7 @@ export interface IndexedDbRepositoriesOptions extends IdbDbOptions {}
 
 export class IndexedDbRepositories implements Repositories {
   readonly mintRepository: MintRepository;
-  readonly keyRingRepository: KeyRingRepository;
+  readonly keyRingRepository: KeyRingAllocationRepository;
   readonly counterRepository: CounterRepository;
   readonly keysetRepository: KeysetRepository;
   readonly proofRepository: ProofRepository;

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -2,7 +2,7 @@ import type {
   Repositories,
   MintRepository,
   KeysetRepository,
-  KeyRingAllocationRepository,
+  KeyRingRepository,
   CounterRepository,
   ProofRepository,
   MeltQuoteRepository,
@@ -42,7 +42,7 @@ export interface IndexedDbRepositoriesOptions extends IdbDbOptions {}
 
 export class IndexedDbRepositories implements Repositories {
   readonly mintRepository: MintRepository;
-  readonly keyRingRepository: KeyRingAllocationRepository;
+  readonly keyRingRepository: KeyRingRepository;
   readonly counterRepository: CounterRepository;
   readonly keysetRepository: KeysetRepository;
   readonly proofRepository: ProofRepository;

--- a/packages/indexeddb/src/lib/schema.ts
+++ b/packages/indexeddb/src/lib/schema.ts
@@ -1147,4 +1147,63 @@ export async function ensureSchema(db: IdbDb): Promise<void> {
           },
         );
     });
+
+  // Version 33: Atomically allocate purpose-scoped keypair derivation indexes.
+  db.version(33)
+    .stores({
+      coco_cashu_mints: '&mintUrl, name, updatedAt, trusted',
+      coco_cashu_keysets: '&[mintUrl+id], mintUrl, id, updatedAt, unit',
+      coco_cashu_counters: '&[mintUrl+keysetId]',
+      coco_cashu_proofs:
+        '&[mintUrl+secret], [mintUrl+state], [mintUrl+unit+state], [mintUrl+id+state], [mintUrl+id+unit+state], [mintUrl+unit+id+state], [unit+state], state, mintUrl, unit, id, usedByOperationId, createdByOperationId',
+      coco_cashu_mint_quotes: '&[mintUrl+quote], state, mintUrl',
+      coco_cashu_canonical_mint_quotes:
+        '&[mintUrl+method+quoteId], &[mintUrl+quoteId], state, mintUrl, method',
+      coco_cashu_melt_quotes:
+        '&[mintUrl+method+quoteId], &[mintUrl+quoteId], state, mintUrl, method',
+      coco_cashu_history:
+        '++id, mintUrl, type, createdAt, [mintUrl+quoteId+type], [mintUrl+operationId]',
+      coco_cashu_keypairs: '&publicKey, createdAt, derivationIndex, [purpose+derivationIndex]',
+      coco_cashu_keypair_derivation_allocations: '&purpose',
+      coco_cashu_send_operations: '&id, state, mintUrl, createdAt',
+      coco_cashu_melt_operations: '&id, state, mintUrl, createdAt, [mintUrl+quoteId]',
+      coco_cashu_receive_operations: '&id, state, mintUrl, createdAt',
+      coco_cashu_auth_sessions: '&mintUrl',
+      coco_cashu_mint_operations:
+        '&id, state, mintUrl, createdAt, [mintUrl+quoteId], [mintUrl+method+quoteId]',
+      coco_cashu_payment_request_receive_operations: '&id, state, requestId',
+      coco_cashu_payment_request_receive_attempts:
+        '&id, requestOperationId, requestId, state, &[requestOperationId+payloadHash], [requestId+payloadHash], &transportMessageId, &receiveOperationId',
+    })
+    .upgrade(async (tx) => {
+      const keypairTable = tx.table('coco_cashu_keypairs');
+      await keypairTable.toCollection().modify((row: { purpose?: string }) => {
+        row.purpose ??= 'p2pk';
+      });
+
+      const greatestByPurpose = new Map<string, number>();
+      const keypairs = (await keypairTable.toArray()) as Array<{
+        purpose?: string;
+        derivationIndex?: number;
+      }>;
+      for (const keypair of keypairs) {
+        if (keypair.derivationIndex == null) continue;
+        const purpose = keypair.purpose ?? 'p2pk';
+        greatestByPurpose.set(
+          purpose,
+          Math.max(greatestByPurpose.get(purpose) ?? -1, keypair.derivationIndex),
+        );
+      }
+
+      const allocationTable = tx.table('coco_cashu_keypair_derivation_allocations');
+      for (const [purpose, greatestStoredIndex] of greatestByPurpose) {
+        const existing = (await allocationTable.get(purpose)) as
+          | { lastAllocatedIndex: number }
+          | undefined;
+        await allocationTable.put({
+          purpose,
+          lastAllocatedIndex: Math.max(existing?.lastAllocatedIndex ?? -1, greatestStoredIndex),
+        });
+      }
+    });
 }

--- a/packages/indexeddb/src/repositories/KeyRingRepository.ts
+++ b/packages/indexeddb/src/repositories/KeyRingRepository.ts
@@ -1,9 +1,5 @@
 import { DerivationIndexExhaustedError } from '@cashu/coco-core/adapter';
-import type {
-  KeyRingAllocationRepository,
-  Keypair,
-  KeypairPurpose,
-} from '@cashu/coco-core/adapter';
+import type { KeyRingRepository, Keypair, KeypairPurpose } from '@cashu/coco-core/adapter';
 import type { IdbDb } from '../lib/db.ts';
 import { hexToBytes, bytesToHex } from '../utils.ts';
 
@@ -25,7 +21,7 @@ interface KeypairDerivationAllocationRow {
   lastAllocatedIndex: number;
 }
 
-export class IdbKeyRingRepository implements KeyRingAllocationRepository {
+export class IdbKeyRingRepository implements KeyRingRepository {
   private readonly db: IdbDb;
 
   constructor(db: IdbDb) {
@@ -113,7 +109,10 @@ export class IdbKeyRingRepository implements KeyRingAllocationRepository {
     };
   }
 
-  async reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+  async deriveAndPersistKeyPair(
+    purpose: KeypairPurpose,
+    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+  ): Promise<Keypair> {
     return this.db.runTransaction('rw', [ALLOCATION_STORE, KEYPAIR_STORE], async (transaction) => {
       const allocationTable = transaction.table(ALLOCATION_STORE);
       const keypairTable = transaction.table(KEYPAIR_STORE);
@@ -134,8 +133,17 @@ export class IdbKeyRingRepository implements KeyRingAllocationRepository {
       }
 
       const nextIndex = baseIndex + 1;
+      const keyPair = { ...derive(nextIndex), derivationIndex: nextIndex, purpose };
+
+      await keypairTable.put({
+        publicKey: keyPair.publicKeyHex,
+        secretKey: bytesToHex(keyPair.secretKey),
+        createdAt: Date.now(),
+        derivationIndex: nextIndex,
+        purpose,
+      });
       await allocationTable.put({ purpose, lastAllocatedIndex: nextIndex });
-      return nextIndex;
+      return keyPair;
     });
   }
 }

--- a/packages/indexeddb/src/repositories/KeyRingRepository.ts
+++ b/packages/indexeddb/src/repositories/KeyRingRepository.ts
@@ -1,8 +1,16 @@
-import type { KeyRingRepository, Keypair, KeypairPurpose } from '@cashu/coco-core/adapter';
+import { DerivationIndexExhaustedError } from '@cashu/coco-core/adapter';
+import type {
+  KeyRingAllocationRepository,
+  Keypair,
+  KeypairPurpose,
+} from '@cashu/coco-core/adapter';
 import type { IdbDb } from '../lib/db.ts';
 import { hexToBytes, bytesToHex } from '../utils.ts';
 
 const DEFAULT_KEYPAIR_PURPOSE: KeypairPurpose = 'p2pk';
+const MAX_DERIVATION_INDEX = 0x7fffffff;
+const KEYPAIR_STORE = 'coco_cashu_keypairs';
+const ALLOCATION_STORE = 'coco_cashu_keypair_derivation_allocations';
 
 interface KeypairRow {
   publicKey: string;
@@ -12,7 +20,12 @@ interface KeypairRow {
   purpose?: KeypairPurpose;
 }
 
-export class IdbKeyRingRepository implements KeyRingRepository {
+interface KeypairDerivationAllocationRow {
+  purpose: KeypairPurpose;
+  lastAllocatedIndex: number;
+}
+
+export class IdbKeyRingRepository implements KeyRingAllocationRepository {
   private readonly db: IdbDb;
 
   constructor(db: IdbDb) {
@@ -20,7 +33,7 @@ export class IdbKeyRingRepository implements KeyRingRepository {
   }
 
   async getPersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<Keypair | null> {
-    const table = this.db.table('coco_cashu_keypairs');
+    const table = this.db.table(KEYPAIR_STORE);
     const row = await table.get(publicKey);
     if (!row) return null;
 
@@ -38,7 +51,7 @@ export class IdbKeyRingRepository implements KeyRingRepository {
   }
 
   async setPersistedKeyPair(keyPair: Keypair): Promise<void> {
-    const table = this.db.table('coco_cashu_keypairs');
+    const table = this.db.table(KEYPAIR_STORE);
     const secretKeyHex = bytesToHex(keyPair.secretKey);
 
     // Preserve existing derivationIndex if new one is not provided
@@ -61,7 +74,7 @@ export class IdbKeyRingRepository implements KeyRingRepository {
   }
 
   async deletePersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<void> {
-    const table = this.db.table('coco_cashu_keypairs');
+    const table = this.db.table(KEYPAIR_STORE);
     if (purpose) {
       const existing = (await table.get(publicKey)) as KeypairRow | undefined;
       if (existing && (existing.purpose ?? DEFAULT_KEYPAIR_PURPOSE) !== purpose) return;
@@ -70,7 +83,7 @@ export class IdbKeyRingRepository implements KeyRingRepository {
   }
 
   async getAllPersistedKeyPairs(purpose?: KeypairPurpose): Promise<Keypair[]> {
-    const table = this.db.table('coco_cashu_keypairs');
+    const table = this.db.table(KEYPAIR_STORE);
     const rows = (await table.toArray()) as KeypairRow[];
 
     return rows
@@ -84,7 +97,7 @@ export class IdbKeyRingRepository implements KeyRingRepository {
   }
 
   async getLatestKeyPair(purpose?: KeypairPurpose): Promise<Keypair | null> {
-    const table = this.db.table('coco_cashu_keypairs');
+    const table = this.db.table(KEYPAIR_STORE);
     const rows = (await table.orderBy('createdAt').reverse().toArray()) as KeypairRow[];
     const row = rows.find(
       (candidate) => !purpose || (candidate.purpose ?? DEFAULT_KEYPAIR_PURPOSE) === purpose,
@@ -100,19 +113,29 @@ export class IdbKeyRingRepository implements KeyRingRepository {
     };
   }
 
-  async getLastDerivationIndex(purpose?: KeypairPurpose): Promise<number> {
-    const table = this.db.table('coco_cashu_keypairs');
-    const rows = (await table.orderBy('derivationIndex').reverse().toArray()) as KeypairRow[];
-    const row = rows.find(
-      (candidate) =>
-        candidate.derivationIndex != null &&
-        (!purpose || (candidate.purpose ?? DEFAULT_KEYPAIR_PURPOSE) === purpose),
-    );
+  async reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+    return this.db.runTransaction('rw', [ALLOCATION_STORE, KEYPAIR_STORE], async (transaction) => {
+      const allocationTable = transaction.table(ALLOCATION_STORE);
+      const keypairTable = transaction.table(KEYPAIR_STORE);
+      const allocation = (await allocationTable.get(purpose)) as
+        | KeypairDerivationAllocationRow
+        | undefined;
+      const greatestStoredKeypair = (await keypairTable
+        .where('[purpose+derivationIndex]')
+        .between([purpose, 0], [purpose, MAX_DERIVATION_INDEX], true, true)
+        .last()) as KeypairRow | undefined;
+      const baseIndex = Math.max(
+        allocation?.lastAllocatedIndex ?? -1,
+        greatestStoredKeypair?.derivationIndex ?? -1,
+      );
 
-    if (!row || row.derivationIndex == null) {
-      return -1;
-    }
+      if (baseIndex >= MAX_DERIVATION_INDEX) {
+        throw new DerivationIndexExhaustedError(purpose);
+      }
 
-    return row.derivationIndex;
+      const nextIndex = baseIndex + 1;
+      await allocationTable.put({ purpose, lastAllocatedIndex: nextIndex });
+      return nextIndex;
+    });
   }
 }

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Dexie from 'dexie';
 import {
   runRepositoryTransactionContract,
-  runKeyRingAllocationRepositoryContract,
+  runKeyRingDerivationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -16,6 +16,16 @@ import {
 import { IndexedDbRepositories } from '../index.ts';
 
 let dbCounter = 0;
+
+function deriveKeyPair(derivationIndex: number, purpose: 'p2pk' | 'nut20_mint_quote') {
+  return {
+    publicKeyHex:
+      (purpose === 'p2pk' ? '02' : '03') + derivationIndex.toString(16).padStart(64, '0'),
+    secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
+    derivationIndex,
+    purpose,
+  };
+}
 
 async function createRepositories() {
   const dbName = `coco_cashu_contract_${Date.now()}_${dbCounter++}`;
@@ -63,7 +73,7 @@ runRepositoryTransactionContract(
   { describe, it, expect },
 );
 
-runKeyRingAllocationRepositoryContract(
+runKeyRingDerivationRepositoryContract(
   { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );
@@ -87,27 +97,30 @@ runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect })
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
 
 describe('indexeddb quote storage constraints', () => {
-  it('rolls back allocation metadata when an IndexedDB transaction aborts', async () => {
+  it('rolls back the keypair and high-water mark when persistence aborts', async () => {
     const { repositories, dispose } = await createRepositories();
+    const allocationTable = repositories.db.table('coco_cashu_keypair_derivation_allocations');
+    const failAllocationWrite = () => {
+      throw new Error('forced high-water failure');
+    };
+    allocationTable.hook('creating').subscribe(failAllocationWrite);
     try {
       await expectRejects(async () => {
-        await repositories.db.runTransaction(
-          'rw',
-          ['coco_cashu_keypair_derivation_allocations'],
-          async (transaction) => {
-            await transaction.table('coco_cashu_keypair_derivation_allocations').put({
-              purpose: 'p2pk',
-              lastAllocatedIndex: 0,
-            });
-            throw new Error('abort allocation');
-          },
+        await repositories.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+          deriveKeyPair(index, 'p2pk'),
         );
       });
 
-      await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
-        0,
-      );
+      expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([]);
+      expect(await allocationTable.get('p2pk')).toBeUndefined();
+      allocationTable.hook('creating').unsubscribe(failAllocationWrite);
+      await expect(
+        repositories.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+          deriveKeyPair(index, 'p2pk'),
+        ),
+      ).resolves.toMatchObject({ derivationIndex: 0 });
     } finally {
+      allocationTable.hook('creating').unsubscribe(failAllocationWrite);
       await dispose();
     }
   });
@@ -167,12 +180,16 @@ describe('indexeddb quote storage constraints', () => {
           .table('coco_cashu_keypairs')
           .schema.indexes.some((index) => index.name === '[purpose+derivationIndex]'),
       ).toBe(true);
-      await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
-        7,
-      );
       await expect(
-        repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
-      ).resolves.toBe(4);
+        repositories.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+          deriveKeyPair(index, 'p2pk'),
+        ),
+      ).resolves.toMatchObject({ derivationIndex: 7 });
+      await expect(
+        repositories.keyRingRepository.deriveAndPersistKeyPair('nut20_mint_quote', (index) =>
+          deriveKeyPair(index, 'nut20_mint_quote'),
+        ),
+      ).resolves.toMatchObject({ derivationIndex: 4 });
     } finally {
       repositories.db.close();
     }
@@ -180,7 +197,11 @@ describe('indexeddb quote storage constraints', () => {
     const reopened = new IndexedDbRepositories({ name: dbName });
     await reopened.init();
     try {
-      await expect(reopened.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(8);
+      await expect(
+        reopened.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+          deriveKeyPair(index, 'p2pk'),
+        ),
+      ).resolves.toMatchObject({ derivationIndex: 8 });
     } finally {
       reopened.db.close();
       await Dexie.delete(dbName);

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Dexie from 'dexie';
 import {
   runRepositoryTransactionContract,
+  runKeyRingAllocationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -22,7 +23,26 @@ async function createRepositories() {
   await repositories.init();
   return {
     repositories,
-    dispose: async () => {},
+    dispose: async () => {
+      repositories.db.close();
+    },
+  };
+}
+
+async function createSharedRepositories() {
+  const dbName = `coco_cashu_shared_allocation_${Date.now()}_${dbCounter++}`;
+  const first = new IndexedDbRepositories({ name: dbName });
+  const second = new IndexedDbRepositories({ name: dbName });
+  await first.init();
+  await second.init();
+
+  return {
+    first,
+    second,
+    dispose: async () => {
+      first.db.close();
+      second.db.close();
+    },
   };
 }
 
@@ -40,6 +60,11 @@ runRepositoryTransactionContract(
   {
     createRepositories,
   },
+  { describe, it, expect },
+);
+
+runKeyRingAllocationRepositoryContract(
+  { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );
 
@@ -62,6 +87,106 @@ runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect })
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
 
 describe('indexeddb quote storage constraints', () => {
+  it('rolls back allocation metadata when an IndexedDB transaction aborts', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await expectRejects(async () => {
+        await repositories.db.runTransaction(
+          'rw',
+          ['coco_cashu_keypair_derivation_allocations'],
+          async (transaction) => {
+            await transaction.table('coco_cashu_keypair_derivation_allocations').put({
+              purpose: 'p2pk',
+              lastAllocatedIndex: 0,
+            });
+            throw new Error('abort allocation');
+          },
+        );
+      });
+
+      await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
+        0,
+      );
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('migrates version-32 keypairs into purpose-scoped allocation state', async () => {
+    const dbName = `coco_cashu_keyring_migration_${Date.now()}_${dbCounter++}`;
+    const legacy = new Dexie(dbName);
+    legacy.version(32).stores({
+      coco_cashu_keypairs: '&publicKey, createdAt, derivationIndex',
+    });
+    await legacy.open();
+    await legacy.table('coco_cashu_keypairs').bulkAdd([
+      {
+        publicKey: 'legacy-p2pk',
+        secretKey: '01'.repeat(32),
+        createdAt: 1,
+        derivationIndex: 4,
+      },
+      {
+        publicKey: 'current-p2pk',
+        secretKey: '02'.repeat(32),
+        createdAt: 2,
+        derivationIndex: 6,
+        purpose: 'p2pk',
+      },
+      {
+        publicKey: 'quote-lock',
+        secretKey: '03'.repeat(32),
+        createdAt: 3,
+        derivationIndex: 3,
+        purpose: 'nut20_mint_quote',
+      },
+      {
+        publicKey: 'imported',
+        secretKey: '04'.repeat(32),
+        createdAt: 4,
+      },
+    ]);
+    legacy.close();
+
+    const repositories = new IndexedDbRepositories({ name: dbName });
+    await repositories.init();
+    try {
+      const keypairRows = await repositories.db.table('coco_cashu_keypairs').toArray();
+      expect(keypairRows.find((row) => row.publicKey === 'legacy-p2pk')?.purpose).toBe('p2pk');
+      expect(keypairRows.find((row) => row.publicKey === 'imported')?.purpose).toBe('p2pk');
+      expect(
+        await repositories.db.table('coco_cashu_keypair_derivation_allocations').toArray(),
+      ).toEqual(
+        expect.arrayContaining([
+          { purpose: 'p2pk', lastAllocatedIndex: 6 },
+          { purpose: 'nut20_mint_quote', lastAllocatedIndex: 3 },
+        ]),
+      );
+      expect(
+        repositories.db
+          .table('coco_cashu_keypairs')
+          .schema.indexes.some((index) => index.name === '[purpose+derivationIndex]'),
+      ).toBe(true);
+      await expect(repositories.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(
+        7,
+      );
+      await expect(
+        repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+      ).resolves.toBe(4);
+    } finally {
+      repositories.db.close();
+    }
+
+    const reopened = new IndexedDbRepositories({ name: dbName });
+    await reopened.init();
+    try {
+      await expect(reopened.keyRingRepository.reserveNextDerivationIndex('p2pk')).resolves.toBe(8);
+    } finally {
+      reopened.db.close();
+      await Dexie.delete(dbName);
+    }
+  });
+
   it('migrates canonical Mint Quote Accounting without inventing remote time', async () => {
     const dbName = `coco_cashu_migration_${Date.now()}_${dbCounter++}`;
     const legacy = new Dexie(dbName);

--- a/packages/sql-storage/src/index.ts
+++ b/packages/sql-storage/src/index.ts
@@ -7,6 +7,10 @@ export interface SqlRunResult {
   readonly changes: number;
 }
 
+export interface SqlTransactionOptions {
+  mode?: 'deferred' | 'immediate';
+}
+
 export interface SqlDatabase {
   exec(sql: string): Promise<void>;
   run(sql: string, params?: SqlParams): Promise<SqlRunResult>;
@@ -18,7 +22,7 @@ export interface SqlDatabase {
     sql: string,
     params?: SqlParams,
   ): Promise<Row[]>;
-  transaction<T>(fn: (tx: SqlDatabase) => Promise<T>): Promise<T>;
+  transaction<T>(fn: (tx: SqlDatabase) => Promise<T>, options?: SqlTransactionOptions): Promise<T>;
 }
 
 export {

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -3,7 +3,7 @@ import type {
   RepositoryTransactionScope,
   MintRepository,
   KeysetRepository,
-  KeyRingAllocationRepository,
+  KeyRingRepository,
   CounterRepository,
   ProofRepository,
   MeltQuoteRepository,
@@ -70,7 +70,7 @@ function createRepositoryScope(database: SqlDatabase): RepositoryTransactionScop
 
 export class SqlStorageRepositories implements Repositories {
   readonly mintRepository: MintRepository;
-  readonly keyRingRepository: KeyRingAllocationRepository;
+  readonly keyRingRepository: KeyRingRepository;
   readonly counterRepository: CounterRepository;
   readonly keysetRepository: KeysetRepository;
   readonly proofRepository: ProofRepository;

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -3,7 +3,7 @@ import type {
   RepositoryTransactionScope,
   MintRepository,
   KeysetRepository,
-  KeyRingRepository,
+  KeyRingAllocationRepository,
   CounterRepository,
   ProofRepository,
   MeltQuoteRepository,
@@ -70,7 +70,7 @@ function createRepositoryScope(database: SqlDatabase): RepositoryTransactionScop
 
 export class SqlStorageRepositories implements Repositories {
   readonly mintRepository: MintRepository;
-  readonly keyRingRepository: KeyRingRepository;
+  readonly keyRingRepository: KeyRingAllocationRepository;
   readonly counterRepository: CounterRepository;
   readonly keysetRepository: KeysetRepository;
   readonly proofRepository: ProofRepository;
@@ -91,7 +91,7 @@ export class SqlStorageRepositories implements Repositories {
     this.database = options.database;
     const repositories = createRepositoryScope(this.database);
     this.mintRepository = repositories.mintRepository;
-    this.keyRingRepository = repositories.keyRingRepository;
+    this.keyRingRepository = new SqliteKeyRingRepository(this.database);
     this.counterRepository = repositories.counterRepository;
     this.keysetRepository = repositories.keysetRepository;
     this.proofRepository = repositories.proofRepository;

--- a/packages/sql-storage/src/repositories/KeyRingRepository.ts
+++ b/packages/sql-storage/src/repositories/KeyRingRepository.ts
@@ -1,9 +1,5 @@
 import { DerivationIndexExhaustedError } from '@cashu/coco-core/adapter';
-import type {
-  KeyRingAllocationRepository,
-  Keypair,
-  KeypairPurpose,
-} from '@cashu/coco-core/adapter';
+import type { KeyRingRepository, Keypair, KeypairPurpose } from '@cashu/coco-core/adapter';
 import type { SqlDatabase } from '../index.ts';
 import { hexToBytes, bytesToHex } from '../utils.ts';
 
@@ -44,7 +40,7 @@ function rowToKeypair(row: KeypairRow): Keypair {
   };
 }
 
-export class SqliteKeyRingRepository implements KeyRingAllocationRepository {
+export class SqliteKeyRingRepository implements KeyRingRepository {
   private readonly db: SqlDatabase;
 
   constructor(db: SqlDatabase) {
@@ -134,10 +130,13 @@ export class SqliteKeyRingRepository implements KeyRingAllocationRepository {
     }
   }
 
-  async reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+  async deriveAndPersistKeyPair(
+    purpose: KeypairPurpose,
+    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+  ): Promise<Keypair> {
     for (let attempt = 1; ; attempt++) {
       try {
-        return await this.reserveNextDerivationIndexOnce(purpose);
+        return await this.deriveAndPersistKeyPairOnce(purpose, derive);
       } catch (error) {
         if (!isSqliteBusy(error) || attempt > MAX_BUSY_RETRIES) throw error;
         await waitForRetry(attempt);
@@ -145,50 +144,22 @@ export class SqliteKeyRingRepository implements KeyRingAllocationRepository {
     }
   }
 
-  private async reserveNextDerivationIndexOnce(purpose: KeypairPurpose): Promise<number> {
-    return this.db.transaction(async (tx) => {
-      await tx.run(
-        `INSERT INTO coco_cashu_keypair_derivation_allocations (purpose, lastAllocatedIndex)
-         VALUES (?, -1)
-         ON CONFLICT(purpose) DO NOTHING`,
-        [purpose],
-      );
-
-      const update = await tx.run(
-        `UPDATE coco_cashu_keypair_derivation_allocations
-         SET lastAllocatedIndex = MAX(
-           lastAllocatedIndex,
-           COALESCE(
-             (SELECT MAX(keypairs.derivationIndex)
-              FROM coco_cashu_keypairs AS keypairs
-              WHERE keypairs.purpose = ?),
-             -1
-           )
-         ) + 1
-         WHERE purpose = ?
-           AND MAX(
-             lastAllocatedIndex,
-             COALESCE(
-               (SELECT MAX(keypairs.derivationIndex)
-                FROM coco_cashu_keypairs AS keypairs
-                WHERE keypairs.purpose = ?),
-               -1
-             )
-           ) < ?`,
-        [purpose, purpose, purpose, MAX_DERIVATION_INDEX],
-      );
-
-      if (update.changes !== 1) {
+  private async deriveAndPersistKeyPairOnce(
+    purpose: KeypairPurpose,
+    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
+  ): Promise<Keypair> {
+    return this.db.transaction(
+      async (tx) => {
         const allocation = await tx.get<{ lastAllocatedIndex: number }>(
           `SELECT lastAllocatedIndex
-           FROM coco_cashu_keypair_derivation_allocations
-           WHERE purpose = ?`,
+         FROM coco_cashu_keypair_derivation_allocations
+         WHERE purpose = ?`,
           [purpose],
         );
         const greatestStored = await tx.get<{ derivationIndex: number | null }>(
           `SELECT MAX(derivationIndex) AS derivationIndex
-           FROM coco_cashu_keypairs
-           WHERE purpose = ? AND derivationIndex IS NOT NULL`,
+         FROM coco_cashu_keypairs
+         WHERE purpose = ? AND derivationIndex IS NOT NULL`,
           [purpose],
         );
         const baseIndex = Math.max(
@@ -198,19 +169,20 @@ export class SqliteKeyRingRepository implements KeyRingAllocationRepository {
         if (baseIndex >= MAX_DERIVATION_INDEX) {
           throw new DerivationIndexExhaustedError(purpose);
         }
-        throw new Error(`Failed to reserve a derivation index for keypair purpose ${purpose}`);
-      }
 
-      const allocation = await tx.get<{ lastAllocatedIndex: number }>(
-        `SELECT lastAllocatedIndex
-         FROM coco_cashu_keypair_derivation_allocations
-         WHERE purpose = ?`,
-        [purpose],
-      );
-      if (!allocation) {
-        throw new Error(`Missing derivation allocation for keypair purpose ${purpose}`);
-      }
-      return allocation.lastAllocatedIndex;
-    });
+        const nextIndex = baseIndex + 1;
+        const keyPair = { ...derive(nextIndex), derivationIndex: nextIndex, purpose };
+
+        await new SqliteKeyRingRepository(tx).setPersistedKeyPair(keyPair);
+        await tx.run(
+          `INSERT INTO coco_cashu_keypair_derivation_allocations (purpose, lastAllocatedIndex)
+         VALUES (?, ?)
+         ON CONFLICT(purpose) DO UPDATE SET lastAllocatedIndex=excluded.lastAllocatedIndex`,
+          [purpose, nextIndex],
+        );
+        return keyPair;
+      },
+      { mode: 'immediate' },
+    );
   }
 }

--- a/packages/sql-storage/src/repositories/KeyRingRepository.ts
+++ b/packages/sql-storage/src/repositories/KeyRingRepository.ts
@@ -1,8 +1,32 @@
-import type { KeyRingRepository, Keypair, KeypairPurpose } from '@cashu/coco-core/adapter';
+import { DerivationIndexExhaustedError } from '@cashu/coco-core/adapter';
+import type {
+  KeyRingAllocationRepository,
+  Keypair,
+  KeypairPurpose,
+} from '@cashu/coco-core/adapter';
 import type { SqlDatabase } from '../index.ts';
 import { hexToBytes, bytesToHex } from '../utils.ts';
 
 const DEFAULT_KEYPAIR_PURPOSE: KeypairPurpose = 'p2pk';
+const MAX_DERIVATION_INDEX = 0x7fffffff;
+const MAX_BUSY_RETRIES = 3;
+
+function isSqliteBusy(error: unknown): boolean {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? String((error as { code?: unknown }).code)
+      : '';
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return code === 'SQLITE_BUSY' || message.includes('database is locked');
+}
+
+function waitForRetry(attempt: number): Promise<void> {
+  const runtime = globalThis as typeof globalThis & {
+    setTimeout(callback: () => void, milliseconds: number): unknown;
+  };
+  return new Promise((resolve) => runtime.setTimeout(resolve, attempt * 5));
+}
 
 type KeypairRow = {
   publicKey: string;
@@ -20,7 +44,7 @@ function rowToKeypair(row: KeypairRow): Keypair {
   };
 }
 
-export class SqliteKeyRingRepository implements KeyRingRepository {
+export class SqliteKeyRingRepository implements KeyRingAllocationRepository {
   private readonly db: SqlDatabase;
 
   constructor(db: SqlDatabase) {
@@ -110,13 +134,83 @@ export class SqliteKeyRingRepository implements KeyRingRepository {
     }
   }
 
-  async getLastDerivationIndex(purpose?: KeypairPurpose): Promise<number> {
-    const row = await this.db.get<{ derivationIndex: number }>(
-      `SELECT derivationIndex FROM coco_cashu_keypairs
-       WHERE derivationIndex IS NOT NULL ${purpose ? 'AND purpose = ?' : ''}
-       ORDER BY derivationIndex DESC LIMIT 1`,
-      purpose ? [purpose] : [],
-    );
-    return row?.derivationIndex ?? -1;
+  async reserveNextDerivationIndex(purpose: KeypairPurpose): Promise<number> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.reserveNextDerivationIndexOnce(purpose);
+      } catch (error) {
+        if (!isSqliteBusy(error) || attempt > MAX_BUSY_RETRIES) throw error;
+        await waitForRetry(attempt);
+      }
+    }
+  }
+
+  private async reserveNextDerivationIndexOnce(purpose: KeypairPurpose): Promise<number> {
+    return this.db.transaction(async (tx) => {
+      await tx.run(
+        `INSERT INTO coco_cashu_keypair_derivation_allocations (purpose, lastAllocatedIndex)
+         VALUES (?, -1)
+         ON CONFLICT(purpose) DO NOTHING`,
+        [purpose],
+      );
+
+      const update = await tx.run(
+        `UPDATE coco_cashu_keypair_derivation_allocations
+         SET lastAllocatedIndex = MAX(
+           lastAllocatedIndex,
+           COALESCE(
+             (SELECT MAX(keypairs.derivationIndex)
+              FROM coco_cashu_keypairs AS keypairs
+              WHERE keypairs.purpose = ?),
+             -1
+           )
+         ) + 1
+         WHERE purpose = ?
+           AND MAX(
+             lastAllocatedIndex,
+             COALESCE(
+               (SELECT MAX(keypairs.derivationIndex)
+                FROM coco_cashu_keypairs AS keypairs
+                WHERE keypairs.purpose = ?),
+               -1
+             )
+           ) < ?`,
+        [purpose, purpose, purpose, MAX_DERIVATION_INDEX],
+      );
+
+      if (update.changes !== 1) {
+        const allocation = await tx.get<{ lastAllocatedIndex: number }>(
+          `SELECT lastAllocatedIndex
+           FROM coco_cashu_keypair_derivation_allocations
+           WHERE purpose = ?`,
+          [purpose],
+        );
+        const greatestStored = await tx.get<{ derivationIndex: number | null }>(
+          `SELECT MAX(derivationIndex) AS derivationIndex
+           FROM coco_cashu_keypairs
+           WHERE purpose = ? AND derivationIndex IS NOT NULL`,
+          [purpose],
+        );
+        const baseIndex = Math.max(
+          allocation?.lastAllocatedIndex ?? -1,
+          greatestStored?.derivationIndex ?? -1,
+        );
+        if (baseIndex >= MAX_DERIVATION_INDEX) {
+          throw new DerivationIndexExhaustedError(purpose);
+        }
+        throw new Error(`Failed to reserve a derivation index for keypair purpose ${purpose}`);
+      }
+
+      const allocation = await tx.get<{ lastAllocatedIndex: number }>(
+        `SELECT lastAllocatedIndex
+         FROM coco_cashu_keypair_derivation_allocations
+         WHERE purpose = ?`,
+        [purpose],
+      );
+      if (!allocation) {
+        throw new Error(`Missing derivation allocation for keypair purpose ${purpose}`);
+      }
+      return allocation.lastAllocatedIndex;
+    });
   }
 }

--- a/packages/sql-storage/src/schema.ts
+++ b/packages/sql-storage/src/schema.ts
@@ -1490,6 +1490,22 @@ const MIGRATIONS: readonly Migration[] = [
           END;
     `,
   },
+  {
+    id: '038_keypair_derivation_allocations',
+    sql: `
+      CREATE TABLE coco_cashu_keypair_derivation_allocations (
+        purpose TEXT PRIMARY KEY,
+        lastAllocatedIndex INTEGER NOT NULL
+          CHECK (lastAllocatedIndex BETWEEN -1 AND 2147483647)
+      );
+
+      INSERT INTO coco_cashu_keypair_derivation_allocations (purpose, lastAllocatedIndex)
+      SELECT purpose, MAX(derivationIndex)
+      FROM coco_cashu_keypairs
+      WHERE derivationIndex IS NOT NULL
+      GROUP BY purpose;
+    `,
+  },
 ];
 
 // Export for testing
@@ -1513,6 +1529,7 @@ export async function ensureSchemaUpTo(db: SqlDatabase, stopBeforeId?: string): 
     PRAGMA foreign_keys = ON;
     PRAGMA journal_mode = WAL;
     PRAGMA synchronous = NORMAL;
+    PRAGMA busy_timeout = 5000;
   `);
 
   await db.exec(`

--- a/packages/sql-storage/src/test/bunSqlDatabase.ts
+++ b/packages/sql-storage/src/test/bunSqlDatabase.ts
@@ -1,5 +1,5 @@
 import type { Database, Statement } from 'bun:sqlite';
-import type { SqlDatabase, SqlParams, SqlRunResult } from '../index.ts';
+import type { SqlDatabase, SqlParams, SqlRunResult, SqlTransactionOptions } from '../index.ts';
 
 interface BunSqlDatabaseRootState {
   readonly database: Database;
@@ -85,7 +85,10 @@ export class BunSqlDatabase implements SqlDatabase {
     return this.getStatement(sql).all(...params) as Row[];
   }
 
-  async transaction<T>(fn: (tx: SqlDatabase) => Promise<T>): Promise<T> {
+  async transaction<T>(
+    fn: (tx: SqlDatabase) => Promise<T>,
+    options?: SqlTransactionOptions,
+  ): Promise<T> {
     const { root } = this;
 
     if (this.scopeToken && root.currentScope === this.scopeToken) {
@@ -112,7 +115,7 @@ export class BunSqlDatabase implements SqlDatabase {
 
       root.currentScope = scopeToken;
       root.scopeDepth = 1;
-      await scopedDatabase.exec('BEGIN');
+      await scopedDatabase.exec(options?.mode === 'immediate' ? 'BEGIN IMMEDIATE' : 'BEGIN');
 
       try {
         const result = await fn(scopedDatabase);

--- a/packages/sql-storage/src/test/schema.test.ts
+++ b/packages/sql-storage/src/test/schema.test.ts
@@ -5,6 +5,7 @@ import { Database } from 'bun:sqlite';
 import {
   ensureSchemaUpTo,
   MIGRATIONS,
+  SqliteKeyRingRepository,
   SqliteMintQuoteRepository,
   type SqlDatabase,
 } from '../index.ts';
@@ -49,6 +50,7 @@ const EXPECTED_MIGRATION_IDS = [
   '035_duplicate_quote_ids',
   '036_quote_identity_unique_indexes',
   '037_mint_quote_accounting',
+  '038_keypair_derivation_allocations',
 ] as const;
 
 const RECEIVE_OPERATIONS_SQL = `
@@ -186,6 +188,91 @@ describe('shared SQL schema migrations', () => {
     expect(ids).toEqual(
       [...EXPECTED_MIGRATION_IDS, '012_receive_operations', '013_send_operations_method'].sort(),
     );
+
+    const busyTimeout = await db.get<{ timeout: number }>('PRAGMA busy_timeout');
+    expect(busyTimeout?.timeout).toBe(5000);
+  });
+
+  itWithDatabase('backfills per-purpose keypair derivation allocations', async (db) => {
+    await ensureSchemaUpTo(db, '038_keypair_derivation_allocations');
+
+    const rows = [
+      ['p2pk-0', 0, 'p2pk'],
+      ['p2pk-6', 6, 'p2pk'],
+      ['quote-0', 0, 'nut20_mint_quote'],
+      ['quote-3', 3, 'nut20_mint_quote'],
+    ] as const;
+    for (const [publicKey, derivationIndex, purpose] of rows) {
+      await db.run(
+        `INSERT INTO coco_cashu_keypairs
+          (publicKey, secretKey, createdAt, derivationIndex, purpose)
+         VALUES (?, ?, ?, ?, ?)`,
+        [publicKey, '01'.repeat(32), derivationIndex, derivationIndex, purpose],
+      );
+    }
+
+    await ensureSchemaUpTo(db);
+
+    expect(
+      await db.all<{ purpose: string; lastAllocatedIndex: number }>(
+        `SELECT purpose, lastAllocatedIndex
+         FROM coco_cashu_keypair_derivation_allocations
+         ORDER BY purpose`,
+      ),
+    ).toEqual([
+      { purpose: 'nut20_mint_quote', lastAllocatedIndex: 3 },
+      { purpose: 'p2pk', lastAllocatedIndex: 6 },
+    ]);
+
+    const repository = new SqliteKeyRingRepository(db);
+    await expect(repository.reserveNextDerivationIndex('p2pk')).resolves.toBe(7);
+    await expect(repository.reserveNextDerivationIndex('nut20_mint_quote')).resolves.toBe(4);
+  });
+
+  itWithDatabase('normalizes pre-purpose keypairs before allocation backfill', async (db) => {
+    await ensureSchemaUpTo(db, '033_keypair_purpose');
+    await db.run(
+      `INSERT INTO coco_cashu_keypairs (publicKey, secretKey, createdAt, derivationIndex)
+       VALUES (?, ?, ?, ?)`,
+      ['legacy-p2pk', '02'.repeat(32), 1, 12],
+    );
+
+    await ensureSchemaUpTo(db);
+
+    expect(
+      await db.get<{ purpose: string; lastAllocatedIndex: number }>(
+        `SELECT purpose, lastAllocatedIndex
+         FROM coco_cashu_keypair_derivation_allocations
+         WHERE purpose = 'p2pk'`,
+      ),
+    ).toEqual({ purpose: 'p2pk', lastAllocatedIndex: 12 });
+    await expect(new SqliteKeyRingRepository(db).reserveNextDerivationIndex('p2pk')).resolves.toBe(
+      13,
+    );
+  });
+
+  itWithDatabase('does not consume an allocation when its transaction rolls back', async (db) => {
+    await ensureSchemaUpTo(db);
+    await db.exec(`
+      CREATE TRIGGER fail_keypair_allocation
+      BEFORE UPDATE ON coco_cashu_keypair_derivation_allocations
+      BEGIN
+        SELECT RAISE(ABORT, 'forced allocation failure');
+      END;
+    `);
+
+    const repository = new SqliteKeyRingRepository(db);
+    await expect(repository.reserveNextDerivationIndex('p2pk')).rejects.toThrow(
+      'forced allocation failure',
+    );
+    expect(
+      await db.get(
+        `SELECT purpose FROM coco_cashu_keypair_derivation_allocations WHERE purpose = 'p2pk'`,
+      ),
+    ).toBeUndefined();
+
+    await db.exec('DROP TRIGGER fail_keypair_allocation');
+    await expect(repository.reserveNextDerivationIndex('p2pk')).resolves.toBe(0);
   });
 
   itWithDatabase(

--- a/packages/sql-storage/src/test/schema.test.ts
+++ b/packages/sql-storage/src/test/schema.test.ts
@@ -53,6 +53,16 @@ const EXPECTED_MIGRATION_IDS = [
   '038_keypair_derivation_allocations',
 ] as const;
 
+function deriveKeyPair(derivationIndex: number, purpose: 'p2pk' | 'nut20_mint_quote') {
+  return {
+    publicKeyHex:
+      (purpose === 'p2pk' ? '02' : '03') + derivationIndex.toString(16).padStart(64, '0'),
+    secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
+    derivationIndex,
+    purpose,
+  };
+}
+
 const RECEIVE_OPERATIONS_SQL = `
   CREATE TABLE IF NOT EXISTS coco_cashu_receive_operations (
     id TEXT PRIMARY KEY,
@@ -225,8 +235,14 @@ describe('shared SQL schema migrations', () => {
     ]);
 
     const repository = new SqliteKeyRingRepository(db);
-    await expect(repository.reserveNextDerivationIndex('p2pk')).resolves.toBe(7);
-    await expect(repository.reserveNextDerivationIndex('nut20_mint_quote')).resolves.toBe(4);
+    await expect(
+      repository.deriveAndPersistKeyPair('p2pk', (index) => deriveKeyPair(index, 'p2pk')),
+    ).resolves.toMatchObject({ derivationIndex: 7 });
+    await expect(
+      repository.deriveAndPersistKeyPair('nut20_mint_quote', (index) =>
+        deriveKeyPair(index, 'nut20_mint_quote'),
+      ),
+    ).resolves.toMatchObject({ derivationIndex: 4 });
   });
 
   itWithDatabase('normalizes pre-purpose keypairs before allocation backfill', async (db) => {
@@ -246,33 +262,40 @@ describe('shared SQL schema migrations', () => {
          WHERE purpose = 'p2pk'`,
       ),
     ).toEqual({ purpose: 'p2pk', lastAllocatedIndex: 12 });
-    await expect(new SqliteKeyRingRepository(db).reserveNextDerivationIndex('p2pk')).resolves.toBe(
-      13,
-    );
+    await expect(
+      new SqliteKeyRingRepository(db).deriveAndPersistKeyPair('p2pk', (index) =>
+        deriveKeyPair(index, 'p2pk'),
+      ),
+    ).resolves.toMatchObject({ derivationIndex: 13 });
   });
 
-  itWithDatabase('does not consume an allocation when its transaction rolls back', async (db) => {
+  itWithDatabase('rolls back a saved keypair when the high-water write fails', async (db) => {
     await ensureSchemaUpTo(db);
     await db.exec(`
-      CREATE TRIGGER fail_keypair_allocation
-      BEFORE UPDATE ON coco_cashu_keypair_derivation_allocations
+      CREATE TRIGGER fail_keypair_high_water
+      BEFORE INSERT ON coco_cashu_keypair_derivation_allocations
+      WHEN NEW.lastAllocatedIndex >= 0
       BEGIN
-        SELECT RAISE(ABORT, 'forced allocation failure');
+        SELECT RAISE(ABORT, 'forced high-water failure');
       END;
     `);
 
     const repository = new SqliteKeyRingRepository(db);
-    await expect(repository.reserveNextDerivationIndex('p2pk')).rejects.toThrow(
-      'forced allocation failure',
-    );
+    await expect(
+      repository.deriveAndPersistKeyPair('p2pk', (index) => deriveKeyPair(index, 'p2pk')),
+    ).rejects.toThrow('forced high-water failure');
     expect(
       await db.get(
         `SELECT purpose FROM coco_cashu_keypair_derivation_allocations WHERE purpose = 'p2pk'`,
       ),
     ).toBeUndefined();
 
-    await db.exec('DROP TRIGGER fail_keypair_allocation');
-    await expect(repository.reserveNextDerivationIndex('p2pk')).resolves.toBe(0);
+    expect(await db.get(`SELECT publicKey FROM coco_cashu_keypairs LIMIT 1`)).toBeUndefined();
+
+    await db.exec('DROP TRIGGER fail_keypair_high_water');
+    await expect(
+      repository.deriveAndPersistKeyPair('p2pk', (index) => deriveKeyPair(index, 'p2pk')),
+    ).resolves.toMatchObject({ derivationIndex: 0 });
   });
 
   itWithDatabase(

--- a/packages/sqlite-bun/package.json
+++ b/packages/sqlite-bun/package.json
@@ -16,7 +16,8 @@
   ],
   "devDependencies": {
     "@cashu/coco-adapter-tests": "1.0.0",
-    "@cashu/coco-sql-storage": "1.0.0"
+    "@cashu/coco-sql-storage": "1.0.0",
+    "@types/node": "^25.0.9"
   },
   "exports": {
     ".": {

--- a/packages/sqlite-bun/src/db.ts
+++ b/packages/sqlite-bun/src/db.ts
@@ -1,5 +1,10 @@
 import type { Database, Statement } from 'bun:sqlite';
-import type { SqlDatabase, SqlParams, SqlRunResult } from '@cashu/coco-sql-storage';
+import type {
+  SqlDatabase,
+  SqlParams,
+  SqlRunResult,
+  SqlTransactionOptions,
+} from '@cashu/coco-sql-storage';
 
 type SqliteRunResult = SqlRunResult & {
   readonly lastID: number;
@@ -195,7 +200,10 @@ export class SqliteDb implements SqlDatabase {
    * @returns Promise that resolves with the return value of fn
    * @throws Re-throws any error from fn after rolling back the transaction
    */
-  async transaction<T>(fn: (tx: SqliteDb) => Promise<T>): Promise<T> {
+  async transaction<T>(
+    fn: (tx: SqliteDb) => Promise<T>,
+    options?: SqlTransactionOptions,
+  ): Promise<T> {
     const { root } = this;
 
     // NESTED TRANSACTION DETECTION:
@@ -241,7 +249,7 @@ export class SqliteDb implements SqlDatabase {
       // Mark this scope as active and issue BEGIN
       root.currentScope = scopeToken;
       root.scopeDepth = 1;
-      await scopedDb.exec('BEGIN');
+      await scopedDb.exec(options?.mode === 'immediate' ? 'BEGIN IMMEDIATE' : 'BEGIN');
 
       try {
         // Execute user code within the transaction

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'bun:test';
 import { Database } from 'bun:sqlite';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Worker } from 'node:worker_threads';
 import {
   runRepositoryTransactionContract,
+  runKeyRingAllocationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -28,6 +33,29 @@ async function createRepositories() {
   };
 }
 
+async function createSharedRepositories() {
+  const directory = await mkdtemp(join(tmpdir(), 'coco-sqlite-bun-keyring-'));
+  const filename = join(directory, 'wallet.sqlite');
+  const firstDatabase = new Database(filename);
+  const secondDatabase = new Database(filename);
+  const first = new Repositories({ database: firstDatabase });
+  const second = new Repositories({ database: secondDatabase });
+  await first.init();
+  await second.init();
+  firstDatabase.exec('PRAGMA busy_timeout = 10');
+  secondDatabase.exec('PRAGMA busy_timeout = 10');
+
+  return {
+    first,
+    second,
+    dispose: async () => {
+      firstDatabase.close();
+      secondDatabase.close();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
 runSqlDatabaseContract(
   {
     createDatabase() {
@@ -50,6 +78,61 @@ runRepositoryTransactionContract(
   },
   { describe, it, expect },
 );
+
+runKeyRingAllocationRepositoryContract(
+  { createRepositories, createSharedRepositories },
+  { describe, it, expect },
+);
+
+function runAllocationWorker(filename: string, count: number): Promise<number[]> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('./keyringAllocation.worker.ts', import.meta.url), {
+      workerData: { filename, count },
+    });
+    worker.once('message', (message: { indexes?: number[]; error?: string }) => {
+      if (message.error) reject(new Error(message.error));
+      else resolve(message.indexes ?? []);
+    });
+    worker.once('error', reject);
+    worker.once('exit', (code) => {
+      if (code !== 0) reject(new Error(`Allocation worker exited with code ${code}`));
+    });
+  });
+}
+
+describe('keyring allocation process boundary', () => {
+  it('coordinates worker connections through the SQLite file', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'coco-sqlite-bun-worker-'));
+    const filename = join(directory, 'wallet.sqlite');
+    const database = new Database(filename);
+    const repositories = new Repositories({ database });
+    await repositories.init();
+    database.close();
+
+    try {
+      const [first, second] = await Promise.all([
+        runAllocationWorker(filename, 50),
+        runAllocationWorker(filename, 50),
+      ]);
+      const indexes = [...first, ...second].sort((left, right) => left - right);
+      expect(indexes).toEqual(Array.from({ length: 100 }, (_, index) => index));
+      expect(new Set(indexes).size).toBe(100);
+
+      const reopenedDatabase = new Database(filename);
+      const reopened = new Repositories({ database: reopenedDatabase });
+      await reopened.init();
+      try {
+        await expect(
+          reopened.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+        ).resolves.toBe(100);
+      } finally {
+        reopenedDatabase.close();
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
 
 runAuthSessionRepositoryContract({ createRepositories }, { describe, it, expect });
 

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { Worker } from 'node:worker_threads';
 import {
   runRepositoryTransactionContract,
-  runKeyRingAllocationRepositoryContract,
+  runKeyRingDerivationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -79,7 +79,7 @@ runRepositoryTransactionContract(
   { describe, it, expect },
 );
 
-runKeyRingAllocationRepositoryContract(
+runKeyRingDerivationRepositoryContract(
   { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );
@@ -123,8 +123,16 @@ describe('keyring allocation process boundary', () => {
       await reopened.init();
       try {
         await expect(
-          reopened.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
-        ).resolves.toBe(100);
+          reopened.keyRingRepository.deriveAndPersistKeyPair(
+            'nut20_mint_quote',
+            (derivationIndex) => ({
+              publicKeyHex: '03' + derivationIndex.toString(16).padStart(64, '0'),
+              secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
+              derivationIndex,
+              purpose: 'nut20_mint_quote',
+            }),
+          ),
+        ).resolves.toMatchObject({ derivationIndex: 100 });
       } finally {
         reopenedDatabase.close();
       }

--- a/packages/sqlite-bun/src/test/keyringAllocation.worker.ts
+++ b/packages/sqlite-bun/src/test/keyringAllocation.worker.ts
@@ -15,7 +15,14 @@ try {
   const repositories = new SqliteRepositories({ database });
   const indexes = await Promise.all(
     Array.from({ length: count }, () =>
-      repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+      repositories.keyRingRepository
+        .deriveAndPersistKeyPair('nut20_mint_quote', (derivationIndex) => ({
+          publicKeyHex: '03' + derivationIndex.toString(16).padStart(64, '0'),
+          secretKey: new Uint8Array(32).fill((derivationIndex % 254) + 1),
+          derivationIndex,
+          purpose: 'nut20_mint_quote',
+        }))
+        .then((keyPair) => keyPair.derivationIndex),
     ),
   );
   parentPort?.postMessage({ indexes });

--- a/packages/sqlite-bun/src/test/keyringAllocation.worker.ts
+++ b/packages/sqlite-bun/src/test/keyringAllocation.worker.ts
@@ -1,0 +1,28 @@
+import { parentPort, workerData } from 'node:worker_threads';
+import { Database } from 'bun:sqlite';
+import { SqliteRepositories } from '../index.ts';
+
+type AllocationWorkerData = {
+  filename: string;
+  count: number;
+};
+
+const { filename, count } = workerData as AllocationWorkerData;
+const database = new Database(filename);
+database.exec('PRAGMA busy_timeout = 5000');
+
+try {
+  const repositories = new SqliteRepositories({ database });
+  const indexes = await Promise.all(
+    Array.from({ length: count }, () =>
+      repositories.keyRingRepository.reserveNextDerivationIndex('nut20_mint_quote'),
+    ),
+  );
+  parentPort?.postMessage({ indexes });
+} catch (error) {
+  parentPort?.postMessage({
+    error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+  });
+} finally {
+  database.close();
+}

--- a/packages/sqlite-bun/tsconfig.json
+++ b/packages/sqlite-bun/tsconfig.json
@@ -13,7 +13,7 @@
     "preserveSymlinks": true,
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "types": ["bun"],
+    "types": ["bun", "node"],
     "noEmit": true,
 
     // Best practices

--- a/packages/sqlite3/package.json
+++ b/packages/sqlite3/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@cashu/coco-adapter-tests": "1.0.0",
     "@cashu/coco-sql-storage": "1.0.0",
+    "@types/node": "^25.0.9",
     "vitest": "^2.1.9"
   },
   "exports": {

--- a/packages/sqlite3/src/db.ts
+++ b/packages/sqlite3/src/db.ts
@@ -1,5 +1,10 @@
 import type { Database } from 'better-sqlite3';
-import type { SqlDatabase, SqlParams, SqlRunResult } from '@cashu/coco-sql-storage';
+import type {
+  SqlDatabase,
+  SqlParams,
+  SqlRunResult,
+  SqlTransactionOptions,
+} from '@cashu/coco-sql-storage';
 
 type SqliteRunResult = SqlRunResult & {
   readonly lastID: number;
@@ -144,7 +149,10 @@ export class SqliteDb implements SqlDatabase {
    * @returns Promise that resolves with the return value of fn
    * @throws Re-throws any error from fn after rolling back the transaction
    */
-  async transaction<T>(fn: (tx: SqliteDb) => Promise<T>): Promise<T> {
+  async transaction<T>(
+    fn: (tx: SqliteDb) => Promise<T>,
+    options?: SqlTransactionOptions,
+  ): Promise<T> {
     const { root } = this;
 
     // NESTED TRANSACTION DETECTION:
@@ -185,7 +193,7 @@ export class SqliteDb implements SqlDatabase {
       // Mark this scope as active and issue BEGIN
       root.currentScope = scopeToken;
       root.scopeDepth = 1;
-      await scopedDb.exec('BEGIN');
+      await scopedDb.exec(options?.mode === 'immediate' ? 'BEGIN IMMEDIATE' : 'BEGIN');
 
       try {
         // Execute user code within the transaction

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   runRepositoryTransactionContract,
-  runKeyRingAllocationRepositoryContract,
+  runKeyRingDerivationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -78,7 +78,7 @@ runRepositoryTransactionContract(
   { describe, it, expect },
 );
 
-runKeyRingAllocationRepositoryContract(
+runKeyRingDerivationRepositoryContract(
   { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import Database from 'better-sqlite3';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   runRepositoryTransactionContract,
+  runKeyRingAllocationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
   runMintOperationRepositoryContract,
@@ -28,6 +32,29 @@ async function createRepositories() {
   };
 }
 
+async function createSharedRepositories() {
+  const directory = await mkdtemp(join(tmpdir(), 'coco-sqlite3-keyring-'));
+  const filename = join(directory, 'wallet.sqlite');
+  const firstDatabase = new Database(filename);
+  const secondDatabase = new Database(filename);
+  const first = new Repositories({ database: firstDatabase });
+  const second = new Repositories({ database: secondDatabase });
+  await first.init();
+  await second.init();
+  firstDatabase.pragma('busy_timeout = 10');
+  secondDatabase.pragma('busy_timeout = 10');
+
+  return {
+    first,
+    second,
+    dispose: async () => {
+      firstDatabase.close();
+      secondDatabase.close();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
 runSqlDatabaseContract(
   {
     createDatabase() {
@@ -48,6 +75,11 @@ runRepositoryTransactionContract(
     createRepositories,
     testConcurrentRootOperationIsolation: true,
   },
+  { describe, it, expect },
+);
+
+runKeyRingAllocationRepositoryContract(
+  { createRepositories, createSharedRepositories },
   { describe, it, expect },
 );
 


### PR DESCRIPTION
This pull request resolves #404.

## Problem

Concurrent key generation previously selected `MAX(stored derivation index) + 1` before deriving
and persisting the keypair. Independent Coco sessions sharing storage could therefore observe the
same maximum, derive the same deterministic NUT-20 quote key, and expose duplicate keys to mints.
A process-local mutex would not coordinate separate SQLite connections, processes, IndexedDB
connections, or browser tabs.

## Solution

- Add a required root-only `KeyRingAllocationRepository` capability that commits a unique,
  purpose-scoped derivation index before seed access and key derivation.
- Preserve permanent gaps after later failures or deletion and report BIP32 child-index exhaustion
  through `DerivationIndexExhaustedError`.
- Add a durable SQL high-water table with migration backfill, guarded writer transactions, bounded
  `SQLITE_BUSY` retries, and cross-connection/process coverage for SQLite3, SQLite Bun, and Expo
  SQLite.
- Add IndexedDB schema version 33 with purpose/index lookup and an atomic two-store Dexie
  transaction, including migration and independent-instance browser coverage.
- Add a reusable allocation contract for built-in and third-party adapters, and document the
  transaction, gap, backup, and storage-security semantics.

## Compatibility

This intentionally changes the public adapter contract. Third-party `Repositories`
implementations must provide `reserveNextDerivationIndex(purpose)` on their root keyring
repository. Transaction scopes retain the narrower non-allocating `KeyRingRepository` interface.
The included Changeset marks `@cashu/coco-core` as a major update and versions the affected adapter
packages.


## Changeset

- Added `.changeset/atomic-key-allocation.md` for the core contract and affected adapters.
