### PR TITLE
feat(cocod): add BOLT12 send and receive

### DIFF
--- a/packages/cocod/README.md
+++ b/packages/cocod/README.md
@@ -10,7 +10,7 @@ If you like simple tools: run commands in your terminal, and let the daemon hand
 - Initialize and secure a Cashu wallet
 - Check balances and transaction history
 - Send and receive Cashu tokens
-- Send and receive Lightning payments (BOLT11)
+- Send and receive Lightning payments (BOLT11 invoices and reusable BOLT12 offers)
 - Handle HTTP 402 payments with `X-Cashu`
 - Manage trusted mints
 
@@ -57,10 +57,13 @@ cocod balance
 # Receive
 cocod receive cashu "cashuA..."
 cocod receive bolt11 1000
+cocod receive bolt12                # reusable offer, payable more than once
+cocod receive bolt12 list           # offers that can still be paid
 
 # Send
 cocod send cashu 500
 cocod send bolt11 "lnbc..."
+cocod send bolt12 "lno1..." --amount 1000
 
 # Mints
 cocod mints add https://mint.example.com/Bitcoin

--- a/packages/cocod/SKILL.md
+++ b/packages/cocod/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cocod
-description: A Cashu ecash wallet CLI for Bitcoin and Lightning payments. Use when managing Cashu tokens, sending/receiving payments via Lightning (bolt11) or ecash, handling HTTP 402 X-Cashu payment requests, or viewing wallet history.
+description: A Cashu ecash wallet CLI for Bitcoin and Lightning payments. Use when managing Cashu tokens, sending/receiving payments via Lightning (bolt11 invoices or bolt12 offers) or ecash, handling HTTP 402 X-Cashu payment requests, or viewing wallet history.
 compatibility: Requires the cocod CLI, a private package in this repository that runs from workspace source (packages/cocod). Supports Cashu ecash protocol, Lightning Network payments, and NUT-24 HTTP 402 X-Cashu flows.
 metadata:
   project: cocod
@@ -106,7 +106,18 @@ cocod receive cashu <token>
 
 # Create Lightning invoice to receive
 cocod receive bolt11 <amount> [--mint-url <url>]
+
+# Get a reusable BOLT12 offer to receive
+cocod receive bolt12 [--amount <sats>] [--mint-url <url>]
+
+# List the offers that can still be paid
+cocod receive bolt12 list
 ```
+
+A BOLT12 offer keeps working after it is paid, so one offer can be handed out repeatedly.
+Payments are claimed in the background, so no follow-up command is needed; use `cocod history`
+to check whether an offer was paid. `cocod receive bolt12 list` reports each offer with the
+amount the mint has received against it and the amount this wallet has already claimed.
 
 ### Sending Payments
 
@@ -118,7 +129,16 @@ cocod send cashu <amount> [--mint-url <url>]
 
 # Pay a Lightning invoice
 cocod send bolt11 <invoice> [--mint-url <url>]
+
+# Pay a BOLT12 offer (--amount is required for offers without a fixed amount)
+cocod send bolt12 <offer> [--amount <sats>] [--mint-url <url>]
 ```
+
+`cocod send bolt12` prints the amount plus the fee reserve, which is spent on top of it.
+
+An unconfirmed payment must NOT be retried — every payment to a BOLT12 offer is a separate
+invoice, so retrying pays the payee twice. Report it as unconfirmed, quote the operation id,
+and check `cocod history`.
 
 ### HTTP 402 Web Payments (NUT-24)
 
@@ -246,6 +266,7 @@ cocod history --limit 10
 - **Cashu**: Privacy-preserving ecash protocol using blind signatures
 - **Mint**: Server that issues and redeems Cashu tokens
 - **Token**: Transferable Cashu string representing satoshi value
-- **Bolt11**: Lightning Network invoice format
+- **Bolt11**: Lightning Network invoice format, payable once
+- **Bolt12**: Lightning Network offer format, reusable across payments
 - **NPC**: Lightning Address service for receiving payments
 - **Mnemonic**: Seed phrase for wallet recovery

--- a/packages/cocod/docs/API.md
+++ b/packages/cocod/docs/API.md
@@ -24,6 +24,10 @@ All commands are available under `cocod`.
 - `receive cashu <token>` - Receive a Cashu token
 - `receive bolt11 <amount>` - Create a Lightning invoice
   - `--mint-url <url>` override default mint for this request
