### PR TITLE
fix(core): decouple pending mint checks from wallet instances

### DIFF
--- a/.changeset/lean-mint-pending-context.md
+++ b/.changeset/lean-mint-pending-context.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Observe pending mint operations without requiring a wallet instance or active keyset. Narrow
+payment-method pending contexts to the operation, mint adapter, and optional logger they use.

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -168,9 +168,10 @@ export interface RecoverExecutingContext<
   };
 }
 
-export interface PendingContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+export interface PendingContext<M extends MintMethod = MintMethod> {
   operation: PendingMintOperation<M>;
-  wallet: Wallet;
+  mintAdapter: MintAdapter;
+  logger?: Logger;
 }
 
 export type MintExecutionResult =

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1180,12 +1180,11 @@ export class MintOperationService {
       );
     }
     const handler = this.handlerProvider.get(op.method);
-    const { wallet } = await this.walletService.getWalletWithActiveKeysetId(op.mintUrl, op.unit);
 
     const observation = await handler.checkPending({
-      ...this.buildDeps(),
       operation: op as PendingMintOperation,
-      wallet,
+      mintAdapter: this.mintAdapter,
+      logger: this.logger,
     });
 
     let canonicalQuote: MintQuote | undefined;

--- a/packages/core/test/unit/MintBolt11Handler.test.ts
+++ b/packages/core/test/unit/MintBolt11Handler.test.ts
@@ -194,13 +194,7 @@ describe('MintBolt11Handler', () => {
       ...executingOperation,
       state: 'pending',
     },
-    wallet,
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
     logger,
   });
 

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -114,7 +114,6 @@ describe('MintBolt12Handler', () => {
   const buildPendingContext = (remoteQuote: MintQuoteBolt12Response): PendingContext<'bolt12'> => {
     (mintAdapter.checkMintQuote as Mock<any>).mockImplementation(async () => remoteQuote);
     return {
-      ...buildPrepareContext(),
       operation: {
         ...operation,
         state: 'pending',
@@ -124,6 +123,8 @@ describe('MintBolt12Handler', () => {
         pubkey,
         outputData,
       },
+      mintAdapter,
+      logger,
     };
   };
 

--- a/packages/core/test/unit/MintOnchainHandler.test.ts
+++ b/packages/core/test/unit/MintOnchainHandler.test.ts
@@ -153,11 +153,12 @@ describe('MintOnchainHandler', () => {
   });
 
   const buildPendingContext = (): PendingContext<'onchain'> => ({
-    ...buildPrepareContext(),
     operation: {
       ...buildExecutingOperation(),
       state: 'pending',
     } satisfies PendingMintOperation<'onchain'>,
+    mintAdapter,
+    logger,
   });
 
   beforeEach(() => {

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -2677,6 +2677,20 @@ describe('MintOperationService', () => {
     expect(pendingStored?.state).toBe('finalized');
   });
 
+  it('observes pending operations without resolving a wallet instance', async () => {
+    const pendingOp = makePendingOp('pending-without-wallet-instance');
+    const getWalletWithActiveKeysetId = mock(async () => {
+      throw new Error('Wallet instance is unavailable');
+    });
+    walletService.getWalletWithActiveKeysetId = getWalletWithActiveKeysetId;
+    await operationRepo.create(pendingOp);
+
+    const result = await service.observePendingOperation(pendingOp.id);
+
+    expect(result.category).toBe('waiting');
+    expect(getWalletWithActiveKeysetId).not.toHaveBeenCalled();
+  });
+
   it('checkPendingOperation leaves unpaid operations pending', async () => {
     const pendingOp = makePendingOp('pending-3');
     await operationRepo.create(pendingOp);


### PR DESCRIPTION
## Problem

Pending mint observation loaded a Wallet Instance and active keyset even though payment-method pending checks do not use either dependency. That unrelated lookup could prevent Coco from observing a remote quote.

## Summary

- narrow the mint `PendingContext` interface to the pending operation, mint adapter, and optional logger
- remove Wallet Instance and active-keyset resolution from `observePendingOperation()`
- simplify the BOLT11, BOLT12, and on-chain pending test contexts
- add a regression proving pending observation does not resolve a Wallet Instance
- add a patch changeset for `@cashu/coco-core`

## Impact

Pending mint quote observation no longer depends on Wallet Instance availability. Quote validation, canonical persistence, claimability classification, operation transitions, events, and error behavior remain unchanged.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/MintOperationService.test.ts test/unit/MintBolt11Handler.test.ts test/unit/MintBolt12Handler.test.ts test/unit/MintOnchainHandler.test.ts` (165 passed)
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- Prettier check on all changed files
- `git diff --check`
