### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting a Vulnerability
+
+To report security issues send an email to **cashu-security@pm.me**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,22 @@
-# Reporting a Vulnerability
+# Security Policy
 
-To report security issues send an email to **cashu-security@pm.me**
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately to **cashu-security@pm.me**.
+
+Do not open a public GitHub issue or disclose the vulnerability publicly until we have had a
+reasonable opportunity to investigate and coordinate a fix.
+
+Please include, where possible:
+
+- The affected Coco package and version or commit
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+
+Do not include real Cashu tokens, seed phrases, private keys, or other secrets.
+
+We will acknowledge your report and coordinate remediation and disclosure with you.
+
+## Supported Versions
+
+Security fixes are provided for the latest released version.


### PR DESCRIPTION
Adds a simple security policy pointing security vulnerability reports to cashu-security@pm.me, consistent with the Cashu nutshell repository.