+- `receive bolt12` - Get a reusable BOLT12 offer
+  - `--amount <sats>` embed a fixed amount in the offer
+  - `--mint-url <url>` override default mint for this request
+- `receive bolt12 list` - List the BOLT12 offers that can still be paid
 
 ### Send
 
@@ -31,6 +35,13 @@ All commands are available under `cocod`.
   - `--mint-url <url>` override default mint
 - `send bolt11 <invoice>` - Pay a Lightning invoice
   - `--mint-url <url>` override default mint
+- `send bolt12 <offer>` - Pay a BOLT12 offer
+  - `--amount <sats>` amount to pay; the mint requires it for offers without a fixed amount
+  - `--mint-url <url>` override default mint
+
+An unsettled melt is reported as unconfirmed with its operation id and must not be retried —
+every payment to an offer is a separate invoice, so a retry pays the payee twice. Check
+`cocod history`.
 
 ### Mints
 
@@ -81,8 +92,11 @@ The CLI talks to the daemon over HTTP on a UNIX socket.
 - `GET /balance`
 - `POST /receive/cashu`
 - `POST /receive/bolt11`
+- `POST /receive/bolt12`
+- `GET /receive/bolt12/list`
 - `POST /send/cashu`
 - `POST /send/bolt11`
+- `POST /send/bolt12`
 - `POST /x-cashu/parse`
 - `POST /x-cashu/handle`
 - `POST /mints/add`

--- a/packages/cocod/docs/daemon-api.json
+++ b/packages/cocod/docs/daemon-api.json
@@ -104,6 +104,30 @@
       }
     },
     {
+      "path": "/receive/bolt12",
+      "method": "POST",
+      "state": "UNLOCKED",
+      "body": {
+        "amount": "number (optional, positive integer sats; embedded in the offer)",
+        "mintUrl": "string (optional)"
+      },
+      "responses": {
+        "200": "{ output: string }",
+        "500": "{ error: string }"
+      },
+      "notes": "NUT-25 BOLT12 mint quote. The returned offer is reusable and stays payable after it is paid. Payments are claimed in the background and show up in /history."
+    },
+    {
+      "path": "/receive/bolt12/list",
+      "method": "GET",
+      "state": "UNLOCKED",
+      "responses": {
+        "200": "{ output: Array<{ quoteId, mintUrl, request, amount?, paid, issued, expiry }> }",
+        "500": "{ error: string }"
+      },
+      "notes": "Offers that are still payable. `paid` is what the mint has received against the offer and `issued` is what this wallet has already claimed from it; the difference is claimed in the background."
+    },
+    {
       "path": "/send/cashu",
       "method": "POST",
       "state": "UNLOCKED",
@@ -128,6 +152,23 @@
         "200": "{ output: string }",
         "500": "{ error: string }"
       }
+    },
+    {
+      "path": "/send/bolt12",
+      "method": "POST",
+      "state": "UNLOCKED",
+      "body": {
+        "offer": "string",
+        "amount": "number (optional, positive integer sats; required by the mint for offers without a fixed amount)",
+        "mintUrl": "string (optional)"
+      },
+      "responses": {
+        "200": "{ output: string }",
+        "202": "{ output: string }",
+        "400": "{ error: string }",
+        "500": "{ error: string }"
+      },
+      "notes": "NUT-25 BOLT12 melt. The mint's fee reserve is spent on top of the amount. A 202 means the mint has not settled the payment: it is not confirmed, must not be retried, and carries the operation id."
     },
     {
       "path": "/x-cashu/parse",

--- a/packages/cocod/src/cli.ts
+++ b/packages/cocod/src/cli.ts
@@ -87,6 +87,28 @@ receiveCmd
     });
   });
 
+const receiveBolt12Cmd = receiveCmd
+  .command('bolt12')
+  .description('Get a reusable BOLT12 offer to receive tokens')
+  .option('--amount <amount>', 'Fixed amount in sats to embed in the offer')
+  .option('--mint-url <url>', 'Mint URL to use (defaults to the mint URL configured during init)')
+  .action(async (options: { amount?: string; mintUrl?: string }) => {
+    await handleDaemonCommand('/receive/bolt12', {
+      method: 'POST',
+      body: {
+        amount: options.amount !== undefined ? Number(options.amount) : undefined,
+        mintUrl: options.mintUrl,
+      },
+    });
+  });
+
+receiveBolt12Cmd
+  .command('list')
+  .description('List BOLT12 offers that can still be paid')
+  .action(async () => {
+    await handleDaemonCommand('/receive/bolt12/list');
+  });
+
 // Send - nested subcommands
 const sendCmd = program.command('send').description('Send operations');
 
