### PR TITLE
refactor(core): centralize watcher lifecycles with Effect

### DIFF
--- a/.changeset/effect-mint-operation-processor.md
+++ b/.changeset/effect-mint-operation-processor.md
@@ -1,0 +1,7 @@
+---
+'@cashu/coco-core': patch
+---
+
+Use Effect structured concurrency for mint operation scheduling, retry, and processor cleanup.
+Operation requeues are now deduplicated through processing and retry, and scheduled work is
+cancelled when its mint becomes untrusted.

--- a/.changeset/effect-mint-operation-processor.md
+++ b/.changeset/effect-mint-operation-processor.md
@@ -2,6 +2,7 @@
 '@cashu/coco-core': patch
 ---
 
-Use Effect structured concurrency for mint operation scheduling, retry, and processor cleanup.
-Operation requeues are now deduplicated through processing and retry, and scheduled work is
-cancelled when its mint becomes untrusted.
+Centralize Effect structured concurrency for background task ownership and cleanup. Mint operation
+requeues are now deduplicated through processing and retry, scheduled work is cancelled when its
+mint becomes untrusted, and proof-state event work and subscriptions share the same scoped
+lifecycle.

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@scure/bip32": "^2.0.1",
+        "effect": "^3.22.1",
       },
       "devDependencies": {
         "@cashu/coco-adapter-tests": "1.0.0",
@@ -1248,6 +1249,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1339,6 +1342,8 @@
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
 
     "fake-bolt11": ["fake-bolt11@0.1.0", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1" } }, "sha512-VnOrCOkq5+oTGS0oZZpr+eX89ztAe5KvVdiokRfDh7z22Jz3PnCuvik2y22I/zPXPcS7XDjukJkcQbwqc7qnqw=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1851,6 +1856,8 @@
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qrcode-terminal": ["qrcode-terminal@0.11.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
     "@cashu/cashu-ts": "5.0.0-rc.4",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "@scure/bip32": "^2.0.1"
+    "@scure/bip32": "^2.0.1",
+    "effect": "^3.22.1"
   }
 }

--- a/packages/core/services/watchers/BackgroundTaskRuntime.ts
+++ b/packages/core/services/watchers/BackgroundTaskRuntime.ts
@@ -1,0 +1,118 @@
+import { Effect, Exit, Fiber, FiberMap, FiberSet, Scope } from 'effect';
+
+type BackgroundTask = Effect.Effect<void, never>;
+type ScopedResource<A> = Effect.Effect<A, never, Scope.Scope>;
+type Finalizer = () => void | Promise<void>;
+
+/**
+ * Owns the Effect scope and fibers used by a start/stop background service.
+ * Domain services keep their own state; this runtime only manages task lifetime.
+ */
+export class BackgroundTaskRuntime {
+  private active = true;
+  private closePromise?: Promise<void>;
+
+  private constructor(
+    private readonly scope: Scope.CloseableScope,
+    private readonly keyedTasks: FiberMap.FiberMap<string, void, never>,
+    private readonly tasks: FiberSet.FiberSet<void, never>,
+  ) {}
+
+  static make(): BackgroundTaskRuntime {
+    const scope = Effect.runSync(Scope.make());
+    const { keyedTasks, tasks } = Effect.runSync(
+      Effect.gen(function* () {
+        return {
+          keyedTasks: yield* FiberMap.make<string, void, never>(),
+          tasks: yield* FiberSet.make<void, never>(),
+        };
+      }).pipe(Scope.extend(scope)),
+    );
+
+    return new BackgroundTaskRuntime(scope, keyedTasks, tasks);
+  }
+
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  get keyedTaskCount(): number {
+    return Array.from(this.keyedTasks).length;
+  }
+
+  /** Acquire an Effect resource whose finalizer should share this runtime's lifetime. */
+  acquire<A>(resource: ScopedResource<A>): A {
+    if (!this.active) {
+      throw new Error('Cannot acquire a resource from a closed background task runtime');
+    }
+    return Effect.runSync(resource.pipe(Scope.extend(this.scope)));
+  }
+
+  addFinalizer(finalizer: Finalizer): void {
+    if (!this.active) {
+      throw new Error('Cannot add a finalizer to a closed background task runtime');
+    }
+
+    Effect.runSync(
+      Scope.addFinalizer(
+        this.scope,
+        Effect.promise(async () => {
+          await finalizer();
+        }),
+      ),
+    );
+  }
+
+  /** Track a task and return a promise that settles when its fiber exits. */
+  async run(task: BackgroundTask): Promise<void> {
+    if (!this.active) return;
+
+    const fiber = Effect.runSync(FiberSet.run(this.tasks, task));
+    await Effect.runPromise(Fiber.await(fiber));
+  }
+
+  /** Start a keyed task unless that key is already active. */
+  runKeyed(key: string, task: BackgroundTask): boolean {
+    if (!this.active || FiberMap.unsafeHas(this.keyedTasks, key)) return false;
+
+    Effect.runSync(FiberMap.run(this.keyedTasks, key, task, { onlyIfMissing: true }));
+    return true;
+  }
+
+  async cancelWhere(predicate: (key: string) => boolean): Promise<number> {
+    const keys = Array.from(this.keyedTasks, ([key]) => key).filter(predicate);
+    await Effect.runPromise(
+      Effect.forEach(keys, (key) => FiberMap.remove(this.keyedTasks, key), { discard: true }),
+    );
+    return keys.length;
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (true) {
+      await Effect.runPromise(
+        Effect.all([FiberMap.awaitEmpty(this.keyedTasks), FiberSet.awaitEmpty(this.tasks)], {
+          concurrency: 'unbounded',
+        }),
+      );
+
+      if (this.keyedTaskCount === 0 && Array.from(this.tasks).length === 0) return;
+      await Effect.runPromise(Effect.yieldNow());
+    }
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+
+    this.active = false;
+    this.closePromise = Effect.runPromise(Scope.close(this.scope, Exit.void));
+    return this.closePromise;
+  }
+}
+
+/** Bridge an existing Promise without abandoning it during graceful shutdown. */
+export function uninterruptiblePromise<A>(evaluate: () => Promise<A>): Effect.Effect<A, unknown> {
+  return Effect.tryPromise({
+    try: evaluate,
+    catch: (error) => error,
+  }).pipe(Effect.uninterruptible);
+}

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -1,6 +1,7 @@
+import { Effect, Exit, FiberMap, FiberSet, RateLimiter, Schedule, Scope } from 'effect';
 import type { EventBus, CoreEvents } from '@core/events';
-import type { Logger } from '../../logging/Logger.ts';
 import type { MintMethod, MintOperationService } from '@core/operations/mint';
+import type { Logger } from '../../logging/Logger.ts';
 import { MintOperationError, NetworkError } from '../../models/Error';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 
