### PR TITLE
fix(core): prevent lost polling wake-ups

### DIFF
--- a/.changeset/quiet-mints-poll.md
+++ b/.changeset/quiet-mints-poll.md
@@ -1,0 +1,5 @@
+---
+'@cashu/coco-core': patch
+---
+
+Keep subscription polling scheduled when a timer wakes before its deadline, and cancel pending polling timers when subscriptions are paused or closed.

--- a/packages/core/infra/PollingTransport.ts
+++ b/packages/core/infra/PollingTransport.ts
@@ -22,6 +22,7 @@ type Task = {
 
 type MintScheduler = {
   nextAllowedAt: number;
+  timer?: ReturnType<typeof setTimeout>;
   queue: Task[];
   running: boolean;
   hasProofBatchTask: boolean;
@@ -262,6 +263,7 @@ export class PollingTransport implements RealTimeTransport {
   }
 
   closeAll(): void {
+    for (const scheduler of this.schedByMint.values()) this.clearTimer(scheduler);
     this.schedByMint.clear();
     this.listenersByMint.clear();
     this.proofQueueByMint.clear();
@@ -274,6 +276,8 @@ export class PollingTransport implements RealTimeTransport {
 
   closeMint(mintUrl: string): void {
     mintUrl = normalizeMintUrl(mintUrl);
+    const scheduler = this.schedByMint.get(mintUrl);
+    if (scheduler) this.clearTimer(scheduler);
     this.schedByMint.delete(mintUrl);
     this.listenersByMint.delete(mintUrl);
     this.proofQueueByMint.delete(mintUrl);
@@ -286,6 +290,7 @@ export class PollingTransport implements RealTimeTransport {
 
   pause(): void {
     this.paused = true;
+    for (const scheduler of this.schedByMint.values()) this.clearTimer(scheduler);
   }
 
   resume(): void {
@@ -329,13 +334,44 @@ export class PollingTransport implements RealTimeTransport {
     return s;
   }
 
+  private clearTimer(scheduler: MintScheduler): void {
+    if (scheduler.timer === undefined) return;
+    clearTimeout(scheduler.timer);
+    scheduler.timer = undefined;
+  }
+
+  private scheduleNext(mintUrl: string, scheduler: MintScheduler): void {
+    this.clearTimer(scheduler);
+    if (
+      this.paused ||
+      this.schedByMint.get(mintUrl) !== scheduler ||
+      scheduler.running ||
+      scheduler.queue.length === 0
+    ) {
+      return;
+    }
+    const timer = setTimeout(
+      () => {
+        if (this.schedByMint.get(mintUrl) !== scheduler || scheduler.timer !== timer) return;
+        scheduler.timer = undefined;
+        void this.maybeRun(mintUrl);
+      },
+      Math.max(0, scheduler.nextAllowedAt - Date.now()),
+    );
+    scheduler.timer = timer;
+  }
+
   private async maybeRun(mintUrl: string): Promise<void> {
     if (this.paused) return;
-    const s = this.ensureScheduler(mintUrl);
-    if (s.running) return;
-    const now = Date.now();
-    if (now < s.nextAllowedAt) return;
+    const s = this.schedByMint.get(mintUrl);
+    if (!s || s.running) return;
+    this.clearTimer(s);
     if (s.queue.length === 0) return;
+    if (Date.now() < s.nextAllowedAt) {
+      // A timer can wake before the wall-clock deadline; keep the queued work scheduled.
+      this.scheduleNext(mintUrl, s);
+      return;
+    }
 
     s.running = true;
     const task = s.queue.shift()!;
@@ -353,11 +389,7 @@ export class PollingTransport implements RealTimeTransport {
     } finally {
       s.nextAllowedAt = Date.now() + this.getIntervalForMint(mintUrl);
       s.running = false;
-      // Schedule next attempt when allowed
-      const delay = Math.max(0, s.nextAllowedAt - Date.now());
-      setTimeout(() => {
-        void this.maybeRun(mintUrl);
-      }, delay);
+      this.scheduleNext(mintUrl, s);
     }
   }
 

--- a/packages/core/test/unit/PollingTransport.test.ts
+++ b/packages/core/test/unit/PollingTransport.test.ts
@@ -1,5 +1,5 @@
 import { Amount } from '@cashu/cashu-ts';
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { PollingTransport } from '../../infra/PollingTransport';
 import type { MintAdapter } from '../../infra/MintAdapter';
 import { NullLogger } from '../../logging';
@@ -55,6 +55,217 @@ const createDelayedMockMintAdapter = (delayMs: number): MintAdapter =>
     checkMeltQuoteState: mock(() => Promise.resolve({})),
     checkProofStates: mock(() => Promise.resolve([])),
   }) as unknown as MintAdapter;
+
+describe('PollingTransport scheduler wake-ups', () => {
+  const mintUrl = 'https://mint.example.com';
+  type Timer = ReturnType<typeof setTimeout>;
+  let now: number;
+  let nextTimerId: number;
+  let timers: Map<Timer, { callback: () => void; delay: number }>;
+  let restoreClock: () => void;
+  let transport: PollingTransport;
+  let polling: MintQuotePollingOperation;
+  const check = mock(async () => ({ outcomes: [], responseFailures: [] }));
+  // Let the polling promise chain settle without advancing the controlled clock.
+  const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+  beforeEach(() => {
+    now = 1000;
+    nextTimerId = 0;
+    timers = new Map();
+    const dateSpy = spyOn(Date, 'now').mockImplementation(() => now);
+    const setControlledTimeout = ((callback: () => void, delay = 0) => {
+      const id = ++nextTimerId as unknown as Timer;
+      timers.set(id, { callback, delay });
+      return id;
+    }) as typeof setTimeout;
+    const timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(setControlledTimeout);
+    const clearSpy = spyOn(globalThis, 'clearTimeout').mockImplementation((id) => {
+      timers.delete(id as Timer);
+    });
+    restoreClock = () => {
+      dateSpy.mockRestore();
+      timeoutSpy.mockRestore();
+      clearSpy.mockRestore();
+    };
+    check.mockReset();
+    check.mockImplementation(async () => ({ outcomes: [], responseFailures: [] }));
+    polling = { getMintQuotePollingLimit: mock(async () => 1), checkMintQuotesForPolling: check };
+    transport = new PollingTransport(
+      createMockMintAdapter(),
+      { intervalMs: 20 },
+      undefined,
+      polling,
+    );
+  });
+
+  afterEach(() => {
+    transport.closeAll();
+    restoreClock();
+  });
+
+  function fireNextTimer(at: number): void {
+    expect(timers.size).toBe(1);
+    const [id, timer] = timers.entries().next().value!;
+    timers.delete(id);
+    now = at;
+    timer.callback();
+  }
+
+  it('re-arms an early timer without polling before the deadline', async () => {
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'sub', ['quote']);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(1);
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([20]);
+
+    fireNextTimer(1019);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(1);
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([1]);
+
+    fireNextTimer(1020);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(2);
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([20]);
+  });
+
+  it('keeps one wake-up across new interests and repeated resume calls', async () => {
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'first', ['quote-a']);
+    await settle();
+    now = 1010;
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'second', ['quote-b']);
+    transport.resume();
+    transport.resume();
+    await settle();
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(timers.size).toBe(1);
+
+    fireNextTimer(1020);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(2);
+    expect(timers.size).toBe(1);
+  });
+
+  it('cancels paused timers and resumes at the remaining deadline', async () => {
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'sub', ['quote']);
+    await settle();
+    const staleCallback = [...timers.values()][0]!.callback;
+    transport.pause();
+    expect(timers.size).toBe(0);
+
+    now = 1010;
+    transport.resume();
+    staleCallback();
+    await settle();
+    expect(check).toHaveBeenCalledTimes(1);
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([10]);
+    fireNextTimer(1020);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(2);
+  });
+
+  it('resumes immediately after the deadline and cancels an overdue wake-up', async () => {
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'sub', ['quote']);
+    await settle();
+    now = 1030;
+    transport.resume();
+    transport.resume();
+    await settle();
+    expect(check).toHaveBeenCalledTimes(2);
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([20]);
+  });
+
+  it('waits for an in-flight poll before scheduling another turn', async () => {
+    let finish!: () => void;
+    check.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      return { outcomes: [], responseFailures: [] };
+    });
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'sub', ['quote']);
+    await settle();
+    now = 1030;
+    transport.pause();
+    transport.resume();
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'late', ['quote-b']);
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(timers.size).toBe(0);
+    transport.pause();
+    finish();
+    await settle();
+    expect(timers.size).toBe(0);
+
+    now = 1040;
+    transport.resume();
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([10]);
+    fireNextTimer(1050);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps other mints scheduled when one mint closes', async () => {
+    const otherMint = 'https://other-mint.example.com';
+    transport.setIntervalForMint(otherMint, 50);
+    subscribeToQuotes(transport, mintUrl, 'bolt11', 'first', ['quote-a']);
+    subscribeToQuotes(transport, otherMint, 'bolt11', 'second', ['quote-b']);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(2);
+    expect(timers.size).toBe(2);
+
+    transport.closeMint(mintUrl);
+    expect([...timers.values()].map(({ delay }) => delay)).toEqual([50]);
+    fireNextTimer(1050);
+    await settle();
+    expect(check).toHaveBeenCalledTimes(3);
+    expect(check).toHaveBeenLastCalledWith('bolt11', [{ mintUrl: otherMint, quoteId: 'quote-b' }]);
+    transport.closeAll();
+    expect(timers.size).toBe(0);
+  });
+
+  for (const close of ['closeMint', 'closeAll'] as const) {
+    it(`${close} cancels timers and ignores stale callbacks after reopening`, async () => {
+      subscribeToQuotes(transport, mintUrl, 'bolt11', 'old', ['quote-a']);
+      await settle();
+      const staleCallback = [...timers.values()][0]!.callback;
+      transport[close](mintUrl);
+      expect(timers.size).toBe(0);
+      now = 1020;
+      staleCallback();
+      await settle();
+      expect(check).toHaveBeenCalledTimes(1);
+      expect(timers.size).toBe(0);
+
+      subscribeToQuotes(transport, mintUrl, 'bolt11', 'new', ['quote-b']);
+      await settle();
+      now = 1040;
+      staleCallback();
+      await settle();
+      expect(check).toHaveBeenCalledTimes(2);
+      fireNextTimer(1040);
+      await settle();
+      expect(check).toHaveBeenCalledTimes(3);
+    });
+
+    it(`${close} prevents an in-flight completion from scheduling another turn`, async () => {
+      let finish!: () => void;
+      check.mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+        return { outcomes: [], responseFailures: [] };
+      });
+      subscribeToQuotes(transport, mintUrl, 'bolt11', 'old', ['quote-a']);
+      await settle();
+      transport[close](mintUrl);
+      finish();
+      await settle();
+      expect(timers.size).toBe(0);
+      transport.resume();
+      expect(check).toHaveBeenCalledTimes(1);
+    });
+  }
+});
 
 describe('PollingTransport per-mint intervals', () => {
   let transport: PollingTransport;


### PR DESCRIPTION
Polling could stop indefinitely when a timer fired before its wall-clock deadline: `maybeRun` returned without scheduling another attempt, leaving queued subscriptions idle. Track one wake-up per mint and re-arm it for the remaining delay while preserving the configured interval and serial polling.

Cancel pending timers on pause and close, and ignore stale callbacks or completions from closed schedulers. Add 10 controlled-clock regression tests for early wake-ups, repeated resume calls, in-flight polls, close/reopen, and independent mint schedules. Include a patch changeset for `@cashu/coco-core`.

Verification:
- `bun run build`
- `bun run typecheck`
- `bun run test:coverage:core` with CI's Bun 1.3.11: 1,306 core unit tests passed.
- Prettier check on all three changed files and `git diff --check`.

The early-wake regression failed against the original implementation and passes with this fix. The exact timer timing behind the failures observed in #308 was not captured; this PR fixes the deterministically reproduced scheduler failure.
