### PR TITLE
refactor(core): share the BOLT12 and on-chain Mint lifecycle

### DIFF
--- a/.changeset/quiet-mints-share.md
+++ b/.changeset/quiet-mints-share.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Share the BOLT12 and on-chain Mint lifecycle implementation while preserving quote creation, saved outputs, and existing issuance and recovery outcomes.

--- a/packages/core/infra/handlers/mint/MintBolt12Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt12Handler.ts
@@ -1,17 +1,10 @@
 import { Amount, type MintQuoteBolt12Response, type Wallet } from '@cashu/cashu-ts';
 import { assertSameUnit, normalizeUnitAmount } from '@core/amounts';
 import type { KeyRingService } from '@core/services';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
-import { bytesToHex } from '@noble/curves/utils.js';
-import {
-  MintOperationError,
-  MintQuoteKeyError,
-  MintQuoteValidationError,
-} from '../../../models/Error';
+import { MintQuoteValidationError } from '../../../models/Error';
 import { mintQuoteFromBolt12Response, type MintQuote } from '../../../models/MintQuote';
 import { mintQuoteObservationFromBolt12Response } from '../../../models/MintQuoteObservationFactory';
-import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
-import { getReusableMintQuoteValidationError } from './ReusableMintQuoteValidation.ts';
+import { ReusableMintLifecycle } from './ReusableMintLifecycle';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
@@ -27,7 +20,24 @@ import type {
 } from '../../../operations/mint';
 
 export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
