### PR TITLE
refactor(core): centralize pending mint classification

### DIFF
--- a/.changeset/narrow-mint-pending-observations.md
+++ b/.changeset/narrow-mint-pending-observations.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': patch
+---
+
+Centralize pending mint operation classification on reconciled canonical quote accounting. Keep
+payment-method handlers focused on attributable remote observations and validation failures so
+unattributable responses cannot update canonical quote records.

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -12,7 +12,7 @@ import type {
   RecoverExecutingResult,
   RecoverExecutingContext,
   PendingContext,
-  PendingMintCheckResult,
+  PendingMintObservationResult,
   FetchRemoteMintQuoteContext,
 } from '@core/operations/mint';
 import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
@@ -269,33 +269,31 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     }
   }
 
-  async checkPending(ctx: PendingContext<'bolt11'>): Promise<PendingMintCheckResult<'bolt11'>> {
+  async checkPending(
+    ctx: PendingContext<'bolt11'>,
+  ): Promise<PendingMintObservationResult<'bolt11'>> {
     const { mintUrl, quoteId } = ctx.operation;
     ctx.logger?.info('Checking pending mint operation', { mintUrl, quoteId });
 
     const quote = await ctx.mintAdapter.checkMintQuote(mintUrl, 'bolt11', quoteId);
-    this.assertPendingQuoteMatchesOperation(quote, ctx.operation);
-    const observedRemoteStateAt = Date.now();
-    const canonicalQuote = mintQuoteObservationFromBolt11Response(mintUrl, quote, {
-      now: observedRemoteStateAt,
-    });
-    const assessment = assessMintQuoteClaimability(canonicalQuote, {
-      requestedAmount: ctx.operation.amount,
-    });
-    ctx.logger?.info('Pending mint quote claimability assessed', {
-      mintUrl,
-      status: assessment.status,
-    });
+    const observedAt = Date.now();
+    try {
+      this.assertPendingQuoteMatchesOperation(quote, ctx.operation);
+    } catch (error) {
+      return {
+        observedAt,
+        validationFailure: {
+          reason: error instanceof Error ? error.message : String(error),
+          code: 'invalid_quote',
+          retryable: false,
+          observedAt,
+        },
+      };
+    }
 
     return {
-      observedRemoteStateAt,
+      observedAt,
       quoteSnapshot: quote,
-      category:
-        assessment.status === 'claimable'
-          ? 'ready'
-          : assessment.status === 'complete'
-            ? 'completed'
-            : 'waiting',
     };
   }
 

--- a/packages/core/infra/handlers/mint/MintBolt12Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt12Handler.ts
@@ -11,6 +11,7 @@ import {
 import { mintQuoteFromBolt12Response, type MintQuote } from '../../../models/MintQuote';
 import { mintQuoteObservationFromBolt12Response } from '../../../models/MintQuoteObservationFactory';
 import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
+import { getReusableMintQuoteValidationError } from './ReusableMintQuoteValidation.ts';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
@@ -18,7 +19,7 @@ import type {
   MintExecutionResult,
   MintMethodHandler,
   PendingContext,
-  PendingMintCheckResult,
+  PendingMintObservationResult,
   PendingMintOperation,
   PrepareContext,
   RecoverExecutingContext,
@@ -268,9 +269,11 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
     }
   }
 
-  async checkPending(ctx: PendingContext<'bolt12'>): Promise<PendingMintCheckResult<'bolt12'>> {
+  async checkPending(
+    ctx: PendingContext<'bolt12'>,
+  ): Promise<PendingMintObservationResult<'bolt12'>> {
     const { operation } = ctx;
-    const observedRemoteStateAt = Date.now();
+    const observedAt = Date.now();
     const remoteQuote = await ctx.mintAdapter.checkMintQuote(
       operation.mintUrl,
       'bolt12',
@@ -278,53 +281,35 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
     );
     const expectedPubkey = operation.pubkey;
 
-    if (!expectedPubkey) {
-      return {
-        observedRemoteStateAt,
-        quoteSnapshot: remoteQuote,
-        category: 'terminal',
-        terminalFailure: {
-          reason: `BOLT12 mint operation ${operation.id} is missing NUT-20 quote pubkey`,
-          code: 'missing_quote_pubkey',
-          retryable: false,
-          observedAt: observedRemoteStateAt,
-        },
-      };
-    }
-
-    const validationError = this.getQuoteValidationError(
-      remoteQuote,
-      expectedPubkey,
-      operation.unit,
-    );
+    const validationError = getReusableMintQuoteValidationError(remoteQuote, operation);
     if (validationError) {
       return {
-        observedRemoteStateAt,
-        category: 'terminal',
-        terminalFailure: {
+        observedAt,
+        validationFailure: {
           reason: validationError.message,
           code: 'invalid_quote',
           retryable: false,
-          observedAt: observedRemoteStateAt,
+          observedAt,
         },
       };
     }
 
-    const assessment = assessMintQuoteClaimability(
-      mintQuoteObservationFromBolt12Response(operation.mintUrl, remoteQuote, {
-        now: observedRemoteStateAt,
-      }),
-      { requestedAmount: operation.amount },
-    );
+    if (!expectedPubkey) {
+      return {
+        observedAt,
+        quoteSnapshot: remoteQuote,
+        validationFailure: {
+          reason: `BOLT12 mint operation ${operation.id} is missing NUT-20 quote pubkey`,
+          code: 'missing_quote_pubkey',
+          retryable: false,
+          observedAt,
+        },
+      };
+    }
+
     return {
-      observedRemoteStateAt,
+      observedAt,
       quoteSnapshot: remoteQuote,
-      category:
-        assessment.status === 'claimable'
-          ? 'ready'
-          : assessment.status === 'complete'
-            ? 'completed'
-            : 'waiting',
     };
   }
 

--- a/packages/core/infra/handlers/mint/MintOnchainHandler.ts
+++ b/packages/core/infra/handlers/mint/MintOnchainHandler.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../models/MintQuote';
 import { mintQuoteObservationFromOnchainResponse } from '../../../models/MintQuoteObservationFactory';
 import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
+import { getReusableMintQuoteValidationError } from './ReusableMintQuoteValidation.ts';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
@@ -26,7 +27,7 @@ import type {
   MintExecutionResult,
   MintMethodHandler,
   PendingContext,
-  PendingMintCheckResult,
+  PendingMintObservationResult,
   PendingMintOperation,
   PrepareContext,
   RecoverExecutingContext,
@@ -256,9 +257,11 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     }
   }
 
-  async checkPending(ctx: PendingContext<'onchain'>): Promise<PendingMintCheckResult<'onchain'>> {
+  async checkPending(
+    ctx: PendingContext<'onchain'>,
+  ): Promise<PendingMintObservationResult<'onchain'>> {
     const { operation } = ctx;
-    const observedRemoteStateAt = Date.now();
+    const observedAt = Date.now();
     const remoteQuote = await ctx.mintAdapter.checkMintQuote(
       operation.mintUrl,
       'onchain',
@@ -266,53 +269,35 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     );
     const expectedPubkey = operation.pubkey;
 
-    if (!expectedPubkey) {
-      return {
-        observedRemoteStateAt,
-        quoteSnapshot: remoteQuote,
-        category: 'terminal',
-        terminalFailure: {
-          reason: `Onchain mint operation ${operation.id} is missing NUT-20 quote pubkey`,
-          code: 'missing_quote_pubkey',
-          retryable: false,
-          observedAt: observedRemoteStateAt,
-        },
-      };
-    }
-
-    const validationError = this.getQuoteValidationError(
-      remoteQuote,
-      expectedPubkey,
-      operation.unit,
-    );
+    const validationError = getReusableMintQuoteValidationError(remoteQuote, operation);
     if (validationError) {
       return {
-        observedRemoteStateAt,
-        category: 'terminal',
-        terminalFailure: {
+        observedAt,
+        validationFailure: {
           reason: validationError.message,
           code: 'invalid_quote',
           retryable: false,
-          observedAt: observedRemoteStateAt,
+          observedAt,
         },
       };
     }
 
-    const assessment = assessMintQuoteClaimability(
-      mintQuoteObservationFromOnchainResponse(operation.mintUrl, remoteQuote, {
-        now: observedRemoteStateAt,
-      }),
-      { requestedAmount: operation.amount },
-    );
+    if (!expectedPubkey) {
+      return {
+        observedAt,
+        quoteSnapshot: remoteQuote,
+        validationFailure: {
+          reason: `Onchain mint operation ${operation.id} is missing NUT-20 quote pubkey`,
+          code: 'missing_quote_pubkey',
+          retryable: false,
+          observedAt,
+        },
+      };
+    }
+
     return {
-      observedRemoteStateAt,
+      observedAt,
       quoteSnapshot: remoteQuote,
-      category:
-        assessment.status === 'claimable'
-          ? 'ready'
-          : assessment.status === 'complete'
-            ? 'completed'
-            : 'waiting',
     };
   }
 

--- a/packages/core/infra/handlers/mint/ReusableMintQuoteValidation.ts
+++ b/packages/core/infra/handlers/mint/ReusableMintQuoteValidation.ts
@@ -1,0 +1,37 @@
+import type { MintQuoteBolt12Response, MintQuoteOnchainResponse } from '@cashu/cashu-ts';
+import { assertSameUnit } from '@core/amounts';
+import type { PendingMintOperation } from '@core/operations/mint';
+import { MintQuoteValidationError } from '../../../models/Error';
+
+type ReusableMintQuoteResponse = MintQuoteBolt12Response | MintQuoteOnchainResponse;
+type ReusablePendingMintOperation = PendingMintOperation<'bolt12' | 'onchain'>;
+
+/**
+ * Returns a validation error when a reusable quote response is not attributable to an operation.
+ */
+export function getReusableMintQuoteValidationError(
+  quote: ReusableMintQuoteResponse,
+  operation: ReusablePendingMintOperation,
+): Error | null {
+  const identityLabel = operation.method === 'bolt12' ? 'BOLT12' : 'onchain';
+  const quoteLabel = operation.method === 'bolt12' ? 'BOLT12' : 'Onchain';
+
+  try {
+    if (quote.quote !== operation.quoteId || quote.request !== operation.request) {
+      throw new MintQuoteValidationError(
+        `Polled ${identityLabel} mint quote ${quote.quote} ` +
+          'conflicts with pending operation identity',
+      );
+    }
+    assertSameUnit(quote.unit, operation.unit, `${quoteLabel} mint quote ${quote.quote}`);
+    if (operation.pubkey !== undefined && quote.pubkey !== operation.pubkey) {
+      throw new MintQuoteValidationError(
+        `${quoteLabel} mint quote ${quote.quote} returned pubkey ${quote.pubkey} ` +
+          `instead of requested pubkey ${operation.pubkey}`,
+      );
+    }
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error), { cause: error });
+  }
+}

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -202,6 +202,24 @@ export interface PendingMintCheckResult<M extends MintMethod = MintMethod> {
   terminalFailure?: MintOperationFailure;
 }
 
+/**
+ * Method-specific facts observed while checking a pending mint operation.
+ *
+ * Handlers validate whether remote responses belong to their operation. The durable mint saga
+ * reconciles attributable snapshots and decides the resulting local operation state.
+ */
+export type PendingMintObservationResult<M extends MintMethod = MintMethod> =
+  | {
+      observedAt: number;
+      quoteSnapshot: MintMethodQuoteSnapshot<M>;
+      validationFailure?: never;
+    }
+  | {
+      observedAt: number;
+      quoteSnapshot?: MintMethodQuoteSnapshot<M>;
+      validationFailure: MintOperationFailure;
+    };
+
 export interface MintMethodHandler<M extends MintMethod = MintMethod> {
   createQuote(ctx: CreateMintQuoteContext<M>): Promise<MintQuote<M>>;
   fetchRemoteQuote(ctx: FetchRemoteMintQuoteContext<M>): Promise<MintQuote<M>>;
@@ -209,7 +227,7 @@ export interface MintMethodHandler<M extends MintMethod = MintMethod> {
   prepare(ctx: PrepareContext<M>): Promise<PendingMintOperation<M>>;
   execute(ctx: ExecuteContext<M>): Promise<MintExecutionResult>;
   recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<RecoverExecutingResult>;
-  checkPending(ctx: PendingContext<M>): Promise<PendingMintCheckResult<M>>;
+  checkPending(ctx: PendingContext<M>): Promise<PendingMintObservationResult<M>>;
 }
 
 export type MintMethodHandlerRegistry = {

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -21,7 +21,6 @@ import type {
   MintMethodData,
   MintMethodMeta,
   PendingMintCheckResult,
-  MintMethodQuoteSnapshot,
 } from './MintMethodHandler';
 import type { MintService } from '../../services/MintService';
 import type { WalletService } from '../../services/WalletService';
@@ -1183,30 +1182,33 @@ export class MintOperationService {
     const handler = this.handlerProvider.get(op.method);
     const { wallet } = await this.walletService.getWalletWithActiveKeysetId(op.mintUrl, op.unit);
 
-    let result = await handler.checkPending({
+    const observation = await handler.checkPending({
       ...this.buildDeps(),
       operation: op as PendingMintOperation,
       wallet,
     });
 
     let canonicalQuote: MintQuote | undefined;
-    if (result.quoteSnapshot) {
+    if (observation.quoteSnapshot) {
       canonicalQuote = await this.quoteLifecycle.recordMintQuoteSnapshot(
         op.mintUrl,
         op.method,
-        result.quoteSnapshot as MintMethodQuoteSnapshot,
+        observation.quoteSnapshot,
       );
     }
 
-    if (result.observedRemoteState !== undefined) {
-      canonicalQuote = await this.quoteLifecycle.recordMintQuoteObservation(
-        op,
-        result.observedRemoteState,
-        result.observedRemoteStateAt,
-      );
-    }
-
-    if (canonicalQuote && result.category !== 'terminal') {
+    let result: PendingMintCheckResult;
+    if (observation.validationFailure) {
+      result = {
+        observedRemoteStateAt: observation.observedAt,
+        quoteSnapshot: observation.quoteSnapshot,
+        category: 'terminal',
+        terminalFailure: observation.validationFailure,
+      };
+    } else {
+      if (!canonicalQuote) {
+        throw new Error(`Pending mint observation for operation ${op.id} has no quote snapshot`);
+      }
       const siblings = await this.mintOperationRepository.getByQuoteId(
         op.mintUrl,
         op.method,
@@ -1217,7 +1219,8 @@ export class MintOperationService {
         targetOperationId: op.id,
       });
       result = {
-        ...result,
+        observedRemoteStateAt: observation.observedAt,
+        quoteSnapshot: observation.quoteSnapshot,
         category:
           assessment.status === 'claimable'
             ? 'ready'
@@ -1232,7 +1235,7 @@ export class MintOperationService {
                 reason: `Mint quote ${op.quoteId} has invalid claimability accounting`,
                 code: 'invalid_quote',
                 retryable: false,
-                observedAt: result.observedRemoteStateAt,
+                observedAt: observation.observedAt,
               }
             : undefined,
       };

--- a/packages/core/test/unit/MintBolt11Handler.test.ts
+++ b/packages/core/test/unit/MintBolt11Handler.test.ts
@@ -537,18 +537,24 @@ describe('MintBolt11Handler', () => {
       ['amount', { amount: Amount.from(11) }],
       ['NUT-20 pubkey', { pubkey: quotePubkey }],
     ] as Array<[string, Partial<MintQuoteBolt11Response>]>)(
-      'rejects a polled snapshot with a mismatched %s',
+      'reports a polled snapshot with a mismatched %s as a validation failure',
       async (_field, override) => {
         (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
           ...quote,
           ...override,
         });
 
-        await expect(handler.checkPending(buildPendingContext())).rejects.toThrow();
+        const result = await handler.checkPending(buildPendingContext());
+
+        expect(result.quoteSnapshot).toBeUndefined();
+        expect(result.validationFailure).toMatchObject({
+          code: 'invalid_quote',
+          retryable: false,
+        });
       },
     );
 
-    it('uses canonical accounting when compatibility state disagrees', async () => {
+    it('reports the validated remote snapshot and observation time', async () => {
       (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
         ...quote,
         state: 'UNPAID',
@@ -556,17 +562,11 @@ describe('MintBolt11Handler', () => {
 
       const result = await handler.checkPending(buildPendingContext());
 
-      expect(result.observedRemoteState).toBeUndefined();
       expect(result.quoteSnapshot).toEqual(expect.objectContaining({ state: 'UNPAID' }));
-      expect(result.category).toBe('ready');
-      expect(result.observedRemoteStateAt).toEqual(expect.any(Number));
+      expect(result.observedAt).toEqual(expect.any(Number));
       expect(logger.info).toHaveBeenCalledWith('Checking pending mint operation', {
         mintUrl,
         quoteId,
-      });
-      expect(logger.info).toHaveBeenCalledWith('Pending mint quote claimability assessed', {
-        mintUrl,
-        status: 'claimable',
       });
     });
   });

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -350,7 +350,7 @@ describe('MintBolt12Handler', () => {
     expect(error.message).toContain('Missing NUT-20 mint quote key');
   });
 
-  it('marks amountless quotes ready when paid amount covers the operation amount', async () => {
+  it('reports the validated remote snapshot for an amountless quote', async () => {
     const result = await handler.checkPending(
       buildPendingContext(
         quote({
@@ -362,60 +362,50 @@ describe('MintBolt12Handler', () => {
     );
 
     expect(result.quoteSnapshot?.quote).toBe(quoteId);
-    expect(result.category).toBe('ready');
+    expect(result.observedAt).toEqual(expect.any(Number));
   });
 
-  it('keeps a funded quote with no-expiry sentinel claimable', async () => {
-    const result = await handler.checkPending(
-      buildPendingContext(
-        quote({
-          expiry: 0,
-          amount_paid: Amount.from(10),
-        }),
-      ),
+  it('reports an unattributable pending response as a validation failure', async () => {
+    const context = buildPendingContext(quote());
+    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce(
+      quote({ quote: 'other-quote' }),
     );
 
-    expect(result.category).toBe('ready');
+    const result = await handler.checkPending(context);
+
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(result.validationFailure).toMatchObject({
+      code: 'invalid_quote',
+      retryable: false,
+    });
+    expect(result.validationFailure?.reason).toContain('conflicts with pending operation identity');
   });
 
-  it('keeps a funded quote with null expiry claimable', async () => {
-    const result = await handler.checkPending(
-      buildPendingContext(
-        quote({
-          expiry: null,
-          amount_paid: Amount.from(10),
-        }),
-      ),
+  it('does not attribute a mismatched response when the operation pubkey is missing', async () => {
+    const baseContext = buildPendingContext(quote());
+    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce(
+      quote({ request: 'lno1other' }),
     );
 
-    expect(result.category).toBe('ready');
+    const result = await handler.checkPending({
+      ...baseContext,
+      operation: { ...baseContext.operation, pubkey: undefined },
+    });
+
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(result.validationFailure?.code).toBe('invalid_quote');
   });
 
-  it('keeps a funded quote with a future positive expiry claimable', async () => {
-    const result = await handler.checkPending(
-      buildPendingContext(
-        quote({
-          expiry: Math.floor(Date.now() / 1000) + 60,
-          amount_paid: Amount.from(10),
-        }),
-      ),
-    );
+  it('preserves the missing-pubkey terminal code for an attributable response', async () => {
+    const baseContext = buildPendingContext(quote());
 
-    expect(result.category).toBe('ready');
-  });
+    const result = await handler.checkPending({
+      ...baseContext,
+      operation: { ...baseContext.operation, pubkey: undefined },
+    });
 
-  it('keeps a funded quote claimable after expiry', async () => {
-    const result = await handler.checkPending(
-      buildPendingContext(
-        quote({
-          expiry: Math.floor(Date.now() / 1000) - 1,
-          amount_paid: Amount.from(10),
-        }),
-      ),
-    );
-
-    expect(result.category).toBe('ready');
-    expect(result.terminalFailure).toBeUndefined();
+    expect(result.quoteSnapshot?.quote).toBe(quoteId);
+    expect(result.validationFailure?.code).toBe('missing_quote_pubkey');
   });
 
   it('mints with the keyring private key and custom outputs', async () => {

--- a/packages/core/test/unit/MintOnchainHandler.test.ts
+++ b/packages/core/test/unit/MintOnchainHandler.test.ts
@@ -489,25 +489,58 @@ describe('MintOnchainHandler', () => {
     expect(proofService.saveProofs).not.toHaveBeenCalled();
   });
 
-  it('checks pending onchain operations as ready when the quote can cover the amount', async () => {
+  it('reports the validated remote snapshot for a pending operation', async () => {
     const result = await handler.checkPending(buildPendingContext());
 
-    expect(result.category).toBe('ready');
     expect(result.quoteSnapshot).toBe(remoteQuote);
+    expect(result.observedAt).toEqual(expect.any(Number));
   });
 
-  it('keeps a funded onchain quote with no-expiry sentinel claimable', async () => {
+  it('reports an unattributable pending response as a validation failure', async () => {
     (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
       ...remoteQuote,
-      expiry: 0,
+      request: 'bc1qotheraddress',
     });
 
     const result = await handler.checkPending(buildPendingContext());
 
-    expect(result.category).toBe('ready');
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(result.validationFailure).toMatchObject({
+      code: 'invalid_quote',
+      retryable: false,
+    });
+    expect(result.validationFailure?.reason).toContain('conflicts with pending operation identity');
   });
 
-  it('checks pending onchain operations as waiting when the quote cannot cover the amount', async () => {
+  it('does not attribute a mismatched response when the operation pubkey is missing', async () => {
+    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
+      ...remoteQuote,
+      quote: 'other-quote',
+    });
+    const baseContext = buildPendingContext();
+
+    const result = await handler.checkPending({
+      ...baseContext,
+      operation: { ...baseContext.operation, pubkey: undefined },
+    });
+
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(result.validationFailure?.code).toBe('invalid_quote');
+  });
+
+  it('preserves the missing-pubkey terminal code for an attributable response', async () => {
+    const baseContext = buildPendingContext();
+
+    const result = await handler.checkPending({
+      ...baseContext,
+      operation: { ...baseContext.operation, pubkey: undefined },
+    });
+
+    expect(result.quoteSnapshot).toBe(remoteQuote);
+    expect(result.validationFailure?.code).toBe('missing_quote_pubkey');
+  });
+
+  it('preserves remote accounting in the pending observation', async () => {
     (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
       ...remoteQuote,
       amount_paid: Amount.from(8),
@@ -516,21 +549,6 @@ describe('MintOnchainHandler', () => {
 
     const result = await handler.checkPending(buildPendingContext());
 
-    expect(result.category).toBe('waiting');
     expect(result.quoteSnapshot?.amount_paid?.equals(Amount.from(8))).toBe(true);
-  });
-
-  it('keeps an unfunded onchain operation waiting after expiry', async () => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      expiry: Math.floor(Date.now() / 1000) - 1,
-      amount_paid: Amount.from(8),
-      amount_issued: Amount.from(8),
-    });
-
-    const result = await handler.checkPending(buildPendingContext());
-
-    expect(result.category).toBe('waiting');
-    expect(result.terminalFailure).toBeUndefined();
   });
 });

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -22,7 +22,7 @@ import type {
   MintMethodHandler,
   MintMethodQuoteImportSnapshot,
   MintMethodQuoteSnapshot,
-  PendingMintCheckResult,
+  PendingMintObservationResult,
   RecoverExecutingResult,
 } from '../../operations/mint/MintMethodHandler';
 import type { MintHandlerProvider } from '../../infra/handlers/mint';
@@ -146,7 +146,7 @@ describe('MintOperationService', () => {
     amounts: {
       paid?: Amount;
       issued?: Amount;
-      expiry?: number;
+      expiry?: number | null;
       remoteUpdatedAt?: number | null;
     } = {},
   ): Promise<void> => {
@@ -155,7 +155,8 @@ describe('MintOperationService', () => {
         quote,
         request: 'bc1qtest',
         unit: 'sat',
-        expiry: amounts.expiry ?? Math.floor(Date.now() / 1000) + 3600,
+        expiry:
+          amounts.expiry === undefined ? Math.floor(Date.now() / 1000) + 3600 : amounts.expiry,
         pubkey: '02'.padEnd(66, '1'),
         amount_paid: amounts.paid ?? Amount.zero(),
         amount_issued: amounts.issued ?? Amount.zero(),
@@ -227,6 +228,23 @@ describe('MintOperationService', () => {
     return { onchainHandler, executedAmounts };
   };
 
+  const usePendingOnchainHandler = (quoteSnapshot: MintMethodQuoteSnapshot<'onchain'>) => {
+    const checkPending = mock(
+      async (): Promise<PendingMintObservationResult<'onchain'>> => ({
+        observedAt: Date.now(),
+        quoteSnapshot,
+      }),
+    );
+    const onchainHandler = {
+      ...handler,
+      checkPending,
+    } as unknown as MintMethodHandler<'onchain'>;
+    (handlerProvider.get as Mock<any>).mockImplementation((method: string) =>
+      method === 'onchain' ? onchainHandler : handler,
+    );
+    return checkPending;
+  };
+
   const makePendingOp = (id: string, secret = 'out-1'): PendingMintOperation => ({
     ...makeInitOp(id),
     state: 'pending',
@@ -267,10 +285,19 @@ describe('MintOperationService', () => {
     });
 
     const mockCheckPending = mock(
-      async (): Promise<PendingMintCheckResult<'bolt11'>> => ({
-        observedRemoteState: 'UNPAID',
-        observedRemoteStateAt: Date.now(),
-        category: 'waiting',
+      async (): Promise<PendingMintObservationResult<'bolt11'>> => ({
+        observedAt: Date.now(),
+        quoteSnapshot: cashuNormalizedBolt11Fixture({
+          quote: quoteId,
+          request: 'lnbc1test',
+          amount: Amount.from(10),
+          unit: 'sat',
+          expiry: Math.floor(Date.now() / 1000) + 3600,
+          state: 'UNPAID',
+          amount_paid: Amount.zero(),
+          amount_issued: Amount.zero(),
+          updated_at: null,
+        }),
       }),
     );
 
@@ -2627,9 +2654,18 @@ describe('MintOperationService', () => {
     await operationRepo.create(pendingOp);
 
     (handler.checkPending as Mock<any>).mockResolvedValueOnce({
-      observedRemoteState: 'PAID',
-      observedRemoteStateAt: Date.now(),
-      category: 'ready',
+      observedAt: Date.now(),
+      quoteSnapshot: cashuNormalizedBolt11Fixture({
+        quote: quoteId,
+        request: 'lnbc1test',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: pendingOp.expiry,
+        state: 'PAID',
+        amount_paid: Amount.from(10),
+        amount_issued: Amount.zero(),
+        updated_at: null,
+      }),
     });
 
     await service.recoverPendingOperations();
@@ -2649,11 +2685,40 @@ describe('MintOperationService', () => {
     const stored = await operationRepo.getById(pendingOp.id);
 
     expect(result.category).toBe('waiting');
-    expect(result.observedRemoteState).toBe('UNPAID');
+    expect(result.observedRemoteState).toBeUndefined();
+    expect((result.quoteSnapshot as MintQuoteBolt11Response | undefined)?.state).toBe('UNPAID');
     expect(stored?.state).toBe('pending');
     if (!stored || stored.state !== 'pending') {
       throw new Error('Expected pending operation to remain pending after unpaid check');
     }
+  });
+
+  it('classifies a fully issued canonical quote as completed', async () => {
+    await persistQuote();
+    const pendingOp = await service.prepare(
+      { mintUrl, method: 'bolt11', quoteId },
+      Amount.from(10),
+    );
+    (handler.checkPending as Mock<any>).mockResolvedValueOnce({
+      observedAt: Date.now(),
+      quoteSnapshot: cashuNormalizedBolt11Fixture({
+        quote: quoteId,
+        request: 'lnbc1test',
+        amount: Amount.from(10),
+        unit: 'sat',
+        expiry: pendingOp.expiry,
+        state: 'ISSUED',
+        amount_paid: Amount.from(10),
+        amount_issued: Amount.from(10),
+        updated_at: 10,
+      }),
+    });
+
+    const result = await service.checkPendingOperation(pendingOp.id);
+    const stored = await operationRepo.getById(pendingOp.id);
+
+    expect(result.category).toBe('completed');
+    expect(stored?.state).toBe('finalized');
   });
 
   it('checkPendingOperation emits mint-op:failed for terminal pending failures', async () => {
@@ -2671,7 +2736,7 @@ describe('MintOperationService', () => {
     });
 
     (handler.checkPending as Mock<any>).mockResolvedValueOnce({
-      observedRemoteStateAt: observedAt,
+      observedAt,
       quoteSnapshot: cashuNormalizedBolt11Fixture({
         quote: quoteId,
         request: 'lnbc1test',
@@ -2683,8 +2748,7 @@ describe('MintOperationService', () => {
         amount_issued: Amount.zero(),
         updated_at: 10,
       }),
-      category: 'terminal',
-      terminalFailure: {
+      validationFailure: {
         reason: 'Mint operation is missing NUT-20 quote pubkey',
         code: 'missing_quote_pubkey',
         retryable: false,
@@ -2713,14 +2777,48 @@ describe('MintOperationService', () => {
     );
   });
 
+  it('does not persist an unattributable snapshot for a validation failure', async () => {
+    await persistQuote();
+    const pendingOp = await service.prepare(
+      { mintUrl, method: 'bolt11', quoteId },
+      Amount.from(10),
+    );
+    const observedAt = Date.now();
+    (handler.checkPending as Mock<any>).mockResolvedValueOnce({
+      observedAt,
+      validationFailure: {
+        reason: `Polled BOLT11 mint quote other-quote conflicts with pending operation identity`,
+        code: 'invalid_quote',
+        retryable: false,
+        observedAt,
+      },
+    });
+
+    const result = await service.checkPendingOperation(pendingOp.id);
+    const storedOperation = await operationRepo.getById(pendingOp.id);
+    const storedQuote = await quoteRepo.getMintQuote(mintUrl, 'bolt11', quoteId);
+
+    expect(result.category).toBe('terminal');
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(storedOperation?.state).toBe('failed');
+    expect(storedOperation?.terminalFailure?.code).toBe('invalid_quote');
+    expect(storedQuote?.request).toBe('lnbc1test');
+  });
+
   it('classifies pending work from the resolved quote after ignoring invalid accounting', async () => {
     await persistQuote();
     const pendingOp = await service.prepare(
       { mintUrl, method: 'bolt11', quoteId },
       Amount.from(10),
     );
+    const observedAt = Date.now();
+    const paidAmountsDuringFinalization: string[] = [];
+    eventBus.on('mint-op:finalized', async () => {
+      const quote = await quoteRepo.getMintQuote(mintUrl, 'bolt11', quoteId);
+      paidAmountsDuringFinalization.push(quote?.amountPaid.toString() ?? 'missing');
+    });
     (handler.checkPending as Mock<any>).mockResolvedValueOnce({
-      observedRemoteStateAt: Date.now(),
+      observedAt,
       quoteSnapshot: cashuNormalizedBolt11Fixture({
         quote: quoteId,
         request: 'lnbc1contradictory',
@@ -2732,7 +2830,6 @@ describe('MintOperationService', () => {
         amount_issued: Amount.from(10),
         updated_at: 20,
       }),
-      category: 'waiting',
     });
 
     const result = await service.checkPendingOperation(pendingOp.id);
@@ -2740,9 +2837,11 @@ describe('MintOperationService', () => {
     const storedQuote = await quoteRepo.getMintQuote(mintUrl, 'bolt11', quoteId);
 
     expect(result.category).toBe('ready');
+    expect(result.observedRemoteStateAt).toBe(observedAt);
     expect(storedOperation?.state).toBe('finalized');
     expect(storedQuote?.amountPaid.equals(Amount.from(10))).toBe(true);
     expect(storedQuote?.request).not.toBe('lnbc1contradictory');
+    expect(paidAmountsDuringFinalization).toEqual(['10']);
   });
 
   it('checkPendingOperation records onchain quote snapshots without protocol state', async () => {
@@ -2756,29 +2855,19 @@ describe('MintOperationService', () => {
     };
     await operationRepo.create(pendingOp);
 
-    const onchainHandler = {
-      ...handler,
-      checkPending: mock(
-        async (): Promise<PendingMintCheckResult<'onchain'>> => ({
-          observedRemoteStateAt: Date.now(),
-          quoteSnapshot: cashuNormalizedOnchainFixture({
-            quote: onchainQuoteId,
-            request: 'bc1qtest',
-            unit: 'sat',
-            expiry: Math.floor(Date.now() / 1000) + 3600,
-            pubkey: '02'.padEnd(66, '1'),
-            amount_paid: Amount.from(7),
-            amount_issued: Amount.zero(),
-          }),
-          category: 'waiting',
-        }),
-      ),
-    } as unknown as MintMethodHandler<'onchain'>;
-    (handlerProvider.get as Mock<any>).mockImplementation((method: string) =>
-      method === 'onchain' ? onchainHandler : handler,
+    usePendingOnchainHandler(
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(7),
+        amount_issued: Amount.zero(),
+      }),
     );
 
-    await service.checkPendingOperation(pendingOp.id);
+    const result = await service.checkPendingOperation(pendingOp.id);
 
     const stored = await operationRepo.getById(pendingOp.id);
     const quote = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
@@ -2786,6 +2875,7 @@ describe('MintOperationService', () => {
     expect(stored?.state).toBe('pending');
     expect(quote?.method).toBe('onchain');
     if (quote?.method !== 'onchain') throw new Error('Expected onchain quote');
+    expect(result.category).toBe('waiting');
     expect(quote.amountPaid.equals(Amount.from(7))).toBe(true);
   });
 
@@ -2800,37 +2890,157 @@ describe('MintOperationService', () => {
     };
     await operationRepo.create(pendingOp);
 
-    const onchainHandler = {
-      ...handler,
-      checkPending: mock(
-        async (): Promise<PendingMintCheckResult<'onchain'>> => ({
-          observedRemoteStateAt: Date.now(),
-          quoteSnapshot: cashuNormalizedOnchainFixture({
-            quote: onchainQuoteId,
-            request: 'bc1qtest',
-            unit: 'sat',
-            expiry: Math.floor(Date.now() / 1000) + 3600,
-            pubkey: '02'.padEnd(66, '1'),
-            amount_paid: Amount.from(7),
-            amount_issued: Amount.from(5),
-          }),
-          category: 'waiting',
-        }),
-      ),
-    } as unknown as MintMethodHandler<'onchain'>;
-    (handlerProvider.get as Mock<any>).mockImplementation((method: string) =>
-      method === 'onchain' ? onchainHandler : handler,
+    usePendingOnchainHandler(
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: Math.floor(Date.now() / 1000) + 3600,
+        pubkey: '02'.padEnd(66, '1'),
+        amount_paid: Amount.from(7),
+        amount_issued: Amount.from(5),
+      }),
     );
 
-    await service.checkPendingOperation(pendingOp.id);
+    const result = await service.checkPendingOperation(pendingOp.id);
 
     const quote = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
 
     expect(quote?.method).toBe('onchain');
     if (quote?.method !== 'onchain') throw new Error('Expected onchain quote');
+    expect(result.category).toBe('waiting');
     expect(quote.amountPaid.equals(Amount.from(10))).toBe(true);
     expect(quote.amountIssued.equals(Amount.from(8))).toBe(true);
   });
+
+  it('classifies conflicting reusable accounting from the canonical quote', async () => {
+    const onchainQuoteId = 'onchain-quote-conflicting-check';
+    const pubkey = '02'.padEnd(66, '1');
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.zero(),
+      remoteUpdatedAt: 20,
+    });
+    const pendingOp: PendingMintOperation<'onchain'> = {
+      ...makePendingOp('onchain-conflicting-check'),
+      method: 'onchain',
+      quoteId: onchainQuoteId,
+      request: 'bc1qtest',
+      pubkey,
+    };
+    await operationRepo.create(pendingOp);
+    usePendingOnchainHandler(
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry: pendingOp.expiry,
+        pubkey,
+        amount_paid: Amount.from(8),
+        amount_issued: Amount.zero(),
+        updated_at: 20,
+      }),
+    );
+
+    const result = await service.observePendingOperation(pendingOp.id);
+    const quote = await quoteRepo.getMintQuote(mintUrl, 'onchain', onchainQuoteId);
+
+    expect(result.category).toBe('ready');
+    expect(quote?.amountPaid.equals(Amount.from(10))).toBe(true);
+  });
+
+  it.each([
+    ['zero-expiry sentinel', 0],
+    ['null expiry', null],
+    ['elapsed expiry', Math.floor(Date.now() / 1000) - 1],
+  ] as const)('classifies a funded reusable quote with %s as ready', async (label, expiry) => {
+    const onchainQuoteId = `onchain-quote-${label.replaceAll(' ', '-')}`;
+    const pubkey = '02'.padEnd(66, '1');
+    await persistOnchainQuote(onchainQuoteId, {
+      paid: Amount.from(10),
+      issued: Amount.zero(),
+      expiry,
+    });
+    const pendingOp: PendingMintOperation<'onchain'> = {
+      ...makePendingOp(`onchain-operation-${label.replaceAll(' ', '-')}`),
+      method: 'onchain',
+      quoteId: onchainQuoteId,
+      request: 'bc1qtest',
+      expiry,
+      pubkey,
+    };
+    await operationRepo.create(pendingOp);
+    usePendingOnchainHandler(
+      cashuNormalizedOnchainFixture({
+        quote: onchainQuoteId,
+        request: 'bc1qtest',
+        unit: 'sat',
+        expiry,
+        pubkey,
+        amount_paid: Amount.from(10),
+        amount_issued: Amount.zero(),
+      }),
+    );
+
+    const result = await service.observePendingOperation(pendingOp.id);
+
+    expect(result.category).toBe('ready');
+  });
+
+  it.each([
+    ['subtracting executing sibling reservations', 'executing', 6, 5, 'waiting'],
+    ['accounting for finalized siblings', 'finalized', 4, 6, 'ready'],
+  ] as const)(
+    'classifies reusable pending work after %s',
+    async (label, siblingState, targetAmount, siblingAmount, expectedCategory) => {
+      const scenario = label.replaceAll(' ', '-');
+      const onchainQuoteId = `onchain-quote-${scenario}`;
+      const pubkey = '02'.padEnd(66, '1');
+      await persistOnchainQuote(onchainQuoteId, {
+        paid: Amount.from(10),
+        issued: Amount.zero(),
+      });
+      const pendingOp: PendingMintOperation<'onchain'> = {
+        ...makePendingOp(`onchain-target-${scenario}`),
+        method: 'onchain',
+        quoteId: onchainQuoteId,
+        request: 'bc1qtest',
+        pubkey,
+        amount: Amount.from(targetAmount),
+      };
+      const sibling =
+        siblingState === 'executing'
+          ? ({
+              ...pendingOp,
+              id: `onchain-sibling-${scenario}`,
+              state: 'executing',
+              amount: Amount.from(siblingAmount),
+            } satisfies ExecutingMintOperation<'onchain'>)
+          : ({
+              ...pendingOp,
+              id: `onchain-sibling-${scenario}`,
+              state: 'finalized',
+              amount: Amount.from(siblingAmount),
+            } satisfies FinalizedMintOperation<'onchain'>);
+      await operationRepo.create(pendingOp);
+      await operationRepo.create(sibling);
+      usePendingOnchainHandler(
+        cashuNormalizedOnchainFixture({
+          quote: onchainQuoteId,
+          request: 'bc1qtest',
+          unit: 'sat',
+          expiry: pendingOp.expiry,
+          pubkey,
+          amount_paid: Amount.from(10),
+          amount_issued: Amount.zero(),
+        }),
+      );
+
+      const result = await service.observePendingOperation(pendingOp.id);
+
+      expect(result.category).toBe(expectedCategory);
+    },
+  );
 
   it('recordQuoteObservation persists the canonical quote before emitting mint-quote:updated', async () => {
     const pendingOp = makePendingOp('pending-quote-event');


### PR DESCRIPTION
## Problem

Payment-method handlers and `MintOperationService` independently classified the same pending mint observation. Handler policy ran before canonical quote reconciliation, so it could disagree with monotonic accounting and local sibling-operation facts.

## Summary

- return normalized remote snapshots or validation failures from mint handlers
- reconcile snapshots through `QuoteLifecycle` before classifying operations
- centralize `waiting`, `ready`, `completed`, and `terminal` decisions in `MintOperationService`
- prevent unattributable responses from updating canonical quote records
- preserve public `PendingMintCheckResult` compatibility and persistence-before-advancement ordering
- add a patch changeset for `@cashu/coco-core`

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MintOperationService.test.ts test/unit/MintOperationWatcherService.test.ts test/unit/MintQuoteProcessor.test.ts test/unit/MintBolt11Handler.test.ts test/unit/MintBolt12Handler.test.ts test/unit/MintOnchainHandler.test.ts test/unit/MintQuoteClaimability.test.ts test/unit/MintQuoteObservation.test.ts test/unit/QuoteLifecyclePolling.test.ts test/unit/MintOpsApi.test.ts test/unit/QuoteApi.test.ts` (297 passed)
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run --filter='@cashu/coco-core' build`
- Prettier and `git diff --check`
