### PR TITLE
fix: rehydrate persisted melt change amounts

### DIFF
--- a/.changeset/calm-melt-change.md
+++ b/.changeset/calm-melt-change.md
@@ -1,0 +1,12 @@
+---
+'@cashu/coco-core': patch
+'@cashu/coco-adapter-tests': patch
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-sql-storage': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+---
+
+Restore `Amount` instances when persisted melt change signatures are loaded by SQL and IndexedDB
+adapters, including change stored by earlier IndexedDB releases.

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -1305,6 +1305,36 @@ export async function runMeltQuoteRepositoryContract(
       }
     });
 
+    it('rehydrates cached melt change signature amounts', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const quote = createDummyMeltQuote({
+          quoteId: 'paid-melt-with-change',
+          quote: 'paid-melt-with-change',
+          state: 'PAID',
+          change: [
+            {
+              id: 'keyset-1',
+              amount: Amount.from(2),
+              C_: '02'.padEnd(66, '1'),
+            },
+          ],
+        });
+
+        await repositories.meltQuoteRepository.upsertMeltQuote(quote);
+        const stored = await repositories.meltQuoteRepository.getMeltQuote(
+          quote.mintUrl,
+          quote.method,
+          quote.quoteId,
+        );
+
+        expect(stored?.change).toHaveLength(1);
+        expect(stored?.change?.[0]?.amount.equals(Amount.from(2))).toBe(true);
+      } finally {
+        await dispose();
+      }
+    });
+
     it('looks up canonical melt quotes by identity without method', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {

--- a/packages/core/adapter.ts
+++ b/packages/core/adapter.ts
@@ -80,14 +80,21 @@ export type { BalanceQuery, CoreProof, ProofState } from './types.ts';
 export { DEFAULT_UNIT, normalizeUnit } from './amounts.ts';
 export {
   deserializeAmount,
+  deserializeBlindedSignatures,
   deserializeOutput,
   deserializeOutputData,
   deserializeToken,
   getSecretsFromSerializedOutputData,
   normalizeMintUrl,
   serializeAmount,
+  serializeBlindedSignatures,
   serializeOutput,
   serializeOutputData,
   stringifyJson,
 } from './utils.ts';
-export type { SerializedOutput, SerializedOutputData, StoredBlindedMessage } from './utils.ts';
+export type {
+  SerializedOutput,
+  SerializedOutputData,
+  StoredBlindedMessage,
+  StoredBlindedSignature,
+} from './utils.ts';

--- a/packages/core/utils.ts
+++ b/packages/core/utils.ts
@@ -5,6 +5,7 @@ import {
   type AmountLike,
   type OutputDataLike,
   type Proof,
+  type SerializedBlindedSignature,
   type Token,
 } from '@cashu/cashu-ts';
 import type { CoreProof, ProofState } from './types';
@@ -47,6 +48,13 @@ export interface ProofStateInput {
   id: string;
   secret: string;
 }
+
+/**
+ * JSON-safe form of a blinded signature for repository persistence.
+ */
+export type StoredBlindedSignature = Omit<SerializedBlindedSignature, 'amount'> & {
+  amount: string;
+};
 
 // ============================================================================
 // OutputData Serialization Functions
@@ -201,6 +209,68 @@ export function stringifyJson(value: unknown): string {
 
 export function deserializeAmount(value: string | number | bigint | Amount): Amount {
   return Amount.from(value);
+}
+
+function deserializeStoredAmount(value: unknown): Amount {
+  if (
+    value instanceof Amount ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'bigint'
+  ) {
+    return deserializeAmount(value);
+  }
+
+  // IndexedDB structured cloning removed the Amount prototype from legacy rows while retaining
+  // its private TypeScript field as an own property.
+  if (value && typeof value === 'object' && 'value' in value) {
+    const legacyValue = (value as { value: unknown }).value;
+    if (
+      typeof legacyValue === 'string' ||
+      typeof legacyValue === 'number' ||
+      typeof legacyValue === 'bigint'
+    ) {
+      return deserializeAmount(legacyValue);
+    }
+  }
+
+  throw new TypeError('Stored amount is invalid');
+}
+
+/**
+ * Convert blinded signatures to a repository-safe form.
+ */
+export function serializeBlindedSignatures(
+  signatures: SerializedBlindedSignature[] | undefined,
+): StoredBlindedSignature[] | undefined {
+  return signatures?.map((signature) => ({
+    ...signature,
+    amount: serializeAmount(signature.amount),
+  }));
+}
+
+/**
+ * Restore blinded signature Amount instances after repository hydration.
+ */
+export function deserializeBlindedSignatures(
+  value: unknown,
+): SerializedBlindedSignature[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new TypeError('Stored blinded signatures must be an array');
+  }
+
+  return value.map((signature, index) => {
+    if (!signature || typeof signature !== 'object' || !('amount' in signature)) {
+      throw new TypeError(`Stored blinded signature ${index} is invalid`);
+    }
+    return {
+      ...(signature as Omit<SerializedBlindedSignature, 'amount'>),
+      amount: deserializeStoredAmount((signature as { amount: unknown }).amount),
+    };
+  });
 }
 
 export function deserializeToken(value: unknown): Token | undefined {

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -1,5 +1,5 @@
 import Dexie, { type Transaction as DexieTransaction } from 'dexie';
-import type { SerializedBlindedSignature } from '@cashu/cashu-ts';
+import type { StoredBlindedSignature } from '@cashu/coco-core/adapter';
 
 export interface IdbDbOptions {
   name?: string;
@@ -182,7 +182,7 @@ export interface MeltQuoteRow {
   fee_options?: { fee_index: number; fee_reserve: string | number; estimated_blocks: number }[];
   outpoint?: string | null;
   payment_preimage?: string | null;
-  change?: SerializedBlindedSignature[];
+  change?: StoredBlindedSignature[];
   lastObservedRemoteState?: 'UNPAID' | 'PENDING' | 'PAID' | null;
   lastObservedRemoteStateAt?: number | null;
   createdAt: number;

--- a/packages/indexeddb/src/repositories/MeltQuoteRepository.ts
+++ b/packages/indexeddb/src/repositories/MeltQuoteRepository.ts
@@ -1,9 +1,11 @@
 import type { MeltQuoteRepository } from '@cashu/coco-core/adapter';
 import {
   deserializeAmount,
+  deserializeBlindedSignatures,
   normalizeMintUrl,
   QuoteIdentityConflictError,
   serializeAmount,
+  serializeBlindedSignatures,
 } from '@cashu/coco-core/adapter';
 import type { MeltQuote } from '@cashu/coco-core/adapter';
 import type { QuoteIdentity } from '@cashu/coco-core/adapter';
@@ -20,7 +22,7 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
     amount: deserializeAmount(row.amount),
     unit: row.unit,
     expiry: row.expiry,
-    change: row.change ?? undefined,
+    change: deserializeBlindedSignatures(row.change),
     lastObservedRemoteState: row.lastObservedRemoteState ?? undefined,
     lastObservedRemoteStateAt: row.lastObservedRemoteStateAt ?? undefined,
     createdAt: row.createdAt,
@@ -120,7 +122,7 @@ export class IdbMeltQuoteRepository implements MeltQuoteRepository {
       outpoint: quote.method === 'onchain' ? (quote.outpoint ?? null) : null,
       expiry: quote.expiry,
       payment_preimage: quote.method === 'onchain' ? null : (quote.payment_preimage ?? null),
-      change: quote.change,
+      change: serializeBlindedSignatures(quote.change),
       lastObservedRemoteState: quote.lastObservedRemoteState ?? quote.state,
       lastObservedRemoteStateAt: quote.lastObservedRemoteStateAt ?? now,
       createdAt: existing?.createdAt ?? quote.createdAt,

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { Amount } from '@cashu/cashu-ts';
 import Dexie from 'dexie';
 import {
   runRepositoryTransactionContract,
@@ -422,6 +423,46 @@ describe('indexeddb quote storage constraints', () => {
 });
 
 describe('hydration corruption guard', () => {
+  it('rehydrates legacy melt change amounts that lost their prototype', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await repositories.db.table('coco_cashu_melt_quotes').put({
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+        quoteId: 'legacy-change-amount',
+        quote: 'legacy-change-amount',
+        state: 'PAID',
+        request: 'bolt11-request',
+        amount: '10',
+        unit: 'sat',
+        fee_reserve: '1',
+        expiry: 0,
+        payment_preimage: 'preimage',
+        change: [
+          {
+            id: 'keyset-1',
+            amount: { value: 2n },
+            C_: '02'.padEnd(66, '1'),
+          },
+        ],
+        lastObservedRemoteState: 'PAID',
+        lastObservedRemoteStateAt: 0,
+        createdAt: 0,
+        updatedAt: 0,
+      });
+
+      const stored = await repositories.meltQuoteRepository.getMeltQuote(
+        'https://mint.test',
+        'bolt11',
+        'legacy-change-amount',
+      );
+
+      expect(stored?.change?.[0]?.amount.equals(Amount.from(2))).toBe(true);
+    } finally {
+      await dispose();
+    }
+  });
+
   it('throws when send operation has prepared state but null financial fields', async () => {
     const { repositories, dispose } = await createRepositories();
     try {

--- a/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
+++ b/packages/sql-storage/src/repositories/MeltQuoteRepository.ts
@@ -1,8 +1,10 @@
 import {
   deserializeAmount,
+  deserializeBlindedSignatures,
   normalizeMintUrl,
   QuoteIdentityConflictError,
   serializeAmount,
+  serializeBlindedSignatures,
   stringifyJson,
   type MeltQuote,
   type MeltQuoteRepository,
@@ -41,7 +43,7 @@ function rowToQuote(row: MeltQuoteRow): MeltQuote {
     amount: deserializeAmount(row.amount),
     unit: row.unit,
     expiry: row.expiry,
-    change: row.changeJson ? JSON.parse(row.changeJson) : undefined,
+    change: row.changeJson ? deserializeBlindedSignatures(JSON.parse(row.changeJson)) : undefined,
     lastObservedRemoteState: (row.lastObservedRemoteState ?? undefined) as
       | MeltQuote['state']
       | undefined,
@@ -151,7 +153,7 @@ export class SqliteMeltQuoteRepository implements MeltQuoteRepository {
             )
           : null,
       outpoint: quote.method === 'onchain' ? (quote.outpoint ?? null) : null,
-      changeJson: quote.change ? stringifyJson(quote.change) : null,
+      changeJson: quote.change ? stringifyJson(serializeBlindedSignatures(quote.change)) : null,
       lastObservedRemoteState: quote.lastObservedRemoteState ?? quote.state,
       lastObservedRemoteStateAt: quote.lastObservedRemoteStateAt ?? now,
       createdAt: quote.createdAt,


### PR DESCRIPTION
## Problem

Persisted melt change signatures lost their `Amount` instances when SQL or IndexedDB loaded the
canonical Melt Quote row. Operation Recovery could then receive strings or plain objects instead of
`Amount` values and fail while it finalized a paid melt.

This issue was found by Project Loupe.

## Summary

- serialize blinded signature amounts to decimal strings and restore `Amount` instances on load
- support IndexedDB rows that already contain the legacy structured-clone amount shape
- add shared repository contract coverage for every adapter and an IndexedDB compatibility test
- add a patch changeset for the affected packages

## Verification

- `bun run build`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/adapter-tests typecheck`
- `bun run --cwd packages/sql-storage typecheck`
- `bun run --cwd packages/indexeddb typecheck`
- `bun run --filter='@cashu/coco-sqlite' test -- src/test/contract.test.ts`
- `bun run --filter='@cashu/coco-sqlite-bun' test -- src/test/contract.test.ts`
- `bun --cwd packages/expo-sqlite test src/test/contract.test.ts`
- `bun run --cwd packages/indexeddb test:browser -- src/test/contract.test.ts`
