### PR TITLE
fix(core): await mint settlement before releasing execution lock

### DIFF
--- a/.changeset/tidy-mints-wait.md
+++ b/.changeset/tidy-mints-wait.md
@@ -1,0 +1,6 @@
+---
+'@cashu/coco-core': patch
+---
+
+Keep the Mint Operation execution lock until issuance or recovery finishes so concurrent callers
+in the same Coco Session wait for proofs to be committed before returning.

--- a/.changeset/tidy-mints-wait.md
+++ b/.changeset/tidy-mints-wait.md
@@ -4,3 +4,6 @@
 
 Keep the Mint Operation execution lock until issuance or recovery finishes so concurrent callers
 in the same Coco Session wait for proofs to be committed before returning.
+
+Publish issuance and recovery events after releasing the lock so asynchronous settlement listeners
+can await the same Mint Operation without deadlocking.

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -121,7 +121,7 @@ export class MintOperationService {
       const migrated = await this.deps.transactions.migrate(id);
       await this.publish(migrated);
       const operation = migrated.operation;
-      if (operation.state === 'executing') return this.reconcile(operation);
+      if (operation.state === 'executing') return await this.reconcile(operation);
       if (operation.state === 'finalized' || operation.state === 'failed') return operation;
       if (operation.state !== 'pending')
         throw new Error(`Cannot execute operation ${id} in state ${operation.state}`);
@@ -131,8 +131,9 @@ export class MintOperationService {
       // Only the caller that committed authorization may transmit. Other coordinators restore.
       if (!authorized.changed || !authorized.recovery || authorized.operation.state !== 'executing')
         return authorized.operation;
-      return this.transmit(authorized.operation, authorized.recovery);
+      return await this.transmit(authorized.operation, authorized.recovery);
     } finally {
+      // Await remote work and local settlement before allowing another local caller to proceed.
       release();
     }
   }

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -117,11 +117,12 @@ export class MintOperationService {
 
   async execute(id: string): Promise<MintOperation> {
     const release = await this.acquire(id);
+    const commits: MintCommit[] = [];
     try {
       const migrated = await this.deps.transactions.migrate(id);
       await this.publish(migrated);
       const operation = migrated.operation;
-      if (operation.state === 'executing') return await this.reconcile(operation);
+      if (operation.state === 'executing') return await this.reconcile(operation, commits);
       if (operation.state === 'finalized' || operation.state === 'failed') return operation;
       if (operation.state !== 'pending')
         throw new Error(`Cannot execute operation ${id} in state ${operation.state}`);
@@ -131,21 +132,23 @@ export class MintOperationService {
       // Only the caller that committed authorization may transmit. Other coordinators restore.
       if (!authorized.changed || !authorized.recovery || authorized.operation.state !== 'executing')
         return authorized.operation;
-      return await this.transmit(authorized.operation, authorized.recovery);
+      return await this.transmit(authorized.operation, authorized.recovery, commits);
     } finally {
-      // Await remote work and local settlement before allowing another local caller to proceed.
+      // Settlement stays locked; its listeners may re-enter the operation after release.
       release();
+      for (const commit of commits) await this.publish(commit);
     }
   }
 
   private async transmit(
     operation: ExecutingMintOperation,
     recovery: MintRecoveryRecord,
+    commits: MintCommit[],
   ): Promise<MintOperation> {
     try {
       const receipts = await this.deps.remote.issue(operation, recovery);
       const result = await this.deps.transactions.applyEvidence(operation.id, receipts);
-      await this.publish(result);
+      commits.push(result);
       return result.operation;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -157,20 +160,23 @@ export class MintOperationService {
           message,
           useLegacy,
         );
-        await this.publish(rejected);
+        commits.push(rejected);
         if (rejected.changed && rejected.operation.state === 'executing' && rejected.recovery)
-          return this.transmit(rejected.operation, rejected.recovery);
+          return this.transmit(rejected.operation, rejected.recovery, commits);
         if (rejected.operation.state === 'failed') return rejected.operation;
       }
       await this.deps.transactions.noteAmbiguity(operation.id, recovery.revision, message);
-      const reconciled = await this.reconcile(operation);
+      const reconciled = await this.reconcile(operation, commits);
       if (reconciled.state === 'finalized') return reconciled;
       throw error;
     }
   }
 
   /** Bounded recovery: exact evidence first. Quote totals and empty Restore never cancel a request. */
-  private async reconcile(operation: PendingOrLaterOperation): Promise<MintOperation> {
+  private async reconcile(
+    operation: PendingOrLaterOperation,
+    commits: MintCommit[],
+  ): Promise<MintOperation> {
     let recovery = await this.deps.recovery.get(operation.id);
     if (!recovery) throw new Error('Mint recovery provenance is missing');
     const cached = await this.deps.proofs.getProofsByOperationId(operation.mintUrl, operation.id);
@@ -195,7 +201,7 @@ export class MintOperationService {
     });
     if (localReceipts.length) {
       const saved = await this.deps.transactions.applyEvidence(operation.id, localReceipts);
-      await this.publish(saved);
+      commits.push(saved);
       recovery = saved.recovery ?? recovery;
       if (
         saved.operation.state === 'finalized' &&
@@ -208,14 +214,14 @@ export class MintOperationService {
         .checkReceipts(operation, recovery.receipts)
         .catch(() => recovery!.receipts);
       const local = await this.deps.transactions.applyEvidence(operation.id, checked);
-      await this.publish(local);
+      commits.push(local);
       if (local.operation.state === 'finalized') return local.operation;
       recovery = local.recovery ?? recovery;
     }
     try {
       const receipts = await this.deps.remote.restore(operation);
       const result = await this.deps.transactions.applyEvidence(operation.id, receipts);
-      await this.publish(result);
+      commits.push(result);
       if (result.operation.state === 'finalized') return result.operation;
       recovery = result.recovery ?? recovery;
     } catch (error) {
@@ -282,10 +288,13 @@ export class MintOperationService {
           operation?.state === 'finalized' &&
           (await this.deps.remote.isTrusted(operation.mintUrl))
         ) {
+          const commits: MintCommit[] = [];
           try {
-            await this.reconcile(operation);
+            await this.reconcile(operation, commits);
           } catch {
             /* retain durable holding area */
+          } finally {
+            for (const commit of commits) await this.publish(commit);
           }
         }
       }

--- a/packages/core/test/helpers/mintReconciliation.ts
+++ b/packages/core/test/helpers/mintReconciliation.ts
@@ -79,6 +79,7 @@ export async function mintFixture(
     restore: 'success' as 'success' | 'empty' | 'fail' | 'duplicate' | 'wrong-amount',
     proofState: 'UNSPENT' as 'UNSPENT' | 'SPENT' | 'PENDING' | 'fail',
     beforeIssue: undefined as (() => Promise<void>) | undefined,
+    beforeRestore: undefined as (() => Promise<void>) | undefined,
     fullOnly: false,
     proofStates: undefined as undefined | Array<'UNSPENT' | 'SPENT' | 'PENDING'>,
     legacyQuoteState: undefined as undefined | 'UNPAID' | 'PAID' | 'ISSUED',
@@ -134,6 +135,7 @@ export async function mintFixture(
           control.issue === 'malformed' ? signatures.map((s) => ({ ...s, amount: 3 })) : signatures,
       };
     } else if (path === '/v1/restore') {
+      await control.beforeRestore?.();
       if (control.restore === 'fail') throw new Error('Restore unavailable');
       const found =
         control.restore === 'empty'

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -147,6 +147,10 @@ for (const method of ['bolt11', 'bolt12', 'onchain'] as const)
           await f.remote.issue(operation, authorized.recovery!);
         }
 
+        let executionAnnounced = false;
+        f.events.once('mint-op:executing', () => {
+          executionAnnounced = true;
+        });
         let start!: () => void, finish!: () => void;
         const started = new Promise<void>((resolve) => (start = resolve));
         const waiting = new Promise<void>((resolve) => (finish = resolve));
@@ -163,6 +167,7 @@ for (const method of ['bolt11', 'bolt12', 'onchain'] as const)
         const second = f.service.execute(operation.id);
         try {
           expect(lockedDuringResponse).toBe(true);
+          if (phase === 'issuance') expect(executionAnnounced).toBe(true);
           expect(await f.repositories.proofRepository.getReadyProofs(f.mintUrl)).toEqual([]);
         } finally {
           finish();
@@ -183,12 +188,62 @@ for (const method of ['bolt11', 'bolt12', 'onchain'] as const)
         );
       },
     );
+    it.each(['issuance', 'recovery'] as const)(
+      'allows settlement listeners to await the same operation after %s',
+      async (phase) => {
+        const f = await mintFixture(method);
+        const operation = await f.service.prepare(await f.quote(), Amount.from(100));
+        if (phase === 'recovery') {
+          const authorized = await f.transactions.authorize({
+            operationId: operation.id,
+            ...(await f.remote.prepareRequest(operation)),
+          });
+          await f.remote.issue(operation, authorized.recovery!);
+        }
+
+        const observed: string[] = [];
+        f.events.once('proofs:saved', async () => {
+          const result = await f.service.execute(operation.id);
+          observed.push(`proofs:${result.state}`);
+        });
+        f.events.once('mint-op:finalized', async ({ operationId }) => {
+          const result = await f.service.finalize(operationId);
+          observed.push(`operation:${result.state}`);
+        });
+
+        expect((await f.service.execute(operation.id)).state).toBe('finalized');
+        expect(observed).toEqual(['proofs:finalized', 'operation:finalized']);
+        expect(f.service.isOperationLocked(operation.id)).toBe(false);
+        expect(f.calls.filter((c) => c.path === `/v1/mint/${method}`)).toHaveLength(1);
+        expect(f.calls.filter((c) => c.path === '/v1/restore')).toHaveLength(
+          phase === 'recovery' ? 1 : 0,
+        );
+      },
+      1000,
+    );
+    it('allows a rejection listener to await the same failed operation', async () => {
+      const f = await mintFixture(method);
+      f.control.issue = 'expired';
+      const operation = await f.service.prepare(await f.quote(), Amount.from(100));
+      let observed: string | undefined;
+      f.events.once('mint-op:failed', async ({ operationId }) => {
+        observed = (await f.service.finalize(operationId)).state;
+      });
+
+      expect((await f.service.execute(operation.id)).state).toBe('failed');
+      expect(observed).toBe('failed');
+      expect(f.service.isOperationLocked(operation.id)).toBe(false);
+      expect(f.calls.filter((c) => c.path === `/v1/mint/${method}`)).toHaveLength(1);
+    });
     it('does not repeat remote effects when an event listener fails after commit', async () => {
       const f = await mintFixture(method);
       f.events.on('mint-op:executing', () => {
         throw new Error('listener failed');
       });
       f.events.on('proofs:saved', () => {
+        throw new Error('listener failed');
+      });
+      f.events.on('mint-op:finalized', () => {
         throw new Error('listener failed');
       });
       const operation = await f.service.prepare(await f.quote(), Amount.from(100));
@@ -211,6 +266,26 @@ for (const method of ['bolt11', 'bolt12', 'onchain'] as const)
       );
       expect(f.calls.filter((c) => c.path === `/v1/mint/${method}`)).toHaveLength(0);
     });
+    if (method !== 'bolt11')
+      it('publishes committed signature fallback even when the next issuance throws', async () => {
+        const f = await mintFixture(method);
+        f.control.issue = 'legacy';
+        const operation = await f.service.prepare(await f.quote(), Amount.from(100));
+        const lockedAtEvent: boolean[] = [];
+        f.events.on('mint-op:executing', () => {
+          lockedAtEvent.push(f.service.isOperationLocked(operation.id));
+        });
+        f.control.beforeIssue = async () => {
+          if (f.calls.filter((c) => c.path === `/v1/mint/${method}`).length === 2)
+            f.control.issue = 'timeout';
+        };
+
+        await expect(f.service.execute(operation.id)).rejects.toThrow('Network timeout');
+        expect(lockedAtEvent).toEqual([true, false]);
+        expect(f.service.isOperationLocked(operation.id)).toBe(false);
+        expect((await f.service.getOperation(operation.id))!.state).toBe('executing');
+        expect(f.calls.filter((c) => c.path === `/v1/mint/${method}`)).toHaveLength(2);
+      });
     if (method !== 'bolt11')
       it('persists a rejected current signature before submitting the legacy variant', async () => {
         const f = await mintFixture(method);

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -32,6 +32,7 @@ for (const method of ['bolt11', 'bolt12', 'onchain'] as const)
       f.control.issue = 'timeout';
       const operation = await f.service.prepare(await f.quote(), Amount.from(100));
       await expect(f.service.execute(operation.id)).rejects.toThrow('Network timeout');
+      expect(f.service.isOperationLocked(operation.id)).toBe(false);
       const request = (await f.repositories.mintRecoveryRepository.get(operation.id))!.request;
       await f.accounting(100, 40);
       const restart = f.restart();
@@ -132,6 +133,56 @@ for (const method of ['bolt11', 'bolt12', 'onchain'] as const)
       expect((await executing).state).toBe('finalized');
       expect(f.calls.filter((c) => c.path === `/v1/mint/${method}`)).toHaveLength(1);
     });
+    it.each(['issuance', 'recovery'] as const)(
+      'keeps concurrent local callers locked until delayed %s commits proofs',
+      async (phase) => {
+        const f = await mintFixture(method);
+        const operation = await f.service.prepare(await f.quote(), Amount.from(100));
+        if (phase === 'recovery') {
+          const authorized = await f.transactions.authorize({
+            operationId: operation.id,
+            ...(await f.remote.prepareRequest(operation)),
+          });
+          // Simulate issuance whose response was lost before local settlement.
+          await f.remote.issue(operation, authorized.recovery!);
+        }
+
+        let start!: () => void, finish!: () => void;
+        const started = new Promise<void>((resolve) => (start = resolve));
+        const waiting = new Promise<void>((resolve) => (finish = resolve));
+        const delayResponse = async () => {
+          start();
+          await waiting;
+        };
+        if (phase === 'issuance') f.control.beforeIssue = delayResponse;
+        else f.control.beforeRestore = delayResponse;
+
+        const first = f.service.execute(operation.id);
+        await started;
+        const lockedDuringResponse = f.service.isOperationLocked(operation.id);
+        const second = f.service.execute(operation.id);
+        try {
+          expect(lockedDuringResponse).toBe(true);
+          expect(await f.repositories.proofRepository.getReadyProofs(f.mintUrl)).toEqual([]);
+        } finally {
+          finish();
+          await Promise.allSettled([first, second]);
+        }
+
+        const results = await Promise.all([first, second]);
+        expect(results.map((result) => result.state)).toEqual(['finalized', 'finalized']);
+        expect(
+          Amount.sum(
+            (await f.repositories.proofRepository.getReadyProofs(f.mintUrl)).map((p) => p.amount),
+          ).toString(),
+        ).toBe('100');
+        expect(f.service.isOperationLocked(operation.id)).toBe(false);
+        expect(f.calls.filter((c) => c.path === `/v1/mint/${method}`)).toHaveLength(1);
+        expect(f.calls.filter((c) => c.path === '/v1/restore')).toHaveLength(
+          phase === 'recovery' ? 1 : 0,
+        );
+      },
+    );
     it('does not repeat remote effects when an event listener fails after commit', async () => {
       const f = await mintFixture(method);
       f.events.on('mint-op:executing', () => {


### PR DESCRIPTION
When background minting overlaps an explicit `ops.mint.execute()` call in the same Coco Session, the second caller can return an `executing` operation before proofs are available. `execute()` returned the transmission/reconciliation promise from a `try` block, so `finally` released the operation lock before that work settled.

Await both paths before releasing the lock. Six gated regression cases cover delayed issuance and recovery for BOLT11, BOLT12, and on-chain minting, asserting committed proofs, one remote issuance, and lock release. The existing ambiguous-outcome cases also assert release after rejection.

This PR targets `feat/shared-mint-reconciliation` (#481), which introduces the affected coordinator. Merge this fix into #481 before merging #481 into master. The independent SDK mock cleanup is already on #481 at `6ec3f620`.

Verification:
- All six regression cases fail before the fix and pass afterward.
- Focused reconciliation and memory/SQLite transaction composition suites: 72 passed.
- `bun run test:coverage:core` with CI's Bun 1.3.11: 1,228 core unit tests passed.
- Root build and typecheck passed; changed files pass formatting.
- GitHub Actions: core, Expo SQLite, Bun SQLite, and Node SQLite live-mint integration workflows passed, along with auth integration, build, unit tests, formatting, and coverage checks. IndexedDB integration is still running. Docker is unavailable locally.

Transaction review: authorization and evidence settlement still commit through separate `CoreMintTransactions` calls using the shared runner. Remote I/O remains outside database transactions and events follow commit; the longer lifetime applies only to the session-local operation lock. The base PR's existing retry-sensitive timestamp deviation in `ScopedMintCommands` remains owned by its Mint migration.

Includes a core patch changeset. Public APIs, exports, and storage schemas are unchanged; no documentation update is required.
