### PR TITLE
feat(core): enforce strong wallet repository transactions

### DIFF
--- a/.changeset/strong-wallet-transactions.md
+++ b/.changeset/strong-wallet-transactions.md
@@ -1,0 +1,14 @@
+---
+'@cashu/coco-core': minor
+'@cashu/coco-adapter-tests': minor
+'@cashu/coco-sql-storage': patch
+'@cashu/coco-sqlite': patch
+'@cashu/coco-sqlite-bun': patch
+'@cashu/coco-expo-sqlite': patch
+'@cashu/coco-indexeddb': patch
+---
+
+Establish one strong Wallet repository transaction scope across memory, SQLite, Expo SQLite, and
+IndexedDB adapters. Transactions now provide atomic commit and rollback, isolate concurrent work,
+acquire SQLite writer ownership before callback reads, and report transient adapter contention with
+`RepositoryTransactionConflictError` while preserving callback failures unchanged.

--- a/.changeset/strong-wallet-transactions.md
+++ b/.changeset/strong-wallet-transactions.md
@@ -10,5 +10,6 @@
 
 Establish one strong Wallet repository transaction scope across memory, SQLite, Expo SQLite, and
 IndexedDB adapters. Transactions now provide atomic commit and rollback, isolate concurrent work,
-acquire SQLite writer ownership before callback reads, and report transient adapter contention with
-`RepositoryTransactionConflictError` while preserving callback failures unchanged.
+include keypair allocation in the scoped repository foundation, acquire SQLite writer ownership
+before callback reads, reject nested IndexedDB strong scopes, and report transient adapter
+contention with `RepositoryTransactionConflictError` while preserving callback failures unchanged.

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
   },
   "scripts": {
     "build": "bun scripts/build.ts build",
+    "build:test:core": "bun run --filter='@cashu/coco-core' build && bun run --filter='@cashu/coco-adapter-tests' build",
     "typecheck": "bun scripts/build.ts typecheck",
-    "test:coverage:core": "bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
+    "test:coverage:core": "bun run build:test:core && bun test packages/core/test/unit --coverage --coverage-reporter=lcov --coverage-dir=coverage/core",
     "docs:dev": "vitepress dev packages/docs",
     "docs:build": "vitepress build packages/docs",
     "docs:preview": "vitepress preview packages/docs",

--- a/packages/adapter-tests/README.md
+++ b/packages/adapter-tests/README.md
@@ -64,8 +64,20 @@ runKeyRingDerivationRepositoryContract(
 The factory is responsible for providing a fresh, isolated repositories
 instance for every test and for cleaning up via `dispose()`.
 
+Transaction contract options:
+
+- `createSharedRepositories` supplies two independent roots for one physical store and enables
+  cross-root writer contention coverage.
+- `createIsolationRepositories` supplies independent transaction/root-operation actors when an
+  adapter's ambient transaction context cannot represent a concurrent same-root call.
+- `holdTransactionOpen` adapts the release promise for stores such as IndexedDB that otherwise
+  auto-close a transaction while the contract deliberately holds it open.
+- `testConcurrentRootOperationIsolation` enables root-operation isolation cases.
+- `testWriterOwnershipAtEntry` verifies that a conflicting writer either waits or reports a typed
+  transient conflict before its callback runs. It requires `createSharedRepositories`.
+
 - `runRepositoryTransactionContract()` verifies transactional behavior across the
-  repository set.
+  repository set, including scoped keypair allocation.
 - `runKeyRingDerivationRepositoryContract()` verifies purpose isolation, concurrency,
   transactional rollback, committed-key deletion behavior, exhaustion, and—when
   `createSharedRepositories` is supplied—coordination between independent roots sharing one

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -20,6 +20,7 @@ import {
   type KeyRingRepository,
   DerivationIndexExhaustedError,
   QuoteIdentityConflictError,
+  RepositoryTransactionConflictError,
 } from '@cashu/coco-core/adapter';
 
 type TransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
@@ -27,18 +28,23 @@ type TransactionFactory<TRepositories extends Repositories = Repositories> = () 
   dispose(): Promise<void>;
 }>;
 
+type SharedTransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
+  first: TRepositories;
+  second: TRepositories;
+  dispose(): Promise<void>;
+}>;
+
 type ContractOptions<TRepositories extends Repositories = Repositories> = {
   createRepositories: TransactionFactory<TRepositories>;
+  createSharedRepositories?: SharedTransactionFactory<TRepositories>;
+  holdTransactionOpen?: (release: Promise<void>) => Promise<void>;
   testConcurrentRootOperationIsolation?: boolean;
+  testWriterOwnershipAtEntry?: boolean;
 };
 
 export type KeyRingDerivationContractOptions<TRepositories extends Repositories = Repositories> = {
   createRepositories: TransactionFactory<TRepositories>;
-  createSharedRepositories?: () => Promise<{
-    first: TRepositories;
-    second: TRepositories;
-    dispose(): Promise<void>;
-  }>;
+  createSharedRepositories?: SharedTransactionFactory<TRepositories>;
 };
 
 function sortedIndexes(indexes: number[]): number[] {
@@ -253,18 +259,85 @@ export async function runRepositoryTransactionContract(
         await expectThrows(async () => {
           await repositories.withTransaction(async (tx) => {
             await tx.mintRepository.addOrUpdateMint(createDummyMint());
+            await tx.keysetRepository.addKeyset(createDummyKeyset());
+            await tx.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
+            await tx.meltOperationRepository.create(createDummyMeltOperation());
             throw new Error('boom');
           });
         }, expect);
 
         const mints = await repositories.mintRepository.getAllMints();
         expect(mints.length).toBe(0);
+        const keysets =
+          await repositories.keysetRepository.getKeysetsByMintUrl('https://mint.test');
+        expect(keysets.length).toBe(0);
+        const proofs = await repositories.proofRepository.getAllReadyProofs();
+        expect(proofs.length).toBe(0);
+        const operation = await repositories.meltOperationRepository.getById('melt-op');
+        expect(operation).toBe(null);
+      } finally {
+        await dispose();
+      }
+    });
+
+    it('preserves callback failures as non-conflict errors', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      const invariantError = new Error('database is locked by a domain invariant');
+      try {
+        let thrown: unknown;
+        try {
+          await repositories.withTransaction(async () => {
+            throw invariantError;
+          });
+        } catch (error) {
+          thrown = error;
+        }
+
+        expect(thrown).toBe(invariantError);
+        expect(thrown instanceof RepositoryTransactionConflictError).toBe(false);
       } finally {
         await dispose();
       }
     });
 
     if (options.testConcurrentRootOperationIsolation) {
+      it('does not expose writes from an active transaction that rolls back', async () => {
+        const { repositories, dispose } = await options.createRepositories();
+        const transactionEntered = createDeferred();
+        const releaseTransaction = createDeferred();
+        try {
+          const stagedMint = {
+            ...createDummyMint(),
+            mintUrl: 'https://staged-mint.test',
+          };
+          const transactionOutcomePromise = settle(
+            repositories.withTransaction(async (tx) => {
+              await tx.mintRepository.addOrUpdateMint(stagedMint);
+              transactionEntered.resolve();
+              await (options.holdTransactionOpen?.(releaseTransaction.promise) ??
+                releaseTransaction.promise);
+              throw new Error('rollback staged mint');
+            }),
+          );
+          await transactionEntered.promise;
+
+          const rootReadPromise = repositories.mintRepository.getAllMints();
+          releaseTransaction.resolve();
+          const [transactionOutcome, observedMints] = await Promise.all([
+            transactionOutcomePromise,
+            rootReadPromise,
+          ]);
+          expect(transactionOutcome.status).toBe('rejected');
+          expect(observedMints.some((mint) => mint.mintUrl === stagedMint.mintUrl)).toBe(false);
+
+          const storedMints = await repositories.mintRepository.getAllMints();
+          expect(storedMints.some((mint) => mint.mintUrl === stagedMint.mintUrl)).toBe(false);
+        } finally {
+          releaseTransaction.resolve();
+          await dispose();
+        }
+      });
+
       it('does not include concurrent root repository writes in active transactions', async () => {
         const { repositories, dispose } = await options.createRepositories();
         try {
@@ -279,36 +352,171 @@ export async function runRepositoryTransactionContract(
             mintUrl: 'https://outside-mint.test',
           };
 
-          const transactionPromise = repositories.withTransaction(async (tx) => {
-            await tx.mintRepository.addOrUpdateMint(mintInTransaction);
-            transactionEntered.resolve();
-            await releaseTransaction.promise;
-            throw new Error('rollback transaction');
-          });
+          const transactionOutcomePromise = settle(
+            repositories.withTransaction(async (tx) => {
+              await tx.mintRepository.addOrUpdateMint(mintInTransaction);
+              transactionEntered.resolve();
+              await (options.holdTransactionOpen?.(releaseTransaction.promise) ??
+                releaseTransaction.promise);
+              throw new Error('rollback transaction');
+            }),
+          );
 
           await transactionEntered.promise;
 
-          let outsideWriteResolved = false;
-          const outsideWritePromise = repositories.mintRepository
-            .addOrUpdateMint(outsideMint)
-            .then(() => {
-              outsideWriteResolved = true;
-            });
-
-          await Promise.race([
-            outsideWritePromise,
-            new Promise((resolve) => setTimeout(resolve, 25)),
-          ]);
-          expect(outsideWriteResolved).toBe(false);
+          const outsideWritePromise = repositories.mintRepository.addOrUpdateMint(outsideMint);
 
           releaseTransaction.resolve();
-          await expectThrows(() => transactionPromise, expect);
-          await outsideWritePromise;
+          const [transactionOutcome] = await Promise.all([
+            transactionOutcomePromise,
+            outsideWritePromise,
+          ]);
+          expect(transactionOutcome.status).toBe('rejected');
 
           const mints = await repositories.mintRepository.getAllMints();
           expect(mints).toHaveLength(1);
           expect(mints[0]?.mintUrl).toBe(outsideMint.mintUrl);
         } finally {
+          await dispose();
+        }
+      });
+
+      it('does not clobber concurrent root writes when a transaction commits', async () => {
+        const { repositories, dispose } = await options.createRepositories();
+        const transactionEntered = createDeferred();
+        const releaseTransaction = createDeferred();
+        try {
+          const mintInTransaction = {
+            ...createDummyMint(),
+            mintUrl: 'https://committed-transaction-mint.test',
+          };
+          const outsideMint = {
+            ...createDummyMint(),
+            mintUrl: 'https://outside-committed-transaction.test',
+          };
+
+          const transactionPromise = repositories.withTransaction(async (tx) => {
+            await tx.mintRepository.addOrUpdateMint(mintInTransaction);
+            transactionEntered.resolve();
+            await (options.holdTransactionOpen?.(releaseTransaction.promise) ??
+              releaseTransaction.promise);
+          });
+          await transactionEntered.promise;
+
+          const outsideWritePromise = repositories.mintRepository.addOrUpdateMint(outsideMint);
+          releaseTransaction.resolve();
+          await Promise.all([transactionPromise, outsideWritePromise]);
+
+          const mints = await repositories.mintRepository.getAllMints();
+          expect(mints).toHaveLength(2);
+          expect(mints.some((mint) => mint.mintUrl === mintInTransaction.mintUrl)).toBe(true);
+          expect(mints.some((mint) => mint.mintUrl === outsideMint.mintUrl)).toBe(true);
+        } finally {
+          releaseTransaction.resolve();
+          await dispose();
+        }
+      });
+    }
+
+    if (options.createSharedRepositories) {
+      it('serializes or reports typed conflicts for concurrent Wallet writers', async () => {
+        const { first, second, dispose } = await options.createSharedRepositories!();
+        try {
+          const mintUrl = 'https://transaction-contention.test';
+          const keysetId = 'contention-keyset';
+          await first.counterRepository.setCounter(mintUrl, keysetId, 0);
+
+          const increment = (repositories: Repositories) =>
+            settle(
+              repositories.withTransaction(async (tx) => {
+                const current = await tx.counterRepository.getCounter(mintUrl, keysetId);
+                await tx.counterRepository.setCounter(
+                  mintUrl,
+                  keysetId,
+                  (current?.counter ?? 0) + 1,
+                );
+              }),
+            );
+
+          const outcomes = await Promise.all([increment(first), increment(second)]);
+          const fulfilledCount = outcomes.filter(
+            (outcome) => outcome.status === 'fulfilled',
+          ).length;
+          expect(fulfilledCount > 0).toBe(true);
+          for (const outcome of outcomes) {
+            if (outcome.status === 'rejected') {
+              expect(outcome.reason instanceof RepositoryTransactionConflictError).toBe(true);
+            }
+          }
+
+          const counter = await first.counterRepository.getCounter(mintUrl, keysetId);
+          expect(counter?.counter).toBe(fulfilledCount);
+        } finally {
+          await dispose();
+        }
+      });
+    }
+
+    if (options.createSharedRepositories && options.testWriterOwnershipAtEntry) {
+      it('acquires write ownership before entering a conflicting callback', async () => {
+        const { first, second, dispose } = await options.createSharedRepositories!();
+        const releaseFirst = createDeferred();
+        try {
+          const firstEntered = createDeferred();
+          const firstMint = {
+            ...createDummyMint(),
+            mintUrl: 'https://first-writer.test',
+          };
+          const secondMint = {
+            ...createDummyMint(),
+            mintUrl: 'https://second-writer.test',
+          };
+
+          const firstOutcomePromise = settle(
+            first.withTransaction(async (tx) => {
+              await tx.mintRepository.addOrUpdateMint(firstMint);
+              firstEntered.resolve();
+              await releaseFirst.promise;
+            }),
+          );
+          await firstEntered.promise;
+
+          const secondEntered = createDeferred();
+          const secondOutcomePromise = settle(
+            second.withTransaction(async (tx) => {
+              secondEntered.resolve();
+              await tx.mintRepository.addOrUpdateMint(secondMint);
+            }),
+          );
+
+          const acquisitionOutcome = await Promise.race([
+            secondEntered.promise.then(() => 'callback-entered' as const),
+            secondOutcomePromise.then(() => 'transaction-settled' as const),
+          ]);
+          expect(acquisitionOutcome).toBe('transaction-settled');
+
+          releaseFirst.resolve();
+          const [firstOutcome, secondOutcome] = await Promise.all([
+            firstOutcomePromise,
+            secondOutcomePromise,
+          ]);
+          expect(firstOutcome.status).toBe('fulfilled');
+          if (secondOutcome.status === 'rejected') {
+            expect(secondOutcome.reason instanceof RepositoryTransactionConflictError).toBe(true);
+            expect(
+              secondOutcome.reason instanceof RepositoryTransactionConflictError
+                ? secondOutcome.reason.transient
+                : false,
+            ).toBe(true);
+          }
+
+          const mints = await first.mintRepository.getAllMints();
+          expect(mints.some((mint) => mint.mintUrl === firstMint.mintUrl)).toBe(true);
+          expect(mints.some((mint) => mint.mintUrl === secondMint.mintUrl)).toBe(
+            secondOutcome.status === 'fulfilled',
+          );
+        } finally {
+          releaseFirst.resolve();
           await dispose();
         }
       });
@@ -379,6 +587,13 @@ function createDeferred<T = void>() {
     reject = rej;
   });
   return { promise, resolve, reject } as const;