@@ -109,6 +131,22 @@ sendCmd
     await handleDaemonCommand('/send/bolt11', {
       method: 'POST',
       body: { invoice, mintUrl: options.mintUrl },
+    });
+  });
+
+sendCmd
+  .command('bolt12 <offer>')
+  .description('Pay a BOLT12 offer')
+  .option('--amount <amount>', 'Amount in sats (required for offers without a fixed amount)')
+  .option('--mint-url <url>', 'Mint URL to use (defaults to the mint URL configured during init)')
+  .action(async (offer: string, options: { amount?: string; mintUrl?: string }) => {
+    await handleDaemonCommand('/send/bolt12', {
+      method: 'POST',
+      body: {
+        offer,
+        amount: options.amount !== undefined ? Number(options.amount) : undefined,
+        mintUrl: options.mintUrl,
+      },
     });
   });
 

--- a/packages/cocod/src/routes.test.ts
+++ b/packages/cocod/src/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { initializeCoco, toAmount, type Manager } from '@cashu/coco-core';
 import { SqliteRepositories } from '@cashu/coco-sqlite-bun';
@@ -80,6 +80,22 @@ function postJson(path: string, body: unknown): Request {
     method: 'POST',
     body: JSON.stringify(body),
   });
+}
+
+/** Fakes the melt APIs `/send/bolt12` drives. */
+function bolt12SendManager(execute: () => Promise<unknown>) {
+  const create = mock(async (_input: unknown) => ({
+    quoteId: 'melt-1',
+    amount: toAmount(21),
+    fee_reserve: toAmount(2),
+    unit: 'sat',
+  }));
+  const prepare = mock(async (_input: unknown) => ({ id: 'op1', state: 'prepared' }));
+  const manager = {
+    quotes: { melt: { create } },
+    ops: { melt: { prepare, execute: mock(async (_prepared: unknown) => execute()) } },
+  };
+  return { manager, create, prepare };
 }
 
 describe('routes', () => {
@@ -367,6 +383,117 @@ describe('routes', () => {
     });
     expect(prepareInput).toEqual({ quote: createdQuote });
     expect(executed).toBe(true);
+  });
+
+  test('/receive/bolt12 returns the offer without preparing a mint operation', async () => {
+    // A BOLT12 offer stays payable after it is paid, so there is no single operation to
+    // prepare: core watches the canonical quote and claims each payment on its own.
+    for (const [requestBody, expected] of [
+      [{}, { mintUrl: 'https://mint.example.com', method: 'bolt12', amount: undefined }],
+      [{ amount: 21 }, { mintUrl: 'https://mint.example.com', method: 'bolt12', amount: 21 }],
+    ] as const) {
+      const create = mock(async (_input: unknown) => ({ request: 'lno1created' }));
+      const runtime = runningRuntime({ quotes: { mint: { create } } });
+      const routes = createRouteHandlers(runtime);
+
+      const response = await routes['/receive/bolt12']!.POST!(
+        postJson('/receive/bolt12', requestBody),
+      );
+
+      const body = (await response.json()) as { output?: string };
+      expect(response.status).toBe(200);
+      expect(body.output).toBe('lno1created');
+      expect(create.mock.calls).toEqual([[expected]]);
+    }
+  });
+
+  test('/receive/bolt12/list summarises the offers that are still payable', async () => {
+    const listPending = mock(async (_input: unknown) => [
+      {
+        quoteId: 'quote-1',
+        mintUrl: 'https://mint.example.com',
+        request: 'lno1offer',
+        amount: toAmount(21),
+        amountPaid: toAmount(42),
+        amountIssued: toAmount(21),
+        expiry: null,
+      },
+    ]);
+    const runtime = runningRuntime({ quotes: { mint: { listPending } } });
+    const routes = createRouteHandlers(runtime);
+
+    const response = await routes['/receive/bolt12/list']!.GET!(
+      new Request('http://localhost/receive/bolt12/list'),
+    );
+
+    const body = (await response.json()) as { output?: unknown };
+    expect(response.status).toBe(200);
+    expect(listPending.mock.calls).toEqual([[{ method: 'bolt12' }]]);
+    expect(body.output).toEqual([
+      {
+        quoteId: 'quote-1',
+        mintUrl: 'https://mint.example.com',
+        request: 'lno1offer',
+        amount: 21,
+        paid: 42,
+        issued: 21,
+        expiry: null,
+      },
+    ]);
+  });
+
+  test('/send/bolt12 reports the amount and fee reserve it paid', async () => {
+    const { manager, create } = bolt12SendManager(async () => ({ id: 'op1', state: 'finalized' }));
+    const routes = createRouteHandlers(runningRuntime(manager));
+
+    const response = await routes['/send/bolt12']!.POST!(
+      postJson('/send/bolt12', { offer: ' lno1example ', amount: 21 }),
+    );
+
+    const body = (await response.json()) as { output?: string };
+    expect(response.status).toBe(200);
+    expect(body.output).toBe('Paid 21 sat plus up to 2 fee reserve to offer: lno1example');
+    expect(create.mock.calls).toEqual([
+      [
+        {
+          mintUrl: 'https://mint.example.com',
+          method: 'bolt12',
+          methodData: { offer: 'lno1example', amountSats: 21 },
+        },
+      ],
+    ]);
+  });
+
+  test('/send/bolt12 reports an unsettled melt as unconfirmed instead of paid', async () => {
+    // Every payment to an offer is a separate invoice, so retrying an unconfirmed melt pays
+    // the payee twice.
+    const { manager } = bolt12SendManager(async () => ({ id: 'op2', state: 'pending' }));
+    const routes = createRouteHandlers(runningRuntime(manager));
+
+    const response = await routes['/send/bolt12']!.POST!(
+      postJson('/send/bolt12', { offer: 'lno1example' }),
+    );
+
+    const body = (await response.json()) as { output?: string };
+    expect(response.status).toBe(202);
+    expect(body.output).toContain('is not confirmed (operation op2)');
+    expect(body.output).toContain('Do not retry');
+  });
+
+  test('/send/bolt12 requires an offer before touching the melt APIs', async () => {
+    for (const requestBody of [{}, { offer: '   ' }]) {
+      const { manager, create } = bolt12SendManager(async () => {
+        throw new Error('should not execute');
+      });
+      const routes = createRouteHandlers(runningRuntime(manager));
+
+      const response = await routes['/send/bolt12']!.POST!(postJson('/send/bolt12', requestBody));
+
+      const body = (await response.json()) as { error?: string };
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Offer is required');
+      expect(create).not.toHaveBeenCalled();
+    }
   });
 
   test('/x-cashu/handle settles an inband request into an X-Cashu header', async () => {

--- a/packages/cocod/src/routes.ts
+++ b/packages/cocod/src/routes.ts
@@ -174,6 +174,48 @@ export function createRouteHandlers(
         }
       }),
     },
