### PR TITLE
docs(react): warn about local storage seed risks

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -65,6 +65,13 @@ initialization is serialized across same-origin browser contexts. Call it from a
 secure browser context (HTTPS or localhost), and provide another `seedGetter` in
 environments without `window.navigator.locks`.
 
+> [!WARNING]
+> `localStorageSeedGetter()` is an opt-in convenience helper for development, demos, or
+> applications that accept localStorage's security model. Any JavaScript running on the same
+> origin can read or replace the Wallet Seed. Do not use it for Wallets that hold real funds. For
+> production, provide a `seedGetter` backed by storage appropriate for your application's threat
+> model.
+
 If your application already owns the manager lifecycle, pass an initialized
 manager instead:
 

--- a/packages/react/src/lib/utils/localStorageSeedGetter.ts
+++ b/packages/react/src/lib/utils/localStorageSeedGetter.ts
@@ -63,6 +63,11 @@ const createSeed = (browserWindow: Window & typeof globalThis): Uint8Array => {
  *
  * The returned getter reads or creates the seed once, then serves it from its
  * closure on later calls.
+ *
+ * @warning This is an opt-in convenience helper for development, demos, or applications that
+ * accept localStorage's security model. Any JavaScript running on the same origin can read or
+ * replace the Wallet Seed. Do not use it for Wallets that hold real funds. For production, provide
+ * a `seedGetter` backed by storage appropriate for your application's threat model.
  */
 export const localStorageSeedGetter = (config: LocalStorageSeedGetterConfig = {}) => {
   const storageKey = config.storageKey ?? DEFAULT_STORAGE_KEY;


### PR DESCRIPTION
## Summary

- add an explicit security warning to the `localStorageSeedGetter()` JSDoc
- repeat the warning beside the primary React usage documentation
- direct production applications to provide a `seedGetter` backed by storage appropriate for their threat model

## Why

`localStorageSeedGetter()` intentionally persists the Wallet Seed in localStorage, but its API documentation did not explain that any JavaScript running on the same origin can read or replace that value. This risk was found by Project Loupe.

The helper remains available as an opt-in convenience for development, demos, and applications that explicitly accept the localStorage security model.

## Impact

There are no runtime behavior changes. Developers now receive a clear warning that the helper is not appropriate for Wallets holding real funds.

## Validation

- `bunx prettier@3.8.1 --check packages/react/src/lib/utils/localStorageSeedGetter.ts packages/react/README.md`
- `git diff --cached --check`