### PR TITLE
feat(cocod): align CLI with v1 lifecycle

### DIFF
--- a/FEATURE_TODO.md
+++ b/FEATURE_TODO.md
@@ -1,0 +1,24 @@
+# Cocod CLI v1 Lifecycle Alignment
+
+- [x] Verify authenticated TCP and lifecycle v1 are merged into `master`.
+- [x] Read the Cocod Host and Coco Cashu context documents and lifecycle ADRs.
+- [x] Add focused client and route tests for the v1 cutover.
+- [x] Introduce one typed v1 client interface with structured error parsing.
+- [x] Move CLI health, status, Wallet initialization, and Coco Session commands to v1.
+- [x] Keep Cocod Process reachability separate from Coco Session readiness.
+- [x] Remove `/ping`, `/status`, `/init`, and `/unlock` from the daemon.
+- [x] Update CLI help and daemon API documentation.
+- [x] Build, typecheck, and test `cocod`.
+
+## CLI naming
+
+- Use `health` for public Cocod Process liveness.
+- Use `wallet initialize` for host-generated Wallet Recovery Material.
+- Use `session start` and `session stop` for Coco Session lifecycle transitions.
+- Keep top-level `stop` for Cocod Process shutdown.
+- Do not retain `ping`, `init`, or `unlock` aliases.
+
+## Scope boundary
+
+Keep balance, receive, send, mint, history, event, NPC, and X-Cashu routes on their existing
+authenticated legacy contracts until their v1 resources are designed.

--- a/FEATURE_TODO.md
+++ b/FEATURE_TODO.md
@@ -10,6 +10,12 @@
 - [x] Update CLI help and daemon API documentation.
 - [x] Build, typecheck, and test `cocod`.
 
+## Review follow-up
+
+- [x] Fail lifecycle commands when their requested target state is not reached.
+- [x] Expose repeatable Wallet Recovery Material retrieval through the CLI.
+- [x] Poll lifecycle transitions beyond the server's default 30-second cleanup deadline.
+
 ## CLI naming
 
 - Use `health` for public Cocod Process liveness.

--- a/packages/cocod/README.md
+++ b/packages/cocod/README.md
@@ -41,11 +41,11 @@ with a range peer.
 # Check daemon status
 cocod status
 
-# Create a wallet (auto-generates mnemonic)
-cocod init
+# Create a Wallet and display its host-generated recovery material
+cocod wallet initialize
 
-# If encrypted during init, unlock it
-cocod unlock "your-passphrase"
+# Start a Coco Session for a passphrase-protected Wallet
+cocod session start --passphrase "your-passphrase"
 
 # Check balance
 cocod balance
@@ -144,8 +144,8 @@ Logging defaults:
 - Rotation keeps 5 files at 5 MiB each by default
 - Override with `COCOD_LOG_LEVEL`, `COCOD_LOG_MAX_BYTES`, and `COCOD_LOG_MAX_FILES`
 
-Every route except `/health` and the legacy `/ping` check requires the administrative bearer
-credential stored in the mode-`0600` client file under `~/.cocod/credentials/current/client`.
+Every route except `/health` requires the administrative bearer credential stored in the
+mode-`0600` client file under `~/.cocod/credentials/current/client`.
 `daemon`, `logs`, and `credential rotate` are host-local commands and reject an explicit endpoint;
 `stop` works against either the implicit local process or an explicit remote endpoint.
 

--- a/packages/cocod/README.md
+++ b/packages/cocod/README.md
@@ -44,6 +44,9 @@ cocod status
 # Create a Wallet and display its host-generated recovery material
 cocod wallet initialize
 
+# Display the recovery material again if the initialization response was lost
+cocod wallet recovery-material
+
 # Start a Coco Session for a passphrase-protected Wallet
 cocod session start --passphrase "your-passphrase"
 

--- a/packages/cocod/SKILL.md
+++ b/packages/cocod/SKILL.md
@@ -67,11 +67,8 @@ If the version does not match the pinned values in this file, update `cocod` bef
 ## Quick Start
 
 ```bash
-# Initialize your wallet (generates mnemonic automatically)
-cocod init
-
-# Or with a custom mint
-cocod init --mint-url https://mint.example.com
+# Initialize a Wallet and record the host-generated Wallet Recovery Material
+cocod wallet initialize
 
 # Check balance
 cocod balance
@@ -82,20 +79,21 @@ cocod balance
 ### Core Wallet
 
 ```bash
-# Check daemon and wallet status
+# Show Cocod Process, Wallet Seed Access, and Coco Session status
 cocod status
 
-# Initialize wallet with optional mnemonic
-cocod init [mnemonic] [--passphrase <passphrase>] [--mint-url <url>]
+# Initialize a Wallet with host-generated Wallet Recovery Material
+cocod wallet initialize [--passphrase <passphrase>]
 
-# Unlock encrypted wallet (only required when initialised with passphrase)
-cocod unlock <passphrase>
+# Start or stop the Coco Session without changing the Wallet
+cocod session start [--passphrase <passphrase>]
+cocod session stop
 
 # Get wallet balance
 cocod balance
 
-# Test daemon connection
-cocod ping
+# Check Cocod Process reachability
+cocod health
 ```
 
 ### Receiving Payments
@@ -195,16 +193,16 @@ cocod history --limit 50 --watch
 # Start the background daemon (started automatically when not running when required)
 cocod daemon
 
-# Stop the daemon
+# Stop the Cocod Process (distinct from stopping only the Coco Session)
 cocod stop
 ```
 
 ## Examples
 
-**Initialize with encryption:**
+**Initialize with protected Wallet Seed Access:**
 
 ```bash
-cocod init --passphrase "my-secret"
+cocod wallet initialize --passphrase "my-secret"
 ```
 
 **Receive via Lightning:**

--- a/packages/cocod/SKILL.md
+++ b/packages/cocod/SKILL.md
@@ -85,6 +85,9 @@ cocod status
 # Initialize a Wallet with host-generated Wallet Recovery Material
 cocod wallet initialize [--passphrase <passphrase>]
 
+# Retrieve Wallet Recovery Material again if the initialization response was lost
+cocod wallet recovery-material [--passphrase <passphrase>]
+
 # Start or stop the Coco Session without changing the Wallet
 cocod session start [--passphrase <passphrase>]
 cocod session stop

--- a/packages/cocod/docs/API.md
+++ b/packages/cocod/docs/API.md
@@ -14,6 +14,8 @@ Use the implicit `http://127.0.0.1:62626` endpoint for local auto-start. The glo
 - `status` - Show Cocod Process, Wallet Seed Access, and Coco Session status
 - `wallet initialize` - Create a Wallet and display its host-generated Wallet Recovery Material
   - `--passphrase <str>` protect Wallet Seed Access and require explicit Coco Session start
+- `wallet recovery-material` - Retrieve Wallet Recovery Material again after initialization
+  - `--passphrase <str>` required for protected Wallet Seed Access
 - `session start` - Start the Coco Session
   - `--passphrase <str>` supply the passphrase for protected Wallet Seed Access
 - `session stop` - Stop the Coco Session without stopping the Cocod Process

--- a/packages/cocod/docs/API.md
+++ b/packages/cocod/docs/API.md
@@ -11,11 +11,12 @@ Use the implicit `http://127.0.0.1:62626` endpoint for local auto-start. The glo
 
 ### Wallet
 
-- `status` - Check daemon and wallet status
-- `init [mnemonic]` - Initialize wallet; generates mnemonic if omitted
-  - `--passphrase <str>` encrypt wallet at creation time
-  - `--mint-url <url>` set default mint URL
-- `unlock <passphrase>` - Unlock encrypted wallet
+- `status` - Show Cocod Process, Wallet Seed Access, and Coco Session status
+- `wallet initialize` - Create a Wallet and display its host-generated Wallet Recovery Material
+  - `--passphrase <str>` protect Wallet Seed Access and require explicit Coco Session start
+- `session start` - Start the Coco Session
+  - `--passphrase <str>` supply the passphrase for protected Wallet Seed Access
+- `session stop` - Stop the Coco Session without stopping the Cocod Process
 - `balance` - Get wallet balances
 - `history` - List history entries
   - `--offset <number>` default `0`
@@ -58,9 +59,9 @@ conditions return a 400 before any proofs move.
 
 ### Daemon control
 
-- `ping` - Check daemon connectivity
+- `health` - Check Cocod Process reachability
 - `daemon` - Start daemon in foreground
-- `stop` - Stop daemon
+- `stop` - Stop the Cocod Process (distinct from `session stop`)
 - `logs` - Read this host's daemon log (host-local)
 - `credential rotate` - Rotate this host's administrative Client Credential (host-local)
 
@@ -73,23 +74,28 @@ daemon validates both settings and does not inherit a generic `PORT` variable.
 Listener overrides apply to an explicitly started `cocod daemon`. Auto-start always uses the local
 default; connect to a custom listener with `--url` or `COCOD_URL`, which never starts a process.
 
-Every route except `/health` and `/ping` requires `Authorization: Bearer <credential>`. The local
-client reads the credential from `~/.cocod/credentials/current/client`. Remote TLS belongs at a
-trusted proxy such as Caddy; cocod still authenticates the credential itself, ignores forwarded
-identity headers, and does not enable browser CORS.
+`GET /health` is public. Every `/v1/*` request and every remaining legacy route requires
+`Authorization: Bearer <credential>`. The local client reads the credential from
+`~/.cocod/credentials/current/client`. Remote TLS belongs at a trusted proxy such as Caddy; cocod
+still authenticates the credential itself, ignores forwarded identity headers, and does not enable
+browser CORS.
 