+    '/receive/bolt12': {
+      // No mint operation is prepared: a BOLT12 offer stays payable after it is paid, and core
+      // watches the canonical quote and claims each payment on its own.
+      POST: requireRunning(runtime, async (req, state: RunningCocoSession) => {
+        try {
+          const body = (await req.json()) as { amount?: number; mintUrl?: string };
+          const mintUrl = body.mintUrl || state.mintUrl;
+          const quote = await state.manager.quotes.mint.create({
+            mintUrl,
+            method: 'bolt12',
+            amount: body.amount,
+          });
+          return Response.json({ output: quote.request });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return Response.json({ error: `Failed to create offer: ${message}` }, { status: 500 });
+        }
+      }),
+    },
+    '/receive/bolt12/list': {
+      GET: requireRunning(runtime, async (_req, state: RunningCocoSession) => {
+        try {
+          const quotes = await state.manager.quotes.mint.listPending({ method: 'bolt12' });
+          return Response.json({
+            output: quotes.map((quote) => ({
+              quoteId: quote.quoteId,
+              mintUrl: quote.mintUrl,
+              request: quote.request,
+              amount: quote.amount?.toNumber(),
+              // What the mint has received against the offer, and what this wallet has
+              // already claimed from it.
+              paid: quote.amountPaid.toNumber(),
+              issued: quote.amountIssued.toNumber(),
+              expiry: quote.expiry,
+            })),
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return Response.json({ error: `Failed to list offers: ${message}` }, { status: 500 });
+        }
+      }),
+    },
     '/send/cashu': {
       POST: requireRunning(runtime, async (req, state: RunningCocoSession) => {
         try {
@@ -202,6 +244,42 @@ export function createRouteHandlers(
           const prepared = await state.manager.ops.melt.prepare({ quote });
           await state.manager.ops.melt.execute(prepared);
           return Response.json({ output: `Paid invoice: ${body.invoice}` });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return Response.json({ error: `Payment failed: ${message}` }, { status: 500 });
+        }
+      }),
+    },
+    '/send/bolt12': {
+      POST: requireRunning(runtime, async (req, state: RunningCocoSession) => {
+        try {
+          const body = (await req.json()) as { offer?: string; amount?: number; mintUrl?: string };
+          const offer = body.offer?.trim();
+          if (!offer) {
+            return Response.json({ error: 'Offer is required' }, { status: 400 });
+          }
+          const mintUrl = body.mintUrl || state.mintUrl;
+          const quote = await state.manager.quotes.melt.create({
+            mintUrl,
+            method: 'bolt12',
+            methodData: { offer, amountSats: body.amount },
+          });
+          // The fee reserve is melted alongside the amount, so report what the payment costs.
+          const cost = `${quote.amount.toNumber()} ${quote.unit} plus up to ${quote.fee_reserve.toNumber()} fee reserve`;
+          const prepared = await state.manager.ops.melt.prepare({ quote });
+          const result = await state.manager.ops.melt.execute(prepared);
+          // Tested against `finalized` rather than for `pending` so a state core adds later is
+          // not reported as paid. Every payment to an offer is a separate invoice, so a retry
+          // of an unconfirmed melt pays the payee twice.
+          if (result.state !== 'finalized') {
+            return Response.json(
+              {
+                output: `Payment of ${cost} to offer ${offer} is not confirmed (operation ${result.id}). Do not retry; check 'cocod history'.`,
+              },
+              { status: 202 },
+            );
+          }
+          return Response.json({ output: `Paid ${cost} to offer: ${offer}` });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return Response.json({ error: `Payment failed: ${message}` }, { status: 500 });


### PR DESCRIPTION
Implements checkbox 3 of #399: BOLT12 (NUT-25) send and receive for cocod. No core changes — everything here is served by the existing `quotes.mint` / `quotes.melt` / `ops.melt` APIs.

## What this does

- **`receive bolt12 [--amount]`** creates a canonical BOLT12 mint quote and returns the offer. No mint operation is prepared: an offer stays payable after it is paid, so core's quote watcher and `MintOperationProcessor` claim each payment on their own.
- **`receive bolt12 list`** lists the offers that are still payable, each with what the mint has received against it and what this wallet has already claimed.
- **`send bolt12 <offer> [--amount]`** quotes, prepares, and executes a melt, reporting the amount plus the fee reserve. An unsettled melt returns `202` with the operation id and must not be retried — every payment to an offer is a separate invoice.

## Testing

- [x] `bun run build`, `bun run typecheck`, `bun run format:check`
- [x] `bun run --filter='cocod' test` — 41 tests
- [x] `bun test packages/core/test/unit` — 1249 tests, untouched
- [x] Live against testnut in a sandboxed state dir: reusable offer created, paid, and auto-claimed by the background processor with no follow-up command (3822 sat); fixed-amount offer; `receive bolt12 list`
- [ ] `send bolt12` is covered by route tests only — no live payment yet, as it needs a funded wallet and a payable offer

## Follow-ups

- `send bolt12 --amount` only shapes the melt quote request; core pays whatever the mint quotes back. NUT-25 requires the mint to reject a mismatched request, and cdk additionally verifies the answer in `melt_bolt12_quote`. Happy to open an issue for the equivalent check in `MeltBolt12Handler` if that is wanted — it adds a public error type, so it did not belong here.
- A mint that does not advertise `bolt12` surfaces as a `500`, like every other daemon failure. NUT-25 is optional so this is the likeliest failure; a dedicated status could be worth it, but it is a change to the daemon's error contract rather than part of this feature.

Refs #399