-  constructor(private readonly keyRingService: KeyRingService) {}
+  private readonly lifecycle: ReusableMintLifecycle<'bolt12'>;
+
+  constructor(private readonly keyRingService: KeyRingService) {
+    this.lifecycle = new ReusableMintLifecycle(keyRingService, {
+      method: 'bolt12',
+      quoteLabel: 'BOLT12',
+      recoveryLabel: 'BOLT12',
+      initialAlreadyIssued: 'return',
+      assertQuoteMatchesRequest: (quote, pubkey, unit) =>
+        this.assertQuoteMatchesRequest(quote, pubkey, unit),
+      toObservation: mintQuoteObservationFromBolt12Response,
+      mintProofs: (wallet, amount, quote, secretKey, outputs) =>
+        wallet.mintProofsBolt12(amount, quote, secretKey, undefined, {
+          type: 'custom',
+          data: outputs,
+        }),
+    });
+  }
 
   async createQuote(ctx: CreateMintQuoteContext<'bolt12'>): Promise<MintQuote<'bolt12'>> {
     const quoteKey = await this.keyRingService.generateMintQuoteKeyPair();
@@ -69,248 +79,25 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
   }
 
   async validateQuoteForPrepare(quote: MintQuote<'bolt12'>): Promise<void> {
-    await this.requireQuoteKey(quote.quoteData.pubkey);
+    return this.lifecycle.validateQuoteForPrepare(quote);
   }
 
   async prepare(ctx: PrepareContext<'bolt12'>): Promise<PendingMintOperation<'bolt12'>> {
-    const quote = ctx.importedQuote;
-    if (!quote) {
-      throw new Error(`Mint quote ${ctx.operation.quoteId ?? '(missing)'} was not provided`);
-    }
-
-    if (ctx.operation.quoteId !== quote.quote) {
-      throw new MintQuoteValidationError(
-        `Mint quote ${quote.quote} does not match operation quote ${ctx.operation.quoteId}`,
-      );
-    }
-
-    assertSameUnit(quote.unit, ctx.operation.unit, `BOLT12 mint quote ${quote.quote}`);
-    await this.requireQuoteKey(quote.pubkey);
-
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: ctx.operation.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for BOLT12 mint operation');
-    }
-
-    return {
-      ...ctx.operation,
-      quoteId: quote.quote,
-      request: quote.request,
-      expiry: quote.expiry,
-      pubkey: quote.pubkey,
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
-      state: 'pending',
-    };
+    return this.lifecycle.prepare(ctx);
   }
 
   async execute(ctx: ExecuteContext<'bolt12'>): Promise<MintExecutionResult> {
-    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(ctx.operation.pubkey ?? '');
-    if (!quoteKey) {
-      throw new MintQuoteKeyError(
-        `Missing NUT-20 mint quote key for pubkey ${ctx.operation.pubkey ?? '(missing)'}`,
-      );
-    }
-
-    const outputData = deserializeOutputData(ctx.operation.outputData);
-    const remoteQuote = await ctx.mintAdapter.checkMintQuote(
-      ctx.operation.mintUrl,
-      'bolt12',
-      ctx.operation.quoteId,
-    );
-    this.assertQuoteMatchesRequest(remoteQuote, ctx.operation.pubkey ?? '', ctx.operation.unit);
-    const assessment = assessMintQuoteClaimability(
-      mintQuoteObservationFromBolt12Response(ctx.operation.mintUrl, remoteQuote),
-      { requestedAmount: ctx.operation.amount },
-    );
-    if (assessment.status === 'invalid') {
-      throw new MintQuoteValidationError(
-        `BOLT12 mint quote ${ctx.operation.quoteId} is not claimable: ${assessment.status}`,
-      );
-    }
-
-    try {
-      const proofs = await ctx.wallet.mintProofsBolt12(
-        ctx.operation.amount,
-        remoteQuote,
-        bytesToHex(quoteKey.secretKey),
-        undefined,
-        { type: 'custom', data: outputData.keep },
-      );
-
-      return { status: 'ISSUED', proofs };
-    } catch (error) {
-      if (this.isAlreadyIssuedError(error)) {
-        return { status: 'ALREADY_ISSUED' };
-      }
-      throw error;
-    }
+    return this.lifecycle.execute(ctx);
   }
 
   async recoverExecuting(ctx: RecoverExecutingContext<'bolt12'>): Promise<RecoverExecutingResult> {
-    const restored = await this.recoverSignedOutputs(ctx);
-    if (restored) {
-      return restored;
-    }
-
-    const { operation } = ctx;
-    const expectedPubkey = operation.pubkey;
-    if (!expectedPubkey) {
-      return {
-        status: 'TERMINAL',
-        error: `Recovered: BOLT12 mint operation ${operation.id} is missing NUT-20 quote pubkey`,
-      };
-    }
-
-    let remoteQuote: MintQuoteBolt12Response;
-    try {
-      remoteQuote = await ctx.mintAdapter.checkMintQuote(
-        operation.mintUrl,
-        'bolt12',
-        operation.quoteId,
-      );
-    } catch (error) {
-      ctx.logger?.warn('Failed to check BOLT12 mint quote during recovery', {
-        mintUrl: operation.mintUrl,
-        quoteId: operation.quoteId,
-        operationId: operation.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        status: 'PENDING',
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-
-    const validationError = this.getQuoteValidationError(
-      remoteQuote,
-      expectedPubkey,
-      operation.unit,
-    );
-    if (validationError) {
-      return {
-        status: 'TERMINAL',
-        error: validationError.message,
-      };
-    }
-
-    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(expectedPubkey);
-    if (!quoteKey) {
-      return {
-        status: 'TERMINAL',
-        error: `Missing NUT-20 mint quote key for pubkey ${expectedPubkey}`,
-      };
-    }
-
-    const assessment = assessMintQuoteClaimability(
-      mintQuoteObservationFromBolt12Response(operation.mintUrl, remoteQuote),
-      { ...ctx.localClaimabilityFacts, requestedAmount: operation.amount },
-    );
-    if (assessment.status === 'invalid') {
-      return {
-        status: 'TERMINAL',
-        error: `Recovered: BOLT12 quote ${operation.quoteId} has invalid claimability accounting`,
-      };
-    }
-    if (assessment.status !== 'claimable') {
-      return {
-        status: 'PENDING',
-        error: `Recovered: BOLT12 quote ${operation.quoteId} has ${assessment.remoteAvailable} remotely available, requested ${operation.amount}`,
-      };
-    }
-
-    const outputData = deserializeOutputData(operation.outputData);
-    try {
-      const proofs = await ctx.wallet.mintProofsBolt12(
-        operation.amount,
-        remoteQuote,
-        bytesToHex(quoteKey.secretKey),
-        undefined,
-        { type: 'custom', data: outputData.keep },
-      );
-
-      await ctx.proofService.saveProofs(
-        operation.mintUrl,
-        mapProofToCoreProof(operation.mintUrl, 'ready', proofs, {
-          unit: operation.unit,
-          createdByOperationId: operation.id,
-        }),
-      );
-
-      return { status: 'FINALIZED' };
-    } catch (error) {
-      if (this.isAlreadyIssuedError(error)) {
-        return (
-          (await this.recoverSignedOutputs(ctx)) ?? {
-            status: 'PENDING',
-            error: `Recovered: BOLT12 quote ${operation.quoteId} was already issued but proofs were not recoverable`,
-          }
-        );
-      }
-
-      if (error instanceof MintOperationError && error.code === 20007) {
-        return {
-          status: 'TERMINAL',
-          error: `Recovered: BOLT12 quote ${operation.quoteId} expired while executing mint`,
-        };
-      }
-
-      return {
-        status: 'PENDING',
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
+    return this.lifecycle.recoverExecuting(ctx);
   }
 
   async checkPending(
     ctx: PendingContext<'bolt12'>,
   ): Promise<PendingMintObservationResult<'bolt12'>> {
-    const { operation } = ctx;
-    const observedAt = Date.now();
-    const remoteQuote = await ctx.mintAdapter.checkMintQuote(
-      operation.mintUrl,
-      'bolt12',
-      operation.quoteId,
-    );
-    const expectedPubkey = operation.pubkey;
-
-    const validationError = getReusableMintQuoteValidationError(remoteQuote, operation);
-    if (validationError) {
-      return {
-        observedAt,
-        validationFailure: {
-          reason: validationError.message,
-          code: 'invalid_quote',
-          retryable: false,
-          observedAt,
-        },
-      };
-    }
-
-    if (!expectedPubkey) {
-      return {
-        observedAt,
-        quoteSnapshot: remoteQuote,
-        validationFailure: {
-          reason: `BOLT12 mint operation ${operation.id} is missing NUT-20 quote pubkey`,
-          code: 'missing_quote_pubkey',
-          retryable: false,
-          observedAt,
-        },
-      };
-    }
-
-    return {
-      observedAt,
-      quoteSnapshot: remoteQuote,
-    };
+    return this.lifecycle.checkPending(ctx);
   }
 
   private async createRemoteQuote(
@@ -328,13 +115,6 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
     });
     assertSameUnit(quote.unit, payload.unit, `BOLT12 mint quote ${quote.quote}`);
     return quote;
-  }
-
-  private async requireQuoteKey(pubkey: string): Promise<void> {
-    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(pubkey);
-    if (!quoteKey) {
-      throw new MintQuoteKeyError(`Missing NUT-20 mint quote key for pubkey ${pubkey}`);
-    }
   }
 
   private assertQuoteMatchesRequest(
@@ -365,55 +145,5 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
           `does not match requested amount ${expectedAmount}`,
       );
     }
-  }
-
-  private async recoverSignedOutputs(
-    ctx: RecoverExecutingContext<'bolt12'>,
-  ): Promise<RecoverExecutingResult | null> {
-    try {
-      const recovered = await ctx.proofService.recoverProofsFromOutputData(
-        ctx.operation.mintUrl,
-        ctx.operation.outputData,
-        {
-          unit: ctx.operation.unit,
-          createdByOperationId: ctx.operation.id,
-        },
-      );
-
-      return recovered.length > 0 ? { status: 'FINALIZED' } : null;
-    } catch (error) {
-      ctx.logger?.warn('Failed to recover BOLT12 mint outputs from output data', {
-        mintUrl: ctx.operation.mintUrl,
-        quoteId: ctx.operation.quoteId,
-        operationId: ctx.operation.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        status: 'PENDING',
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  private getQuoteValidationError(
-    quote: MintQuoteBolt12Response,
-    expectedPubkey: string,
-    expectedUnit: string,
-  ): Error | null {
-    try {
-      this.assertQuoteMatchesRequest(quote, expectedPubkey, expectedUnit);
-      return null;
-    } catch (error) {
-      return error instanceof Error ? error : new Error(String(error));
-    }
-  }
-
-  private isAlreadyIssuedError(error: unknown): boolean {
-    if (error instanceof MintOperationError && (error.code === 20002 || error.code === 11003)) {
-      return true;
-    }
-
-    const message = error instanceof Error ? error.message : String(error);
-    return /already (issued|signed)|outputs? already/i.test(message);
   }
 }

--- a/packages/core/infra/handlers/mint/MintOnchainHandler.ts
+++ b/packages/core/infra/handlers/mint/MintOnchainHandler.ts
@@ -1,25 +1,14 @@
-import {
-  Amount,
-  type MintQuoteOnchainResponse as CashuMintQuoteOnchainResponse,
-  type Wallet,
-} from '@cashu/cashu-ts';
+import type { Wallet } from '@cashu/cashu-ts';
 import { assertSameUnit } from '@core/amounts';
 import type { KeyRingService } from '@core/services';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
-import { bytesToHex } from '@noble/curves/utils.js';
-import {
-  MintOperationError,
-  MintQuoteKeyError,
-  MintQuoteValidationError,
-} from '../../../models/Error';
+import { MintQuoteValidationError } from '../../../models/Error';
 import {
   mintQuoteFromOnchainResponse,
   type MintQuote,
   type MintQuoteOnchainResponse,
 } from '../../../models/MintQuote';
 import { mintQuoteObservationFromOnchainResponse } from '../../../models/MintQuoteObservationFactory';
-import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
-import { getReusableMintQuoteValidationError } from './ReusableMintQuoteValidation.ts';
+import { ReusableMintLifecycle } from './ReusableMintLifecycle';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
@@ -35,7 +24,24 @@ import type {
 } from '../../../operations/mint';
 
 export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
-  constructor(private readonly keyRingService: KeyRingService) {}
+  private readonly lifecycle: ReusableMintLifecycle<'onchain'>;
+
+  constructor(private readonly keyRingService: KeyRingService) {
+    this.lifecycle = new ReusableMintLifecycle(keyRingService, {
+      method: 'onchain',
+      quoteLabel: 'Onchain',
+      recoveryLabel: 'onchain',
+      initialAlreadyIssued: 'throw',
+      assertQuoteMatchesRequest: (quote, pubkey, unit) =>
+        this.assertQuoteMatchesRequest(quote, pubkey, unit),
+      toObservation: mintQuoteObservationFromOnchainResponse,
+      mintProofs: (wallet, amount, quote, secretKey, outputs) =>
+        wallet.mintProofsOnchain(amount, quote, secretKey, undefined, {
+          type: 'custom',
+          data: outputs,
+        }),
+    });
+  }
 
   async createQuote(ctx: CreateMintQuoteContext<'onchain'>): Promise<MintQuote<'onchain'>> {
     const quoteKey = await this.keyRingService.generateMintQuoteKeyPair();
@@ -64,241 +70,25 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
   }
 
   async validateQuoteForPrepare(quote: MintQuote<'onchain'>): Promise<void> {
-    await this.requireQuoteKey(quote.quoteData.pubkey);
+    return this.lifecycle.validateQuoteForPrepare(quote);
   }
 
   async prepare(ctx: PrepareContext<'onchain'>): Promise<PendingMintOperation<'onchain'>> {
-    const quote = ctx.importedQuote;
-    if (!quote) {
-      throw new Error(`Mint quote ${ctx.operation.quoteId ?? '(missing)'} was not provided`);
-    }
-
-    if (ctx.operation.quoteId !== quote.quote) {
-      throw new MintQuoteValidationError(
-        `Mint quote ${quote.quote} does not match operation quote ${ctx.operation.quoteId}`,
-      );
-    }
-
-    assertSameUnit(quote.unit, ctx.operation.unit, `Onchain mint quote ${quote.quote}`);
-    await this.requireQuoteKey(quote.pubkey);
-
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: ctx.operation.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for onchain mint operation');
-    }
-
-    return {
-      ...ctx.operation,
-      quoteId: quote.quote,
-      request: quote.request,
-      expiry: quote.expiry,
-      pubkey: quote.pubkey,
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
-      state: 'pending',
-    };
+    return this.lifecycle.prepare(ctx);
   }
 
   async execute(ctx: ExecuteContext<'onchain'>): Promise<MintExecutionResult> {
-    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(ctx.operation.pubkey ?? '');
-    if (!quoteKey) {
-      throw new MintQuoteKeyError(
-        `Missing NUT-20 mint quote key for pubkey ${ctx.operation.pubkey ?? '(missing)'}`,
-      );
-    }
-
-    const outputData = deserializeOutputData(ctx.operation.outputData);
-    const remoteQuote = await ctx.mintAdapter.checkMintQuote(
-      ctx.operation.mintUrl,
-      'onchain',
-      ctx.operation.quoteId,
-    );
-    this.assertQuoteMatchesRequest(remoteQuote, ctx.operation.pubkey ?? '', ctx.operation.unit);
-    const assessment = assessMintQuoteClaimability(
-      mintQuoteObservationFromOnchainResponse(ctx.operation.mintUrl, remoteQuote),
-      { requestedAmount: ctx.operation.amount },
-    );
-    if (assessment.status === 'invalid') {
-      throw new MintQuoteValidationError(
-        `Onchain mint quote ${ctx.operation.quoteId} is not claimable: ${assessment.status}`,
-      );
-    }
-
-    const proofs = await ctx.wallet.mintProofsOnchain(
-      ctx.operation.amount,
-      remoteQuote as CashuMintQuoteOnchainResponse,
-      bytesToHex(quoteKey.secretKey),
-      undefined,
-      { type: 'custom', data: outputData.keep },
-    );
-
-    return { status: 'ISSUED', proofs };
+    return this.lifecycle.execute(ctx);
   }
 
   async recoverExecuting(ctx: RecoverExecutingContext<'onchain'>): Promise<RecoverExecutingResult> {
-    const restored = await this.recoverSignedOutputs(ctx);
-    if (restored) {
-      return restored;
-    }
-
-    const { operation } = ctx;
-    const expectedPubkey = operation.pubkey;
-    if (!expectedPubkey) {
-      return {
-        status: 'TERMINAL',
-        error: `Recovered: onchain mint operation ${operation.id} is missing NUT-20 quote pubkey`,
-      };
-    }
-
-    let remoteQuote: MintQuoteOnchainResponse;
-    try {
-      remoteQuote = await ctx.mintAdapter.checkMintQuote(
-        operation.mintUrl,
-        'onchain',
-        operation.quoteId,
-      );
-    } catch (error) {
-      ctx.logger?.warn('Failed to check onchain mint quote during recovery', {
-        mintUrl: operation.mintUrl,
-        quoteId: operation.quoteId,
-        operationId: operation.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        status: 'PENDING',
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-
-    const validationError = this.getQuoteValidationError(
-      remoteQuote,
-      expectedPubkey,
-      operation.unit,
-    );
-    if (validationError) {
-      return {
-        status: 'TERMINAL',
-        error: validationError.message,
-      };
-    }
-
-    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(expectedPubkey);
-    if (!quoteKey) {
-      return {
-        status: 'TERMINAL',
-        error: `Missing NUT-20 mint quote key for pubkey ${expectedPubkey}`,
-      };
-    }
-
-    const assessment = assessMintQuoteClaimability(
-      mintQuoteObservationFromOnchainResponse(operation.mintUrl, remoteQuote),
-      { ...ctx.localClaimabilityFacts, requestedAmount: operation.amount },
-    );
-    if (assessment.status === 'invalid') {
-      return {
-        status: 'TERMINAL',
-        error: `Recovered: onchain quote ${operation.quoteId} has invalid claimability accounting`,
-      };
-    }
-    if (assessment.status !== 'claimable') {
-      return {
-        status: 'PENDING',
-        error: `Recovered: onchain quote ${operation.quoteId} has ${assessment.remoteAvailable} remotely available, requested ${operation.amount}`,
-      };
-    }
-
-    const outputData = deserializeOutputData(operation.outputData);
-    try {
-      const proofs = await ctx.wallet.mintProofsOnchain(
-        operation.amount,
-        remoteQuote as CashuMintQuoteOnchainResponse,
-        bytesToHex(quoteKey.secretKey),
-        undefined,
-        { type: 'custom', data: outputData.keep },
-      );
-
-      await ctx.proofService.saveProofs(
-        operation.mintUrl,
-        mapProofToCoreProof(operation.mintUrl, 'ready', proofs, {
-          unit: operation.unit,
-          createdByOperationId: operation.id,
-        }),
-      );
-
-      return { status: 'FINALIZED' };
-    } catch (error) {
-      if (this.isAlreadyIssuedError(error)) {
-        return (
-          (await this.recoverSignedOutputs(ctx)) ?? {
-            status: 'PENDING',
-            error: `Recovered: onchain quote ${operation.quoteId} was already issued but proofs were not recoverable`,
-          }
-        );
-      }
-
-      if (error instanceof MintOperationError && error.code === 20007) {
-        return {
-          status: 'TERMINAL',
-          error: `Recovered: onchain quote ${operation.quoteId} expired while executing mint`,
-        };
-      }
-
-      return {
-        status: 'PENDING',
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
+    return this.lifecycle.recoverExecuting(ctx);
   }
 
   async checkPending(
     ctx: PendingContext<'onchain'>,
   ): Promise<PendingMintObservationResult<'onchain'>> {
-    const { operation } = ctx;
-    const observedAt = Date.now();
-    const remoteQuote = await ctx.mintAdapter.checkMintQuote(
-      operation.mintUrl,
-      'onchain',
-      operation.quoteId,
-    );
-    const expectedPubkey = operation.pubkey;
-
-    const validationError = getReusableMintQuoteValidationError(remoteQuote, operation);
-    if (validationError) {
-      return {
-        observedAt,
-        validationFailure: {
-          reason: validationError.message,
-          code: 'invalid_quote',
-          retryable: false,
-          observedAt,
-        },
-      };
-    }
-
-    if (!expectedPubkey) {
-      return {
-        observedAt,
-        quoteSnapshot: remoteQuote,
-        validationFailure: {
-          reason: `Onchain mint operation ${operation.id} is missing NUT-20 quote pubkey`,
-          code: 'missing_quote_pubkey',
-          retryable: false,
-          observedAt,
-        },
-      };
-    }
-
-    return {
-      observedAt,
-      quoteSnapshot: remoteQuote,
-    };
+    return this.lifecycle.checkPending(ctx);
   }
 
   private async createRemoteQuote(
@@ -308,13 +98,6 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     const quote = await wallet.createMintQuoteOnchain(payload.pubkey);
     assertSameUnit(quote.unit, payload.unit, `Onchain mint quote ${quote.quote}`);
     return quote;
-  }
-
-  private async requireQuoteKey(pubkey: string): Promise<void> {
-    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(pubkey);
-    if (!quoteKey) {
-      throw new MintQuoteKeyError(`Missing NUT-20 mint quote key for pubkey ${pubkey}`);
-    }
   }
 
   private assertQuoteMatchesRequest(
@@ -329,55 +112,5 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     }
 
     assertSameUnit(quote.unit, expectedUnit, `Onchain mint quote ${quote.quote}`);
-  }
-
-  private async recoverSignedOutputs(
-    ctx: RecoverExecutingContext<'onchain'>,
-  ): Promise<RecoverExecutingResult | null> {
-    try {
-      const recovered = await ctx.proofService.recoverProofsFromOutputData(
-        ctx.operation.mintUrl,
-        ctx.operation.outputData,
-        {
-          unit: ctx.operation.unit,
-          createdByOperationId: ctx.operation.id,
-        },
-      );
-
-      return recovered.length > 0 ? { status: 'FINALIZED' } : null;
-    } catch (error) {
-      ctx.logger?.warn('Failed to recover onchain mint outputs from output data', {
-        mintUrl: ctx.operation.mintUrl,
-        quoteId: ctx.operation.quoteId,
-        operationId: ctx.operation.id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return {
-        status: 'PENDING',
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  private getQuoteValidationError(
-    quote: MintQuoteOnchainResponse,
-    expectedPubkey: string,
-    expectedUnit: string,
-  ): Error | null {
-    try {
-      this.assertQuoteMatchesRequest(quote, expectedPubkey, expectedUnit);
-      return null;
-    } catch (error) {
-      return error instanceof Error ? error : new Error(String(error));
-    }
-  }
-
-  private isAlreadyIssuedError(error: unknown): boolean {
-    if (error instanceof MintOperationError && (error.code === 20002 || error.code === 11003)) {
-      return true;
-    }
-
-    const message = error instanceof Error ? error.message : String(error);
-    return /already (issued|signed)|outputs? already/i.test(message);
   }
 }

--- a/packages/core/infra/handlers/mint/ReusableMintLifecycle.ts
+++ b/packages/core/infra/handlers/mint/ReusableMintLifecycle.ts
@@ -1,0 +1,375 @@
+import { Amount, type OutputData, type Proof, type Wallet } from '@cashu/cashu-ts';
+import { assertSameUnit } from '@core/amounts';
+import type { KeyRingService } from '@core/services';
+import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
+import { bytesToHex } from '@noble/curves/utils.js';
+import {
+  MintOperationError,
+  MintQuoteKeyError,
+  MintQuoteValidationError,
+} from '../../../models/Error';
+import type { MintQuote } from '../../../models/MintQuote';
+import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
+import { getReusableMintQuoteValidationError } from './ReusableMintQuoteValidation.ts';
+import type {
+  ExecuteContext,
+  MintExecutionResult,
+  MintMethodQuoteSnapshot,
+  PendingContext,
+  PendingMintObservationResult,
+  PendingMintOperation,
+  PrepareContext,
+  RecoverExecutingContext,
+  RecoverExecutingResult,
+} from '../../../operations/mint';
+
+type ReusableMintMethod = 'bolt12' | 'onchain';
+
+interface ReusableMintAdapter<M extends ReusableMintMethod> {
+  readonly method: M;
+  readonly quoteLabel: string;
+  readonly recoveryLabel: string;
+  /**
+   * BOLT12 returns ALREADY_ISSUED; onchain throws into Operation Recovery. These lead to
+   * different durable outcomes when Restore is empty, so keep this compatibility policy explicit.
+   */
+  readonly initialAlreadyIssued: 'return' | 'throw';
+  assertQuoteMatchesRequest(
+    quote: MintMethodQuoteSnapshot<M>,
+    expectedPubkey: string,
+    expectedUnit: string,
+  ): void;
+  toObservation(mintUrl: string, quote: MintMethodQuoteSnapshot<M>): MintQuote<M>;
+  mintProofs(
+    wallet: Wallet,
+    amount: Amount,
+    quote: MintMethodQuoteSnapshot<M>,
+    secretKey: string,
+    outputs: OutputData[],
+  ): Promise<Proof[]>;
+}
+
+/**
+ * Shared standalone Mint lifecycle for reusable quotes. Creation stays method-specific.
+ * This retains the handlers' existing effects; transaction ownership stays with the owning
+ * workflow and is migrated separately under ADR-0011.
+ */
+export class ReusableMintLifecycle<M extends ReusableMintMethod> {
+  constructor(
+    private readonly keyRingService: Pick<KeyRingService, 'getMintQuoteKeyPair'>,
+    private readonly adapter: ReusableMintAdapter<M>,
+  ) {}
+
+  async validateQuoteForPrepare(quote: MintQuote<M>): Promise<void> {
+    await this.requireQuoteKey(quote.quoteData.pubkey);
+  }
+
+  async prepare(ctx: PrepareContext<M>): Promise<PendingMintOperation<M>> {
+    const quote = ctx.importedQuote;
+    if (!quote) {
+      throw new Error(`Mint quote ${ctx.operation.quoteId ?? '(missing)'} was not provided`);
+    }
+
+    if (ctx.operation.quoteId !== quote.quote) {
+      throw new MintQuoteValidationError(
+        `Mint quote ${quote.quote} does not match operation quote ${ctx.operation.quoteId}`,
+      );
+    }
+
+    assertSameUnit(
+      quote.unit,
+      ctx.operation.unit,
+      `${this.adapter.quoteLabel} mint quote ${quote.quote}`,
+    );
+    await this.requireQuoteKey(quote.pubkey);
+
+    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
+      ctx.operation.mintUrl,
+      {
+        keep: { amount: ctx.operation.amount, unit: ctx.operation.unit },
+        send: { amount: Amount.zero(), unit: ctx.operation.unit },
+      },
+      {},
+    );
+
+    if (outputData.keep.length === 0) {
+      throw new Error(
+        `Failed to create deterministic outputs for ${this.adapter.recoveryLabel} mint operation`,
+      );
+    }
+
+    return {
+      ...ctx.operation,
+      quoteId: quote.quote,
+      request: quote.request,
+      expiry: quote.expiry,
+      pubkey: quote.pubkey,
+      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
+      state: 'pending',
+    };
+  }
+
+  async execute(ctx: ExecuteContext<M>): Promise<MintExecutionResult> {
+    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(ctx.operation.pubkey ?? '');
+    if (!quoteKey) {
+      throw new MintQuoteKeyError(
+        `Missing NUT-20 mint quote key for pubkey ${ctx.operation.pubkey ?? '(missing)'}`,
+      );
+    }
+
+    const outputData = deserializeOutputData(ctx.operation.outputData);
+    const remoteQuote = await ctx.mintAdapter.checkMintQuote(
+      ctx.operation.mintUrl,
+      this.adapter.method,
+      ctx.operation.quoteId,
+    );
+    this.adapter.assertQuoteMatchesRequest(
+      remoteQuote,
+      ctx.operation.pubkey ?? '',
+      ctx.operation.unit,
+    );
+    const assessment = assessMintQuoteClaimability(
+      this.adapter.toObservation(ctx.operation.mintUrl, remoteQuote),
+      { requestedAmount: ctx.operation.amount },
+    );
+    if (assessment.status === 'invalid') {
+      throw new MintQuoteValidationError(
+        `${this.adapter.quoteLabel} mint quote ${ctx.operation.quoteId} is not claimable: ${assessment.status}`,
+      );
+    }
+
+    try {
+      const proofs = await this.adapter.mintProofs(
+        ctx.wallet,
+        ctx.operation.amount,
+        remoteQuote,
+        bytesToHex(quoteKey.secretKey),
+        outputData.keep,
+      );
+
+      return { status: 'ISSUED', proofs };
+    } catch (error) {
+      if (this.adapter.initialAlreadyIssued === 'return' && this.isAlreadyIssuedError(error)) {
+        return { status: 'ALREADY_ISSUED' };
+      }
+      throw error;
+    }
+  }
+
+  async recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<RecoverExecutingResult> {
+    const restored = await this.recoverSignedOutputs(ctx);
+    if (restored) {
+      return restored;
+    }
+
+    const { operation } = ctx;
+    const expectedPubkey = operation.pubkey;
+    if (!expectedPubkey) {
+      return {
+        status: 'TERMINAL',
+        error: `Recovered: ${this.adapter.recoveryLabel} mint operation ${operation.id} is missing NUT-20 quote pubkey`,
+      };
+    }
+
+    let remoteQuote: MintMethodQuoteSnapshot<M>;
+    try {
+      remoteQuote = await ctx.mintAdapter.checkMintQuote(
+        operation.mintUrl,
+        this.adapter.method,
+        operation.quoteId,
+      );
+    } catch (error) {
+      ctx.logger?.warn(`Failed to check ${this.adapter.recoveryLabel} mint quote during recovery`, {
+        mintUrl: operation.mintUrl,
+        quoteId: operation.quoteId,
+        operationId: operation.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        status: 'PENDING',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+
+    const validationError = this.getQuoteValidationError(
+      remoteQuote,
+      expectedPubkey,
+      operation.unit,
+    );
+    if (validationError) {
+      return {
+        status: 'TERMINAL',
+        error: validationError.message,
+      };
+    }
+
+    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(expectedPubkey);
+    if (!quoteKey) {
+      return {
+        status: 'TERMINAL',
+        error: `Missing NUT-20 mint quote key for pubkey ${expectedPubkey}`,
+      };
+    }
+
+    const assessment = assessMintQuoteClaimability(
+      this.adapter.toObservation(operation.mintUrl, remoteQuote),
+      { ...ctx.localClaimabilityFacts, requestedAmount: operation.amount },
+    );
+    if (assessment.status === 'invalid') {
+      return {
+        status: 'TERMINAL',
+        error: `Recovered: ${this.adapter.recoveryLabel} quote ${operation.quoteId} has invalid claimability accounting`,
+      };
+    }
+    if (assessment.status !== 'claimable') {
+      return {
+        status: 'PENDING',
+        error: `Recovered: ${this.adapter.recoveryLabel} quote ${operation.quoteId} has ${assessment.remoteAvailable} remotely available, requested ${operation.amount}`,
+      };
+    }
+
+    const outputData = deserializeOutputData(operation.outputData);
+    try {
+      const proofs = await this.adapter.mintProofs(
+        ctx.wallet,
+        operation.amount,
+        remoteQuote,
+        bytesToHex(quoteKey.secretKey),
+        outputData.keep,
+      );
+
+      await ctx.proofService.saveProofs(
+        operation.mintUrl,
+        mapProofToCoreProof(operation.mintUrl, 'ready', proofs, {
+          unit: operation.unit,
+          createdByOperationId: operation.id,
+        }),
+      );
+
+      return { status: 'FINALIZED' };
+    } catch (error) {
+      if (this.isAlreadyIssuedError(error)) {
+        return (
+          (await this.recoverSignedOutputs(ctx)) ?? {
+            status: 'PENDING',
+            error: `Recovered: ${this.adapter.recoveryLabel} quote ${operation.quoteId} was already issued but proofs were not recoverable`,
+          }
+        );
+      }
+
+      if (error instanceof MintOperationError && error.code === 20007) {
+        return {
+          status: 'TERMINAL',
+          error: `Recovered: ${this.adapter.recoveryLabel} quote ${operation.quoteId} expired while executing mint`,
+        };
+      }
+
+      return {
+        status: 'PENDING',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async checkPending(ctx: PendingContext<M>): Promise<PendingMintObservationResult<M>> {
+    const { operation } = ctx;
+    const observedAt = Date.now();
+    const remoteQuote = await ctx.mintAdapter.checkMintQuote(
+      operation.mintUrl,
+      this.adapter.method,
+      operation.quoteId,
+    );
+    const expectedPubkey = operation.pubkey;
+
+    const validationError = getReusableMintQuoteValidationError(remoteQuote, operation);
+    if (validationError) {
+      return {
+        observedAt,
+        validationFailure: {
+          reason: validationError.message,
+          code: 'invalid_quote',
+          retryable: false,
+          observedAt,
+        },
+      };
+    }
+
+    if (!expectedPubkey) {
+      return {
+        observedAt,
+        quoteSnapshot: remoteQuote,
+        validationFailure: {
+          reason: `${this.adapter.quoteLabel} mint operation ${operation.id} is missing NUT-20 quote pubkey`,
+          code: 'missing_quote_pubkey',
+          retryable: false,
+          observedAt,
+        },
+      };
+    }
+
+    return {
+      observedAt,
+      quoteSnapshot: remoteQuote,
+    };
+  }
+
+  private async requireQuoteKey(pubkey: string): Promise<void> {
+    const quoteKey = await this.keyRingService.getMintQuoteKeyPair(pubkey);
+    if (!quoteKey) {
+      throw new MintQuoteKeyError(`Missing NUT-20 mint quote key for pubkey ${pubkey}`);
+    }
+  }
+
+  private async recoverSignedOutputs(
+    ctx: RecoverExecutingContext<M>,
+  ): Promise<RecoverExecutingResult | null> {
+    try {
+      const recovered = await ctx.proofService.recoverProofsFromOutputData(
+        ctx.operation.mintUrl,
+        ctx.operation.outputData,
+        {
+          unit: ctx.operation.unit,
+          createdByOperationId: ctx.operation.id,
+        },
+      );
+
+      return recovered.length > 0 ? { status: 'FINALIZED' } : null;
+    } catch (error) {
+      ctx.logger?.warn(
+        `Failed to recover ${this.adapter.recoveryLabel} mint outputs from output data`,
+        {
+          mintUrl: ctx.operation.mintUrl,
+          quoteId: ctx.operation.quoteId,
+          operationId: ctx.operation.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return {
+        status: 'PENDING',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private getQuoteValidationError(
+    quote: MintMethodQuoteSnapshot<M>,
+    expectedPubkey: string,
+    expectedUnit: string,
+  ): Error | null {
+    try {
+      this.adapter.assertQuoteMatchesRequest(quote, expectedPubkey, expectedUnit);
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  private isAlreadyIssuedError(error: unknown): boolean {
+    if (error instanceof MintOperationError && (error.code === 20002 || error.code === 11003)) {
+      return true;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return /already (issued|signed)|outputs? already/i.test(message);
+  }
+}

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -1,30 +1,19 @@
 import { Amount, OutputData, type MintQuoteBolt12Response, type Wallet } from '@cashu/cashu-ts';
-import { bytesToHex } from '@noble/curves/utils.js';
 import { beforeEach, describe, expect, it, mock, type Mock } from 'bun:test';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { MintAdapter } from '../../infra';
 import { MintBolt12Handler } from '../../infra/handlers/mint/MintBolt12Handler';
 import type { Logger } from '../../logging/Logger';
-import {
-  MintOperationError,
-  MintQuoteKeyError,
-  MintQuoteValidationError,
-} from '../../models/Error';
+import { MintQuoteValidationError } from '../../models/Error';
 import { mintQuoteFromBolt12Response } from '../../models/MintQuote';
 import type { ProofRepository } from '../../repositories';
 import type { KeyRingService } from '../../services/KeyRingService';
 import type { MintService } from '../../services/MintService';
 import type { ProofService } from '../../services/ProofService';
 import type { WalletService } from '../../services/WalletService';
-import type {
-  ExecuteContext,
-  FetchRemoteMintQuoteContext,
-  PendingContext,
-  PrepareContext,
-  RecoverExecutingContext,
-} from '../../operations/mint';
-import { serializeOutputData } from '../../utils';
+import type { FetchRemoteMintQuoteContext, PrepareContext } from '../../operations/mint';
+import { deserializeOutputData, serializeOutputData } from '../../utils';
 
 describe('MintBolt12Handler', () => {
   const mintUrl = 'https://mint.test';
@@ -111,50 +100,6 @@ describe('MintBolt12Handler', () => {
     logger,
   });
 
-  const buildPendingContext = (remoteQuote: MintQuoteBolt12Response): PendingContext<'bolt12'> => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockImplementation(async () => remoteQuote);
-    return {
-      operation: {
-        ...operation,
-        state: 'pending',
-        quoteId,
-        request: remoteQuote.request,
-        expiry: remoteQuote.expiry,
-        pubkey,
-        outputData,
-      },
-      mintAdapter,
-      logger,
-    };
-  };
-
-  const buildExecuteContext = (remoteQuote: MintQuoteBolt12Response): ExecuteContext<'bolt12'> => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockImplementation(async () => remoteQuote);
-    return {
-      ...buildPrepareContext(),
-      operation: {
-        ...operation,
-        state: 'executing',
-        quoteId,
-        request: remoteQuote.request,
-        expiry: remoteQuote.expiry,
-        pubkey,
-        outputData,
-      },
-    };
-  };
-
-  const buildRecoverContext = (
-    remoteQuote: MintQuoteBolt12Response,
-    localClaimabilityFacts = {
-      finalizedAmount: Amount.zero(),
-      reservedAmount: Amount.zero(),
-    },
-  ): RecoverExecutingContext<'bolt12'> => ({
-    ...buildExecuteContext(remoteQuote),
-    localClaimabilityFacts,
-  });
-
   beforeEach(() => {
     wallet = {
       createMintQuoteBolt12: mock(async () => quote()),
@@ -164,7 +109,10 @@ describe('MintBolt12Handler', () => {
       checkMintQuote: mock(async () => quote()),
     } as unknown as MintAdapter;
     proofService = {
-      createOutputsAndIncrementCounters: mock(async () => ({ keep: outputData.keep, send: [] })),
+      createOutputsAndIncrementCounters: mock(async () => ({
+        keep: deserializeOutputData(outputData).keep,
+        send: [],
+      })),
       saveProofs: mock(async () => {}),
       recoverProofsFromOutputData: mock(async () => []),
     } as unknown as ProofService;
@@ -323,241 +271,53 @@ describe('MintBolt12Handler', () => {
     expect(wallet.createMintQuoteBolt12).not.toHaveBeenCalled();
     expect(result.amount).toEqual(Amount.from(10));
   });
-
-  it('rejects imported quotes that do not match the bound operation quote id', async () => {
+  it('issues and replays a claim whose amount differs from the fixed offer amount', async () => {
+    const remoteQuote = quote({ amount: Amount.from(50), amount_paid: Amount.from(50) });
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValue(
+      remoteQuote,
+    );
+    const pending = await handler.prepare({
+      ...buildPrepareContext(),
+      importedQuote: remoteQuote,
+    });
+    const ctx = {
+      ...buildPrepareContext(),
+      operation: { ...pending, state: 'executing' as const },
+    };
+    await handler.execute(ctx);
+    await handler.recoverExecuting({
+      ...ctx,
+      localClaimabilityFacts: { finalizedAmount: Amount.zero(), reservedAmount: Amount.zero() },
+    });
+    expect(wallet.mintProofsBolt12).toHaveBeenCalledTimes(2);
+    expect(wallet.mintProofsBolt12).toHaveBeenCalledWith(
+      Amount.from(10),
+      remoteQuote,
+      '07'.repeat(32),
+      undefined,
+      { type: 'custom', data: deserializeOutputData(pending.outputData).keep },
+    );
+  });
+  it.each(['unit', 'pubkey'] as const)('rejects creation with a changed %s', async (field) => {
+    (
+      wallet.createMintQuoteBolt12 as Mock<typeof wallet.createMintQuoteBolt12>
+    ).mockResolvedValueOnce({ ...quote(), [field]: 'changed' });
     await expect(
-      handler.prepare(
-        buildPrepareContext({
-          importedQuote: quote({ quote: 'quote-other' }),
-          operation: {
-            ...operation,
-            quoteId,
-          },
-        }),
-      ),
-    ).rejects.toThrow(`Mint quote quote-other does not match operation quote ${quoteId}`);
-
-    expect(proofService.createOutputsAndIncrementCounters).not.toHaveBeenCalled();
+      handler.createQuote({ ...buildPrepareContext(), mintUrl, createQuoteData: { unit: 'sat' } }),
+    ).rejects.toThrow();
   });
 
-  it('requires the imported quote pubkey to exist in the keyring', async () => {
-    (keyRingService.getMintQuoteKeyPair as Mock<any>).mockImplementation(async () => null);
-
-    const error = await handler
-      .prepare(buildPrepareContext({ importedQuote: quote() }))
-      .catch((caught) => caught);
-
-    expect(error).toBeInstanceOf(MintQuoteKeyError);
-    expect(error.message).toContain('Missing NUT-20 mint quote key');
-  });
-
-  it('reports the validated remote snapshot for an amountless quote', async () => {
-    const result = await handler.checkPending(
-      buildPendingContext(
-        quote({
-          amount: undefined,
-          amount_paid: Amount.from(15),
-          amount_issued: Amount.from(4),
-        }),
-      ),
-    );
-
-    expect(result.quoteSnapshot?.quote).toBe(quoteId);
-    expect(result.observedAt).toEqual(expect.any(Number));
-  });
-
-  it('reports an unattributable pending response as a validation failure', async () => {
-    const context = buildPendingContext(quote());
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce(
-      quote({ quote: 'other-quote' }),
-    );
-
-    const result = await handler.checkPending(context);
-
-    expect(result.quoteSnapshot).toBeUndefined();
-    expect(result.validationFailure).toMatchObject({
-      code: 'invalid_quote',
-      retryable: false,
+  it('requires an owned key before preparing a canonical quote', async () => {
+    const canonical = await handler.createQuote({
+      ...buildPrepareContext(),
+      mintUrl,
+      createQuoteData: { unit: 'sat' },
     });
-    expect(result.validationFailure?.reason).toContain('conflicts with pending operation identity');
-  });
-
-  it('does not attribute a mismatched response when the operation pubkey is missing', async () => {
-    const baseContext = buildPendingContext(quote());
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce(
-      quote({ request: 'lno1other' }),
+    (
+      keyRingService.getMintQuoteKeyPair as Mock<typeof keyRingService.getMintQuoteKeyPair>
+    ).mockResolvedValueOnce(null);
+    await expect(handler.validateQuoteForPrepare(canonical)).rejects.toThrow(
+      'Missing NUT-20 mint quote key',
     );
-
-    const result = await handler.checkPending({
-      ...baseContext,
-      operation: { ...baseContext.operation, pubkey: undefined },
-    });
-
-    expect(result.quoteSnapshot).toBeUndefined();
-    expect(result.validationFailure?.code).toBe('invalid_quote');
-  });
-
-  it('preserves the missing-pubkey terminal code for an attributable response', async () => {
-    const baseContext = buildPendingContext(quote());
-
-    const result = await handler.checkPending({
-      ...baseContext,
-      operation: { ...baseContext.operation, pubkey: undefined },
-    });
-
-    expect(result.quoteSnapshot?.quote).toBe(quoteId);
-    expect(result.validationFailure?.code).toBe('missing_quote_pubkey');
-  });
-
-  it('mints with the keyring private key and custom outputs', async () => {
-    await handler.execute(
-      buildExecuteContext(
-        quote({
-          amount_paid: Amount.from(10),
-        }),
-      ),
-    );
-
-    const call = (wallet.mintProofsBolt12 as Mock<any>).mock.calls[0]! as any[];
-    expect(call[0]).toEqual(Amount.from(10));
-    expect(call[1].quote).toBe(quoteId);
-    expect(call[2]).toBe(bytesToHex(secretKey));
-    expect(call[3]).toBeUndefined();
-    expect(call[4].type).toBe('custom');
-    expect(call[4].data).toHaveLength(1);
-    expect(call[4].data[0].blindedMessage.B_).toBe('B_out_1');
-  });
-
-  it('rejects contradictory fresh accounting before mint submission', async () => {
-    await expect(
-      handler.execute(
-        buildExecuteContext(
-          quote({
-            amount_paid: Amount.from(9),
-            amount_issued: Amount.from(10),
-          }),
-        ),
-      ),
-    ).rejects.toThrow(`BOLT12 mint quote ${quoteId} is not claimable: invalid`);
-
-    expect(wallet.mintProofsBolt12).not.toHaveBeenCalled();
-  });
-
-  it('does not let a stale valid fresh balance veto service-authorized execution', async () => {
-    const result = await handler.execute(
-      buildExecuteContext(
-        quote({
-          amount_paid: Amount.from(1),
-          amount_issued: Amount.zero(),
-        }),
-      ),
-    );
-
-    expect(result.status).toBe('ISSUED');
-    expect(wallet.mintProofsBolt12).toHaveBeenCalledTimes(1);
-  });
-
-  it('rejects execution when the remote quote pubkey changes', async () => {
-    const changedPubkey = '02' + '22'.repeat(32);
-
-    const error = await handler
-      .execute(
-        buildExecuteContext(
-          quote({
-            amount_paid: Amount.from(10),
-            pubkey: changedPubkey,
-          }),
-        ),
-      )
-      .catch((caught) => caught);
-
-    expect(error).toBeInstanceOf(MintQuoteValidationError);
-    expect(error.message).toContain(
-      `BOLT12 mint quote ${quoteId} returned pubkey ${changedPubkey}`,
-    );
-
-    expect(wallet.mintProofsBolt12).not.toHaveBeenCalled();
-  });
-
-  it('recovers remote pubkey changes as terminal failures without signing', async () => {
-    const changedPubkey = '02' + '33'.repeat(32);
-
-    const result = await handler.recoverExecuting(
-      buildRecoverContext(
-        quote({
-          amount_paid: Amount.from(10),
-          pubkey: changedPubkey,
-        }),
-      ),
-    );
-
-    expect(result.status).toBe('TERMINAL');
-    if (result.status !== 'TERMINAL') {
-      throw new Error('Expected terminal recovery result');
-    }
-    expect(result.error).toContain(`BOLT12 mint quote ${quoteId} returned pubkey ${changedPubkey}`);
-    expect(wallet.mintProofsBolt12).not.toHaveBeenCalled();
-  });
-
-  it('retries funded execution recovery after expiry', async () => {
-    const expiredQuote = quote({
-      expiry: Math.floor(Date.now() / 1000) - 1,
-      amount_paid: Amount.from(10),
-    });
-
-    const result = await handler.recoverExecuting(buildRecoverContext(expiredQuote));
-
-    expect(result).toEqual({ status: 'FINALIZED' });
-    expect(wallet.mintProofsBolt12).toHaveBeenCalled();
-    expect(proofService.saveProofs).toHaveBeenCalled();
-  });
-
-  it('fails recovery when the mint rejects BOLT12 issuance with quote expired', async () => {
-    const expiredQuote = quote({
-      expiry: Math.floor(Date.now() / 1000) - 1,
-      amount_paid: Amount.from(10),
-    });
-    (wallet.mintProofsBolt12 as Mock<any>).mockRejectedValueOnce(
-      new MintOperationError(20007, 'Quote expired'),
-    );
-
-    const result = await handler.recoverExecuting(buildRecoverContext(expiredQuote));
-
-    expect(result).toEqual({
-      status: 'TERMINAL',
-      error: `Recovered: BOLT12 quote ${quoteId} expired while executing mint`,
-    });
-    expect(wallet.mintProofsBolt12).toHaveBeenCalledTimes(1);
-    expect(proofService.saveProofs).not.toHaveBeenCalled();
-  });
-
-  it('keeps non-protocol expiry errors pending during BOLT12 recovery', async () => {
-    const expiredQuote = quote({
-      expiry: Math.floor(Date.now() / 1000) - 1,
-      amount_paid: Amount.from(10),
-    });
-    (wallet.mintProofsBolt12 as Mock<any>).mockRejectedValueOnce(
-      new Error('Authentication session expired'),
-    );
-
-    const result = await handler.recoverExecuting(buildRecoverContext(expiredQuote));
-
-    expect(result).toEqual({
-      status: 'PENDING',
-      error: 'Authentication session expired',
-    });
-    expect(proofService.saveProofs).not.toHaveBeenCalled();
-  });
-
-  it('does not retry balance already consumed by finalized local operations', async () => {
-    const result = await handler.recoverExecuting(
-      buildRecoverContext(quote({ amount_paid: Amount.from(10) }), {
-        finalizedAmount: Amount.from(10),
-        reservedAmount: Amount.zero(),
-      }),
-    );
-
-    expect(result.status).toBe('PENDING');
-    expect(wallet.mintProofsBolt12).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/test/unit/MintOnchainHandler.test.ts
+++ b/packages/core/test/unit/MintOnchainHandler.test.ts
@@ -1,32 +1,15 @@
-import { Amount, OutputData, type Wallet } from '@cashu/cashu-ts';
+import { Amount, type Wallet } from '@cashu/cashu-ts';
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import { MintOnchainHandler } from '../../infra/handlers/mint/MintOnchainHandler';
 import type { MintAdapter } from '../../infra/MintAdapter';
 import type { Logger } from '../../logging/Logger';
-import {
-  MintOperationError,
-  MintQuoteKeyError,
-  MintQuoteValidationError,
-} from '../../models/Error';
-import type {
-  CreateMintQuoteContext,
-  ExecuteContext,
-  FetchRemoteMintQuoteContext,
-  PendingContext,
-  PrepareContext,
-  RecoverExecutingContext,
-} from '../../operations/mint';
+import { MintQuoteValidationError } from '../../models/Error';
+import type { CreateMintQuoteContext, FetchRemoteMintQuoteContext } from '../../operations/mint';
 import { getMintQuoteAvailableAmount, type MintQuoteOnchainResponse } from '../../models/MintQuote';
-import type {
-  ExecutingMintOperation,
-  InitMintOperation,
-  PendingMintOperation,
-} from '../../operations/mint/MintOperation';
 import type { ProofRepository } from '../../repositories';
 import type { KeyRingService, MintService, ProofService, WalletService } from '../../services';
-import { deserializeOutputData, serializeOutputData } from '../../utils';
 
 describe('MintOnchainHandler', () => {
   const mintUrl = 'https://mint.test';
@@ -55,16 +38,6 @@ describe('MintOnchainHandler', () => {
     amount_issued: Amount.from(8),
     updated_at: null,
   };
-
-  const output = new OutputData(
-    {
-      amount: Amount.from(10),
-      id: 'keyset-1',
-      B_: 'B_out_1',
-    },
-    BigInt(1),
-    new TextEncoder().encode('out-1'),
-  );
 
   const buildCreateQuoteContext = (): CreateMintQuoteContext<'onchain'> => ({
     mintUrl,
@@ -108,59 +81,6 @@ describe('MintOnchainHandler', () => {
     logger,
   });
 
-  const buildPrepareContext = (): PrepareContext<'onchain'> => ({
-    operation: {
-      id: 'op-1',
-      state: 'init',
-      mintUrl,
-      amount: Amount.from(10),
-      unit: 'sat',
-      method: 'onchain',
-      methodData: {},
-      quoteId,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    } satisfies InitMintOperation<'onchain'>,
-    wallet,
-    mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
-    logger,
-  });
-
-  const buildExecutingOperation = (): ExecutingMintOperation<'onchain'> => ({
-    ...buildPrepareContext().operation,
-    state: 'executing',
-    quoteId,
-    request: remoteQuote.request,
-    expiry: remoteQuote.expiry,
-    pubkey,
-    outputData: serializeOutputData({ keep: [output], send: [] }),
-  });
-
-  const buildRecoverContext = (
-    localClaimabilityFacts = {
-      finalizedAmount: Amount.zero(),
-      reservedAmount: Amount.zero(),
-    },
-  ): RecoverExecutingContext<'onchain'> => ({
-    ...buildPrepareContext(),
-    operation: buildExecutingOperation(),
-    localClaimabilityFacts,
-  });
-
-  const buildPendingContext = (): PendingContext<'onchain'> => ({
-    operation: {
-      ...buildExecutingOperation(),
-      state: 'pending',
-    } satisfies PendingMintOperation<'onchain'>,
-    mintAdapter,
-    logger,
-  });
-
   beforeEach(() => {
     keyRingService = {
       generateMintQuoteKeyPair: mock(async () => ({
@@ -196,7 +116,7 @@ describe('MintOnchainHandler', () => {
     } as unknown as MintAdapter;
 
     proofService = {
-      createOutputsAndIncrementCounters: mock(async () => ({ keep: [output], send: [] })),
+      createOutputsAndIncrementCounters: mock(async () => ({ keep: [], send: [] })),
       saveProofs: mock(async () => {}),
       recoverProofsFromOutputData: mock(async () => []),
     } as unknown as ProofService;
@@ -270,286 +190,20 @@ describe('MintOnchainHandler', () => {
     expect(result.amountPaid.equals(Amount.from(21))).toBe(true);
     expect(result.amountIssued.equals(Amount.from(8))).toBe(true);
   });
+  it.each(['unit'] as const)('rejects creation with a changed %s', async (field) => {
+    (
+      wallet.createMintQuoteOnchain as Mock<typeof wallet.createMintQuoteOnchain>
+    ).mockResolvedValueOnce({ ...remoteQuote, [field]: 'changed' });
+    await expect(handler.createQuote(buildCreateQuoteContext())).rejects.toThrow();
+  });
 
-  it('prepares deterministic outputs without requiring available quote balance', async () => {
-    const result = await handler.prepare({
-      ...buildPrepareContext(),
-      importedQuote: { ...remoteQuote, amount_paid: Amount.zero(), amount_issued: Amount.zero() },
-    });
-
-    expect(keyRingService.getMintQuoteKeyPair).toHaveBeenCalledWith(pubkey);
-    expect(proofService.createOutputsAndIncrementCounters).toHaveBeenCalledWith(
-      mintUrl,
-      {
-        keep: { amount: Amount.from(10), unit: 'sat' },
-        send: { amount: Amount.zero(), unit: 'sat' },
-      },
-      {},
+  it('requires an owned key before preparing a canonical quote', async () => {
+    const canonical = await handler.createQuote(buildCreateQuoteContext());
+    (
+      keyRingService.getMintQuoteKeyPair as Mock<typeof keyRingService.getMintQuoteKeyPair>
+    ).mockResolvedValueOnce(null);
+    await expect(handler.validateQuoteForPrepare(canonical)).rejects.toThrow(
+      'Missing NUT-20 mint quote key',
     );
-    expect(result.state).toBe('pending');
-    expect(result.quoteId).toBe(quoteId);
-    expect(result.pubkey).toBe(pubkey);
-    expect(deserializeOutputData(result.outputData).keep).toHaveLength(1);
-  });
-
-  it('fails onchain preparation when the quote key is missing', async () => {
-    (keyRingService.getMintQuoteKeyPair as Mock<any>).mockResolvedValueOnce(null);
-
-    const error = await handler
-      .prepare({ ...buildPrepareContext(), importedQuote: remoteQuote })
-      .catch((caught) => caught);
-
-    expect(error).toBeInstanceOf(MintQuoteKeyError);
-    expect(error.message).toContain('Missing NUT-20 mint quote key');
-  });
-
-  it('executes onchain mint proofs with the persisted quote key', async () => {
-    const pending = await handler.prepare({
-      ...buildPrepareContext(),
-      importedQuote: remoteQuote,
-    });
-    const context: ExecuteContext<'onchain'> = {
-      ...buildPrepareContext(),
-      operation: {
-        ...pending,
-        state: 'executing',
-      },
-    };
-
-    const result = await handler.execute(context);
-
-    expect(result.status).toBe('ISSUED');
-    expect(mintAdapter.checkMintQuote).toHaveBeenCalledWith(mintUrl, 'onchain', quoteId);
-    expect(wallet.mintProofsOnchain).toHaveBeenCalledWith(
-      Amount.from(10),
-      remoteQuote,
-      ''.padEnd(64, '0'),
-      undefined,
-      { type: 'custom', data: deserializeOutputData(pending.outputData).keep },
-    );
-  });
-
-  it('rejects contradictory fresh accounting before mint submission', async () => {
-    const pending = await handler.prepare({
-      ...buildPrepareContext(),
-      importedQuote: remoteQuote,
-    });
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      amount_paid: Amount.from(9),
-      amount_issued: Amount.from(10),
-    });
-
-    await expect(
-      handler.execute({
-        ...buildPrepareContext(),
-        operation: { ...pending, state: 'executing' },
-      }),
-    ).rejects.toThrow(`Onchain mint quote ${quoteId} is not claimable: invalid`);
-
-    expect(wallet.mintProofsOnchain).not.toHaveBeenCalled();
-  });
-
-  it('does not let a stale valid fresh balance veto service-authorized execution', async () => {
-    const pending = await handler.prepare({
-      ...buildPrepareContext(),
-      importedQuote: remoteQuote,
-    });
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      amount_paid: Amount.from(1),
-      amount_issued: Amount.zero(),
-    });
-
-    const result = await handler.execute({
-      ...buildPrepareContext(),
-      operation: { ...pending, state: 'executing' },
-    });
-
-    expect(result.status).toBe('ISSUED');
-    expect(wallet.mintProofsOnchain).toHaveBeenCalledTimes(1);
-  });
-
-  it('recovers signed onchain outputs before retrying the mint', async () => {
-    (proofService.recoverProofsFromOutputData as Mock<any>).mockResolvedValueOnce([
-      {
-        id: 'keyset-1',
-        amount: Amount.from(10),
-        secret: 'out-1',
-        C: 'C_out_1',
-      },
-    ]);
-
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result).toEqual({ status: 'FINALIZED' });
-    expect(proofService.recoverProofsFromOutputData).toHaveBeenCalled();
-    expect(wallet.mintProofsOnchain).not.toHaveBeenCalled();
-  });
-
-  it('retries onchain minting from persisted output data when the quote is still available', async () => {
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result).toEqual({ status: 'FINALIZED' });
-    expect(proofService.recoverProofsFromOutputData).toHaveBeenCalled();
-    expect(wallet.mintProofsOnchain).toHaveBeenCalledWith(
-      Amount.from(10),
-      remoteQuote,
-      ''.padEnd(64, '0'),
-      undefined,
-      { type: 'custom', data: [output] },
-    );
-    expect(proofService.saveProofs).toHaveBeenCalled();
-  });
-
-  it('returns pending during recovery when output restore is empty and balance is unavailable', async () => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      amount_paid: Amount.from(8),
-      amount_issued: Amount.from(8),
-    });
-
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result.status).toBe('PENDING');
-    expect(wallet.mintProofsOnchain).not.toHaveBeenCalled();
-  });
-
-  it('subtracts other in-flight reservations before retrying onchain recovery', async () => {
-    const result = await handler.recoverExecuting(
-      buildRecoverContext({
-        finalizedAmount: Amount.zero(),
-        reservedAmount: Amount.from(10),
-      }),
-    );
-
-    expect(result.status).toBe('PENDING');
-    expect(wallet.mintProofsOnchain).not.toHaveBeenCalled();
-  });
-
-  it('attempts restore again after an already-issued retry result', async () => {
-    (wallet.mintProofsOnchain as Mock<any>).mockImplementationOnce(async () => {
-      throw new MintOperationError(20002, 'already issued');
-    });
-    (proofService.recoverProofsFromOutputData as Mock<any>)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          id: 'keyset-1',
-          amount: Amount.from(10),
-          secret: 'out-1',
-          C: 'C_out_1',
-        },
-      ]);
-
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result).toEqual({ status: 'FINALIZED' });
-    expect(proofService.recoverProofsFromOutputData).toHaveBeenCalledTimes(2);
-  });
-
-  it('retries funded onchain execution recovery after expiry', async () => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      expiry: Math.floor(Date.now() / 1000) - 1,
-    });
-
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result).toEqual({ status: 'FINALIZED' });
-    expect(wallet.mintProofsOnchain).toHaveBeenCalled();
-    expect(proofService.saveProofs).toHaveBeenCalled();
-  });
-
-  it('fails recovery when the mint rejects onchain issuance with quote expired', async () => {
-    (wallet.mintProofsOnchain as Mock<any>).mockRejectedValueOnce(
-      new MintOperationError(20007, 'Quote expired'),
-    );
-
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result).toEqual({
-      status: 'TERMINAL',
-      error: `Recovered: onchain quote ${quoteId} expired while executing mint`,
-    });
-    expect(wallet.mintProofsOnchain).toHaveBeenCalledTimes(1);
-    expect(proofService.saveProofs).not.toHaveBeenCalled();
-  });
-
-  it('keeps non-protocol expiry errors pending during onchain recovery', async () => {
-    (wallet.mintProofsOnchain as Mock<any>).mockRejectedValueOnce(
-      new Error('Authentication session expired'),
-    );
-
-    const result = await handler.recoverExecuting(buildRecoverContext());
-
-    expect(result).toEqual({
-      status: 'PENDING',
-      error: 'Authentication session expired',
-    });
-    expect(proofService.saveProofs).not.toHaveBeenCalled();
-  });
-
-  it('reports the validated remote snapshot for a pending operation', async () => {
-    const result = await handler.checkPending(buildPendingContext());
-
-    expect(result.quoteSnapshot).toBe(remoteQuote);
-    expect(result.observedAt).toEqual(expect.any(Number));
-  });
-
-  it('reports an unattributable pending response as a validation failure', async () => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      request: 'bc1qotheraddress',
-    });
-
-    const result = await handler.checkPending(buildPendingContext());
-
-    expect(result.quoteSnapshot).toBeUndefined();
-    expect(result.validationFailure).toMatchObject({
-      code: 'invalid_quote',
-      retryable: false,
-    });
-    expect(result.validationFailure?.reason).toContain('conflicts with pending operation identity');
-  });
-
-  it('does not attribute a mismatched response when the operation pubkey is missing', async () => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      quote: 'other-quote',
-    });
-    const baseContext = buildPendingContext();
-
-    const result = await handler.checkPending({
-      ...baseContext,
-      operation: { ...baseContext.operation, pubkey: undefined },
-    });
-
-    expect(result.quoteSnapshot).toBeUndefined();
-    expect(result.validationFailure?.code).toBe('invalid_quote');
-  });
-
-  it('preserves the missing-pubkey terminal code for an attributable response', async () => {
-    const baseContext = buildPendingContext();
-
-    const result = await handler.checkPending({
-      ...baseContext,
-      operation: { ...baseContext.operation, pubkey: undefined },
-    });
-
-    expect(result.quoteSnapshot).toBe(remoteQuote);
-    expect(result.validationFailure?.code).toBe('missing_quote_pubkey');
-  });
-
-  it('preserves remote accounting in the pending observation', async () => {
-    (mintAdapter.checkMintQuote as Mock<any>).mockResolvedValueOnce({
-      ...remoteQuote,
-      amount_paid: Amount.from(8),
-      amount_issued: Amount.from(0),
-    });
-
-    const result = await handler.checkPending(buildPendingContext());
-
-    expect(result.quoteSnapshot?.amount_paid?.equals(Amount.from(8))).toBe(true);
   });
 });

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -25,11 +25,16 @@ import type {
   PendingMintObservationResult,
   RecoverExecutingResult,
 } from '../../operations/mint/MintMethodHandler';
-import type { MintHandlerProvider } from '../../infra/handlers/mint';
+import {
+  MintHandlerProvider,
+  MintBolt12Handler,
+  MintOnchainHandler,
+} from '../../infra/handlers/mint';
+import type { KeyRingService } from '../../services/KeyRingService';
 import { MemoryMintOperationRepository } from '../../repositories/memory/MemoryMintOperationRepository';
 import { MemoryMintQuoteRepository } from '../../repositories/memory/MemoryMintQuoteRepository';
 import { MemoryProofRepository } from '../../repositories/memory/MemoryProofRepository';
-import { getMintQuoteAvailableAmount } from '../../models/MintQuote';
+import { getMintQuoteAvailableAmount, mintQuoteToMethodSnapshot } from '../../models/MintQuote';
 import { mintQuoteObservationFromOnchainResponse } from '../../models/MintQuoteObservationFactory';
 import {
   cashuNormalizedBolt11Fixture,
@@ -46,7 +51,11 @@ import type { MintAdapter } from '../../infra/MintAdapter';
 import type { Logger } from '../../logging/Logger';
 import { serializeOutputData } from '../../utils';
 import type { CoreProof } from '../../types';
-import { MintQuoteValidationError, QuoteIdentityConflictError } from '../../models/Error';
+import {
+  MintOperationError,
+  MintQuoteValidationError,
+  QuoteIdentityConflictError,
+} from '../../models/Error';
 
 describe('MintOperationService', () => {
   const mintUrl = 'https://mint.test';
@@ -2645,6 +2654,78 @@ describe('MintOperationService', () => {
       `Recovered issued quote ${pendingOp.quoteId} but no proofs could be restored`,
     );
   });
+
+  it.each(['bolt12', 'onchain'] as const)(
+    'preserves the durable %s outcome when issuance was already completed but Restore is empty',
+    async (method) => {
+      if (method === 'bolt12') {
+        await persistBolt12Quote(quoteId, { paid: Amount.from(10) });
+      } else {
+        await persistOnchainQuote(quoteId, { paid: Amount.from(10) });
+      }
+      const quote = await quoteRepo.getMintQuote(mintUrl, method, quoteId);
+      if (!quote || quote.method === 'bolt11') throw new Error('Expected reusable quote');
+      const quoteKey = {
+        publicKeyHex: quote.quoteData.pubkey,
+        secretKey: new Uint8Array(32),
+      };
+      const keyRing = {
+        getMintQuoteKeyPair: mock(async () => quoteKey),
+      } as unknown as KeyRingService;
+      const realHandlers = new MintHandlerProvider({
+        bolt12: new MintBolt12Handler(keyRing),
+        onchain: new MintOnchainHandler(keyRing),
+      });
+      (handlerProvider.get as Mock<typeof handlerProvider.get>).mockImplementation(
+        realHandlers.get.bind(realHandlers),
+      );
+      const error = new MintOperationError(20002, 'already issued');
+      const walletResult = await walletService.getWalletWithActiveKeysetId(mintUrl, 'sat');
+      walletResult.wallet.mintProofsBolt12 = mock(async () => {
+        throw error;
+      });
+      walletResult.wallet.mintProofsOnchain = mock(async () => {
+        throw error;
+      });
+      (
+        walletService.getWalletWithActiveKeysetId as Mock<
+          typeof walletService.getWalletWithActiveKeysetId
+        >
+      ).mockResolvedValue(walletResult);
+      (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValue({
+        ...mintQuoteToMethodSnapshot(quote),
+        amount_issued: Amount.from(10),
+      });
+      (
+        proofService.recoverProofsFromOutputData as Mock<
+          typeof proofService.recoverProofsFromOutputData
+        >
+      ).mockResolvedValue([]);
+      const pending: PendingMintOperation<typeof method> = {
+        ...makePendingOp(`already-issued-${method}`),
+        method,
+        pubkey: quote.quoteData.pubkey,
+        request: quote.request,
+      };
+      await operationRepo.create(pending);
+      const finalizedEvent = mock(() => {});
+      eventBus.on('mint-op:finalized', finalizedEvent);
+
+      if (method === 'bolt12') {
+        expect((await service.execute(pending.id)).state).toBe('finalized');
+        expect(await operationRepo.getById(pending.id)).toMatchObject({
+          state: 'finalized',
+          error: `Recovered issued quote ${quoteId} but no proofs could be restored`,
+        });
+        expect(finalizedEvent).toHaveBeenCalledTimes(1);
+      } else {
+        await expect(service.execute(pending.id)).rejects.toBe(error);
+        expect(await operationRepo.getById(pending.id)).toMatchObject({ state: 'pending' });
+        expect(finalizedEvent).not.toHaveBeenCalled();
+      }
+      expect(await proofRepo.getProofsByOperationId(mintUrl, pending.id)).toEqual([]);
+    },
+  );
 
   it('recoverPendingOperations cleans init operations and reconciles stale pending ones', async () => {
     const initOp = makeInitOp('init-1');

--- a/packages/core/test/unit/ReusableMintHandler.test.ts
+++ b/packages/core/test/unit/ReusableMintHandler.test.ts
@@ -1,0 +1,654 @@
+import { Amount, OutputData, type Wallet } from '@cashu/cashu-ts';
+import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
+import { EventBus } from '../../events/EventBus';
+import type { CoreEvents } from '../../events/types';
+import { MintBolt12Handler } from '../../infra/handlers/mint/MintBolt12Handler';
+import { MintOnchainHandler } from '../../infra/handlers/mint/MintOnchainHandler';
+import type { MintAdapter } from '../../infra/MintAdapter';
+import type { Logger } from '../../logging/Logger';
+import {
+  MintOperationError,
+  MintQuoteKeyError,
+  MintQuoteValidationError,
+} from '../../models/Error';
+import type {
+  ExecuteContext,
+  MintMethodHandler,
+  MintMethodQuoteSnapshot,
+  PendingContext,
+  PrepareContext,
+  RecoverExecutingContext,
+} from '../../operations/mint';
+import type {
+  ExecutingMintOperation,
+  InitMintOperation,
+  PendingMintOperation,
+} from '../../operations/mint/MintOperation';
+import type { ProofRepository } from '../../repositories';
+import type { KeyRingService, MintService, ProofService, WalletService } from '../../services';
+import { deserializeOutputData, serializeOutputData } from '../../utils';
+
+type ReusableMethod = 'bolt12' | 'onchain';
+
+describe.each(['bolt12', 'onchain'] as const)('%s Mint lifecycle', (method) => {
+  const quoteLabel = method === 'bolt12' ? 'BOLT12' : 'Onchain';
+  const recoveryLabel = method === 'bolt12' ? 'BOLT12' : 'onchain';
+  const mintProofsEndpoint = method === 'bolt12' ? 'mintProofsBolt12' : 'mintProofsOnchain';
+  const mintUrl = 'https://mint.test';
+  const quoteId = `${method}-quote-1`;
+  const pubkey = '02'.padEnd(66, '1');
+
+  let handler: MintMethodHandler<ReusableMethod>;
+  let keyRingService: KeyRingService;
+  let wallet: Wallet;
+  let mintAdapter: MintAdapter;
+  let proofService: ProofService;
+  let proofRepository: ProofRepository;
+  let walletService: WalletService;
+  let mintService: MintService;
+  let eventBus: EventBus<CoreEvents>;
+  let logger: Logger;
+
+  const remoteQuote: MintMethodQuoteSnapshot<ReusableMethod> = {
+    quote: quoteId,
+    request: method === 'bolt12' ? 'lno1offer' : 'bc1qtestaddress',
+    method,
+    unit: 'sat',
+    expiry: Math.floor(Date.now() / 1000) + 3600,
+    pubkey,
+    amount_paid: Amount.from(21),
+    amount_issued: Amount.from(8),
+    updated_at: null,
+  };
+
+  const output = new OutputData(
+    {
+      amount: Amount.from(10),
+      id: 'keyset-1',
+      B_: 'B_out_1',
+    },
+    BigInt(1),
+    new TextEncoder().encode('out-1'),
+  );
+
+  const buildPrepareContext = (): PrepareContext<ReusableMethod> => ({
+    operation: {
+      id: 'op-1',
+      state: 'init',
+      mintUrl,
+      amount: Amount.from(10),
+      unit: 'sat',
+      method,
+      methodData: {},
+      quoteId,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } satisfies InitMintOperation<ReusableMethod>,
+    wallet,
+    mintAdapter,
+    proofService,
+    proofRepository,
+    walletService,
+    mintService,
+    eventBus,
+    logger,
+  });
+
+  const buildExecutingOperation = (): ExecutingMintOperation<ReusableMethod> => ({
+    ...buildPrepareContext().operation,
+    state: 'executing',
+    quoteId,
+    request: remoteQuote.request,
+    expiry: remoteQuote.expiry,
+    pubkey,
+    outputData: serializeOutputData({ keep: [output], send: [] }),
+  });
+
+  const buildRecoverContext = (
+    localClaimabilityFacts = {
+      finalizedAmount: Amount.zero(),
+      reservedAmount: Amount.zero(),
+    },
+  ): RecoverExecutingContext<ReusableMethod> => ({
+    ...buildPrepareContext(),
+    operation: buildExecutingOperation(),
+    localClaimabilityFacts,
+  });
+
+  const buildPendingContext = (): PendingContext<ReusableMethod> => ({
+    operation: {
+      ...buildExecutingOperation(),
+      state: 'pending',
+    } satisfies PendingMintOperation<ReusableMethod>,
+    mintAdapter,
+    logger,
+  });
+
+  beforeEach(() => {
+    keyRingService = {
+      generateMintQuoteKeyPair: mock(async () => ({
+        publicKeyHex: pubkey,
+        secretKey: new Uint8Array(32).fill(7),
+        derivationIndex: 0,
+        purpose: 'nut20_mint_quote' as const,
+      })),
+      getMintQuoteKeyPair: mock(async () => ({
+        publicKeyHex: pubkey,
+        secretKey: new Uint8Array(32).fill(7),
+        derivationIndex: 0,
+        purpose: 'nut20_mint_quote' as const,
+      })),
+    } as unknown as KeyRingService;
+
+    handler =
+      method === 'bolt12'
+        ? new MintBolt12Handler(keyRingService)
+        : new MintOnchainHandler(keyRingService);
+
+    wallet = {
+      [mintProofsEndpoint]: mock(async () => [
+        {
+          id: 'keyset-1',
+          amount: Amount.from(10),
+          secret: 'out-1',
+          C: 'C_out_1',
+        },
+      ]),
+    } as unknown as Wallet;
+
+    mintAdapter = {
+      checkMintQuote: mock(async () => remoteQuote),
+    } as unknown as MintAdapter;
+
+    proofService = {
+      createOutputsAndIncrementCounters: mock(async () => ({ keep: [output], send: [] })),
+      saveProofs: mock(async () => {}),
+      recoverProofsFromOutputData: mock(async () => []),
+    } as unknown as ProofService;
+    proofRepository = {} as ProofRepository;
+    walletService = {} as WalletService;
+    mintService = {} as MintService;
+    eventBus = new EventBus<CoreEvents>();
+    logger = { info: mock(() => {}), warn: mock(() => {}) } as unknown as Logger;
+  });
+
+  it('prepares deterministic outputs without requiring available quote balance', async () => {
+    const result = await handler.prepare({
+      ...buildPrepareContext(),
+      importedQuote: { ...remoteQuote, amount_paid: Amount.zero(), amount_issued: Amount.zero() },
+    });
+
+    expect(keyRingService.getMintQuoteKeyPair).toHaveBeenCalledWith(pubkey);
+    expect(proofService.createOutputsAndIncrementCounters).toHaveBeenCalledWith(
+      mintUrl,
+      {
+        keep: { amount: Amount.from(10), unit: 'sat' },
+        send: { amount: Amount.zero(), unit: 'sat' },
+      },
+      {},
+    );
+    expect(result.state).toBe('pending');
+    expect(result.quoteId).toBe(quoteId);
+    expect(result.pubkey).toBe(pubkey);
+    expect(result.amount).toEqual(Amount.from(10));
+    expect(result.outputData).toEqual(serializeOutputData({ keep: [output], send: [] }));
+  });
+
+  it('fails preparation when the quote key is missing', async () => {
+    (
+      keyRingService.getMintQuoteKeyPair as Mock<typeof keyRingService.getMintQuoteKeyPair>
+    ).mockResolvedValueOnce(null);
+
+    const error = await handler
+      .prepare({ ...buildPrepareContext(), importedQuote: remoteQuote })
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(MintQuoteKeyError);
+    expect(error.message).toContain('Missing NUT-20 mint quote key');
+  });
+
+  it('executes mint proofs with the persisted quote key', async () => {
+    const pending = await handler.prepare({
+      ...buildPrepareContext(),
+      importedQuote: remoteQuote,
+    });
+    const context: ExecuteContext<ReusableMethod> = {
+      ...buildPrepareContext(),
+      operation: {
+        ...pending,
+        state: 'executing',
+      },
+    };
+
+    const result = await handler.execute(context);
+
+    expect(result.status).toBe('ISSUED');
+    expect(mintAdapter.checkMintQuote).toHaveBeenCalledWith(mintUrl, method, quoteId);
+    expect(wallet[mintProofsEndpoint]).toHaveBeenCalledWith(
+      Amount.from(10),
+      remoteQuote,
+      '07'.repeat(32),
+      undefined,
+      { type: 'custom', data: deserializeOutputData(pending.outputData).keep },
+    );
+  });
+
+  it('rejects contradictory fresh accounting before mint submission', async () => {
+    const pending = await handler.prepare({
+      ...buildPrepareContext(),
+      importedQuote: remoteQuote,
+    });
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      amount_paid: Amount.from(9),
+      amount_issued: Amount.from(10),
+    });
+
+    await expect(
+      handler.execute({
+        ...buildPrepareContext(),
+        operation: { ...pending, state: 'executing' },
+      }),
+    ).rejects.toThrow(`${quoteLabel} mint quote ${quoteId} is not claimable: invalid`);
+
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('does not let a stale valid fresh balance veto service-authorized execution', async () => {
+    const pending = await handler.prepare({
+      ...buildPrepareContext(),
+      importedQuote: remoteQuote,
+    });
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      amount_paid: Amount.from(1),
+      amount_issued: Amount.zero(),
+    });
+
+    const result = await handler.execute({
+      ...buildPrepareContext(),
+      operation: { ...pending, state: 'executing' },
+    });
+
+    expect(result.status).toBe('ISSUED');
+    expect(wallet[mintProofsEndpoint]).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers signed outputs before retrying the mint', async () => {
+    (
+      proofService.recoverProofsFromOutputData as Mock<
+        typeof proofService.recoverProofsFromOutputData
+      >
+    ).mockResolvedValueOnce([
+      {
+        id: 'keyset-1',
+        amount: Amount.from(10),
+        secret: 'out-1',
+        C: 'C_out_1',
+      },
+    ]);
+
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(proofService.recoverProofsFromOutputData).toHaveBeenCalledWith(
+      mintUrl,
+      buildExecutingOperation().outputData,
+      { unit: 'sat', createdByOperationId: 'op-1' },
+    );
+    expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('retries minting from persisted output data when the quote is still available', async () => {
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(proofService.recoverProofsFromOutputData).toHaveBeenCalled();
+    expect(wallet[mintProofsEndpoint]).toHaveBeenCalledWith(
+      Amount.from(10),
+      remoteQuote,
+      '07'.repeat(32),
+      undefined,
+      { type: 'custom', data: [output] },
+    );
+    expect(proofService.saveProofs).toHaveBeenCalledWith(mintUrl, [
+      expect.objectContaining({
+        unit: 'sat',
+        createdByOperationId: 'op-1',
+        state: 'ready',
+        secret: 'out-1',
+      }),
+    ]);
+  });
+
+  it('returns pending during recovery when output restore is empty and balance is unavailable', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      amount_paid: Amount.from(8),
+      amount_issued: Amount.from(8),
+    });
+
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result.status).toBe('PENDING');
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('subtracts other in-flight reservations before retrying recovery', async () => {
+    const result = await handler.recoverExecuting(
+      buildRecoverContext({
+        finalizedAmount: Amount.zero(),
+        reservedAmount: Amount.from(10),
+      }),
+    );
+
+    expect(result.status).toBe('PENDING');
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('attempts restore again after an already-issued retry result', async () => {
+    (
+      wallet[mintProofsEndpoint] as Mock<(typeof wallet)[typeof mintProofsEndpoint]>
+    ).mockImplementationOnce(async () => {
+      throw new MintOperationError(20002, 'already issued');
+    });
+    (
+      proofService.recoverProofsFromOutputData as Mock<
+        typeof proofService.recoverProofsFromOutputData
+      >
+    )
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'keyset-1',
+          amount: Amount.from(10),
+          secret: 'out-1',
+          C: 'C_out_1',
+        },
+      ]);
+
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(proofService.recoverProofsFromOutputData).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries funded execution recovery after expiry', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      expiry: Math.floor(Date.now() / 1000) - 1,
+    });
+
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(wallet[mintProofsEndpoint]).toHaveBeenCalled();
+    expect(proofService.saveProofs).toHaveBeenCalled();
+  });
+
+  it('fails recovery when the mint rejects issuance with quote expired', async () => {
+    (
+      wallet[mintProofsEndpoint] as Mock<(typeof wallet)[typeof mintProofsEndpoint]>
+    ).mockRejectedValueOnce(new MintOperationError(20007, 'Quote expired'));
+
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result).toEqual({
+      status: 'TERMINAL',
+      error: `Recovered: ${recoveryLabel} quote ${quoteId} expired while executing mint`,
+    });
+    expect(wallet[mintProofsEndpoint]).toHaveBeenCalledTimes(1);
+    expect(proofService.saveProofs).not.toHaveBeenCalled();
+  });
+
+  it('keeps non-protocol expiry errors pending during recovery', async () => {
+    (
+      wallet[mintProofsEndpoint] as Mock<(typeof wallet)[typeof mintProofsEndpoint]>
+    ).mockRejectedValueOnce(new Error('Authentication session expired'));
+
+    const result = await handler.recoverExecuting(buildRecoverContext());
+
+    expect(result).toEqual({
+      status: 'PENDING',
+      error: 'Authentication session expired',
+    });
+    expect(proofService.saveProofs).not.toHaveBeenCalled();
+  });
+
+  it('reports the validated remote snapshot for a pending operation', async () => {
+    const result = await handler.checkPending(buildPendingContext());
+
+    expect(result.quoteSnapshot).toBe(remoteQuote);
+    expect(result.observedAt).toEqual(expect.any(Number));
+  });
+
+  it('reports an unattributable pending response as a validation failure', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      request: 'bc1qotheraddress',
+    });
+
+    const result = await handler.checkPending(buildPendingContext());
+
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(result.validationFailure).toMatchObject({
+      code: 'invalid_quote',
+      retryable: false,
+    });
+    expect(result.validationFailure?.reason).toContain('conflicts with pending operation identity');
+  });
+
+  it('does not attribute a mismatched response when the operation pubkey is missing', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      quote: 'other-quote',
+    });
+    const baseContext = buildPendingContext();
+
+    const result = await handler.checkPending({
+      ...baseContext,
+      operation: { ...baseContext.operation, pubkey: undefined },
+    });
+
+    expect(result.quoteSnapshot).toBeUndefined();
+    expect(result.validationFailure?.code).toBe('invalid_quote');
+  });
+
+  it('preserves the missing-pubkey terminal code for an attributable response', async () => {
+    const baseContext = buildPendingContext();
+
+    const result = await handler.checkPending({
+      ...baseContext,
+      operation: { ...baseContext.operation, pubkey: undefined },
+    });
+
+    expect(result.quoteSnapshot).toBe(remoteQuote);
+    expect(result.validationFailure?.code).toBe('missing_quote_pubkey');
+  });
+
+  it('preserves remote accounting in the pending observation', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      amount_paid: Amount.from(8),
+      amount_issued: Amount.from(0),
+    });
+
+    const result = await handler.checkPending(buildPendingContext());
+
+    expect(result.quoteSnapshot?.amount_paid?.equals(Amount.from(8))).toBe(true);
+  });
+  it('rejects preparation with a different quote identity before allocating outputs', async () => {
+    await expect(
+      handler.prepare({
+        ...buildPrepareContext(),
+        importedQuote: { ...remoteQuote, quote: 'other-quote' },
+      }),
+    ).rejects.toBeInstanceOf(MintQuoteValidationError);
+    expect(proofService.createOutputsAndIncrementCounters).not.toHaveBeenCalled();
+  });
+
+  it('rejects preparation without a quote or deterministic outputs', async () => {
+    await expect(handler.prepare(buildPrepareContext())).rejects.toThrow('was not provided');
+    (
+      proofService.createOutputsAndIncrementCounters as Mock<
+        typeof proofService.createOutputsAndIncrementCounters
+      >
+    ).mockResolvedValueOnce({
+      keep: [],
+      send: [],
+      keepAmount: Amount.zero(),
+      sendAmount: Amount.zero(),
+    });
+    await expect(
+      handler.prepare({ ...buildPrepareContext(), importedQuote: remoteQuote }),
+    ).rejects.toThrow('Failed to create deterministic outputs');
+  });
+
+  it.each(['unit', 'pubkey'] as const)(
+    'rejects changed remote %s before issuance or replay',
+    async (field) => {
+      (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValue({
+        ...remoteQuote,
+        [field]: 'changed',
+      });
+      await expect(handler.execute(buildRecoverContext())).rejects.toThrow();
+      expect((await handler.recoverExecuting(buildRecoverContext())).status).toBe('TERMINAL');
+      expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+    },
+  );
+
+  it('requires an owned quote key for execution and recovery', async () => {
+    (
+      keyRingService.getMintQuoteKeyPair as Mock<typeof keyRingService.getMintQuoteKeyPair>
+    ).mockResolvedValue(null);
+    await expect(handler.execute(buildRecoverContext())).rejects.toBeInstanceOf(MintQuoteKeyError);
+    expect(await handler.recoverExecuting(buildRecoverContext())).toEqual({
+      status: 'TERMINAL',
+      error: `Missing NUT-20 mint quote key for pubkey ${pubkey}`,
+    });
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing operation pubkey after empty Restore', async () => {
+    const ctx = buildRecoverContext();
+    ctx.operation.pubkey = undefined;
+    expect(await handler.recoverExecuting(ctx)).toEqual({
+      status: 'TERMINAL',
+      error: `Recovered: ${recoveryLabel} mint operation op-1 is missing NUT-20 quote pubkey`,
+    });
+    expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+  });
+
+  it('leaves recovery pending when Restore fails without checking or replaying the quote', async () => {
+    (
+      proofService.recoverProofsFromOutputData as Mock<
+        typeof proofService.recoverProofsFromOutputData
+      >
+    ).mockRejectedValueOnce(new Error('Restore unavailable'));
+    expect(await handler.recoverExecuting(buildRecoverContext())).toEqual({
+      status: 'PENDING',
+      error: 'Restore unavailable',
+    });
+    expect(mintAdapter.checkMintQuote).not.toHaveBeenCalled();
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('keeps remote observation failures pending after empty Restore', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockRejectedValueOnce(
+      new Error('Mint unavailable'),
+    );
+    expect(await handler.recoverExecuting(buildRecoverContext())).toEqual({
+      status: 'PENDING',
+      error: 'Mint unavailable',
+    });
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('rejects contradictory recovery accounting without replay', async () => {
+    (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce({
+      ...remoteQuote,
+      amount_paid: Amount.from(7),
+    });
+    expect(await handler.recoverExecuting(buildRecoverContext())).toEqual({
+      status: 'TERMINAL',
+      error: `Recovered: ${recoveryLabel} quote ${quoteId} has invalid claimability accounting`,
+    });
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  it('does not replay balance already consumed by finalized local operations', async () => {
+    expect(
+      (
+        await handler.recoverExecuting(
+          buildRecoverContext({
+            finalizedAmount: Amount.from(21),
+            reservedAmount: Amount.zero(),
+          }),
+        )
+      ).status,
+    ).toBe('PENDING');
+    expect(wallet[mintProofsEndpoint]).not.toHaveBeenCalled();
+  });
+
+  // MintOperationService consumes these outcomes differently; this refactor must retain both.
+  it.each([
+    new MintOperationError(20002, 'issued'),
+    new MintOperationError(11003, 'signed'),
+    new Error('outputs already signed'),
+  ])('preserves the method-specific initial already-issued outcome: %s', async (error) => {
+    (
+      wallet[mintProofsEndpoint] as Mock<(typeof wallet)[typeof mintProofsEndpoint]>
+    ).mockRejectedValueOnce(error);
+    const execution = handler.execute(buildRecoverContext());
+    if (method === 'bolt12') {
+      expect(await execution).toEqual({ status: 'ALREADY_ISSUED' });
+    } else {
+      await expect(execution).rejects.toBe(error);
+    }
+  });
+
+  it('propagates other issuance errors with their original cause', async () => {
+    const error = new Error('Mint unavailable', { cause: new Error('Connection closed') });
+    (
+      wallet[mintProofsEndpoint] as Mock<(typeof wallet)[typeof mintProofsEndpoint]>
+    ).mockRejectedValueOnce(error);
+    await expect(handler.execute(buildRecoverContext())).rejects.toBe(error);
+  });
+
+  it.each(['empty', 'failed'] as const)(
+    'keeps an already-issued replay pending when the second Restore is %s',
+    async (outcome) => {
+      (
+        wallet[mintProofsEndpoint] as Mock<(typeof wallet)[typeof mintProofsEndpoint]>
+      ).mockRejectedValueOnce(new MintOperationError(11003, 'already signed'));
+      const restore = proofService.recoverProofsFromOutputData as Mock<
+        typeof proofService.recoverProofsFromOutputData
+      >;
+      restore.mockResolvedValueOnce([]);
+      if (outcome === 'failed') restore.mockRejectedValueOnce(new Error('Restore unavailable'));
+      const result = await handler.recoverExecuting(buildRecoverContext());
+      expect(result).toEqual({
+        status: 'PENDING',
+        error:
+          outcome === 'failed'
+            ? 'Restore unavailable'
+            : `Recovered: ${recoveryLabel} quote ${quoteId} was already issued but proofs were not recoverable`,
+      });
+      expect(restore).toHaveBeenCalledTimes(2);
+      expect(proofService.saveProofs).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['quote', 'request', 'unit', 'pubkey'] as const)(
+    'does not attribute pending responses with a changed %s',
+    async (field) => {
+      (mintAdapter.checkMintQuote as Mock<typeof mintAdapter.checkMintQuote>).mockResolvedValueOnce(
+        { ...remoteQuote, [field]: 'changed' },
+      );
+      const result = await handler.checkPending(buildPendingContext());
+      expect(result.quoteSnapshot).toBeUndefined();
+      expect(result.validationFailure).toMatchObject({ code: 'invalid_quote', retryable: false });
+    },
+  );
+});


### PR DESCRIPTION
BOLT12 and on-chain Mint handlers duplicated preparation, issuance, and recovery decisions. Both now delegate to one internal reusable Mint lifecycle with typed method adapters, so fixes to the shared behavior apply to both methods.

Preserves method-specific quote creation, exact saved outputs, proof attribution, and existing durable outcomes, including the different initial already-issued handling. Adds a parameterized handler test matrix and service-level regression coverage. Includes a core patch changeset.

This pull request resolves #469.

Stacked on #461 (`split/pr459-keypair`); retarget to `master` after that PR merges.

## Verification

- `bun run --filter='@cashu/coco-core' test:unit` — 1,352 passed.
- `bun run build` — passed.
- `bun run typecheck` — passed, including the transaction architecture check with no added exceptions.
- Prettier check on changed files and `git diff --check` — passed.