+}
+
+function settle<T>(promise: Promise<T>) {
+  return promise.then(
+    (value) => ({ status: 'fulfilled' as const, value }),
+    (reason: unknown) => ({ status: 'rejected' as const, reason }),
+  );
 }
 
 export function createDummyMint(): Mint {

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -23,22 +23,33 @@ import {
   RepositoryTransactionConflictError,
 } from '@cashu/coco-core/adapter';
 
-type TransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
+/** Creates one initialized, isolated repository root for a contract test. */
+export type TransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
   repositories: TRepositories;
   dispose(): Promise<void>;
 }>;
 
-type SharedTransactionFactory<TRepositories extends Repositories = Repositories> = () => Promise<{
-  first: TRepositories;
-  second: TRepositories;
-  dispose(): Promise<void>;
-}>;
+/** Creates two independent repository roots backed by the same physical Wallet store. */
+export type SharedTransactionFactory<TRepositories extends Repositories = Repositories> =
+  () => Promise<{
+    first: TRepositories;
+    second: TRepositories;
+    dispose(): Promise<void>;
+  }>;
 
-type ContractOptions<TRepositories extends Repositories = Repositories> = {
+/** Configuration shared by repository adapter contract suites. */
+export type ContractOptions<TRepositories extends Repositories = Repositories> = {
+  /** Creates a fresh repository root for each contract case. */
   createRepositories: TransactionFactory<TRepositories>;
+  /** Enables cross-root concurrency cases against one physical Wallet store. */
   createSharedRepositories?: SharedTransactionFactory<TRepositories>;
+  /** Supplies independent roots when same-root ambient context cannot model root-operation probes. */
+  createIsolationRepositories?: SharedTransactionFactory<TRepositories>;
+  /** Keeps adapters with auto-closing transactions alive until the supplied release settles. */
   holdTransactionOpen?: (release: Promise<void>) => Promise<void>;
+  /** Enables cases asserting that root operations cannot observe or join staged transaction work. */
   testConcurrentRootOperationIsolation?: boolean;
+  /** Enables the case asserting writer ownership is acquired before callback entry. */
   testWriterOwnershipAtEntry?: boolean;
 };
 
@@ -234,11 +245,18 @@ export async function runRepositoryTransactionContract(
       const { repositories, dispose } = await options.createRepositories();
       try {
         let committed = false;
+        let committedPublicKey = '';
         await repositories.withTransaction(async (tx) => {
           await tx.mintRepository.addOrUpdateMint(createDummyMint());
           await tx.keysetRepository.addKeyset(createDummyKeyset());
           await tx.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
           await tx.meltOperationRepository.create(createDummyMeltOperation());
+          await tx.counterRepository.setCounter('https://mint.test', 'keyset-id', 7);
+          committedPublicKey = (
+            await tx.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+              derivedKeypair(index, 'p2pk'),
+            )
+          ).publicKeyHex;
           committed = true;
         });
 
@@ -248,6 +266,19 @@ export async function runRepositoryTransactionContract(
         const operation = await repositories.meltOperationRepository.getById('melt-op');
         expect(operation).toBeDefined();
         expect(operation?.methodData.amountSats?.toString()).toBe('1');
+        const counter = await repositories.counterRepository.getCounter(
+          'https://mint.test',
+          'keyset-id',
+        );
+        expect(counter?.counter).toBe(7);
+        const keypair = await repositories.keyRingRepository.getPersistedKeyPair(
+          committedPublicKey,
+          'p2pk',
+        );
+        expect(keypair).toBeDefined();
+        await repositories.keyRingRepository.deletePersistedKeyPair(committedPublicKey, 'p2pk');
+        const nextKeypair = await deriveNext(repositories.keyRingRepository, 'p2pk');
+        expect(nextKeypair.derivationIndex).toBe(1);
       } finally {
         await dispose();
       }
@@ -262,6 +293,10 @@ export async function runRepositoryTransactionContract(
             await tx.keysetRepository.addKeyset(createDummyKeyset());
             await tx.proofRepository.saveProofs('https://mint.test', [createDummyProof()]);
             await tx.meltOperationRepository.create(createDummyMeltOperation());
+            await tx.counterRepository.setCounter('https://mint.test', 'keyset-id', 7);
+            await tx.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+              derivedKeypair(index, 'p2pk'),
+            );
             throw new Error('boom');
           });
         }, expect);
@@ -275,6 +310,15 @@ export async function runRepositoryTransactionContract(
         expect(proofs.length).toBe(0);
         const operation = await repositories.meltOperationRepository.getById('melt-op');
         expect(operation).toBe(null);
+        const counter = await repositories.counterRepository.getCounter(
+          'https://mint.test',
+          'keyset-id',
+        );
+        expect(counter).toBe(null);
+        const keypairs = await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk');
+        expect(keypairs).toHaveLength(0);
+        const reallocated = await deriveNext(repositories.keyRingRepository, 'p2pk');
+        expect(reallocated.derivationIndex).toBe(0);
       } finally {
         await dispose();
       }