-### Response shape
+### Response shapes
 
-- Success: `{ "output": <value> }`
-- Error: `{ "error": "message" }`
+- The v1 lifecycle resources return typed documents directly. Their errors use
+  `{ "error": { "code": string, "message": string, "retryable": boolean, "details"?: object } }`.
+- The remaining operational legacy routes retain `{ "output": <value> }` success and
+  `{ "error": "message" }` error envelopes.
 
 ### Endpoint list
 
-- `GET /ping`
-- `GET /status`
-  - returns `STARTING` or `STOPPING` while a Coco Session lifecycle transition is in progress
-- `POST /init`
-- `POST /unlock`
+- `GET /health` (public)
+- `GET /v1/status`
+- `POST /v1/admin/wallet/initialize`
+- `POST /v1/admin/wallet/recovery-material`
+- `POST /v1/admin/session/start`
+- `POST /v1/admin/session/stop`
+- `POST /v1/admin/process/stop`
 - `GET /balance`
 - `POST /receive/cashu`
 - `POST /receive/bolt11`
@@ -104,7 +110,6 @@ identity headers, and does not enable browser CORS.
 - `GET /events` (SSE stream)
 - `GET /npc/address`
 - `POST /npc/username`
-- `POST /v1/admin/process/stop` (authenticated; returns `202 { "status": "stopping" }`)
 
-For full legacy request/response details, see `docs/daemon-api.json`. The generated structured
-lifecycle description is `docs/lifecycle-api-v1.json`.
+For the remaining operational legacy request/response details, see `docs/daemon-api.json`. The
+generated structured lifecycle description is `docs/lifecycle-api-v1.json`.

