### PR TITLE
feat(core): allow callers to force send swaps

### DIFF
--- a/.changeset/force-swap-send.md
+++ b/.changeset/force-swap-send.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': minor
+---
+
+Allow callers to force default sends to swap exact-match proofs into fresh send outputs.

--- a/packages/core/api/SendOpsApi.ts
+++ b/packages/core/api/SendOpsApi.ts
@@ -25,6 +25,8 @@ export interface PrepareSendInput {
   amount: UnitAmountLike;
   /** Unit to send. */
   unit?: string;
+  /** Force a default send to swap proofs even when an exact match is available. */
+  forceSwap?: boolean;
   /** Optional non-default send target, for example a P2PK recipient. */
   target?: SendTarget;
 }
@@ -75,7 +77,7 @@ export class SendOpsApi {
     const initOp = await this.sendOperationService.init(
       input.mintUrl,
       parsed,
-      this.getCreateOptions(input.target),
+      this.getCreateOptions(input),
     );
     return this.sendOperationService.prepare(initOp);
   }
@@ -173,11 +175,14 @@ export class SendOpsApi {
     await this.sendOperationService.finalize(operationId);
   }
 
-  private getCreateOptions(target?: SendTarget): CreateSendOperationOptions {
+  private getCreateOptions({
+    forceSwap,
+    target,
+  }: Pick<PrepareSendInput, 'forceSwap' | 'target'>): CreateSendOperationOptions {
     if (!target) {
       return {
         method: 'default',
-        methodData: {},
+        methodData: forceSwap ? { forceSwap: true } : {},
       };
     }
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -18,6 +18,7 @@ export type { EventHandler } from './events/EventBus.ts';
 export { type Logger, ConsoleLogger } from './logging/index.ts';
 export { MemoryRepositories } from './repositories/memory/MemoryRepositories.ts';
 export type {
+  DefaultSendMethodData,
   P2pkSendMethodData,
   P2pkSendOptions,
   SendMethod,

--- a/packages/core/infra/handlers/send/DefaultSendHandler.ts
+++ b/packages/core/infra/handlers/send/DefaultSendHandler.ts
@@ -8,6 +8,7 @@ import type {
   RecoverExecutingContext,
   ExecutionResult,
   RecoveryResult,
+  SendMethodData,
 } from '../../../operations/send/SendMethodHandler';
 import type {
   PreparedSendOperation,
@@ -35,11 +36,14 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
   async prepare(ctx: BasePrepareContext): Promise<PreparedSendOperation> {
     const { operation, wallet, proofService, logger } = ctx;
     const { mintUrl, amount, unit } = operation;
+    const { forceSwap = false } = operation.methodData as SendMethodData<'default'>;
 
-    // Try exact match first (no swap needed)
-    const exactProofs = await proofService.selectProofsToSend(mintUrl, { amount, unit }, false);
+    // Try exact match first unless the caller requested fresh send proofs.
+    const exactProofs = forceSwap
+      ? []
+      : await proofService.selectProofsToSend(mintUrl, { amount, unit }, false);
     const exactAmount = sumProofs(exactProofs);
-    const needsSwap = !exactAmount.equals(amount);
+    const needsSwap = forceSwap || !exactAmount.equals(amount);
 
     let selectedProofs: Proof[];
     let fee = Amount.zero();
@@ -91,6 +95,7 @@ export class DefaultSendHandler implements SendMethodHandler<'default'> {
         proofCount: selectedProofs.length,
         keepOutputs: outputResult.keep.length,
         sendOutputs: outputResult.send.length,
+        forceSwap,
       });
     }
 

--- a/packages/core/operations/send/SendMethodHandler.ts
+++ b/packages/core/operations/send/SendMethodHandler.ts
@@ -61,6 +61,12 @@ export type P2pkSendMethodData =
       pubkey?: never;
     };
 
+/** Options that control a standard unlocked token send. */
+export interface DefaultSendMethodData {
+  /** Swap selected proofs even when they exactly match the requested amount. */
+  forceSwap?: boolean;
+}
+
 /**
  * Registry of supported send methods and their payload shapes.
  * Extend via declaration merging if you need to add methods externally.
@@ -69,7 +75,7 @@ export type P2pkSendMethodData =
  * - htlc: { hash: string; timeout: number } - HTLC locked tokens
  */
 export interface SendMethodDefinitions {
-  default: Record<string, never>;
+  default: DefaultSendMethodData;
   p2pk: P2pkSendMethodData;
 }
 

--- a/packages/core/test/unit/DefaultSendHandler.test.ts
+++ b/packages/core/test/unit/DefaultSendHandler.test.ts
@@ -303,6 +303,38 @@ describe('DefaultSendHandler', () => {
       });
     });
 