@@ -302,7 +346,8 @@ export async function runRepositoryTransactionContract(
 
     if (options.testConcurrentRootOperationIsolation) {
       it('does not expose writes from an active transaction that rolls back', async () => {
-        const { repositories, dispose } = await options.createRepositories();
+        const { transactionRepositories, rootRepositories, dispose } =
+          await createIsolationRepositories(options);
         const transactionEntered = createDeferred();
         const releaseTransaction = createDeferred();
         try {
@@ -311,7 +356,7 @@ export async function runRepositoryTransactionContract(
             mintUrl: 'https://staged-mint.test',
           };
           const transactionOutcomePromise = settle(
-            repositories.withTransaction(async (tx) => {
+            transactionRepositories.withTransaction(async (tx) => {
               await tx.mintRepository.addOrUpdateMint(stagedMint);
               transactionEntered.resolve();
               await (options.holdTransactionOpen?.(releaseTransaction.promise) ??
@@ -321,7 +366,7 @@ export async function runRepositoryTransactionContract(
           );
           await transactionEntered.promise;
 
-          const rootReadPromise = repositories.mintRepository.getAllMints();
+          const rootReadPromise = rootRepositories.mintRepository.getAllMints();
           releaseTransaction.resolve();
           const [transactionOutcome, observedMints] = await Promise.all([
             transactionOutcomePromise,
@@ -330,7 +375,7 @@ export async function runRepositoryTransactionContract(
           expect(transactionOutcome.status).toBe('rejected');
           expect(observedMints.some((mint) => mint.mintUrl === stagedMint.mintUrl)).toBe(false);
 
-          const storedMints = await repositories.mintRepository.getAllMints();
+          const storedMints = await rootRepositories.mintRepository.getAllMints();
           expect(storedMints.some((mint) => mint.mintUrl === stagedMint.mintUrl)).toBe(false);
         } finally {
           releaseTransaction.resolve();
@@ -339,7 +384,8 @@ export async function runRepositoryTransactionContract(
       });
 
       it('does not include concurrent root repository writes in active transactions', async () => {
-        const { repositories, dispose } = await options.createRepositories();
+        const { transactionRepositories, rootRepositories, dispose } =
+          await createIsolationRepositories(options);
         try {
           const transactionEntered = createDeferred();
           const releaseTransaction = createDeferred();
@@ -353,7 +399,7 @@ export async function runRepositoryTransactionContract(
           };
 
           const transactionOutcomePromise = settle(
-            repositories.withTransaction(async (tx) => {
+            transactionRepositories.withTransaction(async (tx) => {
               await tx.mintRepository.addOrUpdateMint(mintInTransaction);
               transactionEntered.resolve();
               await (options.holdTransactionOpen?.(releaseTransaction.promise) ??
@@ -364,7 +410,7 @@ export async function runRepositoryTransactionContract(
 
           await transactionEntered.promise;
 
-          const outsideWritePromise = repositories.mintRepository.addOrUpdateMint(outsideMint);
+          const outsideWritePromise = rootRepositories.mintRepository.addOrUpdateMint(outsideMint);
 
           releaseTransaction.resolve();
           const [transactionOutcome] = await Promise.all([
@@ -373,7 +419,7 @@ export async function runRepositoryTransactionContract(
           ]);
           expect(transactionOutcome.status).toBe('rejected');
 
-          const mints = await repositories.mintRepository.getAllMints();
+          const mints = await rootRepositories.mintRepository.getAllMints();
           expect(mints).toHaveLength(1);
           expect(mints[0]?.mintUrl).toBe(outsideMint.mintUrl);
         } finally {
@@ -382,7 +428,8 @@ export async function runRepositoryTransactionContract(
       });
 
       it('does not clobber concurrent root writes when a transaction commits', async () => {
-        const { repositories, dispose } = await options.createRepositories();
+        const { transactionRepositories, rootRepositories, dispose } =
+          await createIsolationRepositories(options);
         const transactionEntered = createDeferred();
         const releaseTransaction = createDeferred();
         try {
@@ -395,7 +442,7 @@ export async function runRepositoryTransactionContract(
             mintUrl: 'https://outside-committed-transaction.test',
           };
 
-          const transactionPromise = repositories.withTransaction(async (tx) => {
+          const transactionPromise = transactionRepositories.withTransaction(async (tx) => {
             await tx.mintRepository.addOrUpdateMint(mintInTransaction);
             transactionEntered.resolve();
             await (options.holdTransactionOpen?.(releaseTransaction.promise) ??
@@ -403,11 +450,11 @@ export async function runRepositoryTransactionContract(
           });
           await transactionEntered.promise;
 
-          const outsideWritePromise = repositories.mintRepository.addOrUpdateMint(outsideMint);
+          const outsideWritePromise = rootRepositories.mintRepository.addOrUpdateMint(outsideMint);
           releaseTransaction.resolve();
           await Promise.all([transactionPromise, outsideWritePromise]);
 
-          const mints = await repositories.mintRepository.getAllMints();
+          const mints = await rootRepositories.mintRepository.getAllMints();
           expect(mints).toHaveLength(2);
           expect(mints.some((mint) => mint.mintUrl === mintInTransaction.mintUrl)).toBe(true);
           expect(mints.some((mint) => mint.mintUrl === outsideMint.mintUrl)).toBe(true);
@@ -471,19 +518,23 @@ export async function runRepositoryTransactionContract(
             ...createDummyMint(),
             mintUrl: 'https://second-writer.test',
           };
+          let firstWriterHeld = true;
 
           const firstOutcomePromise = settle(
             first.withTransaction(async (tx) => {
               await tx.mintRepository.addOrUpdateMint(firstMint);
               firstEntered.resolve();
               await releaseFirst.promise;
+              firstWriterHeld = false;
             }),
           );
           await firstEntered.promise;
 
           const secondEntered = createDeferred();
+          let secondEnteredWhileFirstHeld = false;
           const secondOutcomePromise = settle(
             second.withTransaction(async (tx) => {
+              secondEnteredWhileFirstHeld = firstWriterHeld;
               secondEntered.resolve();
               await tx.mintRepository.addOrUpdateMint(secondMint);
             }),
@@ -492,14 +543,16 @@ export async function runRepositoryTransactionContract(
           const acquisitionOutcome = await Promise.race([
             secondEntered.promise.then(() => 'callback-entered' as const),
             secondOutcomePromise.then(() => 'transaction-settled' as const),
+            new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 0)),
           ]);
-          expect(acquisitionOutcome).toBe('transaction-settled');
+          expect(acquisitionOutcome === 'callback-entered').toBe(false);
 
           releaseFirst.resolve();
           const [firstOutcome, secondOutcome] = await Promise.all([
             firstOutcomePromise,
             secondOutcomePromise,
           ]);
+          expect(secondEnteredWhileFirstHeld).toBe(false);
           expect(firstOutcome.status).toBe('fulfilled');
           if (secondOutcome.status === 'rejected') {
             expect(secondOutcome.reason instanceof RepositoryTransactionConflictError).toBe(true);
@@ -529,6 +582,24 @@ export type ContractRunner = {
   it(name: string, fn: () => Promise<void> | void): void;
   expect: Expectation;
 };
+
+async function createIsolationRepositories(options: ContractOptions): Promise<{
+  transactionRepositories: Repositories;
+  rootRepositories: Repositories;
+  dispose(): Promise<void>;
+}> {
+  if (options.createIsolationRepositories) {
+    const { first, second, dispose } = await options.createIsolationRepositories();
+    return { transactionRepositories: first, rootRepositories: second, dispose };
+  }
+
+  const { repositories, dispose } = await options.createRepositories();
+  return {
+    transactionRepositories: repositories,
+    rootRepositories: repositories,
+    dispose,
+  };
+}
 
 type Expectation = {
   (value: unknown): ExpectApi;

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -144,3 +144,24 @@ _Avoid_: Recovery, Wallet Import, restored mint, restored wallet
 **Operation Recovery**:
 The act of reconciling persisted in-flight wallet operations after interruption so local operation state, proof state, and mint state agree again.
 _Avoid_: Restore, restart, resume
+
+**Exact Operation Request**:
+Immutable mint request material owned by a durable operation and reused for both initial submission
+and Operation Recovery.
+_Avoid_: Retry request, regenerated request, execution attempt
+
+**Ambiguous Operation Outcome**:
+An operation outcome for which Coco cannot prove whether its Exact Operation Request affected the
+mint. The operation retains its locally owned resources until Operation Recovery establishes a safe
+result.
+_Avoid_: Failed operation, timed-out operation
+
+**Output Allocation**:
+A durable commitment of deterministic counter positions to planned Cashu outputs. Output derivation
+inside a transaction that does not commit is not an Output Allocation.
+_Avoid_: Output generation, tentative outputs, counter increment
+
+**Keypair Allocation**:
+A durable commitment of one purpose-specific Wallet derivation index and its derived keypair. Key
+derivation inside a transaction that does not commit is not a Keypair Allocation.
+_Avoid_: Key generation, tentative key, high-water-mark increment

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -205,34 +205,11 @@ If you prefer manual wiring, construct `Manager` directly and call `initPlugins(
 - `manager.on(...)` exposes typed `CoreEvents`, including subscription,
   operation, proof, quote, history, mint, and auth-session events.
 
-### Repositories
+### Storage
 
-Repository contracts for storage adapters are exported from `@cashu/coco-core/adapter`:
-
-```ts
-import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
-```
-
-- `MintRepository`
-- `KeysetRepository`
-- `CounterRepository`
-- `ProofRepository`
-- `MintQuoteRepository`
-- `HistoryRepository`
-- `KeyRingRepository`
-- `AuthSessionRepository`
-- `SendOperationRepository`
-- `MeltOperationRepository`
-- `MintOperationRepository`
-- `ReceiveOperationRepository`
-
-The package root exports `MemoryRepositories` as an in-memory test/example repository bundle.
-
-`KeyRingRepository.deriveAndPersistKeyPair(purpose, derive)` selects the next purpose-scoped
-derivation index, invokes the synchronous derivation callback, and atomically commits the keypair
-with its durable high-water mark. It returns the keypair only after commit. See the
-[storage adapter contract](../docs/pages/storage-adapters.md) for transaction and backup
-requirements.
+Initialize Coco with the built-in storage adapter for your runtime. The package root also exports
+`MemoryRepositories` for in-memory tests and examples. See [Storage Adapters](../docs/pages/storage-adapters.md)
+for setup and storage-security guidance.
 
 ## Public API surface
 

--- a/packages/core/adapter.ts
+++ b/packages/core/adapter.ts
@@ -20,6 +20,7 @@ export type {
   RepositoryTransactionScope,
   SendOperationRepository,
 } from './repositories/index.ts';
+export { RepositoryTransactionConflictError } from './repositories/index.ts';
 export type {
   AuthSession,
   Counter,

--- a/packages/core/docs/adr/0011-use-domain-transaction-gateways.md
+++ b/packages/core/docs/adr/0011-use-domain-transaction-gateways.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+---
+
+# Use domain transaction gateways for critical Wallet mutations
+
+Coco uses one composition-root-owned transaction runner behind narrow domain transaction gateways
+for critical Wallet mutations. Orchestration performs preflight, remote mint I/O, and post-commit
+events, while each authoritative local transition uses one adapter transaction; this avoids
+repository access and transaction-scoped service clones in orchestration while remaining portable
+to IndexedDB. Send and core Receive validate the seam incrementally, while durable outbox delivery
+and systematic network fault injection remain separate work.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,8 +46,8 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "test": "bun test",
-    "test:unit": "bun test test/unit",
+    "test": "bun run --cwd ../.. build:test:core && bun test",
+    "test:unit": "bun run --cwd ../.. build:test:core && bun test test/unit",
     "test:integration": "bun test test/integration",
     "prepublishOnly": "bun run build"
   },

--- a/packages/core/repositories/RepositoryTransactionError.ts
+++ b/packages/core/repositories/RepositoryTransactionError.ts
@@ -1,0 +1,14 @@
+/**
+ * Reports transient adapter contention while acquiring or committing a Wallet transaction.
+ * Callers may apply a bounded retry policy to this error; domain and invariant errors must pass
+ * through unchanged.
+ */
+export class RepositoryTransactionConflictError extends Error {
+  readonly transient = true;
+
+  constructor(message = 'Wallet repository transaction conflicted', cause?: unknown) {
+    super(message);
+    this.name = 'RepositoryTransactionConflictError';
+    (this as unknown as { cause?: unknown }).cause = cause;
+  }
+}

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -385,6 +385,15 @@ interface RepositoriesBase {
 
 export interface Repositories extends RepositoriesBase {
   init(): Promise<void>;
+
+  /**
+   * Runs one strong Wallet write transaction across the complete repository scope.
+   *
+   * Successful callbacks commit atomically and failed callbacks roll back completely. Adapters
+   * isolate concurrent work and either serialize conflicting writers or reject them with
+   * `RepositoryTransactionConflictError`. Callbacks must remain compatible with IndexedDB's
+   * transaction lifetime and therefore must not perform remote or unrelated asynchronous work.
+   */
   withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
 }
 
@@ -392,4 +401,5 @@ export type RepositoryTransactionScope = Omit<RepositoriesBase, 'keyRingReposito
   keyRingRepository: Omit<KeyRingRepository, 'deriveAndPersistKeyPair'>;
 };
 
+export { RepositoryTransactionConflictError } from './RepositoryTransactionError.ts';
 export * from './memory';

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -393,13 +393,12 @@ export interface Repositories extends RepositoriesBase {
    * isolate concurrent work and either serialize conflicting writers or reject them with
    * `RepositoryTransactionConflictError`. Callbacks must remain compatible with IndexedDB's
    * transaction lifetime and therefore must not perform remote or unrelated asynchronous work.
+   * Use only the scoped repositories passed to the callback and do not nest `withTransaction`.
    */
   withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T>;
 }
 
-export type RepositoryTransactionScope = Omit<RepositoriesBase, 'keyRingRepository'> & {
-  keyRingRepository: Omit<KeyRingRepository, 'deriveAndPersistKeyPair'>;
-};
+export type RepositoryTransactionScope = RepositoriesBase;
 
 export { RepositoryTransactionConflictError } from './RepositoryTransactionError.ts';
 export * from './memory';

--- a/packages/core/repositories/memory/MemoryAuthSessionRepository.ts
+++ b/packages/core/repositories/memory/MemoryAuthSessionRepository.ts
@@ -1,8 +1,13 @@
 import type { AuthSession } from '@core/models/AuthSession';
 import type { AuthSessionRepository } from '..';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryAuthSessionRepository implements AuthSessionRepository {
-  private readonly sessions = new Map<string, AuthSession>();
+  private sessions = new Map<string, AuthSession>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryAuthSessionRepository): void {
+    this.sessions = cloneMemoryValue(source.sessions);
+  }
 
   async getSession(mintUrl: string): Promise<AuthSession | null> {
     return this.sessions.get(mintUrl) ?? null;

--- a/packages/core/repositories/memory/MemoryCounterRepository.ts
+++ b/packages/core/repositories/memory/MemoryCounterRepository.ts
@@ -1,8 +1,13 @@
 import type { Counter } from '../../models/Counter';
 import type { CounterRepository } from '..';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryCounterRepository implements CounterRepository {
   private counters: Map<string, Counter> = new Map();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryCounterRepository): void {
+    this.counters = cloneMemoryValue(source.counters);
+  }
 
   private key(mintUrl: string, keysetId: string): string {
     return `${mintUrl}::${keysetId}`;

--- a/packages/core/repositories/memory/MemoryHistoryRepository.ts
+++ b/packages/core/repositories/memory/MemoryHistoryRepository.ts
@@ -21,6 +21,7 @@ import type { MintOperation } from '@core/operations/mint';
 import type { MemoryMeltOperationRepository } from './MemoryMeltOperationRepository';
 import type { MemoryMintOperationRepository } from './MemoryMintOperationRepository';
 import type { MemoryReceiveOperationRepository } from './MemoryReceiveOperationRepository';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 import type { MemorySendOperationRepository } from './MemorySendOperationRepository';
 
 type OperationRepositories = {
@@ -32,9 +33,13 @@ type OperationRepositories = {
 };
 
 export class MemoryHistoryRepository implements HistoryProjectionRepository {
-  private readonly legacyEntries: LegacyHistoryEntry[] = [];
+  private legacyEntries: LegacyHistoryEntry[] = [];
 
   constructor(private readonly operationRepositories: OperationRepositories = {}) {}
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryHistoryRepository): void {
+    this.legacyEntries = cloneMemoryValue(source.legacyEntries);
+  }
 
   async getPaginatedHistoryEntries(limit: number, offset: number): Promise<HistoryEntry[]> {
     const entries = await this.getProjectedEntries();

--- a/packages/core/repositories/memory/MemoryKeyRingRepository.ts
+++ b/packages/core/repositories/memory/MemoryKeyRingRepository.ts
@@ -1,6 +1,7 @@
 import type { Keypair, KeypairPurpose } from '../../models/Keypair';
 import { DerivationIndexExhaustedError } from '../../models/Error.ts';
 import type { KeyRingRepository } from '..';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 const DEFAULT_KEYPAIR_PURPOSE: KeypairPurpose = 'p2pk';
 const MAX_DERIVATION_INDEX = 0x7fffffff;
@@ -9,6 +10,12 @@ export class MemoryKeyRingRepository implements KeyRingRepository {
   private keyPairs: Map<string, Keypair> = new Map();
   private insertionOrder: string[] = [];
   private highWaterMarks: Map<KeypairPurpose, number> = new Map();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryKeyRingRepository): void {
+    this.keyPairs = cloneMemoryValue(source.keyPairs);
+    this.insertionOrder = cloneMemoryValue(source.insertionOrder);
+    this.highWaterMarks = cloneMemoryValue(source.highWaterMarks);
+  }
 
   async getPersistedKeyPair(publicKey: string, purpose?: KeypairPurpose): Promise<Keypair | null> {
     const keyPair = this.keyPairs.get(publicKey) ?? null;

--- a/packages/core/repositories/memory/MemoryKeysetRepository.ts
+++ b/packages/core/repositories/memory/MemoryKeysetRepository.ts
@@ -1,8 +1,13 @@
 import type { Keyset } from '../../models/Keyset';
 import type { KeysetRepository } from '..';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryKeysetRepository implements KeysetRepository {
   private keysetsByMint: Map<string, Map<string, Keyset>> = new Map();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryKeysetRepository): void {
+    this.keysetsByMint = cloneMemoryValue(source.keysetsByMint);
+  }
 
   private getMintMap(mintUrl: string): Map<string, Keyset> {
     if (!this.keysetsByMint.has(mintUrl)) {

--- a/packages/core/repositories/memory/MemoryLegacyMintQuoteRepository.ts
+++ b/packages/core/repositories/memory/MemoryLegacyMintQuoteRepository.ts
@@ -1,9 +1,14 @@
 import { isMintQuotePending, type MintQuote } from '@core/models/MintQuote';
 import type { LegacyMintQuoteRepository } from '..';
 import { normalizeMintUrl } from '../../utils';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryLegacyMintQuoteRepository implements LegacyMintQuoteRepository {
-  private readonly quotes = new Map<string, MintQuote>();
+  private quotes = new Map<string, MintQuote>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryLegacyMintQuoteRepository): void {
+    this.quotes = cloneMemoryValue(source.quotes);
+  }
 
   private makeKey(mintUrl: string, method: string, quoteId: string): string {
     return `${normalizeMintUrl(mintUrl)}::${method}::${quoteId}`;

--- a/packages/core/repositories/memory/MemoryMeltOperationRepository.ts
+++ b/packages/core/repositories/memory/MemoryMeltOperationRepository.ts
@@ -1,11 +1,16 @@
 import type { MeltOperationRepository } from '..';
 import type { MeltOperation, MeltOperationState } from '../../operations/melt/MeltOperation';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 const getOperationQuoteId = (operation: MeltOperation): string | undefined =>
   'quoteId' in operation && operation.quoteId ? operation.quoteId : undefined;
 
 export class MemoryMeltOperationRepository implements MeltOperationRepository {
-  private readonly operations = new Map<string, MeltOperation>();
+  private operations = new Map<string, MeltOperation>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryMeltOperationRepository): void {
+    this.operations = cloneMemoryValue(source.operations);
+  }
 
   async create(operation: MeltOperation): Promise<void> {
     if (this.operations.has(operation.id)) {

--- a/packages/core/repositories/memory/MemoryMeltQuoteRepository.ts
+++ b/packages/core/repositories/memory/MemoryMeltQuoteRepository.ts
@@ -3,9 +3,14 @@ import type { MeltQuote } from '@core/models/MeltQuote';
 import type { QuoteIdentity } from '@core/models/QuoteIdentity';
 import type { MeltQuoteRepository } from '..';
 import { normalizeMintUrl } from '../../utils';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryMeltQuoteRepository implements MeltQuoteRepository {
-  private readonly quotes = new Map<string, MeltQuote>();
+  private quotes = new Map<string, MeltQuote>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryMeltQuoteRepository): void {
+    this.quotes = cloneMemoryValue(source.quotes);
+  }
 
   private makeKey(mintUrl: string, method: string, quoteId: string): string {
     return `${normalizeMintUrl(mintUrl)}::${method}::${quoteId}`;

--- a/packages/core/repositories/memory/MemoryMintOperationRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintOperationRepository.ts
@@ -1,8 +1,13 @@
 import type { MintOperationRepository } from '..';
 import type { MintOperation, MintOperationState } from '../../operations/mint/MintOperation';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryMintOperationRepository implements MintOperationRepository {
-  private readonly operations = new Map<string, MintOperation>();
+  private operations = new Map<string, MintOperation>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryMintOperationRepository): void {
+    this.operations = cloneMemoryValue(source.operations);
+  }
 
   async create(operation: MintOperation): Promise<void> {
     if (this.operations.has(operation.id)) {

--- a/packages/core/repositories/memory/MemoryMintQuoteRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintQuoteRepository.ts
@@ -10,9 +10,14 @@ import type { QuoteIdentity } from '@core/models/QuoteIdentity';
 import type { MintMethodRemoteState } from '@core/operations/mint/MintMethodHandler';
 import type { MintQuoteRepository } from '..';
 import { normalizeMintUrl } from '../../utils';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryMintQuoteRepository implements MintQuoteRepository {
-  private readonly quotes = new Map<string, MintQuote>();
+  private quotes = new Map<string, MintQuote>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryMintQuoteRepository): void {
+    this.quotes = cloneMemoryValue(source.quotes);
+  }
 
   private makeKey(mintUrl: string, method: string, quoteId: string): string {
     return `${normalizeMintUrl(mintUrl)}::${method}::${quoteId}`;

--- a/packages/core/repositories/memory/MemoryMintRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintRepository.ts
@@ -1,8 +1,13 @@
 import type { Mint } from '../../models/Mint';
 import type { MintRepository } from '..';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryMintRepository implements MintRepository {
   private mints: Map<string, Mint> = new Map();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryMintRepository): void {
+    this.mints = cloneMemoryValue(source.mints);
+  }
 
   async isTrustedMint(mintUrl: string): Promise<boolean> {
     const mint = this.mints.get(mintUrl);

--- a/packages/core/repositories/memory/MemoryPaymentRequestReceiveRepository.ts
+++ b/packages/core/repositories/memory/MemoryPaymentRequestReceiveRepository.ts
@@ -8,6 +8,7 @@ import type {
   PaymentRequestReceiveOperation,
   PaymentRequestReceiveState,
 } from '../../operations/paymentRequestReceive/PaymentRequestReceiveOperation';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 function cloneOperation(operation: PaymentRequestReceiveOperation): PaymentRequestReceiveOperation {
   return { ...operation, mints: [...operation.mints] };
@@ -23,7 +24,11 @@ function cloneAttempt(attempt: PaymentRequestReceiveAttempt): PaymentRequestRece
 }
 
 export class MemoryPaymentRequestReceiveOperationRepository implements PaymentRequestReceiveOperationRepository {
-  private readonly operations = new Map<string, PaymentRequestReceiveOperation>();
+  private operations = new Map<string, PaymentRequestReceiveOperation>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryPaymentRequestReceiveOperationRepository): void {
+    this.operations = cloneMemoryValue(source.operations);
+  }
 
   async create(operation: PaymentRequestReceiveOperation): Promise<void> {
     if (this.operations.has(operation.id)) {
@@ -66,7 +71,11 @@ export class MemoryPaymentRequestReceiveOperationRepository implements PaymentRe
 }
 
 export class MemoryPaymentRequestReceiveAttemptRepository implements PaymentRequestReceiveAttemptRepository {
-  private readonly attempts = new Map<string, PaymentRequestReceiveAttempt>();
+  private attempts = new Map<string, PaymentRequestReceiveAttempt>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryPaymentRequestReceiveAttemptRepository): void {
+    this.attempts = cloneMemoryValue(source.attempts);
+  }
 
   async create(attempt: PaymentRequestReceiveAttempt): Promise<void> {
     if (this.attempts.has(attempt.id)) {

--- a/packages/core/repositories/memory/MemoryProofRepository.ts
+++ b/packages/core/repositories/memory/MemoryProofRepository.ts
@@ -1,6 +1,7 @@
 import type { ProofRepository, ProofUnitFilter } from '..';
 import type { CoreProof, ProofState } from '../../types';
 import { normalizeUnit } from '../../amounts.ts';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 function normalizeProofUnit(proof: CoreProof): string {
   return normalizeUnit((proof as { unit?: string }).unit);
@@ -18,6 +19,10 @@ function matchesUnit(proof: CoreProof, unitFilter?: Set<string>): boolean {
 
 export class MemoryProofRepository implements ProofRepository {
   private proofsByMint: Map<string, Map<string, CoreProof>> = new Map();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryProofRepository): void {
+    this.proofsByMint = cloneMemoryValue(source.proofsByMint);
+  }
 
   private getMintMap(mintUrl: string): Map<string, CoreProof> {
     if (!this.proofsByMint.has(mintUrl)) {

--- a/packages/core/repositories/memory/MemoryReceiveOperationRepository.ts
+++ b/packages/core/repositories/memory/MemoryReceiveOperationRepository.ts
@@ -3,9 +3,14 @@ import type {
   ReceiveOperation,
   ReceiveOperationState,
 } from '../../operations/receive/ReceiveOperation';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemoryReceiveOperationRepository implements ReceiveOperationRepository {
-  private readonly operations = new Map<string, ReceiveOperation>();
+  private operations = new Map<string, ReceiveOperation>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemoryReceiveOperationRepository): void {
+    this.operations = cloneMemoryValue(source.operations);
+  }
 
   async create(operation: ReceiveOperation): Promise<void> {
     if (this.operations.has(operation.id)) {

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -168,7 +168,7 @@ function createMemoryRepositoryState() {
   const receiveOperationRepository = new MemoryReceiveOperationRepository();
   const mintQuoteRepository = new MemoryMintQuoteRepository();
 
-  return {
+  const state = {
     mintRepository: new MemoryMintRepository(),
     keyRingRepository: new MemoryKeyRingRepository(),
     counterRepository: new MemoryCounterRepository(),
@@ -192,6 +192,11 @@ function createMemoryRepositoryState() {
     paymentRequestReceiveOperationRepository: new MemoryPaymentRequestReceiveOperationRepository(),
     paymentRequestReceiveAttemptRepository: new MemoryPaymentRequestReceiveAttemptRepository(),
   };
+
+  type StateOwnerConstraint = {
+    [Key in keyof typeof state]: MemoryRepositoryStateOwner<(typeof state)[Key]>;
+  };
+  return state satisfies StateOwnerConstraint;
 }
 
 function cloneMemoryRepositoryState(source: MemoryRepositoryState): MemoryRepositoryState {
@@ -205,6 +210,7 @@ function copyMemoryRepositoryState(
   source: MemoryRepositoryState,
 ): void {
   for (const key of Object.keys(source) as (keyof MemoryRepositoryState)[]) {
+    // createMemoryRepositoryState statically enforces the protocol; this loop loses key correlation.
     const targetRepository = target[key] as MemoryRepositoryStateOwner<object>;
     targetRepository[COPY_MEMORY_REPOSITORY_STATE](source[key]);
   }

--- a/packages/core/repositories/memory/MemoryRepositories.ts
+++ b/packages/core/repositories/memory/MemoryRepositories.ts
@@ -36,6 +36,10 @@ import {
   MemoryPaymentRequestReceiveAttemptRepository,
   MemoryPaymentRequestReceiveOperationRepository,
 } from './MemoryPaymentRequestReceiveRepository';
+import {
+  COPY_MEMORY_REPOSITORY_STATE,
+  type MemoryRepositoryStateOwner,
+} from './MemoryRepositoryTransaction.ts';
 
 export class MemoryRepositories implements Repositories {
   mintRepository: MintRepository;
@@ -55,36 +59,37 @@ export class MemoryRepositories implements Repositories {
   paymentRequestReceiveOperationRepository: PaymentRequestReceiveOperationRepository;
   paymentRequestReceiveAttemptRepository: PaymentRequestReceiveAttemptRepository;
 
-  constructor() {
-    this.mintRepository = new MemoryMintRepository();
-    this.keyRingRepository = new MemoryKeyRingRepository();
-    this.counterRepository = new MemoryCounterRepository();
-    this.keysetRepository = new MemoryKeysetRepository();
-    this.proofRepository = new MemoryProofRepository();
-    const sendOperationRepository = new MemorySendOperationRepository();
-    const meltOperationRepository = new MemoryMeltOperationRepository();
-    const mintOperationRepository = new MemoryMintOperationRepository();
-    const receiveOperationRepository = new MemoryReceiveOperationRepository();
+  private readonly state: MemoryRepositoryState;
+  private transactionQueue: Promise<void> = Promise.resolve();
+  private pendingTransactionCount = 0;
+  private activeRootOperationCount = 0;
+  private rootOperationsIdle: Promise<void> = Promise.resolve();
+  private releaseRootOperations!: () => void;
 
-    this.sendOperationRepository = sendOperationRepository;
-    this.meltOperationRepository = meltOperationRepository;
-    this.mintOperationRepository = mintOperationRepository;
-    this.receiveOperationRepository = receiveOperationRepository;
-    this.mintQuoteRepository = new MemoryMintQuoteRepository();
-    this.legacyMintQuoteRepository = new MemoryLegacyMintQuoteRepository();
-    this.meltQuoteRepository = new MemoryMeltQuoteRepository();
-    this.historyRepository = new MemoryHistoryRepository({
-      sendOperationRepository,
-      meltOperationRepository,
-      mintOperationRepository,
-      mintQuoteRepository: this.mintQuoteRepository,
-      receiveOperationRepository,
-    });
-    this.authSessionRepository = new MemoryAuthSessionRepository();
-    this.paymentRequestReceiveOperationRepository =
-      new MemoryPaymentRequestReceiveOperationRepository();
-    this.paymentRequestReceiveAttemptRepository =
-      new MemoryPaymentRequestReceiveAttemptRepository();
+  constructor() {
+    this.state = createMemoryRepositoryState();
+    this.mintRepository = this.wrapRootRepository(this.state.mintRepository);
+    this.keyRingRepository = this.wrapRootRepository(this.state.keyRingRepository);
+    this.counterRepository = this.wrapRootRepository(this.state.counterRepository);
+    this.keysetRepository = this.wrapRootRepository(this.state.keysetRepository);
+    this.proofRepository = this.wrapRootRepository(this.state.proofRepository);
+    this.mintQuoteRepository = this.wrapRootRepository(this.state.mintQuoteRepository);
+    this.legacyMintQuoteRepository = this.wrapRootRepository(this.state.legacyMintQuoteRepository);
+    this.meltQuoteRepository = this.wrapRootRepository(this.state.meltQuoteRepository);
+    this.historyRepository = this.wrapRootRepository(this.state.historyRepository);
+    this.sendOperationRepository = this.wrapRootRepository(this.state.sendOperationRepository);
+    this.meltOperationRepository = this.wrapRootRepository(this.state.meltOperationRepository);
+    this.authSessionRepository = this.wrapRootRepository(this.state.authSessionRepository);
+    this.mintOperationRepository = this.wrapRootRepository(this.state.mintOperationRepository);
+    this.receiveOperationRepository = this.wrapRootRepository(
+      this.state.receiveOperationRepository,
+    );
+    this.paymentRequestReceiveOperationRepository = this.wrapRootRepository(
+      this.state.paymentRequestReceiveOperationRepository,
+    );
+    this.paymentRequestReceiveAttemptRepository = this.wrapRootRepository(
+      this.state.paymentRequestReceiveAttemptRepository,
+    );
   }
 
   async init(): Promise<void> {
@@ -92,6 +97,115 @@ export class MemoryRepositories implements Repositories {
   }
 
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
-    return fn(this);
+    // Reserve a queue position before waiting so new root operations cannot slip between writers.
+    const previousTransaction = this.transactionQueue;
+    let releaseTransaction!: () => void;
+    this.transactionQueue = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+    this.pendingTransactionCount++;
+
+    try {
+      await previousTransaction;
+      await this.rootOperationsIdle;
+
+      // The callback only sees a detached snapshot. Copying it back is the atomic commit point.
+      const staged = cloneMemoryRepositoryState(this.state);
+      const result = await fn(staged);
+      copyMemoryRepositoryState(this.state, staged);
+      return result;
+    } finally {
+      this.pendingTransactionCount--;
+      releaseTransaction();
+    }
+  }
+
+  private wrapRootRepository<T extends object>(repository: T): T {
+    // Root repository calls share the transaction gate while scoped repositories stay detached.
+    return new Proxy(repository, {
+      get: (target, property) => {
+        const value = Reflect.get(target, property, target) as unknown;
+        if (typeof value !== 'function') return value;
+        return (...args: unknown[]) =>
+          this.runRootOperation(() => Reflect.apply(value, target, args));
+      },
+    });
+  }
+
+  private async runRootOperation<T>(operation: () => T | Promise<T>): Promise<T> {
+    while (this.pendingTransactionCount > 0) {
+      await this.transactionQueue;
+    }
+    this.beginRootOperation();
+    try {
+      return await operation();
+    } finally {
+      this.endRootOperation();
+    }
+  }
+
+  private beginRootOperation(): void {
+    if (this.activeRootOperationCount === 0) {
+      this.rootOperationsIdle = new Promise<void>((resolve) => {
+        this.releaseRootOperations = resolve;
+      });
+    }
+    this.activeRootOperationCount++;
+  }
+
+  private endRootOperation(): void {
+    this.activeRootOperationCount--;
+    if (this.activeRootOperationCount === 0) this.releaseRootOperations();
+  }
+}
+
+type MemoryRepositoryState = ReturnType<typeof createMemoryRepositoryState>;
+
+function createMemoryRepositoryState() {
+  const sendOperationRepository = new MemorySendOperationRepository();
+  const meltOperationRepository = new MemoryMeltOperationRepository();
+  const mintOperationRepository = new MemoryMintOperationRepository();
+  const receiveOperationRepository = new MemoryReceiveOperationRepository();
+  const mintQuoteRepository = new MemoryMintQuoteRepository();
+
+  return {
+    mintRepository: new MemoryMintRepository(),
+    keyRingRepository: new MemoryKeyRingRepository(),
+    counterRepository: new MemoryCounterRepository(),
+    keysetRepository: new MemoryKeysetRepository(),
+    proofRepository: new MemoryProofRepository(),
+    mintQuoteRepository,
+    legacyMintQuoteRepository: new MemoryLegacyMintQuoteRepository(),
+    meltQuoteRepository: new MemoryMeltQuoteRepository(),
+    historyRepository: new MemoryHistoryRepository({
+      sendOperationRepository,
+      meltOperationRepository,
+      mintOperationRepository,
+      mintQuoteRepository,
+      receiveOperationRepository,
+    }),
+    sendOperationRepository,
+    meltOperationRepository,
+    authSessionRepository: new MemoryAuthSessionRepository(),
+    mintOperationRepository,
+    receiveOperationRepository,
+    paymentRequestReceiveOperationRepository: new MemoryPaymentRequestReceiveOperationRepository(),
+    paymentRequestReceiveAttemptRepository: new MemoryPaymentRequestReceiveAttemptRepository(),
+  };
+}
+
+function cloneMemoryRepositoryState(source: MemoryRepositoryState): MemoryRepositoryState {
+  const clone = createMemoryRepositoryState();
+  copyMemoryRepositoryState(clone, source);
+  return clone;
+}
+
+function copyMemoryRepositoryState(
+  target: MemoryRepositoryState,
+  source: MemoryRepositoryState,
+): void {
+  for (const key of Object.keys(source) as (keyof MemoryRepositoryState)[]) {
+    const targetRepository = target[key] as MemoryRepositoryStateOwner<object>;
+    targetRepository[COPY_MEMORY_REPOSITORY_STATE](source[key]);
   }
 }

--- a/packages/core/repositories/memory/MemoryRepositoryTransaction.ts
+++ b/packages/core/repositories/memory/MemoryRepositoryTransaction.ts
@@ -11,7 +11,8 @@ export function cloneMemoryValue<T>(value: T, seen = new Map<object, unknown>())
   if (seen.has(value)) return seen.get(value) as T;
 
   if (value instanceof Date) return new Date(value.getTime()) as T;
-  if (value instanceof Uint8Array) return value.slice() as T;
+  // Buffer overrides slice() to return a view over the same storage; use the intrinsic copy.
+  if (value instanceof Uint8Array) return Uint8Array.prototype.slice.call(value) as T;
 
   if (Array.isArray(value)) {
     const clone: unknown[] = [];

--- a/packages/core/repositories/memory/MemoryRepositoryTransaction.ts
+++ b/packages/core/repositories/memory/MemoryRepositoryTransaction.ts
@@ -1,0 +1,48 @@
+/** Internal protocol that lets each memory repository own its transaction-state representation. */
+export const COPY_MEMORY_REPOSITORY_STATE = Symbol('copyMemoryRepositoryState');
+
+export type MemoryRepositoryStateOwner<TRepository extends object> = {
+  [COPY_MEMORY_REPOSITORY_STATE](source: TRepository): void;
+};
+
+/** Clone the domain values stored by memory repositories without sharing mutable references. */
+export function cloneMemoryValue<T>(value: T, seen = new Map<object, unknown>()): T {
+  if (typeof value !== 'object' || value === null) return value;
+  if (seen.has(value)) return seen.get(value) as T;
+
+  if (value instanceof Date) return new Date(value.getTime()) as T;
+  if (value instanceof Uint8Array) return value.slice() as T;
+
+  if (Array.isArray(value)) {
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    for (const item of value) clone.push(cloneMemoryValue(item, seen));
+    return clone as T;
+  }
+
+  if (value instanceof Map) {
+    const clone = new Map<unknown, unknown>();
+    seen.set(value, clone);
+    for (const [key, item] of value) {
+      clone.set(cloneMemoryValue(key, seen), cloneMemoryValue(item, seen));
+    }
+    return clone as T;
+  }
+
+  if (value instanceof Set) {
+    const clone = new Set<unknown>();
+    seen.set(value, clone);
+    for (const item of value) clone.add(cloneMemoryValue(item, seen));
+    return clone as T;
+  }
+
+  const clone = Object.create(Object.getPrototypeOf(value)) as object;
+  seen.set(value, clone);
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) continue;
+    if ('value' in descriptor) descriptor.value = cloneMemoryValue(descriptor.value, seen);
+    Object.defineProperty(clone, key, descriptor);
+  }
+  return clone as T;
+}

--- a/packages/core/repositories/memory/MemorySendOperationRepository.ts
+++ b/packages/core/repositories/memory/MemorySendOperationRepository.ts
@@ -1,8 +1,13 @@
 import type { SendOperationRepository } from '..';
 import type { SendOperation, SendOperationState } from '../../operations/send/SendOperation';
+import { cloneMemoryValue, COPY_MEMORY_REPOSITORY_STATE } from './MemoryRepositoryTransaction.ts';
 
 export class MemorySendOperationRepository implements SendOperationRepository {
-  private readonly operations = new Map<string, SendOperation>();
+  private operations = new Map<string, SendOperation>();
+
+  [COPY_MEMORY_REPOSITORY_STATE](source: MemorySendOperationRepository): void {
+    this.operations = cloneMemoryValue(source.operations);
+  }
 
   async create(operation: SendOperation): Promise<void> {
     if (this.operations.has(operation.id)) {

--- a/packages/core/test/unit/MemoryKeyRingRepository.test.ts
+++ b/packages/core/test/unit/MemoryKeyRingRepository.test.ts
@@ -82,9 +82,25 @@ describe('MemoryKeyRingRepository derivation persistence', () => {
   });
 });
 
-function assertAtomicDerivationIsRootOnly(scope: RepositoryTransactionScope): void {
-  // @ts-expect-error A generated key must not be exposed before its own transaction commits.
+function assertAtomicDerivationIsTransactionScoped(scope: RepositoryTransactionScope): void {
   void scope.keyRingRepository.deriveAndPersistKeyPair;
 }
 
-void assertAtomicDerivationIsRootOnly;
+void assertAtomicDerivationIsTransactionScoped;
+
+describe('MemoryKeyRingRepository transaction scope', () => {
+  it('rolls key allocation back with the enclosing Wallet transaction', async () => {
+    const repositories = new MemoryRepositories();
+
+    await expect(
+      repositories.withTransaction(async (scope) => {
+        await scope.keyRingRepository.deriveAndPersistKeyPair('p2pk', (index) =>
+          derivedKeypair(index, 'p2pk'),
+        );
+        throw new Error('abort Wallet transaction');
+      }),
+    ).rejects.toThrow('abort Wallet transaction');
+
+    expect(await repositories.keyRingRepository.getAllPersistedKeyPairs('p2pk')).toEqual([]);
+  });
+});

--- a/packages/core/test/unit/MemoryRepositoryTransaction.test.ts
+++ b/packages/core/test/unit/MemoryRepositoryTransaction.test.ts
@@ -27,3 +27,27 @@ runRepositoryTransactionContract(
   },
   { describe, it, expect },
 );
+
+describe('MemoryRepositories transaction byte isolation', () => {
+  it('rolls back mutations to Buffer-backed key material', async () => {
+    const repositories = new MemoryRepositories();
+    const publicKeyHex = `02${'01'.repeat(32)}`;
+    await repositories.keyRingRepository.setPersistedKeyPair({
+      publicKeyHex,
+      secretKey: Buffer.from([1, 2, 3]),
+      purpose: 'p2pk',
+    });
+
+    await expect(
+      repositories.withTransaction(async ({ keyRingRepository }) => {
+        const keyPair = await keyRingRepository.getPersistedKeyPair(publicKeyHex, 'p2pk');
+        expect(keyPair).not.toBeNull();
+        keyPair!.secretKey[0] = 9;
+        throw new Error('abort Wallet transaction');
+      }),
+    ).rejects.toThrow('abort Wallet transaction');
+
+    const stored = await repositories.keyRingRepository.getPersistedKeyPair(publicKeyHex, 'p2pk');
+    expect(Array.from(stored!.secretKey)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/test/unit/MemoryRepositoryTransaction.test.ts
+++ b/packages/core/test/unit/MemoryRepositoryTransaction.test.ts
@@ -23,6 +23,7 @@ runRepositoryTransactionContract(
     createRepositories,
     createSharedRepositories,
     testConcurrentRootOperationIsolation: true,
+    testWriterOwnershipAtEntry: true,
   },
   { describe, it, expect },
 );

--- a/packages/core/test/unit/MemoryRepositoryTransaction.test.ts
+++ b/packages/core/test/unit/MemoryRepositoryTransaction.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+import { runRepositoryTransactionContract } from '@cashu/coco-adapter-tests';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+
+async function createRepositories() {
+  return {
+    repositories: new MemoryRepositories(),
+    dispose: async () => {},
+  };
+}
+
+async function createSharedRepositories() {
+  const repositories = new MemoryRepositories();
+  return {
+    first: repositories,
+    second: repositories,
+    dispose: async () => {},
+  };
+}
+
+runRepositoryTransactionContract(
+  {
+    createRepositories,
+    createSharedRepositories,
+    testConcurrentRootOperationIsolation: true,
+  },
+  { describe, it, expect },
+);

--- a/packages/docs/pages/storage-adapters.md
+++ b/packages/docs/pages/storage-adapters.md
@@ -1,67 +1,20 @@
 # Storage Adapters
 
-Coco is built in a platform agnostic way. As we can not assume anything about the presence of a certain storage API (e.g. IndexedDB), coco exposes a storage interface that needs to be satisfied when instantiating.
+Coco does not assume that a particular storage API is available. Choose the built-in adapter for
+your runtime, initialize it, and pass it to `initializeCoco`.
 
 ```ts
 import { initializeCoco } from '@cashu/coco-core';
 import { SqliteRepositories } from '@cashu/coco-sqlite';
 
-const repo = new SqliteRepositories({ database: db }); // Implements the Repositories interface
-await repo.init(); // Ensures schema and applies migrations
+const repo = new SqliteRepositories({ database: db });
+await repo.init();
 const coco = await initializeCoco({
-  repo, // <-- pass the storage implementation
+  repo,
   seedGetter,
   // other params
 });
 ```
-
-Some storage implementations are maintained as part of the cashubtc/coco repository, but technically you can use any class that implements the `Repositories` interface.
-
-App code imports `initializeCoco` and other wallet-facing symbols from
-`@cashu/coco-core`. Adapter implementations and adapter contract tests should
-import repository contracts and serialization helpers from the adapter subpath:
-
-```ts
-import { type Repositories, serializeAmount } from '@cashu/coco-core/adapter';
-```
-
-The adapter subpath is the stable public surface for persistence authors.
-Concrete core services, operation service classes, handler providers, transport
-internals, and individual memory repository classes are not part of the
-app-facing root API.
-
-## Atomic key derivation persistence
-
-`KeyRingRepository` owns the transaction boundary for generated keys:
-
-```ts
-interface KeyRingRepository {
-  deriveAndPersistKeyPair(
-    purpose: KeypairPurpose,
-    derive: (derivationIndex: number) => Pick<Keypair, 'publicKeyHex' | 'secretKey'>,
-  ): Promise<Keypair>;
-}
-```
-
-The caller loads the seed before invoking this method. The repository then starts a writer
-transaction, selects an index greater than both the purpose's durable high-water mark and every
-stored keypair index, synchronously derives the key, and commits the keypair and high-water mark
-together. The promise resolves with the keypair only after commit.
-
-If derivation, persistence, or commit fails, neither the keypair nor the high-water mark may remain
-persisted. Reusing that index is safe because the key was never returned. Once a keypair commits,
-deleting it must not lower the high-water mark or make its index reusable. A process-local mutex
-alone does not satisfy the contract because it cannot coordinate independent processes, database
-connections, or browser tabs.
-
-Call this root repository method directly; it is omitted from `RepositoryTransactionScope` so its
-result cannot be exposed before a surrounding caller transaction commits.
-
-The Memory adapter guarantees this behavior only for callers sharing one repository object. SQL
-adapters use an immediate/exclusive writer transaction, and IndexedDB uses one `readwrite`
-transaction covering the keypair and allocation stores. Adapter authors can run
-`runKeyRingDerivationRepositoryContract` from `@cashu/coco-adapter-tests` to verify rollback,
-purpose isolation, bounds, deletion behavior, and shared-storage coordination.
 
 ## Security
 
@@ -71,8 +24,8 @@ underlying database and any associated journals, write-ahead logs, and backups a
 
 The embedding application is responsible for storage protection. Applications that require
 encryption at rest should use an encrypted database, encrypted filesystem or platform storage, or
-a custom `Repositories` implementation that provides the required protection. Ensure that the
-chosen protection also covers database journals and backups.
+a storage implementation that provides the required protection. Ensure that the chosen protection
+also covers database journals and backups.
 
 Back up and restore keypairs and key-derivation high-water metadata together. A full database
 deletion intentionally starts a new local allocation namespace. Restoring a historical snapshot can

--- a/packages/expo-sqlite/src/test/contract.test.ts
+++ b/packages/expo-sqlite/src/test/contract.test.ts
@@ -15,7 +15,6 @@ import {
   runSendOperationRepositoryContract,
   runMeltOperationRepositoryContract,
   runMeltQuoteRepositoryContract,
-  createDummyMint,
 } from '@cashu/coco-adapter-tests';
 import { runSqlDatabaseContract } from '@cashu/coco-sql-storage/test';
 import { SqliteRepositories as Repositories } from '../index.ts';
@@ -191,7 +190,9 @@ runSqlDatabaseContract(
 runRepositoryTransactionContract(
   {
     createRepositories,
+    createSharedRepositories,
     testConcurrentRootOperationIsolation: true,
+    testWriterOwnershipAtEntry: true,
   },
   { describe, it, expect },
 );
@@ -227,22 +228,22 @@ describe('expo-sqlite web transaction compatibility', () => {
     Object.defineProperty(globalThis, 'document', { value: {}, configurable: true });
 
     const database = new WebExpoSqliteDatabaseShim();
-    const repositories = new Repositories({
+    const wrappedDatabase = new ExpoSqliteDb({
       database: database as unknown as SqliteRepositoriesOptions['database'],
     });
 
     try {
-      await repositories.init();
       database.exclusiveTransactionCalls = 0;
       database.transactionCalls = 0;
 
-      await repositories.withTransaction(async (tx) => {
-        await tx.mintRepository.addOrUpdateMint(createDummyMint());
+      await wrappedDatabase.transaction(async (transaction) => {
+        await expect(transaction.get<{ value: number }>('SELECT 1 AS value')).resolves.toEqual({
+          value: 1,
+        });
       });
 
       expect(database.exclusiveTransactionCalls).toBe(0);
       expect(database.transactionCalls).toBe(1);
-      await expect(repositories.mintRepository.getAllMints()).resolves.toHaveLength(1);
     } finally {
       await database.closeAsync();
       restoreGlobalProperty('window', windowDescriptor);
@@ -254,22 +255,22 @@ describe('expo-sqlite web transaction compatibility', () => {
 describe('expo-sqlite native transaction compatibility', () => {
   it('uses exclusive transactions when available outside web', async () => {
     const database = new NativeExpoSqliteDatabaseShim();
-    const repositories = new Repositories({
+    const wrappedDatabase = new ExpoSqliteDb({
       database: database as unknown as SqliteRepositoriesOptions['database'],
     });
 
     try {
-      await repositories.init();
       database.exclusiveTransactionCalls = 0;
       database.transactionCalls = 0;
 
-      await repositories.withTransaction(async (tx) => {
-        await tx.mintRepository.addOrUpdateMint(createDummyMint());
+      await wrappedDatabase.transaction(async (transaction) => {
+        await expect(transaction.get<{ value: number }>('SELECT 1 AS value')).resolves.toEqual({
+          value: 1,
+        });
       });
 
       expect(database.exclusiveTransactionCalls).toBe(1);
       expect(database.transactionCalls).toBe(0);
-      await expect(repositories.mintRepository.getAllMints()).resolves.toHaveLength(1);
     } finally {
       await database.closeAsync();
     }

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -17,7 +17,7 @@ import type {
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core/adapter';
-import { IdbDb, type IdbDbOptions, runOutsideIdbTransaction } from './lib/db.ts';
+import { IdbDb, type IdbDbOptions } from './lib/db.ts';
 import { ensureSchema } from './lib/schema.ts';
 import { IdbMintRepository } from './repositories/MintRepository.ts';
 import { IdbKeysetRepository } from './repositories/KeysetRepository.ts';
@@ -62,29 +62,25 @@ export class IndexedDbRepositories implements Repositories {
 
   constructor(options: IndexedDbRepositoriesOptions) {
     this.db = new IdbDb(options);
-    this.mintRepository = this.wrapRootRepository(new IdbMintRepository(this.db));
-    this.keyRingRepository = this.wrapRootRepository(new IdbKeyRingRepository(this.db));
-    this.counterRepository = this.wrapRootRepository(new IdbCounterRepository(this.db));
-    this.keysetRepository = this.wrapRootRepository(new IdbKeysetRepository(this.db));
-    this.proofRepository = this.wrapRootRepository(new IdbProofRepository(this.db));
-    this.meltQuoteRepository = this.wrapRootRepository(new IdbMeltQuoteRepository(this.db));
-    this.mintQuoteRepository = this.wrapRootRepository(new IdbMintQuoteRepository(this.db));
-    this.legacyMintQuoteRepository = this.wrapRootRepository(
-      new IdbLegacyMintQuoteRepository(this.db),
+    this.mintRepository = new IdbMintRepository(this.db);
+    this.keyRingRepository = new IdbKeyRingRepository(this.db);
+    this.counterRepository = new IdbCounterRepository(this.db);
+    this.keysetRepository = new IdbKeysetRepository(this.db);
+    this.proofRepository = new IdbProofRepository(this.db);
+    this.meltQuoteRepository = new IdbMeltQuoteRepository(this.db);
+    this.mintQuoteRepository = new IdbMintQuoteRepository(this.db);
+    this.legacyMintQuoteRepository = new IdbLegacyMintQuoteRepository(this.db);
+    this.historyRepository = new IdbHistoryRepository(this.db);
+    this.sendOperationRepository = new IdbSendOperationRepository(this.db);
+    this.meltOperationRepository = new IdbMeltOperationRepository(this.db);
+    this.authSessionRepository = new IdbAuthSessionRepository(this.db);
+    this.mintOperationRepository = new IdbMintOperationRepository(this.db);
+    this.receiveOperationRepository = new IdbReceiveOperationRepository(this.db);
+    this.paymentRequestReceiveOperationRepository = new IdbPaymentRequestReceiveOperationRepository(
+      this.db,
     );
-    this.historyRepository = this.wrapRootRepository(new IdbHistoryRepository(this.db));
-    this.sendOperationRepository = this.wrapRootRepository(new IdbSendOperationRepository(this.db));
-    this.meltOperationRepository = this.wrapRootRepository(new IdbMeltOperationRepository(this.db));
-    this.authSessionRepository = this.wrapRootRepository(new IdbAuthSessionRepository(this.db));
-    this.mintOperationRepository = this.wrapRootRepository(new IdbMintOperationRepository(this.db));
-    this.receiveOperationRepository = this.wrapRootRepository(
-      new IdbReceiveOperationRepository(this.db),
-    );
-    this.paymentRequestReceiveOperationRepository = this.wrapRootRepository(
-      new IdbPaymentRequestReceiveOperationRepository(this.db),
-    );
-    this.paymentRequestReceiveAttemptRepository = this.wrapRootRepository(
-      new IdbPaymentRequestReceiveAttemptRepository(this.db),
+    this.paymentRequestReceiveAttemptRepository = new IdbPaymentRequestReceiveAttemptRepository(
+      this.db,
     );
   }
 
@@ -99,6 +95,10 @@ export class IndexedDbRepositories implements Repositories {
   }
 
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
+    if (this.db.hasAmbientTransaction) {
+      throw new Error('Nested IndexedDB Wallet transactions are not supported');
+    }
+
     const stores = this.db.tables.map((t) => t.name);
     return this.db.runTransaction('rw', stores, async () => {
       const scopedDb = this.db;
@@ -125,17 +125,6 @@ export class IndexedDbRepositories implements Repositories {
         ),
       };
       return fn(scopedRepositories);
-    });
-  }
-
-  private wrapRootRepository<T extends object>(repository: T): T {
-    return new Proxy(repository, {
-      get: (target, property) => {
-        const value = Reflect.get(target, property, target) as unknown;
-        if (typeof value !== 'function') return value;
-        return (...args: unknown[]) =>
-          runOutsideIdbTransaction(() => Reflect.apply(value, target, args));
-      },
     });
   }
 }

--- a/packages/indexeddb/src/index.ts
+++ b/packages/indexeddb/src/index.ts
@@ -17,7 +17,7 @@ import type {
   ReceiveOperationRepository,
   RepositoryTransactionScope,
 } from '@cashu/coco-core/adapter';
-import { IdbDb, type IdbDbOptions } from './lib/db.ts';
+import { IdbDb, type IdbDbOptions, runOutsideIdbTransaction } from './lib/db.ts';
 import { ensureSchema } from './lib/schema.ts';
 import { IdbMintRepository } from './repositories/MintRepository.ts';
 import { IdbKeysetRepository } from './repositories/KeysetRepository.ts';
@@ -62,25 +62,29 @@ export class IndexedDbRepositories implements Repositories {
 
   constructor(options: IndexedDbRepositoriesOptions) {
     this.db = new IdbDb(options);
-    this.mintRepository = new IdbMintRepository(this.db);
-    this.keyRingRepository = new IdbKeyRingRepository(this.db);
-    this.counterRepository = new IdbCounterRepository(this.db);
-    this.keysetRepository = new IdbKeysetRepository(this.db);
-    this.proofRepository = new IdbProofRepository(this.db);
-    this.meltQuoteRepository = new IdbMeltQuoteRepository(this.db);
-    this.mintQuoteRepository = new IdbMintQuoteRepository(this.db);
-    this.legacyMintQuoteRepository = new IdbLegacyMintQuoteRepository(this.db);
-    this.historyRepository = new IdbHistoryRepository(this.db);
-    this.sendOperationRepository = new IdbSendOperationRepository(this.db);
-    this.meltOperationRepository = new IdbMeltOperationRepository(this.db);
-    this.authSessionRepository = new IdbAuthSessionRepository(this.db);
-    this.mintOperationRepository = new IdbMintOperationRepository(this.db);
-    this.receiveOperationRepository = new IdbReceiveOperationRepository(this.db);
-    this.paymentRequestReceiveOperationRepository = new IdbPaymentRequestReceiveOperationRepository(
-      this.db,
+    this.mintRepository = this.wrapRootRepository(new IdbMintRepository(this.db));
+    this.keyRingRepository = this.wrapRootRepository(new IdbKeyRingRepository(this.db));
+    this.counterRepository = this.wrapRootRepository(new IdbCounterRepository(this.db));
+    this.keysetRepository = this.wrapRootRepository(new IdbKeysetRepository(this.db));
+    this.proofRepository = this.wrapRootRepository(new IdbProofRepository(this.db));
+    this.meltQuoteRepository = this.wrapRootRepository(new IdbMeltQuoteRepository(this.db));
+    this.mintQuoteRepository = this.wrapRootRepository(new IdbMintQuoteRepository(this.db));
+    this.legacyMintQuoteRepository = this.wrapRootRepository(
+      new IdbLegacyMintQuoteRepository(this.db),
     );
-    this.paymentRequestReceiveAttemptRepository = new IdbPaymentRequestReceiveAttemptRepository(
-      this.db,
+    this.historyRepository = this.wrapRootRepository(new IdbHistoryRepository(this.db));
+    this.sendOperationRepository = this.wrapRootRepository(new IdbSendOperationRepository(this.db));
+    this.meltOperationRepository = this.wrapRootRepository(new IdbMeltOperationRepository(this.db));
+    this.authSessionRepository = this.wrapRootRepository(new IdbAuthSessionRepository(this.db));
+    this.mintOperationRepository = this.wrapRootRepository(new IdbMintOperationRepository(this.db));
+    this.receiveOperationRepository = this.wrapRootRepository(
+      new IdbReceiveOperationRepository(this.db),
+    );
+    this.paymentRequestReceiveOperationRepository = this.wrapRootRepository(
+      new IdbPaymentRequestReceiveOperationRepository(this.db),
+    );
+    this.paymentRequestReceiveAttemptRepository = this.wrapRootRepository(
+      new IdbPaymentRequestReceiveAttemptRepository(this.db),
     );
   }
 
@@ -121,6 +125,17 @@ export class IndexedDbRepositories implements Repositories {
         ),
       };
       return fn(scopedRepositories);
+    });
+  }
+
+  private wrapRootRepository<T extends object>(repository: T): T {
+    return new Proxy(repository, {
+      get: (target, property) => {
+        const value = Reflect.get(target, property, target) as unknown;
+        if (typeof value !== 'function') return value;
+        return (...args: unknown[]) =>
+          runOutsideIdbTransaction(() => Reflect.apply(value, target, args));
+      },
     });
   }
 }

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -58,6 +58,10 @@ export class IdbDb extends Dexie {
     // NESTED TRANSACTION DETECTION:
     // Check if we're already inside a Dexie transaction context
     const currentTx = Dexie.currentTransaction as DexieTransaction | undefined;
+    if (currentTx && !currentTx.active) {
+      // A completed Dexie zone can echo through a promise continuation; start from its transless PSD.
+      return Dexie.ignoreTransaction(() => this.runTransaction(mode, stores, fn));
+    }
     if (currentTx && currentTx === this.activeTransaction && currentTx.active) {
       // We're nested and transaction is still active - safe to reuse
       return fn(currentTx);
@@ -100,11 +104,11 @@ export class IdbDb extends Dexie {
   get currentTransaction(): DexieTransaction | null {
     return Dexie.currentTransaction ?? this.activeTransaction;
   }
-}
 
-/** Run a root repository operation without inheriting a caller's ambient Dexie transaction. */
-export function runOutsideIdbTransaction<T>(fn: () => T): T {
-  return Dexie.ignoreTransaction(fn);
+  /** Whether this call context already belongs to a Dexie transaction. */
+  get hasAmbientTransaction(): boolean {
+    return Boolean(Dexie.currentTransaction?.active);
+  }
 }
 
 export function getUnixTimeSeconds(): number {

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -102,6 +102,11 @@ export class IdbDb extends Dexie {
   }
 }
 
+/** Run a root repository operation without inheriting a caller's ambient Dexie transaction. */
+export function runOutsideIdbTransaction<T>(fn: () => T): T {
+  return Dexie.ignoreTransaction(fn);
+}
+
 export function getUnixTimeSeconds(): number {
   return Math.floor(Date.now() / 1000);
 }

--- a/packages/indexeddb/src/lib/db.ts
+++ b/packages/indexeddb/src/lib/db.ts
@@ -105,9 +105,10 @@ export class IdbDb extends Dexie {
     return Dexie.currentTransaction ?? this.activeTransaction;
   }
 
-  /** Whether this call context already belongs to a Dexie transaction. */
+  /** Whether this call context already belongs to this logical IndexedDB database. */
   get hasAmbientTransaction(): boolean {
-    return Boolean(Dexie.currentTransaction?.active);
+    const transaction = Dexie.currentTransaction;
+    return Boolean(transaction?.active && transaction.db.name === this.name);
   }
 }
 

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -70,6 +70,9 @@ async function expectRejects(fn: () => Promise<void>) {
 runRepositoryTransactionContract(
   {
     createRepositories,
+    createSharedRepositories,
+    holdTransactionOpen: (release) => Dexie.waitFor(release),
+    testConcurrentRootOperationIsolation: true,
   },
   { describe, it, expect },
 );

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -121,6 +121,45 @@ describe('indexeddb Wallet transaction boundaries', () => {
     }
   });
 
+  it('treats another connection to the same Wallet database as ambient', async () => {
+    const { first, second, dispose } = await createSharedRepositories();
+    try {
+      await first.db.transaction('rw', first.db.tables, () => {
+        expect(second.db.hasAmbientTransaction).toBe(true);
+      });
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('allows a Wallet transaction inside an unrelated Dexie database transaction', async () => {
+    const { repositories, dispose } = await createRepositories();
+    const unrelatedName = `unrelated_${Date.now()}_${dbCounter++}`;
+    const unrelated = new Dexie(unrelatedName);
+    unrelated.version(1).stores({ items: '++id' });
+    await unrelated.open();
+    const walletMint = {
+      ...createDummyMint(),
+      mintUrl: 'https://unrelated-ambient.test',
+    };
+
+    try {
+      await unrelated.transaction('rw', unrelated.table('items'), async () => {
+        await Dexie.waitFor(
+          repositories.withTransaction(async ({ mintRepository }) => {
+            await mintRepository.addOrUpdateMint(walletMint);
+          }),
+        );
+      });
+
+      expect(await repositories.mintRepository.getAllMints()).toContainEqual(walletMint);
+    } finally {
+      unrelated.close();
+      await Dexie.delete(unrelatedName);
+      await dispose();
+    }
+  }, 2_000);
+
   it('keeps closed-over root repository calls in the current Wallet transaction', async () => {
     const { repositories, dispose } = await createRepositories();
     try {

--- a/packages/indexeddb/src/test/contract.test.ts
+++ b/packages/indexeddb/src/test/contract.test.ts
@@ -3,6 +3,7 @@ import { Amount } from '@cashu/cashu-ts';
 import Dexie from 'dexie';
 import {
   runRepositoryTransactionContract,
+  createDummyMint,
   runKeyRingDerivationRepositoryContract,
   runAuthSessionRepositoryContract,
   runProofRepositoryContract,
@@ -71,6 +72,7 @@ runRepositoryTransactionContract(
   {
     createRepositories,
     createSharedRepositories,
+    createIsolationRepositories: createSharedRepositories,
     holdTransactionOpen: (release) => Dexie.waitFor(release),
     testConcurrentRootOperationIsolation: true,
   },
@@ -99,6 +101,45 @@ runMeltOperationRepositoryContract({ createRepositories }, { describe, it, expec
 runMeltQuoteRepositoryContract({ createRepositories }, { describe, it, expect });
 
 runPaymentRequestReceiveRepositoryContract({ createRepositories }, { describe, it, expect });
+
+describe('indexeddb Wallet transaction boundaries', () => {
+  it('does not report a nested strong scope as committed before its ambient parent', async () => {
+    const { repositories, dispose } = await createRepositories();
+    let nestedScopeResolved = false;
+    try {
+      await expect(
+        repositories.db.transaction('rw', repositories.db.tables, async () => {
+          await repositories.withTransaction(async () => {});
+          nestedScopeResolved = true;
+          throw new Error('abort ambient transaction');
+        }),
+      ).rejects.toThrow();
+
+      expect(nestedScopeResolved).toBe(false);
+    } finally {
+      await dispose();
+    }
+  });
+
+  it('keeps closed-over root repository calls in the current Wallet transaction', async () => {
+    const { repositories, dispose } = await createRepositories();
+    try {
+      await expect(
+        repositories.withTransaction(async () => {
+          await repositories.mintRepository.addOrUpdateMint({
+            ...createDummyMint(),
+            mintUrl: 'https://closed-over-root.test',
+          });
+          throw new Error('abort Wallet transaction');
+        }),
+      ).rejects.toThrow('abort Wallet transaction');
+
+      expect(await repositories.mintRepository.getAllMints()).toEqual([]);
+    } finally {
+      await dispose();
+    }
+  }, 2_000);
+});
 
 describe('indexeddb quote storage constraints', () => {
   it('rolls back the keypair and high-water mark when persistence aborts', async () => {

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -59,16 +59,18 @@ function getSqliteErrorCode(error: unknown): string {
   return '';
 }
 
-function isSqliteTransactionConflict(error: unknown): boolean {
+function hasSqliteTransactionConflictCode(error: unknown): boolean {
   const code = getSqliteErrorCode(error);
-  if (
+  return (
     code === '5' ||
     code === '6' ||
     code.startsWith('SQLITE_BUSY') ||
     code.startsWith('SQLITE_LOCKED')
-  ) {
-    return true;
-  }
+  );
+}
+
+function isSqliteTransactionConflict(error: unknown): boolean {
+  if (hasSqliteTransactionConflictCode(error)) return true;
 
   const message =
     error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
@@ -157,6 +159,10 @@ export class SqlStorageRepositories implements Repositories {
           try {
             return await fn(createRepositoryScope(txDatabase));
           } catch (error) {
+            if (error instanceof RepositoryTransactionConflictError) throw error;
+            if (hasSqliteTransactionConflictCode(error)) {
+              throw new RepositoryTransactionConflictError(undefined, error);
+            }
             throw new RepositoryTransactionCallbackFailure(error);
           }
         },

--- a/packages/sql-storage/src/repositories.ts
+++ b/packages/sql-storage/src/repositories.ts
@@ -18,6 +18,7 @@ import type {
   PaymentRequestReceiveAttemptRepository,
   PaymentRequestReceiveOperationRepository,
 } from '@cashu/coco-core/adapter';
+import { RepositoryTransactionConflictError } from '@cashu/coco-core/adapter';
 import type { SqlDatabase } from './index.ts';
 import { ensureSchema } from './schema.ts';
 import { SqliteMintRepository } from './repositories/MintRepository.ts';
@@ -41,6 +42,41 @@ import {
 
 export interface SqlStorageRepositoriesOptions {
   database: SqlDatabase;
+}
+
+class RepositoryTransactionCallbackFailure extends Error {
+  constructor(readonly error: unknown) {
+    super('Repository transaction callback failed');
+    this.name = 'RepositoryTransactionCallbackFailure';
+    (this as unknown as { cause?: unknown }).cause = error;
+  }
+}
+
+function getSqliteErrorCode(error: unknown): string {
+  if (typeof error !== 'object' || error === null) return '';
+  if ('code' in error) return String((error as { code?: unknown }).code).toUpperCase();
+  if ('errno' in error) return String((error as { errno?: unknown }).errno).toUpperCase();
+  return '';
+}
+
+function isSqliteTransactionConflict(error: unknown): boolean {
+  const code = getSqliteErrorCode(error);
+  if (
+    code === '5' ||
+    code === '6' ||
+    code.startsWith('SQLITE_BUSY') ||
+    code.startsWith('SQLITE_LOCKED')
+  ) {
+    return true;
+  }
+
+  const message =
+    error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (
+    message.includes('database is locked') ||
+    message.includes('database table is locked') ||
+    message.includes('database is busy')
+  );
 }
 
 function createRepositoryScope(database: SqlDatabase): RepositoryTransactionScope {
@@ -115,7 +151,25 @@ export class SqlStorageRepositories implements Repositories {
   }
 
   async withTransaction<T>(fn: (repos: RepositoryTransactionScope) => Promise<T>): Promise<T> {
-    return this.database.transaction((txDatabase) => fn(createRepositoryScope(txDatabase)));
+    try {
+      return await this.database.transaction(
+        async (txDatabase) => {
+          try {
+            return await fn(createRepositoryScope(txDatabase));
+          } catch (error) {
+            throw new RepositoryTransactionCallbackFailure(error);
+          }
+        },
+        { mode: 'immediate' },
+      );
+    } catch (error) {
+      if (error instanceof RepositoryTransactionCallbackFailure) throw error.error;
+      if (error instanceof RepositoryTransactionConflictError) throw error;
+      if (isSqliteTransactionConflict(error)) {
+        throw new RepositoryTransactionConflictError(undefined, error);
+      }
+      throw error;
+    }
   }
 }
 

--- a/packages/sql-storage/src/test/repositories.test.ts
+++ b/packages/sql-storage/src/test/repositories.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import { RepositoryTransactionConflictError } from '@cashu/coco-core/adapter';
+import type { SqlDatabase, SqlParams, SqlRunResult, SqlTransactionOptions } from '../index.ts';
+import { SqlStorageRepositories } from '../repositories.ts';
+
+class PassthroughSqlDatabase implements SqlDatabase {
+  async exec(): Promise<void> {}
+
+  async run(): Promise<SqlRunResult> {
+    return { lastInsertRowId: 0, changes: 0 };
+  }
+
+  async get<Row extends object>(_sql: string, _params?: SqlParams): Promise<Row | undefined> {
+    return undefined;
+  }
+
+  async all<Row extends object>(_sql: string, _params?: SqlParams): Promise<Row[]> {
+    return [];
+  }
+
+  async transaction<T>(
+    fn: (tx: SqlDatabase) => Promise<T>,
+    _options?: SqlTransactionOptions,
+  ): Promise<T> {
+    return fn(this);
+  }
+}
+
+describe('SqlStorageRepositories transaction errors', () => {
+  it('maps driver-coded callback lock errors to a typed transient conflict', async () => {
+    const repositories = new SqlStorageRepositories({ database: new PassthroughSqlDatabase() });
+    const lockedError = Object.assign(new Error('statement failed'), { code: 'SQLITE_LOCKED' });
+
+    await expect(
+      repositories.withTransaction(async () => {
+        throw lockedError;
+      }),
+    ).rejects.toBeInstanceOf(RepositoryTransactionConflictError);
+  });
+});

--- a/packages/sqlite-bun/src/test/contract.test.ts
+++ b/packages/sqlite-bun/src/test/contract.test.ts
@@ -74,7 +74,9 @@ runSqlDatabaseContract(
 runRepositoryTransactionContract(
   {
     createRepositories,
+    createSharedRepositories,
     testConcurrentRootOperationIsolation: true,
+    testWriterOwnershipAtEntry: true,
   },
   { describe, it, expect },
 );

--- a/packages/sqlite3/src/test/contract.test.ts
+++ b/packages/sqlite3/src/test/contract.test.ts
@@ -73,7 +73,9 @@ runSqlDatabaseContract(
 runRepositoryTransactionContract(
   {
     createRepositories,
+    createSharedRepositories,
     testConcurrentRootOperationIsolation: true,
+    testWriterOwnershipAtEntry: true,
   },
   { describe, it, expect },
 );


### PR DESCRIPTION
## Stack

Stack 1 of 4 replacing #459:

1. **#460 — transaction foundation (this PR)**
2. #461 — keypair allocation
3. #463 — Send hardening
4. #462 — Receive hardening

This is the transaction primitive itself. It is identical to the already-reviewed #457 slice, reopened as the clean root of the smaller stack.

## Scope

- Strengthen the wallet repository transaction contract and failure semantics.
- Make memory transactions staged and atomic.
- Extend shared adapter conformance coverage across storage backends.
- Add the transaction capability to the public adapter surface.

Resolves #447.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit` — 1,269 passed, 0 failed
- `bun run --filter='@cashu/coco-core' typecheck`
- All GitHub checks pass