@@ -8,12 +9,18 @@ interface QueueItem {
   mintUrl: string;
   operationId: string;
   method: string;
-  retryCount: number;
-  nextRetryAt: number;
 }
 
 interface OperationHandler {
   process(mintUrl: string, operationId: string): Promise<void>;
+}
+
+interface ProcessorRuntime {
+  readonly scope: Scope.CloseableScope;
+  readonly operationFibers: FiberMap.FiberMap<string, void, never>;
+  readonly claimFibers: FiberSet.FiberSet<void, never>;
+  readonly operationSemaphore: Effect.Semaphore;
+  readonly rateLimitOperation: RateLimiter.RateLimiter;
 }
 
 class DefaultMintOperationHandler implements OperationHandler {
@@ -32,6 +39,36 @@ export interface MintOperationProcessorOptions {
   autoClaimMintQuotes?: boolean;
 }
 
+function operationKey(mintUrl: string, operationId: string): string {
+  return JSON.stringify([mintUrl, operationId]);
+}
+
+function mintUrlFromOperationKey(key: string): string | undefined {
+  try {
+    const parsed = JSON.parse(key);
+    return Array.isArray(parsed) && typeof parsed[0] === 'string' ? parsed[0] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function quoteKey(mintUrl: string, method: MintMethod, quoteId: string): string {
+  return JSON.stringify([mintUrl, method, quoteId]);
+}
+
+function isNetworkError(error: unknown): boolean {
+  return (
+    error instanceof NetworkError || (error instanceof Error && error.message.includes('network'))
+  );
+}
+
+function waitForPromise<A>(evaluate: () => Promise<A>): Effect.Effect<A, unknown> {
+  return Effect.tryPromise({
+    try: evaluate,
+    catch: (error) => error,
+  }).pipe(Effect.uninterruptible);
+}
+
 export class MintOperationProcessor {
   private readonly mintOperations: MintOperationService;
   private readonly quoteLifecycle: QuoteLifecycle;
@@ -39,18 +76,10 @@ export class MintOperationProcessor {
   private readonly logger?: Logger;
 
   private running = false;
-  private queue: QueueItem[] = [];
-  private processing = false;
-  private processingTimer?: ReturnType<typeof setTimeout>;
-  private offQuoteUpdated?: () => void;
-  private offPending?: () => void;
-  private offRequeue?: () => void;
-  private offUntrusted?: () => void;
-  private claimingQuotes = new Set<string>();
-  private quoteClaimsNeedingFollowUp = new Set<string>();
-  private claimTasks = new Set<Promise<void>>();
-
-  private handlers = new Map<string, OperationHandler>();
+  private runtime?: ProcessorRuntime;
+  private readonly claimingQuotes = new Set<string>();
+  private readonly quoteClaimsNeedingFollowUp = new Set<string>();
+  private readonly handlers = new Map<string, OperationHandler>();
   private readonly processIntervalMs: number;
   private readonly maxRetries: number;
   private readonly baseRetryDelayMs: number;
@@ -68,8 +97,6 @@ export class MintOperationProcessor {
     this.quoteLifecycle = quoteLifecycle;
     this.bus = bus;
     this.logger = logger;
-
-    // Apply options with defaults
     this.processIntervalMs = options?.processIntervalMs ?? 3000;
     this.maxRetries = options?.maxRetries ?? 3;
     this.baseRetryDelayMs = options?.baseRetryDelayMs ?? 5000;
@@ -94,371 +121,390 @@ export class MintOperationProcessor {
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    this.logger?.info('MintOperationProcessor started');
 
-    // Subscribe to canonical quote updates and resolve all affected local operations.
-    this.offQuoteUpdated = this.bus.on(
-      'mint-quote:updated',
-      async ({ mintUrl, method, quoteId }) => {
-        this.scheduleQuoteClaim(mintUrl, method, quoteId);
-      },
-    );
+    const scope = Effect.runSync(Scope.make());
+    try {
+      const runtime = Effect.runSync(
+        Effect.gen(this, function* () {
+          const operationFibers = yield* FiberMap.make<string, void, never>();
+          const claimFibers = yield* FiberSet.make<void, never>();
+          const operationSemaphore = yield* Effect.makeSemaphore(1);
+          const rateLimitOperation = yield* RateLimiter.make({
+            limit: 1,
+            interval: Math.max(1, this.processIntervalMs),
+          });
 
-    // Subscribe to pending operations so newly created operations reassess their canonical quote.
-    this.offPending = this.bus.on('mint-op:pending', async ({ operation }) => {
-      if (operation.state !== 'pending') {
-        return;
-      }
-
-      const quote = await this.quoteLifecycle.getMintQuote(
-        operation.mintUrl,
-        operation.method,
-        operation.quoteId,
+          return {
+            scope,
+            operationFibers,
+            claimFibers,
+            operationSemaphore,
+            rateLimitOperation,
+          } satisfies ProcessorRuntime;
+        }).pipe(Scope.extend(scope)),
       );
-      if (quote) {
-        this.scheduleQuoteClaim(operation.mintUrl, operation.method, operation.quoteId);
+
+      this.runtime = runtime;
+      const unsubscribe = this.subscribeToEvents(runtime);
+      Effect.runSync(Scope.addFinalizer(scope, Effect.sync(unsubscribe)));
+
+      if (this.autoClaimMintQuotes) {
+        this.schedulePendingQuoteClaims(runtime);
       }
-    });
 
-    // Subscribe to explicit operation requeue events.
-    this.offRequeue = this.bus.on('mint-op:requeue', ({ mintUrl, operationId, operation }) => {
-      this.enqueue(mintUrl, operationId, operation.method);
-    });
-
-    // Clear queue items when mint is untrusted
-    this.offUntrusted = this.bus.on('mint:untrusted', ({ mintUrl }) => {
-      this.clearMintFromQueue(mintUrl);
-    });
-
-    if (this.autoClaimMintQuotes) {
-      this.schedulePendingQuoteClaims();
+      this.logger?.info('MintOperationProcessor started');
+    } catch (error) {
+      this.runtime = undefined;
+      this.running = false;
+      await Effect.runPromise(Scope.close(scope, Exit.fail(error)));
+      throw error;
     }
-
-    // Start processing loop
-    this.scheduleNextProcess();
   }
 
   async stop(): Promise<void> {
     if (!this.running) return;
     this.running = false;
 
-    // Unsubscribe from events
-    if (this.offQuoteUpdated) {
-      try {
-        this.offQuoteUpdated();
-      } catch {
-        // ignore
-      } finally {
-        this.offQuoteUpdated = undefined;
-      }
+    const runtime = this.runtime;
+    this.runtime = undefined;
+    const pendingItems = runtime ? Array.from(runtime.operationFibers).length : 0;
+
+    if (runtime) {
+      await Effect.runPromise(Scope.close(runtime.scope, Exit.void));
     }
 
-    if (this.offPending) {
-      try {
-        this.offPending();
-      } catch {
-        // ignore
-      } finally {
-        this.offPending = undefined;
-      }
-    }
-
-    if (this.offRequeue) {
-      try {
-        this.offRequeue();
-      } catch {
-        // ignore
-      } finally {
-        this.offRequeue = undefined;
-      }
-    }
-
-    if (this.offUntrusted) {
-      try {
-        this.offUntrusted();
-      } catch {
-        // ignore
-      } finally {
-        this.offUntrusted = undefined;
-      }
-    }
-
-    // Clear processing timer
-    if (this.processingTimer) {
-      clearTimeout(this.processingTimer);
-      this.processingTimer = undefined;
-    }
-
-    // Wait for current processing to complete
-    while (this.processing || this.claimTasks.size > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-
-    this.logger?.info('MintOperationProcessor stopped', { pendingItems: this.queue.length });
+    this.claimingQuotes.clear();
+    this.quoteClaimsNeedingFollowUp.clear();
+    this.logger?.info('MintOperationProcessor stopped', { pendingItems });
   }
 
   /**
-   * Wait for the queue to be empty and all processing to complete.
-   * Useful for CLI applications that want to ensure all queued operations are processed before exiting.
+   * Wait for all scheduled operations and quote claims to complete.
+   * Useful for CLI applications that want to drain processor work before exiting.
    */
   async waitForCompletion(): Promise<void> {
-    while (this.queue.length > 0 || this.processing || this.claimTasks.size > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+    const runtime = this.runtime;
+    if (!runtime) return;
+
+    while (this.runtime === runtime) {
+      await Effect.runPromise(
+        Effect.all(
+          [FiberMap.awaitEmpty(runtime.operationFibers), FiberSet.awaitEmpty(runtime.claimFibers)],
+          { concurrency: 'unbounded' },
+        ),
+      );
+
+      if (
+        this.runtime !== runtime ||
+        (Array.from(runtime.operationFibers).length === 0 &&
+          Array.from(runtime.claimFibers).length === 0 &&
+          this.claimingQuotes.size === 0)
+      ) {
+        return;
+      }
+
+      await Effect.runPromise(Effect.yieldNow());
     }
   }
 
   /**
-   * Remove all queued items for a specific mint.
+   * Remove all scheduled work for a specific mint.
    * Called when a mint is untrusted to stop processing its operations.
    */
   clearMintFromQueue(mintUrl: string): void {
-    const before = this.queue.length;
-    this.queue = this.queue.filter((item) => item.mintUrl !== mintUrl);
-    const removed = before - this.queue.length;
-    if (removed > 0) {
-      this.logger?.info('Cleared mint operations from processor queue', { mintUrl, removed });
-    }
-  }
+    const runtime = this.runtime;
+    if (!runtime) return;
 
-  // TODO: Improve deduplication by tracking an "active" set keyed by `${mintUrl}::${operationId}`
-  // to prevent re-enqueueing while an item is currently being processed. Today we only
-  // deduplicate within the queue, so an item can be enqueued again if a new event arrives
-  // during in-flight processing.
-  private enqueue(mintUrl: string, operationId: string, method: string): void {
-    // Check if already in queue
-    const existing = this.queue.find(
-      (item) => item.mintUrl === mintUrl && item.operationId === operationId,
+    const keys = Array.from(runtime.operationFibers, ([key]) => key).filter(
+      (key) => mintUrlFromOperationKey(key) === mintUrl,
     );
-    if (existing) {
-      this.logger?.debug('Mint operation already in queue', { mintUrl, operationId });
-      return;
-    }
+    if (keys.length === 0) return;
 
-    const wasEmpty = this.queue.length === 0;
-
-    this.queue.push({
+    Effect.runFork(
+      Effect.forEach(keys, (key) => FiberMap.remove(runtime.operationFibers, key), {
+        discard: true,
+      }),
+    );
+    this.logger?.info('Cleared mint operations from processor queue', {
       mintUrl,
-      operationId,
-      method,
-      retryCount: 0,
-      nextRetryAt: 0,
+      removed: keys.length,
     });
+  }
 
-    this.logger?.debug('Mint operation enqueued for processing', {
-      mintUrl,
-      operationId,
-      method,
-      queueLength: this.queue.length,
-    });
+  private subscribeToEvents(runtime: ProcessorRuntime): () => void {
+    const unsubscribe = [
+      this.bus.on('mint-quote:updated', ({ mintUrl, method, quoteId }) => {
+        this.scheduleQuoteClaim(runtime, mintUrl, method, quoteId);
+      }),
+      this.bus.on('mint-op:pending', ({ operation }) => {
+        if (operation.state !== 'pending') return;
+        this.schedulePendingOperationClaim(runtime, operation);
+      }),
+      this.bus.on('mint-op:requeue', ({ mintUrl, operationId, operation }) => {
+        this.enqueue(runtime, mintUrl, operationId, operation.method);
+      }),
+      this.bus.on('mint:untrusted', ({ mintUrl }) => {
+        this.clearMintFromQueue(mintUrl);
+      }),
+    ];
 
-    // If queue was empty and processor is idle, schedule a faster first run
-    if (wasEmpty && this.running && !this.processing) {
-      if (this.processingTimer) {
-        clearTimeout(this.processingTimer);
-        this.processingTimer = undefined;
+    return () => {
+      for (const off of unsubscribe) {
+        try {
+          off();
+        } catch {
+          // Event cleanup is best effort; the Effect scope still owns all scheduled work.
+        }
       }
-      this.processingTimer = setTimeout(() => {
-        this.processingTimer = undefined;
-        this.processNext();
-      }, this.initialEnqueueDelayMs);
-    }
+    };
   }
 
-  private scheduleNextProcess(): void {
-    if (!this.running || this.processingTimer) return;
+  private enqueue(
+    runtime: ProcessorRuntime,
+    mintUrl: string,
+    operationId: string,
+    method: string,
+  ): void {
+    if (this.runtime !== runtime) return;
 
-    this.processingTimer = setTimeout(() => {
-      this.processingTimer = undefined;
-      this.processNext();
-    }, this.processIntervalMs);
-  }
-
-  private scheduleQuoteClaim(mintUrl: string, method: MintMethod, quoteId: string): void {
-    if (!this.autoClaimMintQuotes) {
+    const key = operationKey(mintUrl, operationId);
+    if (FiberMap.unsafeHas(runtime.operationFibers, key)) {
+      this.logger?.debug('Mint operation already scheduled', { mintUrl, operationId });
       return;
     }
 
-    const key = `${mintUrl}::${method}::${quoteId}`;
+    const item = { mintUrl, operationId, method } satisfies QueueItem;
+    Effect.runSync(
+      FiberMap.run(runtime.operationFibers, key, this.processOperation(runtime, item), {
+        onlyIfMissing: true,
+      }),
+    );
+
+    this.logger?.debug('Mint operation scheduled for processing', {
+      mintUrl,
+      operationId,
+      method,
+      queueLength: Array.from(runtime.operationFibers).length,
+    });
+  }
+
+  private scheduleQuoteClaim(
+    runtime: ProcessorRuntime,
+    mintUrl: string,
+    method: MintMethod,
+    quoteId: string,
+  ): void {
+    if (!this.autoClaimMintQuotes || this.runtime !== runtime) return;
+
+    const key = quoteKey(mintUrl, method, quoteId);
     if (this.claimingQuotes.has(key)) {
       this.quoteClaimsNeedingFollowUp.add(key);
-      this.logger?.debug('Mint quote claim already in progress', {
-        mintUrl,
-        method,
-        quoteId,
-      });
+      this.logger?.debug('Mint quote claim already in progress', { mintUrl, method, quoteId });
       return;
     }
 
     this.claimingQuotes.add(key);
-    const task = (async () => {
-      try {
-        const assessment = await this.mintOperations.getMintQuoteClaimability(
-          mintUrl,
-          method,
-          quoteId,
-        );
-        if (assessment?.status !== 'claimable' && assessment?.status !== 'complete') {
-          this.logger?.debug('Mint quote has no locally claimable value', {
+    const claim = this.claimMintQuote(mintUrl, method, quoteId).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          this.logger?.warn('Failed to check or claim mint quote', {
             mintUrl,
             method,
             quoteId,
+            error: error instanceof Error ? error.message : String(error),
           });
-          return;
-        }
+        }),
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          this.claimingQuotes.delete(key);
+          const needsFollowUp = this.quoteClaimsNeedingFollowUp.delete(key);
+          if (needsFollowUp && this.runtime === runtime) {
+            this.scheduleQuoteClaim(runtime, mintUrl, method, quoteId);
+          }
+        }),
+      ),
+    );
 
-        await this.mintOperations.claimMintQuote(mintUrl, method, quoteId, {
-          autoClaimRemaining: true,
-        });
-      } catch (error) {
-        this.logger?.warn('Failed to check or claim mint quote', {
+    Effect.runSync(FiberSet.run(runtime.claimFibers, claim));
+  }
+
+  private claimMintQuote(
+    mintUrl: string,
+    method: MintMethod,
+    quoteId: string,
+  ): Effect.Effect<void, unknown> {
+    return Effect.gen(this, function* () {
+      const assessment = yield* waitForPromise(() =>
+        this.mintOperations.getMintQuoteClaimability(mintUrl, method, quoteId),
+      );
+      if (assessment?.status !== 'claimable' && assessment?.status !== 'complete') {
+        this.logger?.debug('Mint quote has no locally claimable value', {
           mintUrl,
           method,
           quoteId,
-          error: error instanceof Error ? error.message : String(error),
         });
-      } finally {
-        this.claimingQuotes.delete(key);
-        const needsFollowUp = this.quoteClaimsNeedingFollowUp.delete(key);
-        if (needsFollowUp && this.running) {
-          this.scheduleQuoteClaim(mintUrl, method, quoteId);
-        }
-      }
-    })();
-
-    this.claimTasks.add(task);
-    task.finally(() => {
-      this.claimTasks.delete(task);
-    });
-  }
-
-  private schedulePendingQuoteClaims(): void {
-    const task = (async () => {
-      try {
-        await this.mintOperations.claimPendingMintQuotes({ autoClaimRemaining: true });
-      } catch (error) {
-        this.logger?.warn('Failed to claim pending mint quotes on startup', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    })();
-
-    this.claimTasks.add(task);
-    task.finally(() => {
-      this.claimTasks.delete(task);
-    });
-  }
-
-  private async processNext(): Promise<void> {
-    if (!this.running || this.processing || this.queue.length === 0) {
-      if (this.running) {
-        this.scheduleNextProcess();
-      }
-      return;
-    }
-
-    // Find next item that's ready to process
-    const now = Date.now();
-    const readyIndex = this.queue.findIndex((item) => item.nextRetryAt <= now);
-
-    if (readyIndex === -1) {
-      // No items ready yet, schedule for when the next one will be
-      const nextReady = Math.min(...this.queue.map((item) => item.nextRetryAt));
-      const delay = Math.max(this.processIntervalMs, nextReady - now);
-      this.processingTimer = setTimeout(() => {
-        this.processingTimer = undefined;
-        this.processNext();
-      }, delay);
-      return;
-    }
-
-    // Remove item from queue
-    const [item] = this.queue.splice(readyIndex, 1);
-    if (!item) {
-      // This shouldn't happen, but handle it gracefully
-      return;
-    }
-    this.processing = true;
-
-    try {
-      await this.processItem(item);
-    } catch (err) {
-      this.handleProcessingError(item, err);
-    } finally {
-      this.processing = false;
-      if (this.running) {
-        this.scheduleNextProcess();
-      }
-    }
-  }
-
-  private async processItem(item: QueueItem): Promise<void> {
-    const { mintUrl, operationId, method } = item;
-
-    const handler = this.handlers.get(method);
-    if (!handler) {
-      this.logger?.warn('No handler registered for mint method', {
-        method,
-        mintUrl,
-        operationId,
-      });
-      return;
-    }
-
-    this.logger?.info('Processing mint operation', {
-      mintUrl,
-      operationId,
-      method,
-      attempt: item.retryCount + 1,
-    });
-
-    await handler.process(mintUrl, operationId);
-    this.logger?.info('Successfully processed mint operation', { mintUrl, operationId, method });
-  }
-
-  private handleProcessingError(item: QueueItem, err: unknown): void {
-    const { mintUrl, operationId } = item;
-
-    if (err instanceof MintOperationError) {
-      if (err.code === 20002) {
-        this.logger?.info('Mint operation quote already issued', { mintUrl, operationId });
         return;
       }
 
-      this.logger?.error('Mint operation error, not retrying', {
-        mintUrl,
-        operationId,
-        code: err.code,
-        detail: err.message,
-      });
-      return;
-    }
+      yield* waitForPromise(() =>
+        this.mintOperations.claimMintQuote(mintUrl, method, quoteId, {
+          autoClaimRemaining: true,
+        }),
+      );
+    });
+  }
 
-    if (err instanceof NetworkError || (err instanceof Error && err.message.includes('network'))) {
-      item.retryCount++;
-      if (item.retryCount <= this.maxRetries) {
-        const delay = this.baseRetryDelayMs * Math.pow(2, item.retryCount - 1);
-        item.nextRetryAt = Date.now() + delay;
+  private schedulePendingOperationClaim(
+    runtime: ProcessorRuntime,
+    operation: { mintUrl: string; method: MintMethod; quoteId: string },
+  ): void {
+    const task = waitForPromise(() =>
+      this.quoteLifecycle.getMintQuote(operation.mintUrl, operation.method, operation.quoteId),
+    ).pipe(
+      Effect.tap((quote) =>
+        Effect.sync(() => {
+          if (quote) {
+            this.scheduleQuoteClaim(
+              runtime,
+              operation.mintUrl,
+              operation.method,
+              operation.quoteId,
+            );
+          }
+        }),
+      ),
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          this.logger?.warn('Failed to check mint quote for pending operation', {
+            mintUrl: operation.mintUrl,
+            method: operation.method,
+            quoteId: operation.quoteId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }),
+      ),
+    );
 
-        this.logger?.warn('Network error, will retry', {
+    Effect.runSync(FiberSet.run(runtime.claimFibers, task));
+  }
+
+  private schedulePendingQuoteClaims(runtime: ProcessorRuntime): void {
+    const task = waitForPromise(() =>
+      this.mintOperations.claimPendingMintQuotes({ autoClaimRemaining: true }),
+    ).pipe(
+      Effect.asVoid,
+      Effect.catchAll((error) =>
+        Effect.sync(() => {
+          this.logger?.warn('Failed to claim pending mint quotes on startup', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }),
+      ),
+    );
+
+    Effect.runSync(FiberSet.run(runtime.claimFibers, task));
+  }
+
+  private processOperation(runtime: ProcessorRuntime, item: QueueItem): Effect.Effect<void, never> {
+    let attemptNumber = 0;
+    const retrySchedule = Schedule.exponential(Math.max(1, this.baseRetryDelayMs)).pipe(
+      Schedule.intersect(Schedule.recurs(this.maxRetries)),
+      Schedule.tapInput((error) =>
+        Effect.sync(() => {
+          if (!isNetworkError(error) || attemptNumber > this.maxRetries) return;
+          const retryInMs = this.baseRetryDelayMs * Math.pow(2, attemptNumber - 1);
+          this.logger?.warn('Network error, will retry', {
+            mintUrl: item.mintUrl,
+            operationId: item.operationId,
+            attempt: attemptNumber,
+            maxRetries: this.maxRetries,
+            retryInMs,
+          });
+        }),
+      ),
+    );
+
+    const attempt = Effect.suspend(() => {
+      const { mintUrl, operationId, method } = item;
+      const handler = this.handlers.get(method);
+      if (!handler) {
+        this.logger?.warn('No handler registered for mint method', {
+          method,
           mintUrl,
           operationId,
-          attempt: item.retryCount,
-          maxRetries: this.maxRetries,
-          retryInMs: delay,
         });
+        return Effect.void;
+      }
 
-        this.queue.push(item);
+      attemptNumber++;
+      this.logger?.info('Processing mint operation', {
+        mintUrl,
+        operationId,
+        method,
+        attempt: attemptNumber,
+      });
+
+      return waitForPromise(() => handler.process(mintUrl, operationId)).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            this.logger?.info('Successfully processed mint operation', {
+              mintUrl,
+              operationId,
+              method,
+            });
+          }),
+        ),
+      );
+    });
+
+    const serializedAttempt = runtime.operationSemaphore.withPermits(1)(
+      runtime.rateLimitOperation(attempt),
+    );
+
+    return Effect.sleep(Math.max(0, this.initialEnqueueDelayMs)).pipe(
+      Effect.andThen(
+        Effect.retry(serializedAttempt, {
+          while: isNetworkError,
+          schedule: retrySchedule,
+        }),
+      ),
+      Effect.catchAll((error) => this.logTerminalProcessingError(item, error)),
+    );
+  }
+
+  private logTerminalProcessingError(item: QueueItem, error: unknown): Effect.Effect<void> {
+    return Effect.sync(() => {
+      const { mintUrl, operationId } = item;
+      if (error instanceof MintOperationError) {
+        if (error.code === 20002) {
+          this.logger?.info('Mint operation quote already issued', { mintUrl, operationId });
+          return;
+        }
+
+        this.logger?.error('Mint operation error, not retrying', {
+          mintUrl,
+          operationId,
+          code: error.code,
+          detail: error.message,
+        });
         return;
       }
 
-      this.logger?.error('Max retries exceeded for network error', {
+      if (isNetworkError(error)) {
+        this.logger?.error('Max retries exceeded for network error', {
+          mintUrl,
+          operationId,
+          maxRetries: this.maxRetries,
+        });
+        return;
+      }
+
+      this.logger?.error('Failed to process mint operation', {
         mintUrl,
         operationId,
-        maxRetries: this.maxRetries,
+        err: error,
       });
-      return;
-    }
-
-    this.logger?.error('Failed to process mint operation', { mintUrl, operationId, err });
+    });
   }
 }

--- a/packages/core/services/watchers/MintOperationProcessor.ts
+++ b/packages/core/services/watchers/MintOperationProcessor.ts
@@ -1,9 +1,10 @@
-import { Effect, Exit, FiberMap, FiberSet, RateLimiter, Schedule, Scope } from 'effect';
+import { Effect, RateLimiter, Schedule } from 'effect';
 import type { EventBus, CoreEvents } from '@core/events';
 import type { MintMethod, MintOperationService } from '@core/operations/mint';
 import type { Logger } from '../../logging/Logger.ts';
 import { MintOperationError, NetworkError } from '../../models/Error';
 import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
+import { BackgroundTaskRuntime, uninterruptiblePromise } from './BackgroundTaskRuntime.ts';
 
 interface QueueItem {
   mintUrl: string;
@@ -16,9 +17,7 @@ interface OperationHandler {
 }
 
 interface ProcessorRuntime {
-  readonly scope: Scope.CloseableScope;
-  readonly operationFibers: FiberMap.FiberMap<string, void, never>;
-  readonly claimFibers: FiberSet.FiberSet<void, never>;
+  readonly tasks: BackgroundTaskRuntime;
   readonly operationSemaphore: Effect.Semaphore;
   readonly rateLimitOperation: RateLimiter.RateLimiter;
 }
@@ -62,20 +61,12 @@ function isNetworkError(error: unknown): boolean {
   );
 }
 
-function waitForPromise<A>(evaluate: () => Promise<A>): Effect.Effect<A, unknown> {
-  return Effect.tryPromise({
-    try: evaluate,
-    catch: (error) => error,
-  }).pipe(Effect.uninterruptible);
-}
-
 export class MintOperationProcessor {
   private readonly mintOperations: MintOperationService;
   private readonly quoteLifecycle: QuoteLifecycle;
   private readonly bus: EventBus<CoreEvents>;
   private readonly logger?: Logger;
 
-  private running = false;
   private runtime?: ProcessorRuntime;
   private readonly claimingQuotes = new Set<string>();
   private readonly quoteClaimsNeedingFollowUp = new Set<string>();
@@ -115,38 +106,28 @@ export class MintOperationProcessor {
   }
 
   isRunning(): boolean {
-    return this.running;
+    return this.runtime?.tasks.isActive ?? false;
   }
 
   async start(): Promise<void> {
-    if (this.running) return;
-    this.running = true;
+    if (this.isRunning()) return;
 
-    const scope = Effect.runSync(Scope.make());
+    const tasks = BackgroundTaskRuntime.make();
     try {
-      const runtime = Effect.runSync(
-        Effect.gen(this, function* () {
-          const operationFibers = yield* FiberMap.make<string, void, never>();
-          const claimFibers = yield* FiberSet.make<void, never>();
-          const operationSemaphore = yield* Effect.makeSemaphore(1);
-          const rateLimitOperation = yield* RateLimiter.make({
+      const runtime = {
+        tasks,
+        operationSemaphore: Effect.runSync(Effect.makeSemaphore(1)),
+        rateLimitOperation: tasks.acquire(
+          RateLimiter.make({
             limit: 1,
             interval: Math.max(1, this.processIntervalMs),
-          });
-
-          return {
-            scope,
-            operationFibers,
-            claimFibers,
-            operationSemaphore,
-            rateLimitOperation,
-          } satisfies ProcessorRuntime;
-        }).pipe(Scope.extend(scope)),
-      );
+          }),
+        ),
+      } satisfies ProcessorRuntime;
 
       this.runtime = runtime;
       const unsubscribe = this.subscribeToEvents(runtime);
-      Effect.runSync(Scope.addFinalizer(scope, Effect.sync(unsubscribe)));
+      tasks.addFinalizer(unsubscribe);
 
       if (this.autoClaimMintQuotes) {
         this.schedulePendingQuoteClaims(runtime);
@@ -155,23 +136,18 @@ export class MintOperationProcessor {
       this.logger?.info('MintOperationProcessor started');
     } catch (error) {
       this.runtime = undefined;
-      this.running = false;
-      await Effect.runPromise(Scope.close(scope, Exit.fail(error)));
+      await tasks.close();
       throw error;
     }
   }
 
   async stop(): Promise<void> {
-    if (!this.running) return;
-    this.running = false;
-
     const runtime = this.runtime;
+    if (!runtime) return;
     this.runtime = undefined;
-    const pendingItems = runtime ? Array.from(runtime.operationFibers).length : 0;
+    const pendingItems = runtime.tasks.keyedTaskCount;
 
-    if (runtime) {
-      await Effect.runPromise(Scope.close(runtime.scope, Exit.void));
-    }
+    await runtime.tasks.close();
 
     this.claimingQuotes.clear();
     this.quoteClaimsNeedingFollowUp.clear();
@@ -187,18 +163,11 @@ export class MintOperationProcessor {
     if (!runtime) return;
 
     while (this.runtime === runtime) {
-      await Effect.runPromise(
-        Effect.all(
-          [FiberMap.awaitEmpty(runtime.operationFibers), FiberSet.awaitEmpty(runtime.claimFibers)],
-          { concurrency: 'unbounded' },
-        ),
-      );
+      await runtime.tasks.waitForIdle();
 
       if (
         this.runtime !== runtime ||
-        (Array.from(runtime.operationFibers).length === 0 &&
-          Array.from(runtime.claimFibers).length === 0 &&
-          this.claimingQuotes.size === 0)
+        (runtime.tasks.keyedTaskCount === 0 && this.claimingQuotes.size === 0)
       ) {
         return;
       }
@@ -215,20 +184,12 @@ export class MintOperationProcessor {
     const runtime = this.runtime;
     if (!runtime) return;
 
-    const keys = Array.from(runtime.operationFibers, ([key]) => key).filter(
-      (key) => mintUrlFromOperationKey(key) === mintUrl,
-    );
-    if (keys.length === 0) return;
-
-    Effect.runFork(
-      Effect.forEach(keys, (key) => FiberMap.remove(runtime.operationFibers, key), {
-        discard: true,
-      }),
-    );
-    this.logger?.info('Cleared mint operations from processor queue', {
-      mintUrl,
-      removed: keys.length,
-    });
+    void runtime.tasks
+      .cancelWhere((key) => mintUrlFromOperationKey(key) === mintUrl)
+      .then((removed) => {
+        if (removed === 0) return;
+        this.logger?.info('Cleared mint operations from processor queue', { mintUrl, removed });
+      });
   }
 
   private subscribeToEvents(runtime: ProcessorRuntime): () => void {
@@ -265,26 +226,21 @@ export class MintOperationProcessor {
     operationId: string,
     method: string,
   ): void {
-    if (this.runtime !== runtime) return;
+    if (this.runtime !== runtime || !runtime.tasks.isActive) return;
 
     const key = operationKey(mintUrl, operationId);
-    if (FiberMap.unsafeHas(runtime.operationFibers, key)) {
+    const item = { mintUrl, operationId, method } satisfies QueueItem;
+    const scheduled = runtime.tasks.runKeyed(key, this.processOperation(runtime, item));
+    if (!scheduled) {
       this.logger?.debug('Mint operation already scheduled', { mintUrl, operationId });
       return;
     }
-
-    const item = { mintUrl, operationId, method } satisfies QueueItem;
-    Effect.runSync(
-      FiberMap.run(runtime.operationFibers, key, this.processOperation(runtime, item), {
-        onlyIfMissing: true,
-      }),
-    );
 
     this.logger?.debug('Mint operation scheduled for processing', {
       mintUrl,
       operationId,
       method,
-      queueLength: Array.from(runtime.operationFibers).length,
+      queueLength: runtime.tasks.keyedTaskCount,
     });
   }
 
@@ -326,7 +282,7 @@ export class MintOperationProcessor {
       ),
     );
 
-    Effect.runSync(FiberSet.run(runtime.claimFibers, claim));
+    void runtime.tasks.run(claim);
   }
 
   private claimMintQuote(
@@ -335,7 +291,7 @@ export class MintOperationProcessor {
     quoteId: string,
   ): Effect.Effect<void, unknown> {
     return Effect.gen(this, function* () {
-      const assessment = yield* waitForPromise(() =>
+      const assessment = yield* uninterruptiblePromise(() =>
         this.mintOperations.getMintQuoteClaimability(mintUrl, method, quoteId),
       );
       if (assessment?.status !== 'claimable' && assessment?.status !== 'complete') {
@@ -347,7 +303,7 @@ export class MintOperationProcessor {
         return;
       }
 
-      yield* waitForPromise(() =>
+      yield* uninterruptiblePromise(() =>
         this.mintOperations.claimMintQuote(mintUrl, method, quoteId, {
           autoClaimRemaining: true,
         }),
@@ -359,7 +315,7 @@ export class MintOperationProcessor {
     runtime: ProcessorRuntime,
     operation: { mintUrl: string; method: MintMethod; quoteId: string },
   ): void {
-    const task = waitForPromise(() =>
+    const task = uninterruptiblePromise(() =>
       this.quoteLifecycle.getMintQuote(operation.mintUrl, operation.method, operation.quoteId),
     ).pipe(
       Effect.tap((quote) =>
@@ -386,11 +342,11 @@ export class MintOperationProcessor {
       ),
     );
 
-    Effect.runSync(FiberSet.run(runtime.claimFibers, task));
+    void runtime.tasks.run(task);
   }
 
   private schedulePendingQuoteClaims(runtime: ProcessorRuntime): void {
-    const task = waitForPromise(() =>
+    const task = uninterruptiblePromise(() =>
       this.mintOperations.claimPendingMintQuotes({ autoClaimRemaining: true }),
     ).pipe(
       Effect.asVoid,
@@ -403,7 +359,7 @@ export class MintOperationProcessor {
       ),
     );
 
-    Effect.runSync(FiberSet.run(runtime.claimFibers, task));
+    void runtime.tasks.run(task);
   }
 
   private processOperation(runtime: ProcessorRuntime, item: QueueItem): Effect.Effect<void, never> {
@@ -445,7 +401,7 @@ export class MintOperationProcessor {
         attempt: attemptNumber,
       });
 
-      return waitForPromise(() => handler.process(mintUrl, operationId)).pipe(
+      return uninterruptiblePromise(() => handler.process(mintUrl, operationId)).pipe(
         Effect.tap(() =>
           Effect.sync(() => {
             this.logger?.info('Successfully processed mint operation', {

--- a/packages/core/services/watchers/ProofStateWatcherService.ts
+++ b/packages/core/services/watchers/ProofStateWatcherService.ts
@@ -1,3 +1,4 @@
+import { Effect } from 'effect';
 import type { EventBus, CoreEvents } from '@core/events';
 import type { Logger } from '../../logging/Logger.ts';
 import type { SubscriptionManager, UnsubscribeHandler } from '@core/infra/SubscriptionManager.ts';
@@ -7,6 +8,7 @@ import type { SendOperationService } from '../../operations/send/SendOperationSe
 import { getSendProofSecrets, hasPreparedData } from '../../operations/send/SendOperation';
 import type { ProofRepository } from '../../repositories';
 import { buildYHexMapsForSecrets } from '../../utils.ts';
+import { BackgroundTaskRuntime, uninterruptiblePromise } from './BackgroundTaskRuntime.ts';
 
 type ProofKey = string; // `${mintUrl}::${secret}`
 
@@ -37,12 +39,9 @@ export class ProofStateWatcherService {
   private readonly options: ProofStateWatcherOptions;
   private sendOperationService?: SendOperationService;
 
-  private running = false;
+  private runtime?: BackgroundTaskRuntime;
   private unsubscribeByKey = new Map<ProofKey, UnsubscribeHandler>();
   private inflightByKey = new Set<ProofKey>();
-  private offProofsStateChanged?: () => void;
-  private offProofsSaved?: () => void;
-  private offUntrusted?: () => void;
 
   constructor(
     subs: SubscriptionManager,
@@ -71,162 +70,166 @@ export class ProofStateWatcherService {
   }
 
   isRunning(): boolean {
-    return this.running;
+    return this.runtime?.isActive ?? false;
   }
 
   async start(): Promise<void> {
-    if (this.running) return;
-    this.running = true;
-    this.logger?.info('ProofStateWatcherService started');
+    if (this.isRunning()) return;
 
-    // React to proofs being marked inflight via state change
-    this.offProofsStateChanged = this.bus.on(
-      'proofs:state-changed',
-      async ({ mintUrl, secrets, state }) => {
-        try {
-          if (!this.running) return;
-          if (state === 'inflight') {
-            try {
-              await this.watchProof(mintUrl, secrets);
-            } catch (err) {
-              this.logger?.warn('Failed to watch inflight proofs', {
+    const runtime = BackgroundTaskRuntime.make();
+    this.runtime = runtime;
+    try {
+      runtime.addFinalizer(
+        this.bus.on('proofs:state-changed', (event) =>
+          this.runTask(
+            runtime,
+            () => this.handleProofStateChanged(runtime, event),
+            (err) => this.logger?.error('Error handling proofs:state-changed', { err }),
+          ),
+        ),
+      );
+      runtime.addFinalizer(
+        this.bus.on('proofs:saved', (event) =>
+          this.runTask(
+            runtime,
+            () => this.handleProofsSaved(runtime, event),
+            (err) => this.logger?.error('Error handling proofs:saved', { err }),
+          ),
+        ),
+      );
+      runtime.addFinalizer(
+        this.bus.on('mint:untrusted', ({ mintUrl }) =>
+          this.runTask(
+            runtime,
+            () => this.stopWatchingMint(mintUrl),
+            (err) =>
+              this.logger?.error('Failed to stop watching mint proofs on untrust', {
                 mintUrl,
-                count: secrets.length,
                 err,
-              });
-            }
-          } else if (state === 'spent') {
-            const operationIds = new Set<string>();
+              }),
+          ),
+        ),
+      );
 
-            // Stop watching if we already are
-            for (const secret of secrets) {
-              const key = toKey(mintUrl, secret);
-              try {
-                await this.stopWatching(key);
-              } catch (err) {
-                this.logger?.warn('Failed to stop watcher on spent proof', {
-                  mintUrl,
-                  secret,
-                  err,
-                });
-              }
-
-              if (!this.sendOperationService) continue;
-
-              try {
-                const operationId = await this.getSendOperationIdForSpentProof(mintUrl, secret);
-                if (operationId) {
-                  operationIds.add(operationId);
-                }
-              } catch (err) {
-                this.logger?.warn('Failed to resolve send operation from spent proof event', {
-                  mintUrl,
-                  secret,
-                  err,
-                });
-              }
-            }
-
-            for (const operationId of operationIds) {
-              await this.tryFinalizeSendOperation(mintUrl, operationId);
-            }
-          }
-        } catch (err) {
-          this.logger?.error('Error handling proofs:state-changed', { err });
-        }
-      },
-    );
-
-    // React to proofs being saved with inflight state (e.g., from swap operations)
-    this.offProofsSaved = this.bus.on('proofs:saved', async ({ mintUrl, proofs }) => {
-      try {
-        if (!this.running) return;
-        const inflightSecrets = proofs.filter((p) => p.state === 'inflight').map((p) => p.secret);
-        if (inflightSecrets.length > 0) {
-          try {
-            await this.watchProof(mintUrl, inflightSecrets);
-          } catch (err) {
-            this.logger?.warn('Failed to watch inflight proofs from saved event', {
-              mintUrl,
-              count: inflightSecrets.length,
-              err,
-            });
-          }
-        }
-      } catch (err) {
-        this.logger?.error('Error handling proofs:saved', { err });
+      if (this.options.watchExistingInflightOnStart) {
+        void this.runTask(
+          runtime,
+          () => this.bootstrapInflightProofs(runtime),
+          (err) => this.logger?.warn('Failed to bootstrap inflight proof watchers', { err }),
+        );
       }
-    });
 
-    // Stop watching proofs when mint is untrusted
-    this.offUntrusted = this.bus.on('mint:untrusted', async ({ mintUrl }) => {
-      try {
-        await this.stopWatchingMint(mintUrl);
-      } catch (err) {
-        this.logger?.error('Failed to stop watching mint proofs on untrust', { mintUrl, err });
-      }
-    });
-
-    if (this.options.watchExistingInflightOnStart) {
-      void this.bootstrapInflightProofs().catch((err) => {
-        this.logger?.warn('Failed to bootstrap inflight proof watchers', { err });
-      });
+      this.logger?.info('ProofStateWatcherService started');
+    } catch (error) {
+      this.runtime = undefined;
+      await runtime.close();
+      throw error;
     }
   }
 
   async stop(): Promise<void> {
-    if (!this.running) return;
-    this.running = false;
+    const runtime = this.runtime;
+    if (!runtime) return;
+    this.runtime = undefined;
 
-    if (this.offProofsStateChanged) {
-      try {
-        this.offProofsStateChanged();
-      } catch {
-        // ignore
-      } finally {
-        this.offProofsStateChanged = undefined;
-      }
-    }
-
-    if (this.offProofsSaved) {
-      try {
-        this.offProofsSaved();
-      } catch {
-        // ignore
-      } finally {
-        this.offProofsSaved = undefined;
-      }
-    }
-
-    if (this.offUntrusted) {
-      try {
-        this.offUntrusted();
-      } catch {
-        // ignore
-      } finally {
-        this.offUntrusted = undefined;
-      }
-    }
-
-    const entries = Array.from(this.unsubscribeByKey.entries());
+    await runtime.close();
     this.unsubscribeByKey.clear();
-    for (const [key, unsub] of entries) {
-      try {
-        await unsub();
-        this.logger?.debug('Stopped watching proof', { key });
-      } catch (err) {
-        this.logger?.warn('Failed to unsubscribe proof watcher', { key, err });
-      }
-    }
     this.inflightByKey.clear();
     this.logger?.info('ProofStateWatcherService stopped');
   }
 
+  private runTask(
+    runtime: BackgroundTaskRuntime,
+    task: () => Promise<void>,
+    onError: (error: unknown) => void,
+  ): Promise<void> {
+    if (this.runtime !== runtime) return Promise.resolve();
+
+    return runtime.run(
+      uninterruptiblePromise(task).pipe(
+        Effect.catchAll((error) => Effect.sync(() => onError(error))),
+      ),
+    );
+  }
+
+  private async handleProofStateChanged(
+    runtime: BackgroundTaskRuntime,
+    { mintUrl, secrets, state }: CoreEvents['proofs:state-changed'],
+  ): Promise<void> {
+    if (this.runtime !== runtime) return;
+
+    if (state === 'inflight') {
+      try {
+        await this.watchProof(mintUrl, secrets);
+      } catch (err) {
+        this.logger?.warn('Failed to watch inflight proofs', {
+          mintUrl,
+          count: secrets.length,
+          err,
+        });
+      }
+      return;
+    }
+
+    if (state !== 'spent') return;
+
+    const operationIds = new Set<string>();
+    for (const secret of secrets) {
+      const key = toKey(mintUrl, secret);
+      try {
+        await this.stopWatching(key);
+      } catch (err) {
+        this.logger?.warn('Failed to stop watcher on spent proof', { mintUrl, secret, err });
+      }
+
+      if (!this.sendOperationService) continue;
+
+      try {
+        const operationId = await this.getSendOperationIdForSpentProof(mintUrl, secret);
+        if (operationId) operationIds.add(operationId);
+      } catch (err) {
+        this.logger?.warn('Failed to resolve send operation from spent proof event', {
+          mintUrl,
+          secret,
+          err,
+        });
+      }
+    }
+
+    for (const operationId of operationIds) {
+      await this.tryFinalizeSendOperation(mintUrl, operationId);
+    }
+  }
+
+  private async handleProofsSaved(
+    runtime: BackgroundTaskRuntime,
+    { mintUrl, proofs }: CoreEvents['proofs:saved'],
+  ): Promise<void> {
+    if (this.runtime !== runtime) return;
+
+    const inflightSecrets = proofs
+      .filter((proof) => proof.state === 'inflight')
+      .map((p) => p.secret);
+    if (inflightSecrets.length === 0) return;
+
+    try {
+      await this.watchProof(mintUrl, inflightSecrets);
+    } catch (err) {
+      this.logger?.warn('Failed to watch inflight proofs from saved event', {
+        mintUrl,
+        count: inflightSecrets.length,
+        err,
+      });
+    }
+  }
+
   async watchProof(mintUrl: string, secrets: string[]): Promise<void> {
-    if (!this.running) return;
+    const runtime = this.runtime;
+    if (!runtime?.isActive) return;
 
     // Only watch proofs for trusted mints
     const trusted = await this.mintService.isTrustedMint(mintUrl);
+    if (this.runtime !== runtime) return;
     if (!trusted) {
       this.logger?.debug('Skipping watch for untrusted mint', { mintUrl });
       return;
@@ -241,31 +244,24 @@ export class ProofStateWatcherService {
     const { secretByYHex, yHexBySecret } = buildYHexMapsForSecrets(toWatch);
     const filters = Array.from(secretByYHex.keys());
 
+    let callbackSubId: string | undefined;
     const { subId, unsubscribe } = await this.subs.subscribe<ProofStateNotification>(
       mintUrl,
       'proof_state',
       filters,
-      async (payload) => {
-        if (payload.state !== 'SPENT') return;
-        const secret = secretByYHex.get(payload.Y);
-        if (!secret) return;
-        const key = toKey(mintUrl, secret);
-        if (this.inflightByKey.has(key)) return;
-        this.inflightByKey.add(key);
-        try {
-          await this.proofs.setProofState(mintUrl, [secret], 'spent');
-          this.logger?.info('Marked inflight proof as spent from mint notification', {
-            mintUrl,
-            subId,
-          });
-          await this.stopWatching(key);
-        } catch (err) {
-          this.logger?.error('Failed to mark inflight proof as spent', { mintUrl, subId, err });
-        } finally {
-          this.inflightByKey.delete(key);
-        }
-      },
+      (payload) =>
+        this.runTask(
+          runtime,
+          () => this.handleProofStateNotification(mintUrl, callbackSubId, secretByYHex, payload),
+          (err) =>
+            this.logger?.error('Error handling proof state notification', {
+              mintUrl,
+              subId: callbackSubId,
+              err,
+            }),
+        ),
     );
+    callbackSubId = subId;
 
     // Wrap a group unsubscribe to be idempotent
     let didUnsubscribe = false;
@@ -276,6 +272,22 @@ export class ProofStateWatcherService {
       await unsubscribe();
       this.logger?.debug('Unsubscribed watcher for inflight proof group', { mintUrl, subId });
     };
+
+    if (this.runtime !== runtime) {
+      await groupUnsubscribeOnce();
+      return;
+    }
+    runtime.addFinalizer(async () => {
+      try {
+        await groupUnsubscribeOnce();
+      } catch (err) {
+        this.logger?.warn('Failed to unsubscribe proof watcher during shutdown', {
+          mintUrl,
+          subId,
+          err,
+        });
+      }
+    });
 
     // For each secret, register a per-key stopper that shrinks the remaining set and
     // unsubscribes the group when the last filter is removed
@@ -298,15 +310,42 @@ export class ProofStateWatcherService {
     });
   }
 
-  private async bootstrapInflightProofs(): Promise<void> {
-    if (!this.running) return;
+  private async handleProofStateNotification(
+    mintUrl: string,
+    subId: string | undefined,
+    secretByYHex: Map<string, string>,
+    payload: ProofStateNotification,
+  ): Promise<void> {
+    if (payload.state !== 'SPENT') return;
+    const secret = secretByYHex.get(payload.Y);
+    if (!secret) return;
+
+    const key = toKey(mintUrl, secret);
+    if (this.inflightByKey.has(key)) return;
+    this.inflightByKey.add(key);
+    try {
+      await this.proofs.setProofState(mintUrl, [secret], 'spent');
+      this.logger?.info('Marked inflight proof as spent from mint notification', {
+        mintUrl,
+        subId,
+      });
+      await this.stopWatching(key);
+    } catch (err) {
+      this.logger?.error('Failed to mark inflight proof as spent', { mintUrl, subId, err });
+    } finally {
+      this.inflightByKey.delete(key);
+    }
+  }
+
+  private async bootstrapInflightProofs(runtime: BackgroundTaskRuntime): Promise<void> {
+    if (this.runtime !== runtime) return;
     this.logger?.info('Bootstrapping inflight proof watchers');
 
     await this.proofs.checkInflightProofs();
-    if (!this.running) return;
+    if (this.runtime !== runtime) return;
 
     const inflightProofs = await this.proofRepository.getInflightProofs();
-    if (!this.running || inflightProofs.length === 0) return;
+    if (this.runtime !== runtime || inflightProofs.length === 0) return;
 
     const byMint = new Map<string, string[]>();
     for (const proof of inflightProofs) {
@@ -317,7 +356,7 @@ export class ProofStateWatcherService {
     }
 
     for (const [mintUrl, secrets] of byMint.entries()) {
-      if (!this.running) return;
+      if (this.runtime !== runtime) return;
       if (secrets.length === 0) continue;
       try {
         await this.watchProof(mintUrl, secrets);

--- a/packages/core/test/unit/BackgroundTaskRuntime.test.ts
+++ b/packages/core/test/unit/BackgroundTaskRuntime.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { Effect } from 'effect';
+import { BackgroundTaskRuntime } from '../../services/watchers/BackgroundTaskRuntime.ts';
+
+describe('BackgroundTaskRuntime', () => {
+  it('deduplicates keyed tasks until the active task completes', async () => {
+    const runtime = BackgroundTaskRuntime.make();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const run = mock(async () => {
+      await gate;
+    });
+    const task = Effect.promise(run);
+
+    expect(runtime.runKeyed('operation-1', task)).toBe(true);
+    expect(runtime.runKeyed('operation-1', task)).toBe(false);
+    expect(runtime.keyedTaskCount).toBe(1);
+
+    release();
+    await runtime.waitForIdle();
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(runtime.runKeyed('operation-1', Effect.void)).toBe(true);
+    await runtime.waitForIdle();
+    await runtime.close();
+  });
+
+  it('cancels selected keyed tasks', async () => {
+    const runtime = BackgroundTaskRuntime.make();
+
+    runtime.runKeyed('mint-a:1', Effect.never);
+    runtime.runKeyed('mint-a:2', Effect.never);
+    runtime.runKeyed('mint-b:1', Effect.never);
+
+    expect(await runtime.cancelWhere((key) => key.startsWith('mint-a:'))).toBe(2);
+    expect(runtime.keyedTaskCount).toBe(1);
+
+    await runtime.close();
+  });
+
+  it('runs finalizers once and waits for uninterruptible tasks while closing', async () => {
+    const runtime = BackgroundTaskRuntime.make();
+    const finalize = mock(async () => {});
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let closed = false;
+
+    runtime.addFinalizer(finalize);
+    void runtime.run(Effect.promise(() => gate).pipe(Effect.uninterruptible));
+
+    const closing = runtime.close().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+
+    release();
+    await closing;
+    await runtime.close();
+
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(runtime.isActive).toBe(false);
+  });
+});

--- a/packages/core/test/unit/MintQuoteProcessor.test.ts
+++ b/packages/core/test/unit/MintQuoteProcessor.test.ts
@@ -400,6 +400,127 @@ describe('MintOperationProcessor', () => {
     },
   );
 
+  it('deduplicates explicit requeues while an operation is being processed', async () => {
+    let releaseFinalize!: () => void;
+    let markStarted!: () => void;
+    const finalizeGate = new Promise<void>((resolve) => {
+      releaseFinalize = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let attemptCount = 0;
+    mockMintOperationService = {
+      ...mockMintOperationService,
+      async finalize() {
+        attemptCount++;
+        markStarted();
+        await finalizeGate;
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: TEST_PROCESS_INTERVAL,
+        baseRetryDelayMs: TEST_RETRY_DELAY,
+        maxRetries: 3,
+        initialEnqueueDelayMs: TEST_INITIAL_DELAY,
+      },
+    );
+    await processor.start();
+
+    const event = {
+      mintUrl: 'https://mint.test',
+      operationId: 'mint-op-deduplicated',
+      operation: {
+        id: 'mint-op-deduplicated',
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+      } as any,
+    };
+    await bus.emit('mint-op:requeue', event);
+    await started;
+    await bus.emit('mint-op:requeue', event);
+
+    releaseFinalize();
+    await processor.waitForCompletion();
+
+    expect(attemptCount).toBe(1);
+  });
+
+  it('cancels scheduled operations when their mint becomes untrusted', async () => {
+    await processor.start();
+    await bus.emit('mint-op:requeue', {
+      mintUrl: 'https://mint.test',
+      operationId: 'mint-op-untrusted',
+      operation: {
+        id: 'mint-op-untrusted',
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+      } as any,
+    });
+    await bus.emit('mint:untrusted', { mintUrl: 'https://mint.test' });
+
+    await sleep(TEST_INITIAL_DELAY + TEST_PROCESS_INTERVAL + 20);
+
+    expect(finalizeCalls).toEqual([]);
+  });
+
+  it('waits for an active operation to finish before stopping', async () => {
+    let releaseFinalize!: () => void;
+    let markStarted!: () => void;
+    const finalizeGate = new Promise<void>((resolve) => {
+      releaseFinalize = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    mockMintOperationService = {
+      ...mockMintOperationService,
+      async finalize() {
+        markStarted();
+        await finalizeGate;
+      },
+    } as unknown as MintOperationService;
+    processor = new MintOperationProcessor(
+      mockMintOperationService,
+      mockQuoteLifecycle,
+      bus,
+      undefined,
+      {
+        processIntervalMs: TEST_PROCESS_INTERVAL,
+        baseRetryDelayMs: TEST_RETRY_DELAY,
+        maxRetries: 3,
+        initialEnqueueDelayMs: TEST_INITIAL_DELAY,
+      },
+    );
+    await processor.start();
+    await bus.emit('mint-op:requeue', {
+      mintUrl: 'https://mint.test',
+      operationId: 'mint-op-active-stop',
+      operation: {
+        id: 'mint-op-active-stop',
+        mintUrl: 'https://mint.test',
+        method: 'bolt11',
+      } as any,
+    });
+    await started;
+
+    let stopped = false;
+    const stopping = processor.stop().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    releaseFinalize();
+    await stopping;
+    expect(stopped).toBe(true);
+  });
+
   it('skips quote updates with no locally claimable value', async () => {
     mockMintOperationService = {
       ...mockMintOperationService,

--- a/packages/core/test/unit/ProofStateWatcherService.test.ts
+++ b/packages/core/test/unit/ProofStateWatcherService.test.ts
@@ -417,4 +417,28 @@ describe('ProofStateWatcherService', () => {
 
     await watcher.stop();
   });
+
+  it('unsubscribes active proof groups when stopped', async () => {
+    const unsubscribe = mock(async () => {});
+    const subscribe = mock(async () => ({ subId: 'sub-1', unsubscribe }));
+    const watcher = new ProofStateWatcherService(
+      { subscribe } as unknown as SubscriptionManager,
+      {
+        isTrustedMint: mock(async () => true),
+      } as unknown as MintService,
+      {} as ProofService,
+      {} as ProofRepository,
+      bus,
+      new NullLogger(),
+      { watchExistingInflightOnStart: false },
+    );
+
+    await watcher.start();
+    await watcher.watchProof(mintUrlA, ['secret-1', 'secret-2']);
+    await watcher.stop();
+    await watcher.stop();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(watcher.isRunning()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Problem

The watcher/processor layer repeats lifecycle machinery for running state, event cleanup, active
tasks, keyed deduplication, cancellation, and graceful shutdown. The first
`MintOperationProcessor` experiment improved state safety but embedded its Effect scope and fiber
collections in one module, so it did not show whether the dependency could pay for itself across
different background-work shapes.

## Summary

- add an internal `BackgroundTaskRuntime` that owns an Effect scope, tracked tasks, keyed tasks,
  finalizers, cancellation, idle waiting, and scoped resource acquisition
- migrate `MintOperationProcessor` onto the shared runtime while preserving its Promise-based
  interface, per-attempt serialization, rate limiting, and exponential retry behavior
- refactor `ProofStateWatcherService` as a contrasting subscription watcher: event work,
  bootstrap work, listener cleanup, active callbacks, and grouped subscriptions now share one
  scoped lifecycle
- deduplicate mint-operation work through execution/retry and cancel it when a mint becomes
  untrusted
- add interface-level runtime tests, proof-watcher cleanup coverage, and a patch changeset

## Experiment results

- mutable lifecycle fields at the two call sites: 17 -> 6; the shared runtime owns 5 once, for 11
  total
- domain module source: 879 -> 920 lines (+41): `MintOperationProcessor` is 464 -> 466 (+2) and
  `ProofStateWatcherService` is 415 -> 454 (+39)
- the shared runtime is 118 lines, so the two-module proof of concept is 1,038 lines total (+159
  over the original two modules); further migrations would amortize this fixed layer
- built core entry: 565.22 -> 569.55 kB (+4.33 kB); gzip 102.13 -> 103.63 kB (+1.50 kB)
- Effect remains external in the core build, so those build deltas understate a downstream
  application's final bundled cost
- local unpacked install footprint remains about 34 MB for Effect plus about 5 MB for its
  transitive packages
- no released public interface, persistence, or protocol contract changes

## Verification

- `bun test test/unit/BackgroundTaskRuntime.test.ts test/unit/ProofStateWatcherService.test.ts test/unit/MintQuoteProcessor.test.ts` (31 pass)
- `bun test test/unit` (1,267 pass)
- `bun test test/integration/PauseResumeIntegration.test.ts --test-name-pattern 'should respect disabled watchers configuration during resume'` (1 pass)
- `bun run build`
- `bun run typecheck`
- targeted Prettier check for all changed source, tests, changeset, and package manifest

The live-mint `should handle multiple pause/resume cycles` case reaches its assertions but still
times out in a before/after hook (about 9.1 seconds). The same isolated test previously failed on
the untouched base commit with the same hook timeout (about 8.4 seconds), so this remains a known
baseline test issue rather than a regression attributed to this refactor.

## Changeset

- `.changeset/effect-mint-operation-processor.md`