+    it('prepares a swap send when forceSwap is true and an exact match exists', async () => {
+      (proofService.selectProofsToSend as Mock<any>).mockImplementation(
+        (_mintUrl: string, _intent: { amount: Amount; unit: string }, includeFees: boolean) =>
+          Promise.resolve(
+            includeFees ? [makeProof('proof-100', 100), makeProof('proof-5', 5)] : [],
+          ),
+      );
+
+      const operation = makeInitOp('op-force-swap', { methodData: { forceSwap: true } });
+      const result = await handler.prepare(buildPrepareContext(operation));
+
+      expect(result.needsSwap).toBe(true);
+      expect(result.fee).toEqual(Amount.from(1));
+      expect(result.methodData).toEqual({ forceSwap: true });
+      expect(result.inputProofSecrets).toEqual(['proof-100', 'proof-5']);
+      expect(result.outputData).toBeDefined();
+      expect(proofService.selectProofsToSend).toHaveBeenCalledTimes(1);
+      expect(proofService.selectProofsToSend).toHaveBeenCalledWith(
+        mintUrl,
+        { amount: Amount.from(100), unit: 'sat' },
+        true,
+      );
+      expect(proofService.createOutputsAndIncrementCounters).toHaveBeenCalledWith(
+        mintUrl,
+        {
+          keep: { amount: Amount.from(4), unit: 'sat' },
+          send: { amount: Amount.from(100), unit: 'sat' },
+        },
+        {},
+      );
+    });
+
     it('prepares a swap send when no exact match exists', async () => {
       (proofRepository.getAvailableProofs as Mock<any>).mockImplementation(() =>
         Promise.resolve([makeCoreProof('input-1', 60), makeCoreProof('input-2', 50)]),

--- a/packages/core/test/unit/SendOpsApi.test.ts
+++ b/packages/core/test/unit/SendOpsApi.test.ts
@@ -7,10 +7,11 @@ import type {
   PreparedSendOperation,
   SendOperation,
 } from '../../operations/send/SendOperation.ts';
-import type { P2pkSendOptions } from '../../operations/send/SendMethodHandler.ts';
+import type { DefaultSendMethodData, P2pkSendOptions } from '../../index.ts';
 import { SendOpsApi } from '../../api/SendOpsApi.ts';
 
 const mintUrl = 'https://mint.test';
+const forcedSwapMethodData = { forceSwap: true } satisfies DefaultSendMethodData;
 
 const p2pkOptionsRejectHashlock = {
   pubkey: 'pubkey-1',
@@ -86,7 +87,11 @@ describe('SendOpsApi', () => {
   });
 
   it('prepare maps forceSwap to default send method data', async () => {
-    await api.prepare({ mintUrl, amount: Amount.from(20), forceSwap: true });
+    await api.prepare({
+      mintUrl,
+      amount: Amount.from(20),
+      forceSwap: forcedSwapMethodData.forceSwap,
+    });
 
     expect(sendOperationService.init).toHaveBeenCalledWith(
       mintUrl,
@@ -96,7 +101,7 @@ describe('SendOpsApi', () => {
       },
       {
         method: 'default',
-        methodData: { forceSwap: true },
+        methodData: forcedSwapMethodData,
       },
     );
   });

--- a/packages/core/test/unit/SendOpsApi.test.ts
+++ b/packages/core/test/unit/SendOpsApi.test.ts
@@ -85,6 +85,31 @@ describe('SendOpsApi', () => {
     expect(result).toBe(preparedOperation);
   });
 
+  it('prepare maps forceSwap to default send method data', async () => {
+    await api.prepare({ mintUrl, amount: Amount.from(20), forceSwap: true });
+
+    expect(sendOperationService.init).toHaveBeenCalledWith(
+      mintUrl,
+      {
+        amount: Amount.from(20),
+        unit: 'sat',
+      },
+      {
+        method: 'default',
+        methodData: { forceSwap: true },
+      },
+    );
+  });
+
+  it('prepare preserves empty default method data when forceSwap is false', async () => {
+    await api.prepare({ mintUrl, amount: Amount.from(20), forceSwap: false });
+
+    expect(sendOperationService.init).toHaveBeenCalledWith(mintUrl, expect.any(Object), {
+      method: 'default',
+      methodData: {},
+    });
+  });
+
   it('prepare maps p2pk target to send method options', async () => {
     await api.prepare({
       mintUrl,

--- a/packages/docs/pages/send-operations.md
+++ b/packages/docs/pages/send-operations.md
@@ -84,6 +84,22 @@ console.log(token.memo); // "Dinner"
 Memos are trimmed before persistence. Whitespace-only memos are treated as
 omitted.
 
+### Forcing a Swap
+
+Default sends reuse ready proofs when they exactly match the requested amount. To reissue the
+amount as fresh send proofs instead, set `forceSwap` while preparing the operation:
+
+```ts
+const prepared = await coco.ops.send.prepare({
+  mintUrl,
+  amount: 100,
+  forceSwap: true,
+});
+```
+
+Forcing a swap may add an input fee, which is reflected in `prepared.fee`. P2PK sends already swap
+to create locked outputs, so this option only changes default sends.
+
 ### P2PK Sends
 
 Use a P2PK target when the token should be locked to one or more public keys:


### PR DESCRIPTION
This pull request adds an optional `forceSwap` preparation policy for default sends so callers can reissue exact-match proofs into fresh send outputs.

This pull request resolves #431.

## Problem

Default sends always reuse ready proofs when their total exactly matches the requested amount. Long-running spenders can therefore produce increasingly fragmented, oversized tokens without a way to request fresh proof denominations.

## Summary

- expose `PrepareSendInput.forceSwap` and persist it in default send method data
- skip exact-match selection when forced and use the existing fee-aware swap path
- preserve the current empty method data and exact-match behavior when the option is omitted or false
- document fee behavior and add a minor core changeset

This is an additive public interface change. Existing callers retain the current behavior by default.

## Verification

- `bun run --filter='@cashu/coco-core' test -- test/unit/SendOpsApi.test.ts test/unit/DefaultSendHandler.test.ts`
- `bun run --filter='@cashu/coco-core' test:unit`
- `bun run --filter='@cashu/coco-adapter-tests' build`
- `bun run --filter='@cashu/coco-core' typecheck`
- `bun run --filter='@cashu/coco-core' build`
- `bun run docs:build`
- Prettier check on all touched files

## Changeset

- `.changeset/force-swap-send.md` — `@cashu/coco-core` minor