--- a/packages/cocod/docs/daemon-api.json
+++ b/packages/cocod/docs/daemon-api.json
@@ -11,11 +11,12 @@
   },
   "authentication": {
     "scheme": "bearer",
-    "publicPaths": ["/health", "/ping"],
-    "protectedPaths": "all other legacy and v1 routes",
+    "publicPaths": ["/health"],
+    "protectedPaths": "all legacy routes and every /v1 route",
     "structuredLifecycleDescription": "lifecycle-api-v1.json"
   },
   "responseContract": {
+    "scope": "remaining operational legacy routes",
     "success": {
       "shape": {
         "output": "unknown"
@@ -29,56 +30,9 @@
   },
   "endpoints": [
     {
-      "path": "/ping",
-      "method": "GET",
-      "state": "any",
-      "responses": {
-        "200": "{ output: \"pong\" }"
-      }
-    },
-    {
-      "path": "/status",
-      "method": "GET",
-      "state": "any",
-      "responses": {
-        "200": "{ output: \"UNINITIALIZED\" | \"LOCKED\" | \"STARTING\" | \"UNLOCKED\" | \"STOPPING\" | \"ERROR\" }"
-      }
-    },
-    {
-      "path": "/init",
-      "method": "POST",
-      "state": "UNINITIALIZED",
-      "body": {
-        "mnemonic": "string (optional)",
-        "passphrase": "string (optional)",
-        "mintUrl": "string (optional)"
-      },
-      "responses": {
-        "200": "{ output: string }",
-        "400": "{ error: \"Invalid mnemonic\" }",
-        "409": "{ error: string }",
-        "500": "{ error: string }"
-      }
-    },
-    {
-      "path": "/unlock",
-      "method": "POST",
-      "state": "LOCKED",
-      "body": {
-        "passphrase": "string"
-      },
-      "responses": {
-        "200": "{ output: \"Unlocked\" }",
-        "400": "{ error: string }",
-        "401": "{ error: string }",
-        "409": "{ error: string }",
-        "503": "{ error: string }"
-      }
-    },
-    {
       "path": "/balance",
       "method": "GET",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "notes": "sats is the total balance (spendable + reserved), matching pre-v2 semantics; sat unit only. Mints with no proofs are omitted.",
       "responses": {
         "200": "{ output: Record<string, { sats: number }> }",
@@ -90,7 +44,7 @@
     {
       "path": "/receive/cashu",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "token": "string"
       },
@@ -102,7 +56,7 @@
     {
       "path": "/receive/bolt11",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "amount": "number",
         "mintUrl": "string (optional)"
@@ -115,7 +69,7 @@
     {
       "path": "/send/cashu",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "amount": "number",
         "mintUrl": "string (optional)"
@@ -128,7 +82,7 @@
     {
       "path": "/send/bolt11",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "invoice": "string",
         "mintUrl": "string (optional)"
@@ -141,7 +95,7 @@
     {
       "path": "/x-cashu/parse",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "request": "string"
       },
@@ -155,7 +109,7 @@
     {
       "path": "/x-cashu/handle",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "request": "string",
         "mintUrl": "string (optional)"
@@ -170,7 +124,7 @@
     {
       "path": "/mints/add",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "url": "string"
       },
@@ -182,7 +136,7 @@
     {
       "path": "/mints/list",
       "method": "GET",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "responses": {
         "200": "{ output: string }",
         "500": "{ error: string }"
@@ -191,7 +145,7 @@
     {
       "path": "/mints/info",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "url": "string"
       },
@@ -203,7 +157,7 @@
     {
       "path": "/history",
       "method": "GET",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "query": {
         "offset": "number (optional, default 0)",
         "limit": "number (optional, default 20, max 100)"
@@ -216,7 +170,7 @@
     {
       "path": "/events",
       "method": "GET",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "responses": {
         "200": "text/event-stream"
       }
@@ -224,7 +178,7 @@
     {
       "path": "/npc/address",
       "method": "GET",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "responses": {
         "200": "{ output: string }",
         "500": "{ error: string }"
@@ -233,7 +187,7 @@
     {
       "path": "/npc/username",
       "method": "POST",
-      "state": "UNLOCKED",
+      "state": "cocoSession.running",
       "body": {
         "username": "string",
         "confirm": "boolean (optional)"

--- a/packages/cocod/src/cli-shared.test.ts
+++ b/packages/cocod/src/cli-shared.test.ts
@@ -5,10 +5,11 @@ import { join } from 'node:path';
 
 import {
   assertHostLocalOperation,
-  callDaemon,
   callDaemonStream,
+  createV1Client,
   ensureDaemonRunning,
   startDaemonProcess,
+  V1ClientError,
 } from './cli-shared';
 
 const originalFetch = globalThis.fetch;
@@ -23,32 +24,86 @@ afterEach(async () => {
   );
 });
 
-test('normal protected requests attach the file-backed bearer credential', async () => {
+test('typed v1 status requests attach the file-backed bearer credential', async () => {
   const credentialFile = await temporaryCredentialFile('a'.repeat(43));
   const authorizations: Array<string | null> = [];
   const requestedUrls: string[] = [];
   globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
     requestedUrls.push(input instanceof Request ? input.url : input.toString());
     authorizations.push(new Headers(init?.headers).get('authorization'));
-    return Response.json({ output: 'UNLOCKED' });
+    return Response.json(lifecycleStatus('stopped'));
   }) as unknown as typeof fetch;
 
-  await callDaemon('/status', { credentialFile, url: 'https://wallet.example.com' });
+  const status = await createV1Client({
+    credentialFile,
+    url: 'https://wallet.example.com',
+  }).status();
 
+  expect(status.cocoSession.state).toBe('stopped');
   expect(authorizations).toEqual([`Bearer ${'a'.repeat(43)}`]);
-  expect(requestedUrls).toEqual(['https://wallet.example.com/status']);
+  expect(requestedUrls).toEqual(['https://wallet.example.com/v1/status']);
 });
 
 test('the liveness request remains credential-free', async () => {
   const authorizations: Array<string | null> = [];
   globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
     authorizations.push(new Headers(init?.headers).get('authorization'));
-    return Response.json({ output: 'pong' });
+    return Response.json({ status: 'ok', interfaceVersion: '1' });
   }) as unknown as typeof fetch;
 
-  await callDaemon('/ping', { credentialFile: '/missing/credential' });
+  await createV1Client({ credentialFile: '/missing/credential' }).health();
 
   expect(authorizations).toEqual([null]);
+});
+
+test('typed v1 requests expose structured error fields', async () => {
+  const credentialFile = await temporaryCredentialFile('e'.repeat(43));
+  globalThis.fetch = mock(async () =>
+    Response.json(
+      {
+        error: {
+          code: 'wallet_not_configured',
+          message: 'No Wallet is configured',
+          retryable: false,
+          details: { operation: 'session_start' },
+        },
+      },
+      { status: 409 },
+    ),
+  ) as unknown as typeof fetch;
+
+  try {
+    await createV1Client({ credentialFile }).startSession({});
+    throw new Error('expected v1 request to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(V1ClientError);
+    expect(error).toMatchObject({
+      code: 'wallet_not_configured',
+      message: 'No Wallet is configured',
+      retryable: false,
+      details: { operation: 'session_start' },
+      status: 409,
+    });
+  }
+});
+
+test('Coco Session stop and Cocod Process stop use distinct v1 resources', async () => {
+  const credentialFile = await temporaryCredentialFile('f'.repeat(43));
+  const requestedPaths: string[] = [];
+  globalThis.fetch = mock(async (input: string | URL | Request) => {
+    const path = new URL(input instanceof Request ? input.url : input.toString()).pathname;
+    requestedPaths.push(path);
+    if (path === '/v1/admin/process/stop') {
+      return Response.json({ status: 'stopping' }, { status: 202 });
+    }
+    return Response.json(lifecycleStatus('stopped'));
+  }) as unknown as typeof fetch;
+  const client = createV1Client({ credentialFile });
+
+  await client.stopSession();
+  await client.stopProcess();
+
+  expect(requestedPaths).toEqual(['/v1/admin/session/stop', '/v1/admin/process/stop']);
 });
 
 test('host-local operations reject an explicit remote endpoint', () => {
@@ -70,10 +125,10 @@ test('streaming requests attach the file-backed bearer credential', async () => 
       streamAuthorizations.push(new Headers(init?.headers).get('authorization'));
       return new Response('data: {"type":"ready"}\n\n');
     }
-    if (path === '/status') {
-      return Response.json({ output: 'UNLOCKED' });
+    if (path === '/v1/status') {
+      return Response.json(lifecycleStatus('running'));
     }
-    return Response.json({ output: 'pong' });
+    return Response.json({ status: 'ok', interfaceVersion: '1' });
   }) as unknown as typeof fetch;
 
   await callDaemonStream('/events', () => {}, {
@@ -83,48 +138,24 @@ test('streaming requests attach the file-backed bearer credential', async () => 
 
   expect(streamAuthorizations).toEqual([`Bearer ${'c'.repeat(43)}`]);
   expect(requestedUrls).toEqual([
-    'https://wallet.example.com/ping',
-    'https://wallet.example.com/status',
+    'https://wallet.example.com/health',
+    'https://wallet.example.com/v1/status',
     'https://wallet.example.com/events',
   ]);
 });
 
 describe('ensureDaemonRunning', () => {
-  test('waits for an already-running daemon to finish startup', async () => {
-    const credentialFile = await temporaryCredentialFile('b'.repeat(43));
+  test('only requires process health when an existing session is stopped', async () => {
     const requestedPaths: string[] = [];
-    const statusAuthorizations: Array<string | null> = [];
-    let statusRequests = 0;
-    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
       const url = new URL(input instanceof Request ? input.url : input.toString());
       requestedPaths.push(url.pathname);
-
-      if (url.pathname === '/ping') {
-        return Response.json({ output: 'pong' });
-      }
-
-      statusRequests += 1;
-      statusAuthorizations.push(new Headers(init?.headers).get('authorization'));
-      return Response.json({ output: statusRequests === 1 ? 'STARTING' : 'UNLOCKED' });
+      return Response.json({ status: 'ok', interfaceVersion: '1' });
     }) as unknown as typeof fetch;
 
-    await ensureDaemonRunning({ credentialFile });
+    await ensureDaemonRunning({ credentialFile: '/missing/credential' });
 
-    expect(statusRequests).toBe(2);
-    expect(requestedPaths).toEqual(['/ping', '/status', '/status']);
-    expect(statusAuthorizations).toEqual([`Bearer ${'b'.repeat(43)}`, `Bearer ${'b'.repeat(43)}`]);
-  });
-
-  test('reports a missing local Client Credential for an existing daemon', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'cocod-cli-credential-'));
-    directories.push(directory);
-    globalThis.fetch = mock(async () =>
-      Response.json({ output: 'pong' }),
-    ) as unknown as typeof fetch;
-
-    await expect(
-      ensureDaemonRunning({ credentialFile: join(directory, 'missing-credential') }),
-    ).rejects.toThrow('Cocod Client Credential file is missing');
+    expect(requestedPaths).toEqual(['/health']);
   });
 
   test('reports a missing local Client Credential once an auto-started daemon is reachable', async () => {
@@ -134,12 +165,12 @@ describe('ensureDaemonRunning', () => {
       unref() {},
     })) as unknown as typeof Bun.spawn;
     globalThis.fetch = mock(async () =>
-      Response.json({ output: 'pong' }),
+      Response.json({ status: 'ok', interfaceVersion: '1' }),
     ) as unknown as typeof fetch;
 
     await expect(
       startDaemonProcess({ credentialFile: join(directory, 'missing-credential') }),
-    ).rejects.toThrow('Cocod Client Credential file is missing');
+    ).resolves.toBeUndefined();
   }, 7_000);
 
   test('never auto-starts when an explicit endpoint is unreachable', async () => {
@@ -157,6 +188,15 @@ describe('ensureDaemonRunning', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 });
+
+function lifecycleStatus(state: 'stopped' | 'running') {
+  return {
+    daemon: { version: '0.0.17', interfaceVersion: '1' as const },
+    wallet: null,
+    seedAccess: null,
+    cocoSession: { state, startedAt: null, lastFailure: null },
+  };
+}
 
 async function temporaryCredentialFile(credential: string): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'cocod-cli-credential-'));

--- a/packages/cocod/src/cli-shared.test.ts
+++ b/packages/cocod/src/cli-shared.test.ts
@@ -7,9 +7,12 @@ import {
   assertHostLocalOperation,
   callDaemonStream,
   createV1Client,
+  DEFAULT_SESSION_TRANSITION_TIMEOUT_MS,
   ensureDaemonRunning,
   startDaemonProcess,
   V1ClientError,
+  waitForSessionTransition,
+  type V1Client,
 } from './cli-shared';
 
 const originalFetch = globalThis.fetch;
@@ -106,6 +109,23 @@ test('Coco Session stop and Cocod Process stop use distinct v1 resources', async
   expect(requestedPaths).toEqual(['/v1/admin/session/stop', '/v1/admin/process/stop']);
 });
 
+test('the lifecycle wait exceeds the server cleanup deadline', () => {
+  expect(DEFAULT_SESSION_TRANSITION_TIMEOUT_MS).toBeGreaterThan(30_000);
+});
+
+test('the lifecycle wait timing is configurable', async () => {
+  const client = {
+    status: async () => lifecycleStatus('starting'),
+  } as unknown as V1Client;
+
+  await expect(
+    waitForSessionTransition(client, lifecycleStatus('starting'), {
+      timeoutMs: 5,
+      pollIntervalMs: 1,
+    }),
+  ).rejects.toThrow('Coco Session transition did not finish within 1 seconds');
+});
+
 test('host-local operations reject an explicit remote endpoint', () => {
   expect(() => assertHostLocalOperation('logs', 'https://wallet.example.com')).toThrow(
     'cocod logs is host-local and cannot use the explicit Cocod endpoint https://wallet.example.com',
@@ -189,7 +209,7 @@ describe('ensureDaemonRunning', () => {
   });
 });
 
-function lifecycleStatus(state: 'stopped' | 'running') {
+function lifecycleStatus(state: 'stopped' | 'starting' | 'running') {
   return {
     daemon: { version: '0.0.17', interfaceVersion: '1' as const },
     wallet: null,

--- a/packages/cocod/src/cli-shared.ts
+++ b/packages/cocod/src/cli-shared.ts
@@ -7,6 +7,7 @@ import {
   lifecycleStatusSchema,
   processShutdownResponseSchema,
   v1ErrorSchema,
+  walletRecoveryMaterialResponseSchema,
   type HealthDocument,
   type InitializeWalletRequest,
   type InitializeWalletResponseDocument,
@@ -15,13 +16,19 @@ import {
   type RuntimeSchema,
   type StartSessionRequest,
   type V1ErrorCode,
+  type WalletRecoveryMaterialRequest,
+  type WalletRecoveryMaterialResponseDocument,
 } from './v1/http.js';
 import {
   CLIENT_CREDENTIAL_FILE,
   DEFAULT_CLIENT_URL,
+  DEFAULT_SHUTDOWN_TIMEOUT_MS,
   resolveClientEndpoint,
   type ClientEndpoint,
 } from './utils/config.js';
+
+const SESSION_TRANSITION_POLL_INTERVAL_MS = 100;
+export const DEFAULT_SESSION_TRANSITION_TIMEOUT_MS = DEFAULT_SHUTDOWN_TIMEOUT_MS + 5_000;
 
 export interface CommandResponse {
   output?: unknown;
@@ -38,10 +45,18 @@ export interface DaemonCallOptions extends ClientCredentialOptions {
   body?: object;
 }
 
+export interface SessionTransitionWaitOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
 export interface V1Client {
   health(): Promise<HealthDocument>;
   status(): Promise<LifecycleStatusDocument>;
   initializeWallet(input: InitializeWalletRequest): Promise<InitializeWalletResponseDocument>;
+  getWalletRecoveryMaterial(
+    input: WalletRecoveryMaterialRequest,
+  ): Promise<WalletRecoveryMaterialResponseDocument>;
   startSession(input: StartSessionRequest): Promise<LifecycleStatusDocument>;
   stopSession(): Promise<LifecycleStatusDocument>;
   stopProcess(): Promise<ProcessShutdownResponseDocument>;
@@ -90,6 +105,15 @@ export function createV1Client(options: ClientCredentialOptions = {}): V1Client 
         'POST',
         input,
         initializeWalletResponseSchema,
+        credentialFile,
+      ),
+    getWalletRecoveryMaterial: (input) =>
+      requestV1(
+        endpoint,
+        '/v1/admin/wallet/recovery-material',
+        'POST',
+        input,
+        walletRecoveryMaterialResponseSchema,
         credentialFile,
       ),
     startSession: (input) =>
@@ -211,17 +235,31 @@ export async function ensureDaemonRunning(options: ClientCredentialOptions = {})
 export async function waitForSessionTransition(
   client: V1Client,
   initialStatus: LifecycleStatusDocument,
+  options: SessionTransitionWaitOptions = {},
 ): Promise<LifecycleStatusDocument> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SESSION_TRANSITION_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? SESSION_TRANSITION_POLL_INTERVAL_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error('Session transition timeout must be a positive finite number');
+  }
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new Error('Session transition poll interval must be a positive finite number');
+  }
+
+  const startedAt = performance.now();
   let status = initialStatus;
-  for (let i = 0; i < 50; i++) {
-    if (status.cocoSession.state !== 'starting' && status.cocoSession.state !== 'stopping') {
-      return status;
+  while (status.cocoSession.state === 'starting' || status.cocoSession.state === 'stopping') {
+    const remainingMs = timeoutMs - (performance.now() - startedAt);
+    if (remainingMs <= 0) {
+      throw new Error(
+        `Coco Session transition did not finish within ${Math.ceil(timeoutMs / 1_000)} seconds`,
+      );
     }
-    await Bun.sleep(100);
+    await Bun.sleep(Math.min(pollIntervalMs, remainingMs));
     status = await client.status();
   }
 
-  throw new Error('Coco Session transition did not finish within 5 seconds');
+  return status;
 }
 
 async function waitForOperationalSession(client: V1Client): Promise<void> {

--- a/packages/cocod/src/cli-shared.ts
+++ b/packages/cocod/src/cli-shared.ts
@@ -1,6 +1,21 @@
 import { program } from 'commander';
 
-import { ClientCredentialFileError, loadClientCredential } from './credentials.js';
+import { loadClientCredential } from './credentials.js';
+import {
+  healthSchema,
+  initializeWalletResponseSchema,
+  lifecycleStatusSchema,
+  processShutdownResponseSchema,
+  v1ErrorSchema,
+  type HealthDocument,
+  type InitializeWalletRequest,
+  type InitializeWalletResponseDocument,
+  type LifecycleStatusDocument,
+  type ProcessShutdownResponseDocument,
+  type RuntimeSchema,
+  type StartSessionRequest,
+  type V1ErrorCode,
+} from './v1/http.js';
 import {
   CLIENT_CREDENTIAL_FILE,
   DEFAULT_CLIENT_URL,
@@ -23,6 +38,29 @@ export interface DaemonCallOptions extends ClientCredentialOptions {
   body?: object;
 }
 
+export interface V1Client {
+  health(): Promise<HealthDocument>;
+  status(): Promise<LifecycleStatusDocument>;
+  initializeWallet(input: InitializeWalletRequest): Promise<InitializeWalletResponseDocument>;
+  startSession(input: StartSessionRequest): Promise<LifecycleStatusDocument>;
+  stopSession(): Promise<LifecycleStatusDocument>;
+  stopProcess(): Promise<ProcessShutdownResponseDocument>;
+}
+
+export class V1ClientError extends Error {
+  override readonly name = 'V1ClientError';
+
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: V1ErrorCode,
+    readonly retryable: boolean,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+  }
+}
+
 export function assertHostLocalOperation(
   operation: string,
   commandUrl = program.opts<{ url?: string }>().url,
@@ -34,6 +72,54 @@ export function assertHostLocalOperation(
       `cocod ${operation} is host-local and cannot use the explicit Cocod endpoint ${endpoint.url}`,
     );
   }
+}
+
+/** Creates one typed client for the implemented v1 lifecycle interface. */
+export function createV1Client(options: ClientCredentialOptions = {}): V1Client {
+  const endpoint = configuredClientEndpoint(options.url);
+  const credentialFile = options.credentialFile;
+
+  return {
+    health: () => requestV1(endpoint, '/health', 'GET', undefined, healthSchema, credentialFile),
+    status: () =>
+      requestV1(endpoint, '/v1/status', 'GET', undefined, lifecycleStatusSchema, credentialFile),
+    initializeWallet: (input) =>
+      requestV1(
+        endpoint,
+        '/v1/admin/wallet/initialize',
+        'POST',
+        input,
+        initializeWalletResponseSchema,
+        credentialFile,
+      ),
+    startSession: (input) =>
+      requestV1(
+        endpoint,
+        '/v1/admin/session/start',
+        'POST',
+        input,
+        lifecycleStatusSchema,
+        credentialFile,
+      ),
+    stopSession: () =>
+      requestV1(
+        endpoint,
+        '/v1/admin/session/stop',
+        'POST',
+        {},
+        lifecycleStatusSchema,
+        credentialFile,
+      ),
+    stopProcess: () =>
+      requestV1(
+        endpoint,
+        '/v1/admin/process/stop',
+        'POST',
+        {},
+        processShutdownResponseSchema,
+        credentialFile,
+      ),
+  };
 }
 
 async function callDaemon(path: string, options: DaemonCallOptions = {}): Promise<CommandResponse> {
@@ -49,7 +135,7 @@ async function callDaemon(path: string, options: DaemonCallOptions = {}): Promis
 }
 
 function isProtectedPath(path: string): boolean {
-  return new URL(path, DEFAULT_CLIENT_URL).pathname !== '/ping';
+  return new URL(path, DEFAULT_CLIENT_URL).pathname !== '/health';
 }
 
 async function buildRequestHeaders(
@@ -69,47 +155,22 @@ async function buildRequestHeaders(
 
 export async function isDaemonRunning(options: ClientCredentialOptions = {}): Promise<boolean> {
   try {
-    const endpoint = configuredClientEndpoint(options.url);
-    const response = await requestDaemon(endpoint, '/ping', { method: 'GET' });
-    return response.ok;
+    await createV1Client(options).health();
+    return true;
   } catch {
     return false;
   }
 }
 
-async function isDaemonReady(options: ClientCredentialOptions = {}): Promise<boolean> {
-  try {
-    const body = await callDaemon('/status', options);
-    return body.output !== 'STARTING' && body.output !== 'STOPPING';
-  } catch (error) {
-    if (error instanceof ClientCredentialFileError) {
-      throw error;
-    }
-    return false;
-  }
-}
-
-async function waitForDaemonReady(
-  options: ClientCredentialOptions = {},
-  retryMissingCredential = false,
-): Promise<void> {
+async function waitForDaemonReachable(options: ClientCredentialOptions = {}): Promise<void> {
   for (let i = 0; i < 50; i++) {
-    try {
-      if (await isDaemonReady(options)) {
-        return;
-      }
-    } catch (error) {
-      if (!(retryMissingCredential && error instanceof ClientCredentialFileError)) {
-        throw error;
-      }
-      if (await isDaemonRunning(options)) {
-        throw error;
-      }
+    if (await isDaemonRunning(options)) {
+      return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await Bun.sleep(100);
   }
 
-  throw new Error('Daemon failed to become ready within 5 seconds');
+  throw new Error('Cocod Process failed to become reachable within 5 seconds');
 }
 
 export async function startDaemonProcess(options: ClientCredentialOptions = {}): Promise<void> {
@@ -129,13 +190,12 @@ export async function startDaemonProcess(options: ClientCredentialOptions = {}):
     stdin: 'ignore',
   });
   proc.unref();
-  await waitForDaemonReady(options, true);
+  await waitForDaemonReachable(options);
 }
 
 export async function ensureDaemonRunning(options: ClientCredentialOptions = {}): Promise<void> {
   const endpoint = configuredClientEndpoint(options.url);
   if (await isDaemonRunning({ ...options, url: endpoint.url })) {
-    await waitForDaemonReady({ ...options, url: endpoint.url });
     return;
   }
 
@@ -143,8 +203,41 @@ export async function ensureDaemonRunning(options: ClientCredentialOptions = {})
     throw explicitEndpointUnavailable(endpoint.url);
   }
 
-  console.log('Starting daemon...');
+  console.log('Starting Cocod Process...');
   await startDaemonProcess({ ...options, url: undefined });
+}
+
+/** Polls only while a Coco Session lifecycle transition is still in progress. */
+export async function waitForSessionTransition(
+  client: V1Client,
+  initialStatus: LifecycleStatusDocument,
+): Promise<LifecycleStatusDocument> {
+  let status = initialStatus;
+  for (let i = 0; i < 50; i++) {
+    if (status.cocoSession.state !== 'starting' && status.cocoSession.state !== 'stopping') {
+      return status;
+    }
+    await Bun.sleep(100);
+    status = await client.status();
+  }
+
+  throw new Error('Coco Session transition did not finish within 5 seconds');
+}
+
+async function waitForOperationalSession(client: V1Client): Promise<void> {
+  await waitForSessionTransition(client, await client.status());
+}
+
+export async function handleV1Command<T>(
+  action: (client: V1Client) => Promise<T>,
+  options: ClientCredentialOptions = {},
+): Promise<T> {
+  try {
+    await ensureDaemonRunning(options);
+    return await action(createV1Client(options));
+  } catch (error) {
+    exitForClientError(error);
+  }
 }
 
 export async function handleDaemonCommand(
@@ -153,6 +246,7 @@ export async function handleDaemonCommand(
 ): Promise<CommandResponse> {
   try {
     await ensureDaemonRunning({ credentialFile: options.credentialFile, url: options.url });
+    await waitForOperationalSession(createV1Client(options));
     const result = await callDaemon(path, options);
 
     if (result.error) {
@@ -161,27 +255,12 @@ export async function handleDaemonCommand(
     }
 
     if (result.output !== undefined) {
-      if (typeof result.output === 'string') {
-        console.log(result.output);
-      } else {
-        try {
-          const formatted = JSON.stringify(result.output, null, 2);
-          console.log(formatted ?? String(result.output));
-        } catch {
-          console.log(String(result.output));
-        }
-      }
+      printValue(result.output);
     }
 
     return result;
   } catch (error) {
-    const message = (error as Error).message;
-    if (message?.includes('fetch failed') || message?.includes('Connection refused')) {
-      console.error('Daemon is not running and failed to auto-start');
-      process.exit(1);
-    }
-    console.error(message);
-    process.exit(1);
+    exitForClientError(error);
   }
 }
 
@@ -191,6 +270,7 @@ export async function callDaemonStream(
   options: ClientCredentialOptions = {},
 ): Promise<void> {
   await ensureDaemonRunning(options);
+  await waitForOperationalSession(createV1Client(options));
   const endpoint = configuredClientEndpoint(options.url);
   const response = await requestDaemon(endpoint, path, options);
 
@@ -213,18 +293,15 @@ export async function callDaemonStream(
       if (done) break;
 
       buffer += decoder.decode(value, { stream: true });
-
       const lines = buffer.split('\n');
       buffer = lines.pop() || '';
 
       for (const line of lines) {
         if (line.startsWith('data: ')) {
-          const jsonStr = line.slice(6);
           try {
-            const data = JSON.parse(jsonStr);
-            onData(data);
+            onData(JSON.parse(line.slice(6)));
           } catch {
-            // Skip malformed JSON
+            // Ignore malformed event data and continue reading the stream.
           }
         }
       }
@@ -250,6 +327,67 @@ async function requestDaemon(
     headers: await buildRequestHeaders(path, credentialFile, body !== undefined),
     body: body ? JSON.stringify(body) : undefined,
   });
+}
+
+async function requestV1<T>(
+  endpoint: ClientEndpoint,
+  path: string,
+  method: 'GET' | 'POST',
+  body: object | undefined,
+  schema: RuntimeSchema<T>,
+  credentialFile = CLIENT_CREDENTIAL_FILE,
+): Promise<T> {
+  const response = await requestDaemon(endpoint, path, { method, body, credentialFile });
+  const document: unknown = await response.json();
+
+  if (!response.ok) {
+    try {
+      const error = v1ErrorSchema.parse(document).error;
+      throw new V1ClientError(
+        error.message,
+        response.status,
+        error.code,
+        error.retryable,
+        error.details,
+      );
+    } catch (error) {
+      if (error instanceof V1ClientError) {
+        throw error;
+      }
+      throw new Error(`HTTP ${response.status}: invalid v1 error response`);
+    }
+  }
+
+  try {
+    return schema.parse(document);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid ${schema.name} response: ${message}`);
+  }
+}
+
+function printValue(value: unknown): void {
+  if (typeof value === 'string') {
+    console.log(value);
+    return;
+  }
+  try {
+    console.log(JSON.stringify(value, null, 2) ?? String(value));
+  } catch {
+    console.log(String(value));
+  }
+}
+
+function exitForClientError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes('fetch failed') || message.includes('Connection refused')) {
+    console.error('Cocod Process is not running and failed to auto-start');
+  } else if (error instanceof V1ClientError) {
+    console.error(`${error.message} [${error.code}]`);
+  } else {
+    console.error(message);
+  }
+  process.exit(1);
 }
 
 function explicitEndpointUnavailable(url: string): Error {

--- a/packages/cocod/src/cli.ts
+++ b/packages/cocod/src/cli.ts
@@ -45,10 +45,19 @@ walletCmd
       client.initializeWallet({ passphrase: options.passphrase }),
     );
     console.log('Wallet initialized.');
-    console.log('\nIMPORTANT: Store this Wallet Recovery Material securely:');
-    console.log(result.generatedMnemonic);
-    console.log('\nAnyone with these words can control the Wallet.');
+    printWalletRecoveryMaterial(result.generatedMnemonic, true);
     printLifecycleStatus(result.status);
+  });
+
+walletCmd
+  .command('recovery-material')
+  .description('Retrieve the Wallet Recovery Material')
+  .option('--passphrase <passphrase>', 'Passphrase for protected Wallet Seed Access')
+  .action(async (options: { passphrase?: string }) => {
+    const result = await handleV1Command((client) =>
+      client.getWalletRecoveryMaterial({ passphrase: options.passphrase }),
+    );
+    printWalletRecoveryMaterial(result.mnemonic);
   });
 
 const sessionCmd = program.command('session').description('Coco Session lifecycle operations');
@@ -59,9 +68,12 @@ sessionCmd
   .option('--passphrase <passphrase>', 'Passphrase for protected Wallet Seed Access')
   .action(async (options: { passphrase?: string }) => {
     const status = await handleV1Command(async (client) =>
-      waitForSessionTransition(
-        client,
-        await client.startSession({ passphrase: options.passphrase }),
+      requireSessionState(
+        await waitForSessionTransition(
+          client,
+          await client.startSession({ passphrase: options.passphrase }),
+        ),
+        'running',
       ),
     );
     printLifecycleStatus(status);
@@ -72,7 +84,10 @@ sessionCmd
   .description('Stop the Coco Session without stopping the Cocod Process')
   .action(async () => {
     const status = await handleV1Command(async (client) =>
-      waitForSessionTransition(client, await client.stopSession()),
+      requireSessionState(
+        await waitForSessionTransition(client, await client.stopSession()),
+        'stopped',
+      ),
     );
     printLifecycleStatus(status);
   });
@@ -360,6 +375,24 @@ function requireHostLocalOperation(operation: string): void {
 
 function printLifecycleStatus(status: LifecycleStatusDocument): void {
   console.log(JSON.stringify(status, null, 2));
+}
+
+function printWalletRecoveryMaterial(mnemonic: string, leadingNewline = false): void {
+  console.log(
+    `${leadingNewline ? '\n' : ''}IMPORTANT: Store this Wallet Recovery Material securely:`,
+  );
+  console.log(mnemonic);
+  console.log('\nAnyone with these words can control the Wallet.');
+}
+
+function requireSessionState(
+  status: LifecycleStatusDocument,
+  expected: 'running' | 'stopped',
+): LifecycleStatusDocument {
+  if (status.cocoSession.state !== expected) {
+    throw new Error(`Coco Session did not reach ${expected}:\n${JSON.stringify(status, null, 2)}`);
+  }
+  return status;
 }
 
 export function cli(args: string[]) {

--- a/packages/cocod/src/cli.ts
+++ b/packages/cocod/src/cli.ts
@@ -5,7 +5,10 @@ import {
   program,
   handleDaemonCommand,
   callDaemonStream,
+  handleV1Command,
+  waitForSessionTransition,
 } from './cli-shared';
+import type { LifecycleStatusDocument } from './v1/http.js';
 import {
   DEFAULT_LOG_LINES,
   followLogFile,
@@ -24,42 +27,54 @@ program
   .version(cliVersion, '--version', 'output the version number')
   .option('--url <url>', 'Cocod HTTP endpoint (or COCOD_URL)');
 
-// Status - check daemon/wallet state
 program
   .command('status')
-  .description('Check daemon and wallet status')
+  .description('Show Cocod Process, Wallet Seed Access, and Coco Session status')
   .action(async () => {
-    await handleDaemonCommand('/status');
+    printLifecycleStatus(await handleV1Command((client) => client.status()));
   });
 
-// Init - initialize wallet
-program
-  .command('init [mnemonic]')
-  .description('Initialize wallet with optional mnemonic (generates one if not provided)')
-  .option('--passphrase <passphrase>', 'Encrypt wallet with passphrase')
-  .option('--mint-url <url>', 'Default mint URL (default: https://mint.minibits.cash/Bitcoin)')
-  .action(
-    async (mnemonic: string | undefined, options: { passphrase?: string; mintUrl?: string }) => {
-      await handleDaemonCommand('/init', {
-        method: 'POST',
-        body: {
-          mnemonic,
-          passphrase: options.passphrase,
-          mintUrl: options.mintUrl,
-        },
-      });
-    },
-  );
+const walletCmd = program.command('wallet').description('Wallet lifecycle operations');
 
-// Unlock - unlock encrypted wallet
-program
-  .command('unlock <passphrase>')
-  .description('Unlock encrypted wallet with passphrase')
-  .action(async (passphrase: string) => {
-    await handleDaemonCommand('/unlock', {
-      method: 'POST',
-      body: { passphrase },
-    });
+walletCmd
+  .command('initialize')
+  .description('Create a Wallet with host-generated Wallet Recovery Material')
+  .option('--passphrase <passphrase>', 'Protect Wallet Seed Access with a passphrase')
+  .action(async (options: { passphrase?: string }) => {
+    const result = await handleV1Command((client) =>
+      client.initializeWallet({ passphrase: options.passphrase }),
+    );
+    console.log('Wallet initialized.');
+    console.log('\nIMPORTANT: Store this Wallet Recovery Material securely:');
+    console.log(result.generatedMnemonic);
+    console.log('\nAnyone with these words can control the Wallet.');
+    printLifecycleStatus(result.status);
+  });
+
+const sessionCmd = program.command('session').description('Coco Session lifecycle operations');
+
+sessionCmd
+  .command('start')
+  .description('Start the Coco Session')
+  .option('--passphrase <passphrase>', 'Passphrase for protected Wallet Seed Access')
+  .action(async (options: { passphrase?: string }) => {
+    const status = await handleV1Command(async (client) =>
+      waitForSessionTransition(
+        client,
+        await client.startSession({ passphrase: options.passphrase }),
+      ),
+    );
+    printLifecycleStatus(status);
+  });
+
+sessionCmd
+  .command('stop')
+  .description('Stop the Coco Session without stopping the Cocod Process')
+  .action(async () => {
+    const status = await handleV1Command(async (client) =>
+      waitForSessionTransition(client, await client.stopSession()),
+    );
+    printLifecycleStatus(status);
   });
 
 // Balance - simple GET command
@@ -119,12 +134,12 @@ sendCmd
     });
   });
 
-// Ping
 program
-  .command('ping')
-  .description('Test connection to the daemon')
+  .command('health')
+  .description('Check Cocod Process reachability')
   .action(async () => {
-    await handleDaemonCommand('/ping');
+    const health = await handleV1Command((client) => client.health());
+    console.log(JSON.stringify(health, null, 2));
   });
 
 // Logs
@@ -177,9 +192,10 @@ program
 // Stop
 program
   .command('stop')
-  .description('Stop the background daemon')
+  .description('Stop the Cocod Process')
   .action(async () => {
-    await handleDaemonCommand('/v1/admin/process/stop', { method: 'POST', body: {} });
+    await handleV1Command((client) => client.stopProcess());
+    console.log('Cocod Process is stopping.');
   });
 
 const credentialCmd = program.command('credential').description('Client Credential operations');
@@ -340,6 +356,10 @@ function requireHostLocalOperation(operation: string): void {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
+}
+
+function printLifecycleStatus(status: LifecycleStatusDocument): void {
+  console.log(JSON.stringify(status, null, 2));
 }
 
 export function cli(args: string[]) {

--- a/packages/cocod/src/routes.test.ts
+++ b/packages/cocod/src/routes.test.ts
@@ -10,12 +10,7 @@ import { AdministrativeCredential, loadClientCredential } from './credentials.js
 import { buildFallbackHandler, buildRoutes, createRouteHandlers } from './routes';
 import { startTcpTestServer } from '../test/helpers/tcp.js';
 import type { AppLogger } from './utils/logger.js';
-import {
-  CocodRuntimeError,
-  type CocodRuntime,
-  type CocodStatus,
-  type RunningCocoSession,
-} from './runtime';
+import { type CocodRuntime, type CocodStatus, type RunningCocoSession } from './runtime';
 
 // A creqB (TLV + bech32m) payment request for 21 sat carrying a P2PK NUT-10
 // spending condition, generated once with the workspace @cashu/cashu-ts.
@@ -44,17 +39,6 @@ function uninitializedRuntime(overrides: Partial<CocodRuntime> = {}): CocodRunti
     null,
     overrides,
   );
-}
-
-function lockedRuntime(): CocodRuntime {
-  return fakeRuntime({
-    wallet: {
-      configuredAt: '2026-08-16T00:00:00.000Z',
-      mintUrl: 'https://mint.example.com',
-    },
-    seedAccess: { state: 'locked', requiresPassphrase: true },
-    cocoSession: { state: 'stopped', startedAt: null, lastFailure: null },
-  });
 }
 
 function runningRuntime(manager?: unknown): CocodRuntime {
@@ -103,6 +87,15 @@ function credentialPaths(directory: string): {
 }
 
 describe('routes', () => {
+  test('does not expose superseded lifecycle command routes', () => {
+    const routes = createRouteHandlers(uninitializedRuntime());
+
+    expect(routes['/ping']).toBeUndefined();
+    expect(routes['/status']).toBeUndefined();
+    expect(routes['/init']).toBeUndefined();
+    expect(routes['/unlock']).toBeUndefined();
+  });
+
   test('rejects a protected route without a bearer credential', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'cocod-routes-auth-'));
     try {
@@ -112,46 +105,11 @@ describe('routes', () => {
       const runtime = uninitializedRuntime();
       const routes = buildRoutes(createRouteHandlers(runtime), runtime, credentials);
 
-      const response = await routes['/status']!.GET!(new Request('http://localhost/status'));
+      const response = await routes['/balance']!.GET!(new Request('http://localhost/balance'));
 
       expect(response.status).toBe(401);
       expect(await response.json()).toEqual({ error: 'Unauthorized' });
     } finally {
-      await rm(directory, { recursive: true, force: true });
-    }
-  });
-
-  test('enforces authentication through the TCP listener while leaving /ping open', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'cocod-tcp-auth-'));
-    let server: ReturnType<typeof Bun.serve> | undefined;
-    try {
-      const paths = credentialPaths(directory);
-      const credentials = await AdministrativeCredential.loadOrBootstrap(paths);
-      const plaintext = await loadClientCredential(paths.clientCredentialFile);
-      const runtime = uninitializedRuntime();
-      server = startTcpTestServer({
-        routes: buildRoutes(createRouteHandlers(runtime), runtime, credentials),
-        fetch: buildFallbackHandler(runtime, credentials),
-      });
-
-      const pingResponse = await fetch(new URL('/ping', server.url));
-      const unauthorizedResponse = await fetch(new URL('/status', server.url));
-      const authorizedResponse = await fetch(new URL('/status', server.url), {
-        headers: { Authorization: `Bearer ${plaintext}` },
-      });
-      const unknownResponse = await fetch(new URL('/unknown', server.url));
-      const authorizedUnknownResponse = await fetch(new URL('/unknown', server.url), {
-        headers: { Authorization: `Bearer ${plaintext}` },
-      });
-
-      expect(pingResponse.status).toBe(200);
-      expect(unauthorizedResponse.status).toBe(401);
-      expect(authorizedResponse.status).toBe(200);
-      expect(await authorizedResponse.json()).toEqual({ output: 'UNINITIALIZED' });
-      expect(unknownResponse.status).toBe(401);
-      expect(authorizedUnknownResponse.status).toBe(404);
-    } finally {
-      await server?.stop(true);
       await rm(directory, { recursive: true, force: true });
     }
   });
@@ -165,6 +123,7 @@ describe('routes', () => {
       const plaintext = await loadClientCredential(paths.clientCredentialFile);
       let publishHistory: ((payload: unknown) => void) | undefined;
       const runtime = runningRuntime({
+        mint: { getAllTrustedMints: async () => [] },
         on: (_event: string, listener: (payload: unknown) => void) => {
           publishHistory = listener;
           return () => {};
@@ -175,7 +134,7 @@ describe('routes', () => {
         fetch: buildFallbackHandler(runtime, credentials),
       });
 
-      const normal = await fetch(new URL('/status', server.url), {
+      const normal = await fetch(new URL('/mints/list', server.url), {
         headers: { Authorization: `Bearer ${plaintext}` },
       });
       const unauthorizedStream = await fetch(new URL('/events', server.url));
@@ -186,7 +145,7 @@ describe('routes', () => {
       });
 
       expect(normal.status).toBe(200);
-      expect(await normal.json()).toEqual({ output: 'UNLOCKED' });
+      expect(await normal.json()).toEqual({ output: '' });
       expect(unauthorizedStream.status).toBe(401);
       for (let attempt = 0; attempt < 20 && !publishHistory; attempt++) {
         await Bun.sleep(5);
@@ -219,8 +178,8 @@ describe('routes', () => {
       const runtime = uninitializedRuntime();
       const routes = buildRoutes(createRouteHandlers(runtime), runtime, credentials);
 
-      const response = await routes['/init']!.POST!(
-        new Request('http://localhost/init', {
+      const response = await routes['/receive/cashu']!.POST!(
+        new Request('http://localhost/receive/cashu', {
           method: 'POST',
           headers: { Authorization: `Bearer ${plaintext}` },
           body: '{}',
@@ -255,8 +214,8 @@ describe('routes', () => {
       const routes = buildRoutes(createRouteHandlers(runtime), runtime, credentials, logger);
       const presentedCredential = 'z'.repeat(43);
 
-      const response = await routes['/status']!.GET!(
-        new Request('http://localhost/status', {
+      const response = await routes['/balance']!.GET!(
+        new Request('http://localhost/balance', {
           headers: { Authorization: `Bearer ${presentedCredential}` },
         }),
       );
@@ -282,8 +241,8 @@ describe('routes', () => {
         isAcceptingWork: () => false,
       });
 
-      const response = await routes['/status']!.GET!(
-        new Request('http://localhost/status', {
+      const response = await routes['/balance']!.GET!(
+        new Request('http://localhost/balance', {
           headers: { Authorization: `Bearer ${plaintext}` },
         }),
       );
@@ -294,90 +253,6 @@ describe('routes', () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
-  });
-
-  test('/init validates invalid mnemonic', async () => {
-    const runtime = uninitializedRuntime({
-      initializeWallet: async () => {
-        throw new CocodRuntimeError('invalid_mnemonic', 'Invalid mnemonic');
-      },
-    });
-    const routes = createRouteHandlers(runtime);
-
-    const response = await routes['/init']!.POST!(
-      postJson('/init', { mnemonic: 'invalid mnemonic' }),
-    );
-
-    const body = (await response.json()) as { error?: string };
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Invalid mnemonic');
-  });
-
-  test('/init validates invalid mint URL', async () => {
-    const runtime = uninitializedRuntime({
-      initializeWallet: async () => {
-        throw new CocodRuntimeError('invalid_mint_url', 'Invalid mint URL');
-      },
-    });
-    const routes = createRouteHandlers(runtime);
-
-    const response = await routes['/init']!.POST!(postJson('/init', { mintUrl: 'not a URL' }));
-
-    const body = (await response.json()) as { error?: string };
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Invalid mint URL');
-  });
-
-  test('/init maps concurrent Wallet initialization to a conflict', async () => {
-    const runtime = uninitializedRuntime({
-      initializeWallet: async () => {
-        throw new CocodRuntimeError('wallet_already_configured', 'Wallet already initialized');
-      },
-    });
-    const routes = createRouteHandlers(runtime);
-
-    const response = await routes['/init']!.POST!(postJson('/init', {}));
-
-    const body = (await response.json()) as { error?: string };
-    expect(response.status).toBe(409);
-    expect(body.error).toBe('Wallet already initialized');
-  });
-
-  test('/status reports a quarantined encrypted Session as an error', async () => {
-    const runtime = fakeRuntime({
-      wallet: {
-        configuredAt: '2026-08-16T00:00:00.000Z',
-        mintUrl: 'https://mint.example.com',
-      },
-      seedAccess: { state: 'locked', requiresPassphrase: true },
-      cocoSession: {
-        state: 'failed',
-        startedAt: null,
-        lastFailure: {
-          code: 'session_start_failed',
-          message: 'Coco Session failed to start',
-          occurredAt: '2026-08-16T00:00:01.000Z',
-        },
-      },
-    });
-    const routes = createRouteHandlers(runtime);
-
-    const response = await routes['/status']!.GET!(new Request('http://localhost/status'));
-
-    const body = (await response.json()) as { output?: string };
-    expect(response.status).toBe(200);
-    expect(body.output).toBe('ERROR');
-  });
-
-  test('/unlock requires passphrase', async () => {
-    const runtime = lockedRuntime();
-    const routes = createRouteHandlers(runtime);
-
-    const response = await routes['/unlock']!.POST!(postJson('/unlock', {}));
-
-    const body = (await response.json()) as { error?: string };
-    expect(response.status).toBe(400);
-    expect(body.error).toBe('Passphrase required');
   });
 
   test('/x-cashu/parse requires request field', async () => {

--- a/packages/cocod/src/routes.ts
+++ b/packages/cocod/src/routes.ts
@@ -2,7 +2,7 @@ import { getEncodedToken, type PaymentRequestSpendingConditionRequirement } from
 import { nip19 } from 'nostr-tools';
 
 import { type AdministrativeCredential, type ClientCapability } from './credentials.js';
-import { CocodRuntimeError, type CocodRuntime, type RunningCocoSession } from './runtime.js';
+import { type CocodRuntime, type RunningCocoSession } from './runtime.js';
 import { serializeError } from './utils/logger.js';
 import type { AppLogger } from './utils/logger.js';
 
@@ -16,66 +16,6 @@ export interface RouteDefinition {
 
 export function createRouteHandlers(runtime: CocodRuntime): Record<string, RouteDefinition> {
   const routes: Record<string, RouteDefinition> = {
-    '/ping': {
-      capability: null,
-      GET: async () => Response.json({ output: 'pong' }),
-    },
-    '/status': {
-      capability: 'wallet:read',
-      GET: async () => {
-        return Response.json({ output: legacyStatus(runtime) });
-      },
-    },
-    '/init': {
-      capability: 'wallet:admin',
-      POST: requireUninitialized(runtime, async (req: Request) => {
-        try {
-          const body = (await req.json()) as {
-            mnemonic?: string;
-            passphrase?: string;
-            mintUrl?: string;
-          };
-
-          const result = await runtime.initializeWallet(body);
-          const output = result.requiresPassphrase
-            ? `Initialized (locked). Mnemonic: ${result.mnemonic}\nIMPORTANT: Write down this mnemonic and keep it safe!`
-            : `Initialized. Mnemonic: ${result.mnemonic}\nIMPORTANT: Write down this mnemonic and keep it safe!`;
-
-          return Response.json({ output });
-        } catch (error) {
-          if (
-            error instanceof CocodRuntimeError &&
-            (error.code === 'invalid_mnemonic' || error.code === 'invalid_mint_url')
-          ) {
-            return Response.json({ error: error.message }, { status: 400 });
-          }
-          if (error instanceof CocodRuntimeError && error.code === 'wallet_already_configured') {
-            return Response.json({ error: error.message }, { status: 409 });
-          }
-          const message = error instanceof Error ? error.message : String(error);
-          return Response.json({ error: `Init failed: ${message}` }, { status: 500 });
-        }
-      }),
-    },
-    '/unlock': {
-      capability: 'wallet:admin',
-      POST: requireLocked(runtime, async (req: Request) => {
-        try {
-          const body = (await req.json()) as { passphrase: string };
-
-          if (!body.passphrase) {
-            return Response.json({ error: 'Passphrase required' }, { status: 400 });
-          }
-
-          await runtime.startSession({ passphrase: body.passphrase }).completion;
-
-          return Response.json({ output: 'Unlocked' });
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return Response.json({ error: `Unlock failed: ${message}` }, { status: 401 });
-        }
-      }),
-    },
     '/npc/address': {
       capability: 'wallet:read',
       GET: requireRunning(runtime, async (_req, state: RunningCocoSession) => {
@@ -444,7 +384,10 @@ function requireRunning(
     }
     if (status.seedAccess?.state === 'locked') {
       return Response.json(
-        { error: "Wallet is locked. Run 'cocod unlock <passphrase>' to decrypt." },
+        {
+          error:
+            "Wallet Seed Access is locked. Run 'cocod session start --passphrase <passphrase>'.",
+        },
         { status: 403 },
       );
     }
@@ -458,53 +401,11 @@ function requireRunning(
   };
 }
 
-function requireUninitialized(runtime: CocodRuntime, handler: RouteHandler): RouteHandler {
-  return async (req: Request) => {
-    if (runtime.getStatus().wallet) {
-      return Response.json(
-        { error: 'Wallet already initialized. Delete ~/.cocod/config.json to reset.' },
-        { status: 409 },
-      );
-    }
-    return handler(req);
-  };
-}
-
-function requireLocked(runtime: CocodRuntime, handler: RouteHandler): RouteHandler {
-  return async (req: Request) => {
-    const status = runtime.getStatus();
-    if (!status.wallet) {
-      return walletNotInitializedResponse();
-    }
-    if (status.seedAccess?.state !== 'locked') {
-      return Response.json({ error: 'Wallet is already unlocked' }, { status: 409 });
-    }
-    return handler(req);
-  };
-}
-
 function walletNotInitializedResponse(): Response {
   return Response.json(
-    { error: "Wallet not initialized. Run 'cocod init [mnemonic]' first." },
+    { error: "Wallet not initialized. Run 'cocod wallet initialize' first." },
     { status: 503 },
   );
-}
-
-function legacyStatus(runtime: CocodRuntime): string {
-  const status = runtime.getStatus();
-  if (!status.wallet) {
-    return 'UNINITIALIZED';
-  }
-  if (status.cocoSession.state === 'running') {
-    return 'UNLOCKED';
-  }
-  if (status.cocoSession.state === 'failed') {
-    return 'ERROR';
-  }
-  if (status.seedAccess?.state === 'locked') {
-    return 'LOCKED';
-  }
-  return status.cocoSession.state.toUpperCase();
 }
 
 export function buildRoutes(

--- a/packages/cocod/test/integration/tcp-daemon.test.ts
+++ b/packages/cocod/test/integration/tcp-daemon.test.ts
@@ -183,6 +183,93 @@ test('Wallet initialization sends only a passphrase and prints generated recover
   }
 });
 
+test('Wallet recovery material can be retrieved after initialization response loss', async () => {
+  const home = await temporaryHome();
+  const credential = 'g'.repeat(43);
+  await writeClientCredential(home, credential);
+  const mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+  const requests: Array<{ path: string; authorization: string | null; body?: unknown }> = [];
+  const server = startTcpTestServer({
+    fetch: async (request) => {
+      const path = new URL(request.url).pathname;
+      const body = request.method === 'POST' ? await request.json() : undefined;
+      requests.push({ path, authorization: request.headers.get('authorization'), body });
+      if (path === '/health') {
+        return Response.json({ status: 'ok', interfaceVersion: '1' });
+      }
+      return Response.json({ mnemonic });
+    },
+  });
+  try {
+    const endpoint = `http://127.0.0.1:${server.port}`;
+    const command = spawnCli(home, [
+      '--url',
+      endpoint,
+      'wallet',
+      'recovery-material',
+      '--passphrase',
+      'correct horse',
+    ]);
+
+    expect(await command.exited).toBe(0);
+    const output = await new Response(command.stdout as ReadableStream<Uint8Array>).text();
+    expect(output).toContain('IMPORTANT: Store this Wallet Recovery Material securely');
+    expect(output).toContain(mnemonic);
+    expect(requests).toEqual([
+      { path: '/health', authorization: null, body: undefined },
+      {
+        path: '/v1/admin/wallet/recovery-material',
+        authorization: `Bearer ${credential}`,
+        body: { passphrase: 'correct horse' },
+      },
+    ]);
+  } finally {
+    await server.stop(true);
+  }
+});
+
+test('Coco Session start fails when the accepted transition does not reach running', async () => {
+  const home = await temporaryHome();
+  await writeClientCredential(home, 'e'.repeat(43));
+  const starting = lifecycleStatus('starting');
+  const failed = {
+    ...lifecycleStatus('stopped'),
+    cocoSession: {
+      state: 'stopped' as const,
+      startedAt: null,
+      lastFailure: {
+        code: 'session_start_failed',
+        message: 'Coco Session failed to start',
+        occurredAt: '2026-08-19T00:00:01.000Z',
+      },
+    },
+  };
+  const server = startTcpTestServer({
+    fetch: (request) => {
+      const path = new URL(request.url).pathname;
+      if (path === '/health') {
+        return Response.json({ status: 'ok', interfaceVersion: '1' });
+      }
+      if (path === '/v1/admin/session/start') {
+        return Response.json(starting, { status: 202 });
+      }
+      return Response.json(failed);
+    },
+  });
+  try {
+    const endpoint = `http://127.0.0.1:${server.port}`;
+    const command = spawnCli(home, ['--url', endpoint, 'session', 'start']);
+
+    expect(await command.exited).toBe(1);
+    const error = await new Response(command.stderr as ReadableStream<Uint8Array>).text();
+    expect(error).toContain('Coco Session did not reach running');
+    expect(error).toContain('session_start_failed');
+  } finally {
+    await server.stop(true);
+  }
+});
+
 test('a TCP bind failure exits clearly without replacing the active listener', async () => {
   const home = await temporaryHome();
   const blocker = startTcpTestServer({
@@ -255,6 +342,15 @@ async function writeClientCredential(home: string, credential: string): Promise<
   const directory = join(home, '.cocod', 'credentials', 'current');
   await mkdir(directory, { recursive: true, mode: 0o700 });
   await writeFile(join(directory, 'client'), `${credential}\n`, { mode: 0o600 });
+}
+
+function lifecycleStatus(state: 'stopped' | 'starting') {
+  return {
+    daemon: { version: '0.0.17', interfaceVersion: '1' as const },
+    wallet: { configuredAt: '2026-08-19T00:00:00.000Z' },
+    seedAccess: { state: 'available' as const, requiresPassphrase: false },
+    cocoSession: { state, startedAt: null, lastFailure: null },
+  };
 }
 
 function spawnDaemon(home: string, port: number, hostname: string): Bun.Subprocess {

--- a/packages/cocod/test/integration/tcp-daemon.test.ts
+++ b/packages/cocod/test/integration/tcp-daemon.test.ts
@@ -41,9 +41,9 @@ test('the implicit local default auto-starts and stops through the shared TCP re
   const command = spawnCli(home, ['status'], environment);
 
   expect(await command.exited).toBe(0);
-  expect(await new Response(command.stdout as ReadableStream<Uint8Array>).text()).toContain(
-    'UNINITIALIZED',
-  );
+  const output = await new Response(command.stdout as ReadableStream<Uint8Array>).text();
+  expect(output).toContain('"wallet": null');
+  expect(output).toContain('"state": "stopped"');
   expect((await waitForHealth(DEFAULT_CLIENT_URL)).status).toBe(200);
 
   const pid = Number(await readFile(join(home, '.cocod', 'cocod.pid'), 'utf8'));
@@ -73,7 +73,9 @@ test.each([
 
 test('COCOD_URL selects client-only mode and never auto-starts a process', async () => {
   const home = await temporaryHome();
-  const reservation = startTcpTestServer({ fetch: () => Response.json({ output: 'pong' }) });
+  const reservation = startTcpTestServer({
+    fetch: () => Response.json({ status: 'ok', interfaceVersion: '1' }),
+  });
   const endpoint = `http://127.0.0.1:${reservation.port}`;
   try {
     const command = spawnCli(home, ['status'], { COCOD_URL: endpoint });
@@ -104,9 +106,7 @@ test('one explicitly configured TCP listener serves local and remote authenticat
     join(home, '.cocod', 'credentials', 'current', 'client'),
   );
   const headers = { Authorization: `Bearer ${credential}` };
-  const legacyStatus = await fetch(`${endpoint}/status`, { headers });
   const v1Status = await fetch(`${endpoint}/v1/status`, { headers });
-  expect(await legacyStatus.json()).toEqual({ output: 'UNINITIALIZED' });
   expect(v1Status.status).toBe(200);
   expect(await v1Status.json()).toMatchObject({
     wallet: null,
@@ -120,6 +120,67 @@ test('one explicitly configured TCP listener serves local and remote authenticat
 
   const stateEntries = await readdir(join(home, '.cocod'));
   expect(stateEntries.some((entry) => entry.endsWith('.sock'))).toBeFalse();
+});
+
+test('Wallet initialization sends only a passphrase and prints generated recovery material', async () => {
+  const home = await temporaryHome();
+  const credential = 'd'.repeat(43);
+  await writeClientCredential(home, credential);
+  const requests: Array<{ path: string; authorization: string | null; body?: unknown }> = [];
+  const mnemonic =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+  const server = startTcpTestServer({
+    fetch: async (request) => {
+      const path = new URL(request.url).pathname;
+      const body = request.method === 'POST' ? await request.json() : undefined;
+      requests.push({
+        path,
+        authorization: request.headers.get('authorization'),
+        body,
+      });
+      if (path === '/health') {
+        return Response.json({ status: 'ok', interfaceVersion: '1' });
+      }
+      return Response.json(
+        {
+          generatedMnemonic: mnemonic,
+          status: {
+            daemon: { version: '0.0.17', interfaceVersion: '1' },
+            wallet: { configuredAt: '2026-08-19T00:00:00.000Z' },
+            seedAccess: { state: 'locked', requiresPassphrase: true },
+            cocoSession: { state: 'stopped', startedAt: null, lastFailure: null },
+          },
+        },
+        { status: 201 },
+      );
+    },
+  });
+  try {
+    const endpoint = `http://127.0.0.1:${server.port}`;
+    const command = spawnCli(home, [
+      '--url',
+      endpoint,
+      'wallet',
+      'initialize',
+      '--passphrase',
+      'correct horse',
+    ]);
+
+    expect(await command.exited).toBe(0);
+    const output = await new Response(command.stdout as ReadableStream<Uint8Array>).text();
+    expect(output).toContain('IMPORTANT: Store this Wallet Recovery Material securely');
+    expect(output).toContain(mnemonic);
+    expect(requests).toEqual([
+      { path: '/health', authorization: null, body: undefined },
+      {
+        path: '/v1/admin/wallet/initialize',
+        authorization: `Bearer ${credential}`,
+        body: { passphrase: 'correct horse' },
+      },
+    ]);
+  } finally {
+    await server.stop(true);
+  }
 });
 
 test('a TCP bind failure exits clearly without replacing the active listener', async () => {
@@ -188,6 +249,12 @@ async function temporaryHome(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'cocod-tcp-daemon-'));
   directories.push(directory);
   return directory;
+}
+
+async function writeClientCredential(home: string, credential: string): Promise<void> {
+  const directory = join(home, '.cocod', 'credentials', 'current');
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await writeFile(join(directory, 'client'), `${credential}\n`, { mode: 0o600 });
 }
 
 function spawnDaemon(home: string, port: number, hostname: string): Bun.Subprocess {

--- a/packages/cocod/test/integration/v1-http.test.ts
+++ b/packages/cocod/test/integration/v1-http.test.ts
@@ -29,7 +29,7 @@ afterEach(async () => {
   );
 });
 
-test('serves public health and authenticated structured status beside legacy routes', async () => {
+test('serves public health and authenticated structured status beside operational legacy routes', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'cocod-v1-listener-'));
   directories.push(directory);
   const credentialDirectory = join(directory, 'credentials');
@@ -119,7 +119,6 @@ test('serves public health and authenticated structured status beside legacy rou
   const unauthenticated = await tcpFetch(server, '/v1/status');
   const status = await tcpFetch(server, '/v1/status', plaintext);
   const unknown = await tcpFetch(server, '/v1/unknown', plaintext);
-  const legacy = await tcpFetch(server, '/status', plaintext);
 
   expect(health.status).toBe(200);
   expect(await health.json()).toEqual({ status: 'ok', interfaceVersion: '1' });
@@ -149,7 +148,6 @@ test('serves public health and authenticated structured status beside legacy rou
       retryable: false,
     },
   });
-  expect(await legacy.json()).toEqual({ output: 'UNINITIALIZED' });
 
   const initialize = await tcpFetch(
     server,


### PR DESCRIPTION
## Problem

The daemon implements structured v1 lifecycle resources, but the CLI still depended on the legacy `/ping`, `/status`, `/init`, and `/unlock` routes and their combined wallet-readiness model.

## Summary

- add a typed v1 client with validated responses and structured errors
- introduce `health`, `wallet initialize`, `session start`, and `session stop`
- keep top-level `stop` distinct as Cocod Process shutdown
- separate Cocod Process reachability from Coco Session readiness
- remove the four superseded HTTP routes and obsolete contract coverage
- update CLI help, README, API documentation, and cocod skill guidance
- preserve the remaining authenticated operational legacy routes

Compatibility note: the old CLI command names and HTTP routes are intentionally removed.

## Verification

- `bun run --filter='cocod' test` — 125 tests passed
- `bun test packages/cocod/src/cli-shared.test.ts` — 9 focused tests passed
- `bun run --filter='cocod' typecheck`
- `bun run --filter='cocod' check:interface`
- Prettier and `git diff --check`

No changeset was added because `cocod` is a private package.