### PR TITLE
refactor(core)!: move Mint mutations into domain transactions

### DIFF
--- a/.changeset/mint-transaction-migration.md
+++ b/.changeset/mint-transaction-migration.md
@@ -1,0 +1,20 @@
+---
+'@cashu/coco-core': major
+'@cashu/coco-indexeddb': patch
+'@cashu/coco-sql-storage': patch
+'@cashu/coco-adapter-tests': patch
+---
+
+Move standalone Mint mutations behind the shared transaction runner. Deterministic counters and
+pending operations commit together; proof settlement, legacy BOLT11 quote accounting, and operation
+completion share one transaction. Existing method-specific claimability, replay, already-issued,
+and expiry behavior is retained.
+
+The internal MintOperationService constructor now accepts narrow queries, a remote interface, and
+MintTransactions. Custom Mint method handlers return preparation metadata and recovery proof
+candidates instead of allocating outputs or saving proofs through handler context services.
+Manager and the public MintOps API retain their interfaces.
+
+Mint repositories must preserve caller-owned millisecond timestamps on create and update. The
+existing timestamp columns remain compatible with old rows; no schema migration or recovery table
+is introduced. Core uses conditional state and timestamp checks to ignore stale transition results.

--- a/.changeset/mint-transaction-migration.md
+++ b/.changeset/mint-transaction-migration.md
@@ -18,3 +18,9 @@ Manager and the public MintOps API retain their interfaces.
 Mint repositories must preserve caller-owned millisecond timestamps on create and update. The
 existing timestamp columns remain compatible with old rows; no schema migration or recovery table
 is introduced. Core uses conditional state and timestamp checks to ignore stale transition results.
+
+Mint preparation and recovery now use an explicit, independently committed metadata refresh and
+read-only snapshots. Reuse the shared metadata gateway, transport, and Output Allocation from the
+Send migration; allocation revalidates the persisted keyset's activity, unit, and keys before
+committing its counter and operation. Method capability checks share pure snapshot logic with
+MintService. Custom MintService construction supplies the metadata action dependencies.

--- a/TRANSACTION_DESIGN.md
+++ b/TRANSACTION_DESIGN.md
@@ -70,10 +70,48 @@ state transitions, remote effects, and recovery. Both occupy the same architectu
 layer and may be invoked by public APIs or background processors.
 
 Services depend on narrow Queries, local capabilities, remote interfaces where
-needed, and their own domain's transaction gateway. Wallet mutations go through
-that gateway; Services do not receive the raw runner or live transaction scopes,
+needed, and their own domain's transaction gateway. They may also invoke a narrow, explicitly
+committing action owned by another coordinator as an independently committed prerequisite (see
+below). Wallet mutations owned by a coordinator go through its gateway; Services do not receive
+the raw runner or live transaction scopes,
 write through repositories, or compose other Services to construct an atomic
 transition. Events describing committed changes are published after commit.
+
+### Independently Committed Actions
+
+A coordinator may expose a narrow action that completes an independent domain change before its
+caller continues. Its method name must disclose persistence, such as
+`MintService.refreshAndCommitIfStale(mintUrl)`. Its contract must disclose remote I/O, independent
+commit semantics, and post-commit event handling. The caller receives only that action, for example
+`Pick<MintService, 'refreshAndCommitIfStale'>`, not the whole Service. Dependency chains must remain
+acyclic.
+
+The action owns freshness policy, remote observation, its own domain gateway call, and post-commit
+events. It returns after any transaction commits and event publication is attempted. A cached path
+may open no transaction. A committed metadata refresh survives a later Send preparation failure;
+that independence is what permits this composition. Changes that must commit or roll back together
+still compose scoped commands within one owning transition.
+
+```text
+SendOperationService
+  -> MintService.refreshAndCommitIfStale
+       -> MintQueries / CashuMintMetadataRemote (outside transactions)
+       -> MintMetadataTransactions.applyObservation (one committed transaction)
+       -> publish mint events
+  -> finish Send preflight
+  -> SendTransactions.prepare (a separate committed transaction)
+```
+
+An independently committed action is application orchestration, not a Query, local preflight
+capability, or `*Transactions` gateway. Gateways and scoped commands must never acquire such an
+action, including through callbacks or helpers. Coordinators still cannot receive the runner or a
+live transaction scope. A narrow interface and an explicit name communicate effects; neither alone
+enforces the dependency rules.
+
+Runtime rejection of nested Wallet transactions is not yet uniform: IndexedDB rejects ambient
+Wallet transactions, while the core runner has no universal guard and root Memory/SQLite calls
+can queue behind an outer transaction awaiting them. Consistent rejection across adapters is
+follow-up work; callers must not rely on a runtime exception to enforce this contract today.
 
 Shared algorithms, read-only access, and transactional invariants belong in
 behavior-specific capabilities, `<Domain>Queries`, and `Scoped*Commands`.
@@ -206,7 +244,9 @@ These dependencies expose their effects:
 - the Operation Service's own `*Transactions` interface commits local state; and
 - a publisher emits live events after commit.
 
-Broad regular Services are not substitutes for those interfaces. For example, depending on a
+Broad regular Services are not substitutes for those interfaces. An independently committed
+action is the explicit exception described above; a pure-looking helper may not conceal it.
+For example, depending on a
 whole `KeyRingService` when only P2PK signing is needed conceals both authority and effects.
 `KeyRingService` remains the user-facing keyring management module; internal consumers should use
 narrow capabilities such as `P2pkSigner` or keypair Queries as they migrate.
@@ -571,12 +611,12 @@ effect.
 Agents and human reviewers apply these rules to module dependencies, including authority supplied
 through helpers, callbacks, and composition-root wiring:
 
-| Module                                            | Forbidden dependencies                                                                                                                                       |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Transaction-scoped implementation                 | Services/coordinators, remote infrastructure, live event bus, raw runner, root repository containers, concrete storage adapters, application-scoped gateways |
-| Application-scoped `*Transactions` implementation | regular Services, remote infrastructure, live event bus, repositories, application-scoped gateways                                                           |
-| Service / Operation Service                       | other Services/coordinators, repositories, `CoreTransactionRunner`, live scoped commands, another domain's transaction gateway                               |
-| Query or local preflight capability               | Services/coordinators, repository mutation interfaces, transaction modules, remote infrastructure, live event bus                                            |
+| Module                                            | Forbidden dependencies                                                                                                                                                                       |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Transaction-scoped implementation                 | Services/coordinators, remote infrastructure, live event bus, raw runner, root repository containers, concrete storage adapters, application-scoped gateways                                 |
+| Application-scoped `*Transactions` implementation | regular Services, remote infrastructure, live event bus, repositories, application-scoped gateways                                                                                           |
+| Service / Operation Service                       | broad Service/coordinator interfaces (narrow independently committed actions are allowed), repositories, `CoreTransactionRunner`, live scoped commands, another domain's transaction gateway |
+| Query or local preflight capability               | Services/coordinators, repository mutation interfaces, transaction modules, remote infrastructure, live event bus                                                                            |
 
 Scoped implementations import repository contracts with `import type`; runtime repository helpers
 and concrete adapters cannot be used to acquire an opener. Repository adapters and composition-root
@@ -605,7 +645,9 @@ storage adapters:
    awaited sequentially and that each concurrent group preserves its invariants when interleaved.
 3. Trace effects across that boundary: asynchronous preflight and remote I/O occur outside it,
    derivation inside it is synchronous, retry-sensitive inputs remain stable, and live events follow
-   commit. Queries and preflight capabilities must remain non-mutating.
+   commit. Queries and preflight capabilities must remain non-mutating. For independently committed
+   actions, verify the call name and interface disclose persistence, the dependency graph is acyclic,
+   the action finishes outside the caller's transaction, and its commit may survive caller failure.
 4. Run the relevant behavior tests from the testing contract below. Add or adjust tests when a
    changed invariant needs coverage. Resolve new design violations before handoff; identify remaining
    legacy deviations and their owning migration without treating them as permission for new ones.

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -1149,6 +1149,28 @@ export async function runMintOperationRepositoryContract(
   const { describe, it, expect } = runner;
 
   describe('MintOperationRepository contract', () => {
+    it('preserves caller-owned millisecond timestamps across Mint transitions', async () => {
+      const { repositories, dispose } = await options.createRepositories();
+      try {
+        const operation = createDummyMintOperation({
+          createdAt: 1_700_000_000_123,
+          updatedAt: 1_700_000_000_123,
+        });
+        await repositories.mintOperationRepository.create(operation);
+        const executing = {
+          ...operation,
+          state: 'executing' as const,
+          updatedAt: operation.updatedAt + 1,
+        };
+        await repositories.mintOperationRepository.update(executing);
+        const stored = await repositories.mintOperationRepository.getById(operation.id);
+        expect(stored!.createdAt).toBe(operation.createdAt);
+        expect(stored!.updatedAt).toBe(executing.updatedAt);
+      } finally {
+        await dispose();
+      }
+    });
+
     it('round-trips init mint operation quote ids', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {

--- a/packages/adapter-tests/src/index.ts
+++ b/packages/adapter-tests/src/index.ts
@@ -1,4 +1,4 @@
-import { Amount } from '@cashu/cashu-ts';
+import { Amount, deriveKeysetId } from '@cashu/cashu-ts';
 import { Manager } from '@cashu/coco-core';
 import {
   type Mint,
@@ -1149,6 +1149,101 @@ export async function runMintOperationRepositoryContract(
   const { describe, it, expect } = runner;
 
   describe('MintOperationRepository contract', () => {
+    for (const changeBeforeCommit of [false, true]) {
+      it(`Mint preparation ${changeBeforeCommit ? 'rejects a keyset changed during preflight' : 'commits allocated outputs and their counter together'}`, async () => {
+        const { repositories, dispose } = await options.createRepositories();
+        const mint = createDummyMint();
+        const keypairs = {
+          '1': '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+          '2': '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+        };
+        const keyset = {
+          mintUrl: mint.mintUrl,
+          id: deriveKeysetId(keypairs, { unit: 'sat' }),
+          unit: 'sat',
+          active: true,
+          feePpk: 0,
+          keypairs,
+        };
+        const manager = new Manager(repositories, async () => {
+          if (changeBeforeCommit)
+            await repositories.keysetRepository.updateKeyset({ ...keyset, active: false });
+          return new Uint8Array(64);
+        });
+        const counters: number[] = [];
+        manager.on('counter:updated', ({ counter }) => {
+          counters.push(counter);
+        });
+        try {
+          await repositories.mintRepository.addOrUpdateMint({
+            ...mint,
+            updatedAt: Math.floor(Date.now() / 1000),
+            mintInfo: {
+              ...mint.mintInfo,
+              nuts: {
+                '5': { disabled: false, methods: [] },
+                '4': {
+                  disabled: false,
+                  methods: [
+                    {
+                      method: 'bolt11',
+                      unit: 'sat',
+                      method_name: null,
+                      min_amount: null,
+                      max_amount: null,
+                    },
+                  ],
+                },
+              },
+            },
+          });
+          await repositories.keysetRepository.addKeyset(keyset);
+          await repositories.counterRepository.setCounter(mint.mintUrl, keyset.id, 7);
+          const quote = createDummyMintQuote({
+            state: 'PAID',
+            amountPaid: Amount.from(3),
+            expiry: Math.floor(Date.now() / 1000) + 3600,
+          });
+          await repositories.mintQuoteRepository.upsertMintQuote(quote);
+          const prepare = manager.ops.mint.prepare({ quote, amount: 3 });
+          if (changeBeforeCommit) {
+            const outcome = await settle(prepare);
+            expect(outcome.status).toBe('rejected');
+            if (outcome.status === 'rejected') {
+              expect(
+                outcome.reason instanceof Error &&
+                  outcome.reason.message.includes('changed after preflight'),
+              ).toBe(true);
+            }
+            expect(
+              await repositories.mintOperationRepository.getByMintUrl(mint.mintUrl),
+            ).toHaveLength(0);
+            expect(
+              (await repositories.counterRepository.getCounter(mint.mintUrl, keyset.id))?.counter,
+            ).toBe(7);
+            expect(counters).toHaveLength(0);
+          } else {
+            const operation = await prepare;
+            expect(operation.outputData.keep.length).toBe(2);
+            expect(
+              operation.outputData.keep.every((output) => output.blindedMessage.id === keyset.id),
+            ).toBe(true);
+            expect((await repositories.mintOperationRepository.getById(operation.id))?.state).toBe(
+              'pending',
+            );
+            expect(
+              (await repositories.counterRepository.getCounter(mint.mintUrl, keyset.id))?.counter,
+            ).toBe(9);
+            expect(counters).toHaveLength(1);
+            expect(counters[0]).toBe(9);
+          }
+        } finally {
+          await manager.dispose();
+          await dispose();
+        }
+      });
+    }
+
     it('preserves caller-owned millisecond timestamps across Mint transitions', async () => {
       const { repositories, dispose } = await options.createRepositories();
       try {

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -1,4 +1,6 @@
 import type { OutputDataCreator } from '@cashu/cashu-ts';
+import { HandlerMintRemote } from './infra/mint/HandlerMintRemote.ts';
+import { CoreMintTransactions } from './transactions/mint/MintTransactions.ts';
 
 import type {
   Repositories,
@@ -1051,19 +1053,29 @@ export class Manager {
     const meltOperationRepository = repositories.meltOperationRepository;
 
     const mintOperationLogger = this.getChildLogger('MintOperationService');
-    const mintOperationService = new MintOperationService(
-      mintHandlerProvider,
-      repositories.mintOperationRepository,
-      quoteLifecycle,
-      repositories.proofRepository,
-      proofService,
-      mintService,
-      walletService,
-      this.mintAdapter,
-      this.eventBus,
-      mintOperationLogger,
+    const mintOperationService = new MintOperationService({
+      operations: repositories.mintOperationRepository,
+      proofs: repositories.proofRepository,
+      quotes: quoteLifecycle,
+      transactions: new CoreMintTransactions(coreTransactionRunner),
+      remote: new HandlerMintRemote(
+        mintHandlerProvider,
+        walletService,
+        mintService,
+        this.mintAdapter,
+        () => seedService.getSeed(),
+        (operation) =>
+          proofService.recoverProofsFromOutputData(operation.mintUrl, operation.outputData, {
+            unit: operation.unit,
+            persistRecoveredProofs: false,
+          }),
+        this.outputDataCreator,
+        mintOperationLogger,
+      ),
+      events: this.eventBus,
+      logger: mintOperationLogger,
       mintScopedLock,
-    );
+    });
     const mintOperationRepository = repositories.mintOperationRepository;
 
     const historyService = new HistoryService(

--- a/packages/core/Manager.ts
+++ b/packages/core/Manager.ts
@@ -1,3 +1,8 @@
+import { CashuMintMetadataRemote } from './infra/CashuMintMetadataRemote.ts';
+import { StoredMintQueries } from './mints/MintMetadata.ts';
+import { CoreMintMetadataTransactions } from './transactions/mints/MintMetadataTransactions.ts';
+import { MintWalletFactory } from './infra/mint/MintWallet.ts';
+import { createCoreTransactionModuleFactory } from './transactions/CoreTransaction.ts';
 import type { OutputDataCreator } from '@cashu/cashu-ts';
 import { HandlerMintRemote } from './infra/mint/HandlerMintRemote.ts';
 import { CoreMintTransactions } from './transactions/mint/MintTransactions.ts';
@@ -914,15 +919,27 @@ export class Manager {
     const keyRingLogger = this.getChildLogger('KeyRingService');
     const historyLogger = this.getChildLogger('HistoryService');
     const tokenLogger = this.getChildLogger('TokenService');
+    const seedService = new SeedService(seedGetter);
+    const coreTransactionRunner = new RepositoryCoreTransactionRunner(
+      repositories,
+      createCoreTransactionModuleFactory(this.outputDataCreator),
+    );
+    const mintQueries = new StoredMintQueries(
+      repositories.mintRepository,
+      repositories.keysetRepository,
+    );
     const mintService = new MintService(
       repositories.mintRepository,
       repositories.keysetRepository,
       this.mintAdapter,
+      {
+        queries: mintQueries,
+        remote: new CashuMintMetadataRemote(this.mintAdapter),
+        transactions: new CoreMintMetadataTransactions(coreTransactionRunner),
+      },
       mintLogger,
       this.eventBus,
     );
-    const seedService = new SeedService(seedGetter);
-    const coreTransactionRunner = new RepositoryCoreTransactionRunner(repositories);
     const keyRingTransactions = new CoreKeyRingTransactions(coreTransactionRunner);
     const keypairDerivation = new KeypairDerivation(() => seedService.getSeed());
     const p2pkSigner = new KeypairP2pkSigner(repositories.keyRingRepository);
@@ -1054,22 +1071,17 @@ export class Manager {
 
     const mintOperationLogger = this.getChildLogger('MintOperationService');
     const mintOperationService = new MintOperationService({
+      mintQueries,
+      mintMetadataRefresh: mintService,
+      loadSeed: () => seedService.getSeed(),
       operations: repositories.mintOperationRepository,
       proofs: repositories.proofRepository,
       quotes: quoteLifecycle,
       transactions: new CoreMintTransactions(coreTransactionRunner),
       remote: new HandlerMintRemote(
         mintHandlerProvider,
-        walletService,
-        mintService,
+        new MintWalletFactory(this.mintAdapter, this.mintRequestProvider, this.outputDataCreator),
         this.mintAdapter,
-        () => seedService.getSeed(),
-        (operation) =>
-          proofService.recoverProofsFromOutputData(operation.mintUrl, operation.outputData, {
-            unit: operation.unit,
-            persistRecoveredProofs: false,
-          }),
-        this.outputDataCreator,
         mintOperationLogger,
       ),
       events: this.eventBus,

--- a/packages/core/docs/adr/0011-use-domain-transaction-gateways.md
+++ b/packages/core/docs/adr/0011-use-domain-transaction-gateways.md
@@ -10,8 +10,9 @@ additionally coordinate durable saga lifecycles. Both use domain gateways, while
 commands compose reusable domain invariants within one adapter transaction. Each gateway method
 returns only after commit, with the runner owning rollback and bounded retries.
 
-This gives each atomic transition an explicit owner and prevents reusable helpers from opening
-nested transactions. Coordinators perform asynchronous preflight and remote mint I/O outside the
+This gives each atomic transition an explicit owner and forbids transactional helpers from opening
+nested transactions. Runtime rejection of nesting is not yet uniform across adapters. Coordinators
+perform asynchronous preflight and remote mint I/O outside the
 transaction and publish live events after commit. Authoritative reads and writes share the
 transaction scope, preserving atomicity across supported adapters, including IndexedDB.
 
@@ -20,11 +21,21 @@ Method-specific argument objects use `*Input` types and the parameter name `inpu
 runner callbacks are named `work`. These names distinguish actions from their inputs and the work
 that composes them.
 
+Coordinators may invoke narrow independently committed actions, such as
+`Pick<MintService, 'refreshAndCommitIfStale'>`. The method name and contract disclose remote I/O
+and persistence. MintService owns freshness policy, its metadata gateway call, and post-commit
+events; Send can reuse the action without reproducing that workflow. Its commit intentionally
+survives a later Send failure. Gateways and scoped commands cannot depend on this action or any
+other coordinator, and coordinator dependencies must remain acyclic.
+
 ## Considered Options
 
 Broad Service dependencies and transaction-scoped Service clones obscure effects and transaction
 ownership. Composing separate gateway calls cannot provide one atomic transition. Shared scoped
 commands preserve algorithm reuse while keeping transaction creation at the owning gateway.
+Requiring every independent commit to appear directly in every caller duplicates refresh workflows;
+allowing pure-looking Service calls hides persistence. Explicitly committing actions preserve reuse
+while disclosing their effects, without opening transactional code to Service dependencies.
 
 We use agent and human review, scoped types, and behavior tests instead of a custom architecture
 checker because partial static analysis adds maintenance cost without establishing effect safety.
@@ -33,7 +44,9 @@ checker because partial static analysis adds maintenance cost without establishi
 
 The design adds interfaces and stricter dependency boundaries. Adoption is incremental: Keypair
 Allocation establishes the baseline, and other workflows migrate through their own gateways while
-reusing shared scoped commands.
+reusing shared scoped commands. Consistent fail-fast rejection of nested Wallet transactions remains
+follow-up work and must distinguish nesting from legitimate concurrent calls. Existing legacy
+MintService add, forced-update, trust, and delete paths remain outside this metadata-action migration.
 
 [Transaction Design](../../../../TRANSACTION_DESIGN.md) is the authoritative implementation
 contract for naming, dependencies, scope lifetime, concurrency, retries, and review requirements.

--- a/packages/core/infra/CashuMintMetadataRemote.ts
+++ b/packages/core/infra/CashuMintMetadataRemote.ts
@@ -1,0 +1,47 @@
+import { isBlsKeyset } from '@cashu/cashu-ts';
+import type { MintMetadataObservation } from '@core/mints/MintMetadata.ts';
+import type { MintMetadataRemote } from '@core/mints/MintMetadataRemote.ts';
+import type { Keyset } from '@core/models/Keyset.ts';
+import { KeysetSyncError, MintFetchError } from '@core/models/Error.ts';
+import type { MintAdapter } from './MintAdapter.ts';
+
+/** Shared mint metadata transport with no persistence authority. */
+export class CashuMintMetadataRemote implements MintMetadataRemote {
+  constructor(
+    private readonly mint: Pick<MintAdapter, 'fetchMintInfo' | 'fetchKeysets' | 'fetchKeysForId'>,
+  ) {}
+
+  async fetchMintMetadata(
+    mintUrl: string,
+    knownKeysets: readonly Keyset[],
+  ): Promise<MintMetadataObservation> {
+    const observedAt = Math.floor(Date.now() / 1000);
+    const mintInfo = await this.mint.fetchMintInfo(mintUrl).catch((error: unknown) => {
+      throw new MintFetchError(mintUrl, undefined, error);
+    });
+    const result = await this.mint.fetchKeysets(mintUrl).catch((error: unknown) => {
+      throw new MintFetchError(mintUrl, 'Failed to fetch keysets', error);
+    });
+    const keysets = await Promise.all(
+      result.keysets
+        .filter((keyset) => !isBlsKeyset(keyset.id))
+        .map(async (keyset) => {
+          const known = knownKeysets.find((candidate) => candidate.id === keyset.id);
+          const keypairs =
+            known?.keypairs ??
+            (await this.mint.fetchKeysForId(mintUrl, keyset.id).catch((error: unknown) => {
+              throw new KeysetSyncError(mintUrl, keyset.id, undefined, error);
+            }));
+          return {
+            mintUrl,
+            id: keyset.id,
+            unit: keyset.unit,
+            active: keyset.active,
+            feePpk: keyset.input_fee_ppk || 0,
+            keypairs,
+          };
+        }),
+    );
+    return { mintUrl, mintInfo, keysets, observedAt };
+  }
+}

--- a/packages/core/infra/ProofRestore.ts
+++ b/packages/core/infra/ProofRestore.ts
@@ -1,0 +1,34 @@
+import type { Keys, Proof, Wallet } from '@cashu/cashu-ts';
+import { assertSameUnit, normalizeUnit } from '@core/amounts.ts';
+import type { Keyset } from '@core/models/Keyset.ts';
+import { deserializeOutputData, type SerializedOutputData } from '@core/utils.ts';
+
+/** Remote restoration and local unblinding only. The owning workflow persists candidate proofs. */
+export async function restoreOutputProofs(
+  wallet: Pick<Wallet, 'mint' | 'checkProofsStates'>,
+  keysets: readonly Keyset[],
+  unit: string,
+  serialized: SerializedOutputData,
+): Promise<Proof[]> {
+  const outputData = deserializeOutputData(serialized);
+  const outputs = [...outputData.keep, ...outputData.send];
+  if (outputs.length === 0) return [];
+  const result = await wallet.mint.restore({
+    outputs: outputs.map((output) => output.blindedMessage),
+  });
+  const restored: Proof[] = [];
+  for (let i = 0; i < result.outputs.length; i++) {
+    const output = outputs.find(
+      (candidate) => candidate.blindedMessage.B_ === result.outputs[i]?.B_,
+    );
+    const signature = result.signatures[i];
+    if (!output || !signature) continue;
+    const keyset = keysets.find((candidate) => candidate.id === signature.id);
+    if (!keyset) continue;
+    assertSameUnit(normalizeUnit(keyset.unit), normalizeUnit(unit), 'Restored proof keyset');
+    restored.push(output.toProof(signature, { id: keyset.id, keys: keyset.keypairs as Keys }));
+  }
+  if (restored.length === 0) return [];
+  const states = await wallet.checkProofsStates(restored);
+  return restored.filter((_, index) => states[index]?.state === 'UNSPENT');
+}

--- a/packages/core/infra/handlers/mint/MintBolt11Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt11Handler.ts
@@ -4,7 +4,6 @@ import { assertSameUnit } from '@core/amounts';
 import type {
   CreateMintQuoteContext,
   ExecuteContext,
-  MintMethodMeta,
   PrepareContext,
   MintMethodHandler,
   MintExecutionResult,
@@ -15,7 +14,7 @@ import type {
   PendingMintObservationResult,
   FetchRemoteMintQuoteContext,
 } from '@core/operations/mint';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
+import { deserializeOutputData } from '@core/utils';
 import {
   MintOperationError,
   MintQuoteKeyError,
@@ -26,8 +25,15 @@ import { mintQuoteFromBolt11Response, type MintQuote } from '../../../models/Min
 import { mintQuoteObservationFromBolt11Response } from '../../../models/MintQuoteObservationFactory';
 import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
 
+import type { PreparedMintOperation } from '../../../operations/mint/MintCommands.ts';
+
 export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
-  constructor(private readonly keyRingService: KeyRingService) {}
+  constructor(
+    private readonly keyRingService: Pick<
+      KeyRingService,
+      'generateMintQuoteKeyPair' | 'getMintQuoteKeyPair'
+    >,
+  ) {}
 
   async createQuote(ctx: CreateMintQuoteContext<'bolt11'>): Promise<MintQuote<'bolt11'>> {
     const { amount, locked, ownedPubkey } = ctx.createQuoteData;
@@ -64,9 +70,7 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     return mintQuoteObservationFromBolt11Response(ctx.quote.mintUrl, remoteQuote);
   }
 
-  async prepare(
-    ctx: PrepareContext<'bolt11'>,
-  ): Promise<PendingMintOperation<'bolt11'> & MintMethodMeta<'bolt11'>> {
+  async prepare(ctx: PrepareContext<'bolt11'>): Promise<PreparedMintOperation<'bolt11'>> {
     const quote = ctx.importedQuote;
     if (!quote) {
       throw new Error(`Mint quote ${ctx.operation.quoteId ?? '(missing)'} was not provided`);
@@ -91,19 +95,6 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     assertSameUnit(quote.unit, ctx.operation.unit, `Mint quote ${quote.quote}`);
     await this.requireQuoteKey(quote.pubkey);
 
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: quote.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for mint operation');
-    }
-
     return {
       ...ctx.operation,
       quoteId: quote.quote,
@@ -112,7 +103,6 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
       request: quote.request,
       expiry: quote.expiry,
       pubkey: quote.pubkey,
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
       state: 'pending',
     };
   }
@@ -210,15 +200,7 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
           },
         );
 
-        await ctx.proofService.saveProofs(
-          ctx.operation.mintUrl,
-          mapProofToCoreProof(ctx.operation.mintUrl, 'ready', proofs, {
-            unit: ctx.operation.unit,
-            createdByOperationId: ctx.operation.id,
-          }),
-        );
-
-        return { status: 'FINALIZED' };
+        return { status: 'FINALIZED', proofs };
       } catch (err) {
         if (err instanceof MintOperationError) {
           if (err.code === 20002) {
@@ -244,21 +226,14 @@ export class MintBolt11Handler implements MintMethodHandler<'bolt11'> {
     }
 
     try {
-      const recovered = await ctx.proofService.recoverProofsFromOutputData(
-        ctx.operation.mintUrl,
-        ctx.operation.outputData,
-        {
-          unit: ctx.operation.unit,
-          createdByOperationId: ctx.operation.id,
-        },
-      );
+      const recovered = await ctx.restoreOutputs();
       if (recovered.length === 0) {
         return {
           status: 'PENDING',
           error: `Recovered: quote ${quoteId} issued remotely but proofs were not recoverable`,
         };
       }
-      return { status: 'FINALIZED' };
+      return { status: 'FINALIZED', proofs: recovered };
     } catch (error) {
       return {
         status: 'PENDING',

--- a/packages/core/infra/handlers/mint/MintBolt12Handler.ts
+++ b/packages/core/infra/handlers/mint/MintBolt12Handler.ts
@@ -1,7 +1,7 @@
 import { Amount, type MintQuoteBolt12Response, type Wallet } from '@cashu/cashu-ts';
 import { assertSameUnit, normalizeUnitAmount } from '@core/amounts';
 import type { KeyRingService } from '@core/services';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
+import { deserializeOutputData } from '@core/utils';
 import { bytesToHex } from '@noble/curves/utils.js';
 import {
   MintOperationError,
@@ -26,8 +26,15 @@ import type {
   RecoverExecutingResult,
 } from '../../../operations/mint';
 
+import type { PreparedMintOperation } from '../../../operations/mint/MintCommands.ts';
+
 export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
-  constructor(private readonly keyRingService: KeyRingService) {}
+  constructor(
+    private readonly keyRingService: Pick<
+      KeyRingService,
+      'generateMintQuoteKeyPair' | 'getMintQuoteKeyPair'
+    >,
+  ) {}
 
   async createQuote(ctx: CreateMintQuoteContext<'bolt12'>): Promise<MintQuote<'bolt12'>> {
     const quoteKey = await this.keyRingService.generateMintQuoteKeyPair();
@@ -72,7 +79,7 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
     await this.requireQuoteKey(quote.quoteData.pubkey);
   }
 
-  async prepare(ctx: PrepareContext<'bolt12'>): Promise<PendingMintOperation<'bolt12'>> {
+  async prepare(ctx: PrepareContext<'bolt12'>): Promise<PreparedMintOperation<'bolt12'>> {
     const quote = ctx.importedQuote;
     if (!quote) {
       throw new Error(`Mint quote ${ctx.operation.quoteId ?? '(missing)'} was not provided`);
@@ -87,26 +94,12 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
     assertSameUnit(quote.unit, ctx.operation.unit, `BOLT12 mint quote ${quote.quote}`);
     await this.requireQuoteKey(quote.pubkey);
 
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: ctx.operation.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for BOLT12 mint operation');
-    }
-
     return {
       ...ctx.operation,
       quoteId: quote.quote,
       request: quote.request,
       expiry: quote.expiry,
       pubkey: quote.pubkey,
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
       state: 'pending',
     };
   }
@@ -236,15 +229,7 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
         { type: 'custom', data: outputData.keep },
       );
 
-      await ctx.proofService.saveProofs(
-        operation.mintUrl,
-        mapProofToCoreProof(operation.mintUrl, 'ready', proofs, {
-          unit: operation.unit,
-          createdByOperationId: operation.id,
-        }),
-      );
-
-      return { status: 'FINALIZED' };
+      return { status: 'FINALIZED', proofs };
     } catch (error) {
       if (this.isAlreadyIssuedError(error)) {
         return (
@@ -371,16 +356,9 @@ export class MintBolt12Handler implements MintMethodHandler<'bolt12'> {
     ctx: RecoverExecutingContext<'bolt12'>,
   ): Promise<RecoverExecutingResult | null> {
     try {
-      const recovered = await ctx.proofService.recoverProofsFromOutputData(
-        ctx.operation.mintUrl,
-        ctx.operation.outputData,
-        {
-          unit: ctx.operation.unit,
-          createdByOperationId: ctx.operation.id,
-        },
-      );
+      const recovered = await ctx.restoreOutputs();
 
-      return recovered.length > 0 ? { status: 'FINALIZED' } : null;
+      return recovered.length > 0 ? { status: 'FINALIZED', proofs: recovered } : null;
     } catch (error) {
       ctx.logger?.warn('Failed to recover BOLT12 mint outputs from output data', {
         mintUrl: ctx.operation.mintUrl,

--- a/packages/core/infra/handlers/mint/MintOnchainHandler.ts
+++ b/packages/core/infra/handlers/mint/MintOnchainHandler.ts
@@ -5,7 +5,7 @@ import {
 } from '@cashu/cashu-ts';
 import { assertSameUnit } from '@core/amounts';
 import type { KeyRingService } from '@core/services';
-import { deserializeOutputData, mapProofToCoreProof, serializeOutputData } from '@core/utils';
+import { deserializeOutputData } from '@core/utils';
 import { bytesToHex } from '@noble/curves/utils.js';
 import {
   MintOperationError,
@@ -34,8 +34,15 @@ import type {
   RecoverExecutingResult,
 } from '../../../operations/mint';
 
+import type { PreparedMintOperation } from '../../../operations/mint/MintCommands.ts';
+
 export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
-  constructor(private readonly keyRingService: KeyRingService) {}
+  constructor(
+    private readonly keyRingService: Pick<
+      KeyRingService,
+      'generateMintQuoteKeyPair' | 'getMintQuoteKeyPair'
+    >,
+  ) {}
 
   async createQuote(ctx: CreateMintQuoteContext<'onchain'>): Promise<MintQuote<'onchain'>> {
     const quoteKey = await this.keyRingService.generateMintQuoteKeyPair();
@@ -67,7 +74,7 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     await this.requireQuoteKey(quote.quoteData.pubkey);
   }
 
-  async prepare(ctx: PrepareContext<'onchain'>): Promise<PendingMintOperation<'onchain'>> {
+  async prepare(ctx: PrepareContext<'onchain'>): Promise<PreparedMintOperation<'onchain'>> {
     const quote = ctx.importedQuote;
     if (!quote) {
       throw new Error(`Mint quote ${ctx.operation.quoteId ?? '(missing)'} was not provided`);
@@ -82,26 +89,12 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     assertSameUnit(quote.unit, ctx.operation.unit, `Onchain mint quote ${quote.quote}`);
     await this.requireQuoteKey(quote.pubkey);
 
-    const outputData = await ctx.proofService.createOutputsAndIncrementCounters(
-      ctx.operation.mintUrl,
-      {
-        keep: { amount: ctx.operation.amount, unit: ctx.operation.unit },
-        send: { amount: Amount.zero(), unit: ctx.operation.unit },
-      },
-      {},
-    );
-
-    if (outputData.keep.length === 0) {
-      throw new Error('Failed to create deterministic outputs for onchain mint operation');
-    }
-
     return {
       ...ctx.operation,
       quoteId: quote.quote,
       request: quote.request,
       expiry: quote.expiry,
       pubkey: quote.pubkey,
-      outputData: serializeOutputData({ keep: outputData.keep, send: [] }),
       state: 'pending',
     };
   }
@@ -224,15 +217,7 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
         { type: 'custom', data: outputData.keep },
       );
 
-      await ctx.proofService.saveProofs(
-        operation.mintUrl,
-        mapProofToCoreProof(operation.mintUrl, 'ready', proofs, {
-          unit: operation.unit,
-          createdByOperationId: operation.id,
-        }),
-      );
-
-      return { status: 'FINALIZED' };
+      return { status: 'FINALIZED', proofs };
     } catch (error) {
       if (this.isAlreadyIssuedError(error)) {
         return (
@@ -335,16 +320,9 @@ export class MintOnchainHandler implements MintMethodHandler<'onchain'> {
     ctx: RecoverExecutingContext<'onchain'>,
   ): Promise<RecoverExecutingResult | null> {
     try {
-      const recovered = await ctx.proofService.recoverProofsFromOutputData(
-        ctx.operation.mintUrl,
-        ctx.operation.outputData,
-        {
-          unit: ctx.operation.unit,
-          createdByOperationId: ctx.operation.id,
-        },
-      );
+      const recovered = await ctx.restoreOutputs();
 
-      return recovered.length > 0 ? { status: 'FINALIZED' } : null;
+      return recovered.length > 0 ? { status: 'FINALIZED', proofs: recovered } : null;
     } catch (error) {
       ctx.logger?.warn('Failed to recover onchain mint outputs from output data', {
         mintUrl: ctx.operation.mintUrl,

--- a/packages/core/infra/mint/HandlerMintRemote.ts
+++ b/packages/core/infra/mint/HandlerMintRemote.ts
@@ -1,5 +1,6 @@
-import { OutputData, type OutputDataCreator, type Proof } from '@cashu/cashu-ts';
 import type { Logger } from '../../logging/Logger.ts';
+import type { MintMetadata } from '../../mints/MintMetadata.ts';
+import { assertMethodUnitCapability } from '../../mints/MintCapabilities.ts';
 import { mintQuoteToMethodSnapshot, type MintQuote } from '../../models/MintQuote.ts';
 import type {
   ExecutingMintOperation,
@@ -8,68 +9,50 @@ import type {
   PendingOrLaterOperation,
 } from '../../operations/mint/MintOperation.ts';
 import type { MintRemote } from '../../operations/mint/MintRemote.ts';
-import type { MintService } from '../../services/MintService.ts';
-import type { WalletService } from '../../services/WalletService.ts';
-import { serializeOutputData } from '../../utils.ts';
 import type { MintHandlerProvider } from '../handlers/mint/MintHandlerProvider.ts';
 import type { MintAdapter } from '../MintAdapter.ts';
+import { restoreOutputProofs } from '../ProofRestore.ts';
+import type { MintWalletFactory } from './MintWallet.ts';
 
-/** Retains the existing method-specific lifecycle while returning all candidates to the owner. */
+/** Method policy and protocol effects using snapshots; no Services or persistence authority. */
 export class HandlerMintRemote implements MintRemote {
   constructor(
     private readonly handlers: MintHandlerProvider,
-    private readonly wallets: Pick<WalletService, 'getWalletWithActiveKeysetId'>,
-    private readonly mints: Pick<MintService, 'isTrustedMint' | 'assertMethodUnitSupported'>,
+    private readonly wallets: Pick<MintWalletFactory, 'create'>,
     private readonly mintAdapter: MintAdapter,
-    private readonly getSeed: () => Promise<Uint8Array>,
-    readonly restoreOutputs: (operation: PendingOrLaterOperation) => Promise<Proof[]>,
-    private readonly outputs: OutputDataCreator = OutputData,
     private readonly logger?: Logger,
   ) {}
 
-  isTrusted(mintUrl: string) {
-    return this.mints.isTrustedMint(mintUrl);
-  }
-
-  async prepare(operation: InitMintOperation, quote: MintQuote) {
+  async prepare(
+    operation: InitMintOperation,
+    quote: MintQuote,
+    metadata: MintMetadata,
+    seed: Uint8Array,
+  ) {
     const handler = this.handlers.get(operation.method);
     await handler.validateQuoteForPrepare?.(quote);
-    await this.mints.assertMethodUnitSupported(
-      operation.mintUrl,
+    assertMethodUnitCapability(
+      metadata.mint.mintInfo,
       4,
       operation.method,
       operation.method === 'onchain'
         ? operation.unit
         : { amount: operation.amount, unit: operation.unit },
     );
-    const { keys, keysetId } = await this.wallets.getWalletWithActiveKeysetId(
-      operation.mintUrl,
-      operation.unit,
-    );
+    const wallet = this.wallets.create(metadata, operation.unit);
+    const activeKeys = wallet.keyChain.getCheapestKeyset().toMintKeys();
+    if (!activeKeys) throw new Error('Active mint keyset has no keys');
     const prepared = await handler.prepare({
       operation,
       importedQuote: mintQuoteToMethodSnapshot(quote),
     });
-    const seed = await this.getSeed();
-    return {
-      operation: prepared,
-      keysetId,
-      derive: (counter: number) =>
-        serializeOutputData({
-          keep: this.outputs.createDeterministicData(prepared.amount, seed, counter, keys),
-          send: [],
-        }),
-    };
+    return { operation: prepared, activeKeys, seed };
   }
 
-  async execute(operation: ExecutingMintOperation) {
-    const { wallet } = await this.wallets.getWalletWithActiveKeysetId(
-      operation.mintUrl,
-      operation.unit,
-    );
+  async execute(operation: ExecutingMintOperation, metadata: MintMetadata) {
     return this.handlers.get(operation.method).execute({
       operation,
-      wallet,
+      wallet: this.wallets.create(metadata, operation.unit),
       mintAdapter: this.mintAdapter,
       logger: this.logger,
     });
@@ -78,18 +61,15 @@ export class HandlerMintRemote implements MintRemote {
   async recoverExecuting(
     operation: ExecutingMintOperation,
     localClaimabilityFacts: Parameters<MintRemote['recoverExecuting']>[1],
+    metadata: MintMetadata,
   ) {
-    const { wallet } = await this.wallets.getWalletWithActiveKeysetId(
-      operation.mintUrl,
-      operation.unit,
-    );
     return this.handlers.get(operation.method).recoverExecuting({
       operation,
-      wallet,
+      wallet: this.wallets.create(metadata, operation.unit),
       mintAdapter: this.mintAdapter,
       logger: this.logger,
       localClaimabilityFacts,
-      restoreOutputs: () => this.restoreOutputs(operation),
+      restoreOutputs: () => this.restoreOutputs(operation, metadata),
     });
   }
 
@@ -99,5 +79,14 @@ export class HandlerMintRemote implements MintRemote {
       mintAdapter: this.mintAdapter,
       logger: this.logger,
     });
+  }
+
+  restoreOutputs(operation: PendingOrLaterOperation, metadata: MintMetadata) {
+    return restoreOutputProofs(
+      this.wallets.create(metadata, operation.unit),
+      metadata.keysets,
+      operation.unit,
+      operation.outputData,
+    );
   }
 }

--- a/packages/core/infra/mint/HandlerMintRemote.ts
+++ b/packages/core/infra/mint/HandlerMintRemote.ts
@@ -1,0 +1,103 @@
+import { OutputData, type OutputDataCreator, type Proof } from '@cashu/cashu-ts';
+import type { Logger } from '../../logging/Logger.ts';
+import { mintQuoteToMethodSnapshot, type MintQuote } from '../../models/MintQuote.ts';
+import type {
+  ExecutingMintOperation,
+  InitMintOperation,
+  PendingMintOperation,
+  PendingOrLaterOperation,
+} from '../../operations/mint/MintOperation.ts';
+import type { MintRemote } from '../../operations/mint/MintRemote.ts';
+import type { MintService } from '../../services/MintService.ts';
+import type { WalletService } from '../../services/WalletService.ts';
+import { serializeOutputData } from '../../utils.ts';
+import type { MintHandlerProvider } from '../handlers/mint/MintHandlerProvider.ts';
+import type { MintAdapter } from '../MintAdapter.ts';
+
+/** Retains the existing method-specific lifecycle while returning all candidates to the owner. */
+export class HandlerMintRemote implements MintRemote {
+  constructor(
+    private readonly handlers: MintHandlerProvider,
+    private readonly wallets: Pick<WalletService, 'getWalletWithActiveKeysetId'>,
+    private readonly mints: Pick<MintService, 'isTrustedMint' | 'assertMethodUnitSupported'>,
+    private readonly mintAdapter: MintAdapter,
+    private readonly getSeed: () => Promise<Uint8Array>,
+    readonly restoreOutputs: (operation: PendingOrLaterOperation) => Promise<Proof[]>,
+    private readonly outputs: OutputDataCreator = OutputData,
+    private readonly logger?: Logger,
+  ) {}
+
+  isTrusted(mintUrl: string) {
+    return this.mints.isTrustedMint(mintUrl);
+  }
+
+  async prepare(operation: InitMintOperation, quote: MintQuote) {
+    const handler = this.handlers.get(operation.method);
+    await handler.validateQuoteForPrepare?.(quote);
+    await this.mints.assertMethodUnitSupported(
+      operation.mintUrl,
+      4,
+      operation.method,
+      operation.method === 'onchain'
+        ? operation.unit
+        : { amount: operation.amount, unit: operation.unit },
+    );
+    const { keys, keysetId } = await this.wallets.getWalletWithActiveKeysetId(
+      operation.mintUrl,
+      operation.unit,
+    );
+    const prepared = await handler.prepare({
+      operation,
+      importedQuote: mintQuoteToMethodSnapshot(quote),
+    });
+    const seed = await this.getSeed();
+    return {
+      operation: prepared,
+      keysetId,
+      derive: (counter: number) =>
+        serializeOutputData({
+          keep: this.outputs.createDeterministicData(prepared.amount, seed, counter, keys),
+          send: [],
+        }),
+    };
+  }
+
+  async execute(operation: ExecutingMintOperation) {
+    const { wallet } = await this.wallets.getWalletWithActiveKeysetId(
+      operation.mintUrl,
+      operation.unit,
+    );
+    return this.handlers.get(operation.method).execute({
+      operation,
+      wallet,
+      mintAdapter: this.mintAdapter,
+      logger: this.logger,
+    });
+  }
+
+  async recoverExecuting(
+    operation: ExecutingMintOperation,
+    localClaimabilityFacts: Parameters<MintRemote['recoverExecuting']>[1],
+  ) {
+    const { wallet } = await this.wallets.getWalletWithActiveKeysetId(
+      operation.mintUrl,
+      operation.unit,
+    );
+    return this.handlers.get(operation.method).recoverExecuting({
+      operation,
+      wallet,
+      mintAdapter: this.mintAdapter,
+      logger: this.logger,
+      localClaimabilityFacts,
+      restoreOutputs: () => this.restoreOutputs(operation),
+    });
+  }
+
+  observePending(operation: PendingMintOperation) {
+    return this.handlers.get(operation.method).checkPending({
+      operation,
+      mintAdapter: this.mintAdapter,
+      logger: this.logger,
+    });
+  }
+}

--- a/packages/core/infra/mint/MintWallet.ts
+++ b/packages/core/infra/mint/MintWallet.ts
@@ -1,0 +1,32 @@
+import { Mint, Wallet, type OutputDataCreator } from '@cashu/cashu-ts';
+import type { MintMetadata } from '../../mints/MintMetadata.ts';
+import { createKeyChain } from '../../proofs/KeysetSelection.ts';
+import { normalizeUnit } from '../../amounts.ts';
+import type { MintAdapter } from '../MintAdapter.ts';
+import type { MintRequestProvider } from '../MintRequestProvider.ts';
+
+/** Builds an SDK wallet from a supplied snapshot; construction never fetches or writes metadata. */
+export class MintWalletFactory {
+  constructor(
+    private readonly mint: Pick<MintAdapter, 'getAuthProvider'>,
+    private readonly requests: Pick<MintRequestProvider, 'getRequestFn'>,
+    private readonly outputs?: OutputDataCreator,
+  ) {}
+
+  create(metadata: MintMetadata, unit: string): Wallet {
+    unit = normalizeUnit(unit);
+    const mintUrl = metadata.mint.mintUrl;
+    const wallet = new Wallet(
+      new Mint(mintUrl, {
+        customRequest: this.requests.getRequestFn(mintUrl),
+        authProvider: this.mint.getAuthProvider(mintUrl),
+      }),
+      { unit, outputDataCreator: this.outputs },
+    );
+    wallet.loadMintFromCache(
+      metadata.mint.mintInfo,
+      createKeyChain(mintUrl, unit, metadata.keysets).cache,
+    );
+    return wallet;
+  }
+}

--- a/packages/core/mints/MintCapabilities.ts
+++ b/packages/core/mints/MintCapabilities.ts
@@ -1,0 +1,139 @@
+import { Amount, type AmountLike } from '@cashu/cashu-ts';
+import { DEFAULT_UNIT, normalizeUnit, normalizeUnitAmount, type UnitAmount } from '../amounts.ts';
+import { ProofValidationError } from '../models/Error.ts';
+import type { MintInfo } from '../types.ts';
+
+export interface MethodUnitCapability {
+  supported: boolean;
+  disabled: boolean;
+  nut: 4 | 5;
+  method: string;
+  unit: string;
+  minAmount?: Amount | null;
+  maxAmount?: Amount | null;
+  options?: unknown;
+  legacySatAllowed?: boolean;
+  reason?: string;
+}
+
+type NutMethodSetting = {
+  method: string;
+  unit: string;
+  min_amount?: AmountLike | null;
+  max_amount?: AmountLike | null;
+  options?: unknown;
+};
+
+type NutMethodSettings = {
+  methods?: NutMethodSetting[];
+  disabled?: boolean;
+};
+
+/** Evaluate method support from a supplied snapshot without fetching or persisting metadata. */
+export function getMethodUnitCapability(
+  mintInfo: MintInfo,
+  nut: 4 | 5,
+  method: string,
+  unit: string,
+): MethodUnitCapability {
+  const normalizedUnit = normalizeUnit(unit, { defaultUnit: DEFAULT_UNIT });
+  const settings = (mintInfo.nuts as Record<string, unknown> | undefined)?.[String(nut)] as
+    | NutMethodSettings
+    | undefined;
+  const nutName = `NUT-${String(nut).padStart(2, '0')}`;
+
+  if (settings?.disabled === true) {
+    return {
+      supported: false,
+      disabled: true,
+      nut,
+      method,
+      unit: normalizedUnit,
+      reason: `${nutName} is disabled`,
+    };
+  }
+
+  if (!settings || !Array.isArray(settings.methods)) {
+    return {
+      supported: false,
+      disabled: false,
+      nut,
+      method,
+      unit: normalizedUnit,
+      reason: `${nutName} method metadata is missing`,
+    };
+  }
+
+  const matchingMethod = settings.methods.find((entry) => {
+    try {
+      return entry.method === method && normalizeUnit(entry.unit) === normalizedUnit;
+    } catch {
+      return false;
+    }
+  });
+
+  if (!matchingMethod) {
+    return {
+      supported: false,
+      disabled: false,
+      nut,
+      method,
+      unit: normalizedUnit,
+      reason: `${nutName} method ${method} does not support unit ${normalizedUnit}`,
+    };
+  }
+
+  return {
+    supported: true,
+    disabled: false,
+    nut,
+    method,
+    unit: normalizedUnit,
+    minAmount: parseOptionalAmount(matchingMethod.min_amount),
+    maxAmount: parseOptionalAmount(matchingMethod.max_amount),
+    options: matchingMethod.options,
+  };
+}
+
+/** Validate a method and amount against an already loaded metadata snapshot. */
+export function assertMethodUnitCapability(
+  mintInfo: MintInfo,
+  nut: 4 | 5,
+  method: string,
+  scope: string | UnitAmount,
+): void {
+  let unit: string;
+  let requestedAmount: Amount | undefined;
+  if (typeof scope === 'string') {
+    unit = scope;
+  } else {
+    const intent = normalizeUnitAmount(scope);
+    unit = intent.unit;
+    requestedAmount = intent.amount;
+  }
+  const capability = getMethodUnitCapability(mintInfo, nut, method, unit);
+  if (!capability.supported) {
+    throw new ProofValidationError(
+      capability.reason ??
+        `NUT-${String(nut).padStart(2, '0')} method ${method} does not support unit ${capability.unit}`,
+    );
+  }
+
+  if (requestedAmount === undefined) return;
+
+  const amountRequirement = `NUT-${String(nut).padStart(2, '0')} method ${method} unit ${capability.unit}`;
+  if (capability.minAmount && requestedAmount.lessThan(capability.minAmount)) {
+    throw new ProofValidationError(
+      `${amountRequirement} requires amount >= ${capability.minAmount}`,
+    );
+  }
+  if (capability.maxAmount && requestedAmount.greaterThan(capability.maxAmount)) {
+    throw new ProofValidationError(
+      `${amountRequirement} requires amount <= ${capability.maxAmount}`,
+    );
+  }
+}
+
+function parseOptionalAmount(amount: AmountLike | null | undefined): Amount | null {
+  return amount === undefined || amount === null ? null : Amount.from(amount);
+}

--- a/packages/core/mints/MintMetadata.ts
+++ b/packages/core/mints/MintMetadata.ts
@@ -1,0 +1,47 @@
+import { isBlsKeyset } from '@cashu/cashu-ts';
+import type { Mint } from '@core/models/Mint.ts';
+import type { Keyset } from '@core/models/Keyset.ts';
+import type { MintInfo } from '@core/types.ts';
+import { normalizeMintUrl } from '@core/utils.ts';
+
+export const MINT_REFRESH_TTL_S = 60 * 5;
+
+export interface MintMetadata {
+  mint: Mint;
+  keysets: Keyset[];
+}
+
+export interface MintMetadataObservation {
+  mintUrl: string;
+  mintInfo: MintInfo;
+  keysets: Omit<Keyset, 'updatedAt'>[];
+  observedAt: number;
+}
+
+export interface MintQueries {
+  isTrustedMint(mintUrl: string): Promise<boolean>;
+  getMetadata(mintUrl: string): Promise<MintMetadata | null>;
+}
+
+/** Composes read-only interfaces; fetching a snapshot never refreshes or repairs storage. */
+export class StoredMintQueries implements MintQueries {
+  constructor(
+    private readonly mints: {
+      isTrustedMint(mintUrl: string): Promise<boolean>;
+      getAllMints(): Promise<Mint[]>;
+    },
+    private readonly keysets: { getKeysetsByMintUrl(mintUrl: string): Promise<Keyset[]> },
+  ) {}
+
+  isTrustedMint(mintUrl: string): Promise<boolean> {
+    return this.mints.isTrustedMint(normalizeMintUrl(mintUrl));
+  }
+
+  async getMetadata(mintUrl: string): Promise<MintMetadata | null> {
+    mintUrl = normalizeMintUrl(mintUrl);
+    const mint = (await this.mints.getAllMints()).find((item) => item.mintUrl === mintUrl);
+    if (!mint) return null;
+    const keysets = await this.keysets.getKeysetsByMintUrl(mintUrl);
+    return { mint, keysets: keysets.filter((keyset) => !isBlsKeyset(keyset.id)) };
+  }
+}

--- a/packages/core/mints/MintMetadataRemote.ts
+++ b/packages/core/mints/MintMetadataRemote.ts
@@ -1,0 +1,10 @@
+import type { Keyset } from '@core/models/Keyset.ts';
+import type { MintMetadataObservation } from './MintMetadata.ts';
+
+/** Remote observation only; no Wallet persistence authority. */
+export interface MintMetadataRemote {
+  fetchMintMetadata(
+    mintUrl: string,
+    knownKeysets: readonly Keyset[],
+  ): Promise<MintMetadataObservation>;
+}

--- a/packages/core/operations/mint/MintCommands.ts
+++ b/packages/core/operations/mint/MintCommands.ts
@@ -1,7 +1,6 @@
-import type { Proof } from '@cashu/cashu-ts';
+import type { MintKeys, Proof } from '@cashu/cashu-ts';
 import type { MintQuote } from '../../models/MintQuote.ts';
 import type { CoreProof } from '../../types.ts';
-import type { SerializedOutputData } from '../../utils.ts';
 import type { MintMethod } from './MintMethodHandler.ts';
 import type {
   MintOperation,
@@ -18,8 +17,8 @@ export type PreparedMintOperation<M extends MintMethod = MintMethod> = Omit<
 
 export interface PrepareMintInput {
   operation: PreparedMintOperation;
-  keysetId: string;
-  derive(counter: number): SerializedOutputData;
+  activeKeys: MintKeys;
+  seed: Uint8Array;
 }
 
 export interface AuthorizeMintInput {

--- a/packages/core/operations/mint/MintCommands.ts
+++ b/packages/core/operations/mint/MintCommands.ts
@@ -1,0 +1,75 @@
+import type { Proof } from '@cashu/cashu-ts';
+import type { MintQuote } from '../../models/MintQuote.ts';
+import type { CoreProof } from '../../types.ts';
+import type { SerializedOutputData } from '../../utils.ts';
+import type { MintMethod } from './MintMethodHandler.ts';
+import type {
+  MintOperation,
+  MintOperationFailure,
+  PendingMintOperation,
+  PendingOrLaterOperation,
+} from './MintOperation.ts';
+
+/** Method validation is complete; deterministic outputs are allocated by the owning transaction. */
+export type PreparedMintOperation<M extends MintMethod = MintMethod> = Omit<
+  PendingMintOperation<M>,
+  'outputData'
+>;
+
+export interface PrepareMintInput {
+  operation: PreparedMintOperation;
+  keysetId: string;
+  derive(counter: number): SerializedOutputData;
+}
+
+export interface AuthorizeMintInput {
+  operationId: string;
+  timestamp: number;
+}
+
+export interface SettleMintInput {
+  operation: PendingOrLaterOperation;
+  proofs: Proof[];
+  outcome: 'issued' | 'already-issued' | 'recovered';
+  timestamp: number;
+}
+
+export interface ReturnMintToPendingInput {
+  operation: PendingOrLaterOperation;
+  error?: string;
+  timestamp: number;
+}
+
+export interface FailMintInput {
+  operation: PendingOrLaterOperation;
+  failure: MintOperationFailure;
+  timestamp: number;
+}
+
+export interface MintQuoteCommit {
+  quote: MintQuote;
+  changed: boolean;
+}
+
+export interface MintCommit {
+  operation: MintOperation;
+  changed: boolean;
+  proofs: CoreProof[];
+  quote?: MintQuoteCommit;
+}
+
+export interface PreparedMintCommit {
+  operation: PendingMintOperation;
+  counter: { mintUrl: string; keysetId: string; counter: number };
+}
+
+/** Domain mutations that can be composed inside one already-open transaction. */
+export interface MintCommands {
+  prepare(input: PrepareMintInput): Promise<PreparedMintCommit>;
+  authorize(input: AuthorizeMintInput): Promise<MintCommit>;
+  settle(input: SettleMintInput): Promise<MintCommit>;
+  returnToPending(input: ReturnMintToPendingInput): Promise<MintCommit>;
+  fail(input: FailMintInput): Promise<MintCommit>;
+  observeQuote(quote: MintQuote): Promise<MintQuoteCommit>;
+  deleteInit(operationId: string): Promise<void>;
+}

--- a/packages/core/operations/mint/MintLocalClaimability.ts
+++ b/packages/core/operations/mint/MintLocalClaimability.ts
@@ -1,0 +1,23 @@
+import { Amount } from '@cashu/cashu-ts';
+import type { MintOperation } from './MintOperation.ts';
+
+/** Existing standalone policy: executing siblings reserve value; pending preparations do not. */
+export function mintLocalClaimabilityFacts(
+  siblings: MintOperation[],
+  targetOperationId?: string,
+): { finalizedAmount: Amount; reservedAmount: Amount } {
+  return {
+    finalizedAmount: Amount.sum(
+      siblings
+        .filter((operation) => operation.state === 'finalized')
+        .map((operation) => operation.amount),
+    ),
+    reservedAmount: Amount.sum(
+      siblings
+        .filter(
+          (operation) => operation.state === 'executing' && operation.id !== targetOperationId,
+        )
+        .map((operation) => operation.amount),
+    ),
+  };
+}

--- a/packages/core/operations/mint/MintMethodHandler.ts
+++ b/packages/core/operations/mint/MintMethodHandler.ts
@@ -7,12 +7,7 @@ import type {
   Proof,
   Wallet,
 } from '@cashu/cashu-ts';
-import type { ProofRepository } from '../../repositories';
-import type { ProofService } from '../../services/ProofService';
-import type { WalletService } from '../../services/WalletService';
 import type { MintService } from '../../services/MintService';
-import type { EventBus } from '../../events/EventBus';
-import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
 import type {
   ExecutingMintOperation,
@@ -23,6 +18,7 @@ import type {
 import type { MintAdapter } from '../../infra/MintAdapter';
 import type { UnitAmount } from '../../amounts.ts';
 import type { MintQuote } from '../../models/MintQuote';
+import type { PreparedMintOperation } from './MintCommands.ts';
 
 type OptionalImportQuoteMetadata<T extends MintQuoteBaseResponse> = Omit<
   T,
@@ -125,12 +121,7 @@ export interface MintMethodMeta<M extends MintMethod = MintMethod> {
 }
 
 export interface BaseHandlerDeps {
-  proofRepository: ProofRepository;
-  proofService: ProofService;
-  walletService: WalletService;
-  mintService: MintService;
   mintAdapter: MintAdapter;
-  eventBus: EventBus<CoreEvents>;
   logger?: Logger;
 }
 
@@ -138,6 +129,7 @@ export interface CreateMintQuoteContext<M extends MintMethod = MintMethod> exten
   mintUrl: string;
   createQuoteData: MintMethodCreateQuoteData<M>;
   wallet: Wallet;
+  mintService: Pick<MintService, 'assertNutSupported'>;
 }
 
 export interface FetchRemoteMintQuoteContext<
@@ -146,9 +138,8 @@ export interface FetchRemoteMintQuoteContext<
   quote: MintQuote<M>;
 }
 
-export interface PrepareContext<M extends MintMethod = MintMethod> extends BaseHandlerDeps {
+export interface PrepareContext<M extends MintMethod = MintMethod> {
   operation: InitMintOperation<M>;
-  wallet: Wallet;
   importedQuote?: MintMethodQuoteSnapshot<M>;
 }
 
@@ -166,6 +157,8 @@ export interface RecoverExecutingContext<
     finalizedAmount: Amount;
     reservedAmount: Amount;
   };
+  /** Restore returns candidates only; the operation's settlement transaction persists them. */
+  restoreOutputs(): Promise<Proof[]>;
 }
 
 export interface PendingContext<M extends MintMethod = MintMethod> {
@@ -188,7 +181,7 @@ export type MintExecutionResult =
     };
 
 export type RecoverExecutingResult =
-  | { status: 'FINALIZED' }
+  | { status: 'FINALIZED'; proofs: Proof[] }
   | { status: 'TERMINAL'; error: string }
   | { status: 'PENDING'; error?: string };
 
@@ -225,7 +218,7 @@ export interface MintMethodHandler<M extends MintMethod = MintMethod> {
   createQuote(ctx: CreateMintQuoteContext<M>): Promise<MintQuote<M>>;
   fetchRemoteQuote(ctx: FetchRemoteMintQuoteContext<M>): Promise<MintQuote<M>>;
   validateQuoteForPrepare?(quote: MintQuote<M>): Promise<void> | void;
-  prepare(ctx: PrepareContext<M>): Promise<PendingMintOperation<M>>;
+  prepare(ctx: PrepareContext<M>): Promise<PreparedMintOperation<M>>;
   execute(ctx: ExecuteContext<M>): Promise<MintExecutionResult>;
   recoverExecuting(ctx: RecoverExecutingContext<M>): Promise<RecoverExecutingResult>;
   checkPending(ctx: PendingContext<M>): Promise<PendingMintObservationResult<M>>;

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1,14 +1,25 @@
 import { Amount, type Proof } from '@cashu/cashu-ts';
-import type { MintOperationRepository, ProofRepository } from '../../repositories';
+import type { MintCommit, MintQuoteCommit, SettleMintInput } from './MintCommands.ts';
+import { mintLocalClaimabilityFacts } from './MintLocalClaimability.ts';
+import type { MintRemote } from './MintRemote.ts';
+import type {
+  MintOperationQueries,
+  MintProofQueries,
+  MintQuoteQueries,
+} from '../../queries/MintOperationQueries.ts';
+import type { MintTransactions } from '../../transactions/mint/MintTransactions.ts';
+import {
+  mintQuoteObservationFromBolt11Response,
+  mintQuoteObservationFromBolt12Response,
+  mintQuoteObservationFromOnchainResponse,
+} from '../../models/MintQuoteObservationFactory.ts';
 import type {
   ExecutingMintOperation,
   FailedMintOperation,
-  FinalizedMintOperation,
   InitMintOperation,
   MintOperation,
   PendingMintOperation,
   PendingOrLaterOperation,
-  TerminalMintOperation,
 } from './MintOperation';
 import {
   createMintOperation,
@@ -18,25 +29,18 @@ import {
 } from './MintOperation';
 import type {
   MintMethod,
-  MintMethodData,
-  MintMethodMeta,
   PendingMintCheckResult,
+  MintMethodQuoteSnapshot,
 } from './MintMethodHandler';
-import type { MintService } from '../../services/MintService';
-import type { WalletService } from '../../services/WalletService';
-import type { ProofService } from '../../services/ProofService';
 import type { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Logger } from '../../logging/Logger';
-import { generateSubId, mapProofToCoreProof, normalizeMintUrl } from '../../utils';
+import { generateSubId, normalizeMintUrl } from '../../utils';
 import {
   OperationInProgressError,
   ProofValidationError,
   UnknownMintError,
 } from '../../models/Error';
-import { normalizeUnitAmount, type UnitAmount } from '../../amounts.ts';
-import type { MintAdapter } from '../../infra';
-import type { MintHandlerProvider } from '../../infra/handlers/mint';
 import { MintScopedLock } from '../MintScopedLock';
 import { OperationIdLock } from '../OperationIdLock';
 import { getMintQuoteAmount, type MintQuote } from '../../models/MintQuote';
@@ -45,67 +49,30 @@ import {
   type MintQuoteClaimabilityAssessment,
 } from '../../models/MintQuoteClaimability.ts';
 import type { MintQuoteRef } from '../../models/QuoteIdentity';
-import type { QuoteLifecycle } from '../../quotes/QuoteLifecycle';
 
 export interface ClaimMintQuoteOptions {
   autoClaimRemaining?: boolean;
 }
 
-/**
- * MintOperationService orchestrates mint quote redemption as a crash-safe saga.
- */
-export class MintOperationService {
-  private readonly handlerProvider: MintHandlerProvider;
-  private readonly mintOperationRepository: MintOperationRepository;
-  private readonly quoteLifecycle: QuoteLifecycle;
-  private readonly proofRepository: ProofRepository;
-  private readonly proofService: ProofService;
-  private readonly mintService: MintService;
-  private readonly walletService: WalletService;
-  private readonly mintAdapter: MintAdapter;
-  private readonly eventBus: EventBus<CoreEvents>;
-  private readonly logger?: Logger;
+export interface MintOperationDependencies {
+  operations: MintOperationQueries;
+  proofs: MintProofQueries;
+  quotes: MintQuoteQueries;
+  remote: MintRemote;
+  transactions: MintTransactions;
+  events: Pick<EventBus<CoreEvents>, 'emit'>;
+  logger?: Logger;
+  mintScopedLock?: MintScopedLock;
+}
 
+/** Coordinates the existing method-specific saga through committed Mint commands. */
+export class MintOperationService {
   private readonly operationIdLock = new OperationIdLock();
   private recoveryLock: Promise<void> | null = null;
   private readonly mintScopedLock: MintScopedLock;
 
-  constructor(
-    handlerProvider: MintHandlerProvider,
-    mintOperationRepository: MintOperationRepository,
-    quoteLifecycle: QuoteLifecycle,
-    proofRepository: ProofRepository,
-    proofService: ProofService,
-    mintService: MintService,
-    walletService: WalletService,
-    mintAdapter: MintAdapter,
-    eventBus: EventBus<CoreEvents>,
-    logger?: Logger,
-    mintScopedLock?: MintScopedLock,
-  ) {
-    this.handlerProvider = handlerProvider;
-    this.mintOperationRepository = mintOperationRepository;
-    this.quoteLifecycle = quoteLifecycle;
-    this.proofRepository = proofRepository;
-    this.proofService = proofService;
-    this.mintService = mintService;
-    this.walletService = walletService;
-    this.mintAdapter = mintAdapter;
-    this.eventBus = eventBus;
-    this.logger = logger;
-    this.mintScopedLock = mintScopedLock ?? new MintScopedLock();
-  }
-
-  private buildDeps() {
-    return {
-      proofRepository: this.proofRepository,
-      proofService: this.proofService,
-      walletService: this.walletService,
-      mintService: this.mintService,
-      mintAdapter: this.mintAdapter,
-      eventBus: this.eventBus,
-      logger: this.logger,
-    };
+  constructor(private readonly deps: MintOperationDependencies) {
+    this.mintScopedLock = deps.mintScopedLock ?? new MintScopedLock();
   }
 
   private async acquireOperationLock(operationId: string): Promise<() => void> {
@@ -133,209 +100,47 @@ export class MintOperationService {
     return this.recoveryLock !== null;
   }
 
-  private async createInitOperation(
-    mintUrl: string,
-    intent: UnitAmount,
-    method: MintMethod,
-    methodData: MintMethodData,
-    options: { quoteId: string },
-  ): Promise<InitMintOperation> {
-    const parsed = normalizeUnitAmount(intent);
-    const trusted = await this.mintService.isTrustedMint(mintUrl);
-    if (!trusted) {
-      throw new UnknownMintError(`Mint ${mintUrl} is not trusted`);
-    }
-
-    if (parsed.amount.isZero()) {
-      throw new ProofValidationError('Amount must be a positive number');
-    }
-
-    const operationId = generateSubId();
-    const releaseMintLock = await this.mintScopedLock.acquire(normalizeMintUrl(mintUrl));
-    try {
-      const quote = await this.resolveMintQuoteForOperationCreation(
-        mintUrl,
-        method,
-        options.quoteId,
-        parsed,
-      );
-      const operation = createMintOperation(
-        operationId,
-        quote.mintUrl,
-        {
-          method,
-          methodData,
-        } as MintMethodMeta,
-        parsed,
-        { quoteId: quote.quoteId },
-      );
-
-      await this.mintOperationRepository.create(operation);
-      this.logger?.debug('Mint operation created', {
-        operationId,
-        mintUrl: operation.mintUrl,
-        quoteId: operation.quoteId,
-        method,
-        amount: parsed.amount,
-        unit: parsed.unit,
-      });
-
-      return operation;
-    } finally {
-      releaseMintLock();
-    }
-  }
-
-  private async resolveMintQuoteForOperationCreation(
-    mintUrl: string,
-    method: MintMethod,
-    quoteId: string,
-    intent: UnitAmount,
-  ): Promise<MintQuote> {
-    const quote = await this.quoteLifecycle.getMintQuote(mintUrl, method, quoteId);
-    if (!quote) {
-      throw new Error(`Mint quote ${quoteId} for ${method} at ${mintUrl} was not found`);
-    }
-
-    const fixedAmount = getMintQuoteAmount(quote);
-    if (fixedAmount && !fixedAmount.equals(intent.amount)) {
-      throw new Error(
-        `Mint quote ${quote.quoteId} amount ${fixedAmount} does not match requested amount ${intent.amount}`,
-      );
-    }
-    if (quote.unit !== intent.unit) {
-      throw new Error(
-        `Mint quote ${quote.quoteId} unit ${quote.unit} does not match requested unit ${intent.unit}`,
-      );
-    }
-
-    if (fixedAmount) {
-      const existing = await this.getOperationByQuote(quote.mintUrl, method, quote.quoteId);
-      if (existing) {
-        throw new Error(
-          `Mint quote ${quote.quoteId} is already tracked by operation ${existing.id} in state ${existing.state}`,
-        );
-      }
-    }
-
-    return quote;
-  }
-
   async prepare(quoteRef: MintQuoteRef, requestedAmount: Amount): Promise<PendingMintOperation> {
-    const quote = await this.quoteLifecycle.requireMintQuoteRefForPrepare(quoteRef);
+    const quote = await this.deps.quotes.requireMintQuoteRefForPrepare(quoteRef);
     const amount = Amount.from(requestedAmount);
-
+    if (amount.isZero()) throw new ProofValidationError('Amount must be a positive number');
+    if (!(await this.deps.remote.isTrusted(quote.mintUrl)))
+      throw new UnknownMintError(`Mint ${quote.mintUrl} is not trusted`);
     const fixedAmount = getMintQuoteAmount(quote);
     if (fixedAmount && !fixedAmount.equals(amount)) {
       throw new Error(
         `Mint quote ${quote.quoteId} amount ${fixedAmount} does not match requested amount ${amount}`,
       );
     }
-
-    const handler = this.handlerProvider.get(quote.method);
-    await handler.validateQuoteForPrepare?.(quote as any);
-
-    const initOperation = await this.createInitOperation(
-      quote.mintUrl,
-      { amount, unit: quote.unit },
-      quote.method,
-      {} as MintMethodData,
-      { quoteId: quote.quoteId },
-    );
-
-    return this.prepareInitOperation(initOperation.id);
-  }
-
-  private async prepareInitOperation(
-    operationId: string,
-    options?: {
-      skipMintLock?: boolean;
-    },
-  ): Promise<PendingMintOperation> {
-    const releaseLock = await this.acquireOperationLock(operationId);
-    let releaseMintLock: (() => void) | null = null;
-    let initOp: InitMintOperation | null = null;
-    let failure: unknown;
+    const releaseMintLock = await this.mintScopedLock.acquire(quote.mintUrl);
     try {
-      const operation = await this.mintOperationRepository.getById(operationId);
-      if (!operation || operation.state !== 'init') {
-        throw new Error(
-          `Cannot prepare operation ${operationId}: expected state 'init' but found '${
-            operation?.state ?? 'not found'
-          }'`,
-        );
+      if (fixedAmount) {
+        const existing = await this.getOperationByQuote(quote.mintUrl, quote.method, quote.quoteId);
+        if (existing)
+          throw new Error(
+            `Mint quote ${quote.quoteId} is already tracked by operation ${existing.id} in state ${existing.state}`,
+          );
       }
-
-      initOp = operation as InitMintOperation;
-      if (!options?.skipMintLock) {
-        releaseMintLock = await this.mintScopedLock.acquire(initOp.mintUrl);
-      }
-      try {
-        const importedQuote = await this.quoteLifecycle.loadMintQuoteSnapshotForOperation(initOp);
-        const handler = this.handlerProvider.get(initOp.method);
-        await this.mintService.assertMethodUnitSupported(
-          initOp.mintUrl,
-          4,
-          initOp.method,
-          initOp.method === 'onchain'
-            ? initOp.unit
-            : {
-                amount: initOp.amount,
-                unit: initOp.unit,
-              },
-        );
-        const { wallet } = await this.walletService.getWalletWithActiveKeysetId(
-          initOp.mintUrl,
-          initOp.unit,
-        );
-        const pending = await handler.prepare({
-          ...this.buildDeps(),
-          operation: initOp as any,
-          wallet,
-          importedQuote: importedQuote as any,
-        });
-
-        const pendingOp: PendingMintOperation = {
-          ...pending,
-          state: 'pending',
-          updatedAt: Date.now(),
-        };
-
-        await this.mintOperationRepository.update(pendingOp);
-        await this.eventBus.emit('mint-op:pending', {
-          mintUrl: pendingOp.mintUrl,
-          operationId: pendingOp.id,
-          operation: pendingOp,
-        });
-
-        this.logger?.info('Mint operation is pending', {
-          operationId: pendingOp.id,
-          mintUrl: pendingOp.mintUrl,
-          quoteId: pendingOp.quoteId,
-          method: pendingOp.method,
-        });
-
-        return pendingOp;
-      } catch (e) {
-        failure = e;
-      } finally {
-        releaseMintLock?.();
-      }
+      const operation = createMintOperation(
+        generateSubId(),
+        quote.mintUrl,
+        { method: quote.method, methodData: {} },
+        { amount, unit: quote.unit },
+        { quoteId: quote.quoteId },
+      );
+      const input = await this.deps.remote.prepare(operation, quote);
+      const prepared = await this.deps.transactions.prepare(input);
+      await this.emit('counter:updated', prepared.counter);
+      await this.publish({ operation: prepared.operation, changed: true, proofs: [] });
+      return prepared.operation;
     } finally {
-      releaseLock();
+      releaseMintLock();
     }
-    if (failure) {
-      if (initOp) {
-        await this.tryRecoverInitOperation(initOp);
-      }
-      throw failure;
-    }
-    throw new Error(`Failed to prepare operation ${operationId}`);
   }
 
   async execute(operationId: string): Promise<MintOperation> {
     while (true) {
-      const operation = await this.mintOperationRepository.getById(operationId);
+      const operation = await this.deps.operations.getById(operationId);
       if (!operation) {
         throw new Error(`Operation ${operationId} not found`);
       }
@@ -360,7 +165,7 @@ export class MintOperationService {
           await this.operationIdLock.waitForUnlock(operationId);
         }
 
-        const recovered = await this.mintOperationRepository.getById(operationId);
+        const recovered = await this.deps.operations.getById(operationId);
         if (recovered?.state === 'executing') {
           throw new Error(`Operation ${operationId} remains executing after recovery`);
         }
@@ -373,7 +178,7 @@ export class MintOperationService {
         );
       }
 
-      const quote = await this.quoteLifecycle.getMintQuote(
+      const quote = await this.deps.quotes.getMintQuote(
         operation.mintUrl,
         operation.method,
         operation.quoteId,
@@ -386,10 +191,10 @@ export class MintOperationService {
     }
   }
 
-  private async executeReadyOperation(operationId: string): Promise<TerminalMintOperation> {
+  private async executeReadyOperation(operationId: string): Promise<MintOperation> {
     const releaseLock = await this.acquireOperationLockAfterWait(operationId);
     try {
-      const operation = await this.mintOperationRepository.getById(operationId);
+      const operation = await this.deps.operations.getById(operationId);
       if (operation && isTerminalOperation(operation)) {
         return operation;
       }
@@ -400,67 +205,42 @@ export class MintOperationService {
           }'`,
         );
       }
-      if (!(await this.mintService.isTrustedMint(operation.mintUrl))) {
+      if (!(await this.deps.remote.isTrusted(operation.mintUrl))) {
         throw new UnknownMintError(`Mint ${operation.mintUrl} is not trusted`);
       }
 
-      const pendingOp = operation as PendingMintOperation;
-      const executing: ExecutingMintOperation = {
-        ...pendingOp,
-        state: 'executing',
-        updatedAt: Date.now(),
-        error: undefined,
-      };
-      await this.mintOperationRepository.update(executing);
-
-      await this.eventBus.emit('mint-op:executing', {
-        mintUrl: executing.mintUrl,
-        operationId: executing.id,
-        operation: executing,
+      const authorized = await this.deps.transactions.authorize({
+        operationId,
+        timestamp: Date.now(),
       });
+      await this.publish(authorized);
+      if (!authorized.changed || authorized.operation.state !== 'executing')
+        return authorized.operation;
+      const executing = authorized.operation;
 
       try {
-        const handler = this.handlerProvider.get(executing.method);
-        const { wallet } = await this.walletService.getWalletWithActiveKeysetId(
-          executing.mintUrl,
-          executing.unit,
-        );
-        const result = await handler.execute({
-          ...this.buildDeps(),
-          operation: executing as any,
-          wallet,
-        });
+        const result = await this.deps.remote.execute(executing);
 
         switch (result.status) {
-          case 'ISSUED':
-            if (!(await this.ensureOutputsSaved(executing, result.proofs))) {
+          case 'ISSUED': {
+            const resultCommit = await this.settleIssuedOperation(
+              executing,
+              result.proofs,
+              'issued',
+            );
+            if (resultCommit.state === 'executing')
               throw new Error(`Failed to persist output proofs for operation ${executing.id}`);
-            }
-            return await this.finalizeIssuedOperation(executing);
-          case 'ALREADY_ISSUED': {
-            //CODEX: Where does recovery actually happen?
-            const proofsRecovered = await this.ensureOutputsSaved(executing);
-            const error = proofsRecovered
-              ? undefined
-              : `Recovered issued quote ${executing.quoteId} but no proofs could be restored`;
-
-            if (error) {
-              this.logger?.warn('Mint quote was already issued but proofs could not be recovered', {
-                operationId: executing.id,
-                mintUrl: executing.mintUrl,
-                quoteId: executing.quoteId,
-              });
-            }
-
-            return await this.finalizeIssuedOperation(executing, error);
+            return resultCommit;
           }
+          case 'ALREADY_ISSUED':
+            return await this.settleIssuedOperation(executing, [], 'already-issued');
           case 'FAILED':
             throw new Error(result.error ?? 'Mint execution failed');
         }
       } catch (e) {
         await this.tryRecoverExecutingOperation(executing);
 
-        const current = await this.mintOperationRepository.getById(operationId);
+        const current = await this.deps.operations.getById(operationId);
         if (current && isTerminalOperation(current)) {
           return current;
         }
@@ -473,13 +253,13 @@ export class MintOperationService {
   }
 
   async finalize(operationId: string): Promise<MintOperation> {
-    const operation = await this.mintOperationRepository.getById(operationId);
+    const operation = await this.deps.operations.getById(operationId);
     if (!operation) {
       throw new Error(`Operation ${operationId} not found`);
     }
 
     if (isTerminalOperation(operation)) {
-      this.logger?.debug('Operation already finalized', { operationId });
+      this.deps.logger?.debug('Operation already finalized', { operationId });
       return operation;
     }
 
@@ -489,7 +269,7 @@ export class MintOperationService {
 
     if (operation.state === 'executing') {
       await this.recoverExecutingOperation(operation as ExecutingMintOperation);
-      const updated = await this.mintOperationRepository.getById(operationId);
+      const updated = await this.deps.operations.getById(operationId);
       if (updated && isTerminalOperation(updated)) {
         return updated;
       }
@@ -521,66 +301,66 @@ export class MintOperationService {
       let pendingCount = 0;
       let executingCount = 0;
 
-      const initOps = await this.mintOperationRepository.getByState('init');
+      const initOps = await this.deps.operations.getByState('init');
       for (const op of initOps) {
         try {
           await this.recoverInitOperation(op as InitMintOperation);
           initCount++;
         } catch (e) {
           if (e instanceof OperationInProgressError) {
-            this.logger?.debug('Mint init operation in progress, skipping recovery', {
+            this.deps.logger?.debug('Mint init operation in progress, skipping recovery', {
               operationId: op.id,
             });
             continue;
           }
-          this.logger?.warn('Failed to recover mint init operation', {
+          this.deps.logger?.warn('Failed to recover mint init operation', {
             operationId: op.id,
             error: e instanceof Error ? e.message : String(e),
           });
         }
       }
 
-      const pendingOps = await this.mintOperationRepository.getByState('pending');
+      const pendingOps = await this.deps.operations.getByState('pending');
       for (const op of pendingOps) {
         try {
-          if (await this.mintService.isTrustedMint(op.mintUrl)) {
+          if (await this.deps.remote.isTrusted(op.mintUrl)) {
             await this.checkPendingOperation(op.id);
             pendingCount++;
           } else {
-            this.logger?.warn('Skipping recovery of pending operation for untrusted mint', {
+            this.deps.logger?.warn('Skipping recovery of pending operation for untrusted mint', {
               operationId: op.id,
               mintUrl: op.mintUrl,
             });
           }
         } catch (e) {
-          this.logger?.warn('Failed to reconcile stale pending mint operation', {
+          this.deps.logger?.warn('Failed to reconcile stale pending mint operation', {
             operationId: op.id,
             error: e instanceof Error ? e.message : String(e),
           });
         }
       }
 
-      const executingOps = await this.mintOperationRepository.getByState('executing');
+      const executingOps = await this.deps.operations.getByState('executing');
       for (const op of executingOps) {
         try {
           await this.recoverExecutingOperation(op as ExecutingMintOperation);
           executingCount++;
         } catch (e) {
           if (e instanceof OperationInProgressError) {
-            this.logger?.debug('Mint executing operation in progress, skipping recovery', {
+            this.deps.logger?.debug('Mint executing operation in progress, skipping recovery', {
               operationId: op.id,
             });
             continue;
           }
 
-          this.logger?.error('Error recovering executing mint operation', {
+          this.deps.logger?.error('Error recovering executing mint operation', {
             operationId: op.id,
             error: e instanceof Error ? e.message : String(e),
           });
         }
       }
 
-      this.logger?.info('Mint operation recovery completed', {
+      this.deps.logger?.info('Mint operation recovery completed', {
         initOperations: initCount,
         pendingOperations: pendingCount,
         executingOperations: executingCount,
@@ -597,9 +377,9 @@ export class MintOperationService {
   ): Promise<void> {
     const releaseLock = options?.skipLock ? undefined : await this.acquireOperationLock(op.id);
     try {
-      const current = await this.mintOperationRepository.getById(op.id);
+      const current = await this.deps.operations.getById(op.id);
       if (!current) {
-        this.logger?.warn('Mint operation missing during recovery', { operationId: op.id });
+        this.deps.logger?.warn('Mint operation missing during recovery', { operationId: op.id });
         return;
       }
 
@@ -608,7 +388,7 @@ export class MintOperationService {
       }
 
       if (current.state !== 'executing') {
-        this.logger?.debug('Mint operation not executing during recovery', {
+        this.deps.logger?.debug('Mint operation not executing during recovery', {
           operationId: current.id,
           state: current.state,
         });
@@ -618,51 +398,40 @@ export class MintOperationService {
       const executing = current as ExecutingMintOperation;
 
       if (await this.hasSavedOutputs(executing)) {
-        await this.finalizeIssuedOperation(executing);
+        await this.settleIssuedOperation(executing, [], 'recovered');
         return;
       }
 
-      if (!(await this.mintService.isTrustedMint(executing.mintUrl))) {
-        this.logger?.warn('Mint is not trusted, skipping recovery of executing mint operation', {
-          operationId: executing.id,
-          mintUrl: executing.mintUrl,
-          quoteId: executing.quoteId,
-        });
+      if (!(await this.deps.remote.isTrusted(executing.mintUrl))) {
+        this.deps.logger?.warn(
+          'Mint is not trusted, skipping recovery of executing mint operation',
+          {
+            operationId: executing.id,
+            mintUrl: executing.mintUrl,
+            quoteId: executing.quoteId,
+          },
+        );
         return;
       }
 
-      const handler = this.handlerProvider.get(executing.method);
-      const { wallet } = await this.walletService.getWalletWithActiveKeysetId(
-        executing.mintUrl,
-        executing.unit,
-      );
-      const siblings = await this.mintOperationRepository.getByQuoteId(
+      const siblings = await this.deps.operations.getByQuoteId(
         executing.mintUrl,
         executing.method,
         executing.quoteId,
       );
-      const result = await handler.recoverExecuting({
-        ...this.buildDeps(),
-        operation: executing as any,
-        wallet,
-        localClaimabilityFacts: this.getLocalClaimabilityFacts(siblings, executing.id),
-      });
+      const result = await this.deps.remote.recoverExecuting(
+        executing,
+        mintLocalClaimabilityFacts(siblings, executing.id),
+      );
 
       switch (result.status) {
         case 'FINALIZED': {
-          if (await this.ensureOutputsSaved(executing)) {
-            await this.finalizeIssuedOperation(executing);
-          } else {
-            await this.transitionToPending(
-              executing,
-              `Recovered issued quote ${executing.quoteId} but no proofs could be restored`,
-            );
-          }
+          await this.settleIssuedOperation(executing, result.proofs, 'recovered');
           break;
         }
         case 'PENDING': {
           await this.transitionToPending(executing, result.error);
-          this.logger?.warn('Mint operation returned to pending after recovery', {
+          this.deps.logger?.warn('Mint operation returned to pending after recovery', {
             operationId: executing.id,
             mintUrl: executing.mintUrl,
             quoteId: executing.quoteId,
@@ -672,7 +441,7 @@ export class MintOperationService {
         }
         case 'TERMINAL': {
           await this.failOperation(executing, result.error);
-          this.logger?.warn('Mint operation moved to failed during recovery', {
+          this.deps.logger?.warn('Mint operation moved to failed during recovery', {
             operationId: executing.id,
             mintUrl: executing.mintUrl,
             quoteId: executing.quoteId,
@@ -689,7 +458,7 @@ export class MintOperationService {
   }
 
   async getOperation(operationId: string): Promise<MintOperation | null> {
-    return this.mintOperationRepository.getById(operationId);
+    return this.deps.operations.getById(operationId);
   }
 
   async getOperationByQuote(
@@ -730,11 +499,11 @@ export class MintOperationService {
     method: MintMethod,
     quoteId: string,
   ): Promise<MintOperation[]> {
-    return this.mintOperationRepository.getByQuoteId(mintUrl, method, quoteId);
+    return this.deps.operations.getByQuoteId(mintUrl, method, quoteId);
   }
 
   async listOperationsByQuote(mintUrl: string, quoteId: string): Promise<MintOperation[]> {
-    const operations = await this.mintOperationRepository.getByMintUrl(normalizeMintUrl(mintUrl));
+    const operations = await this.deps.operations.getByMintUrl(normalizeMintUrl(mintUrl));
     return operations
       .filter((operation) => operation.quoteId === quoteId)
       .sort((a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id));
@@ -750,13 +519,13 @@ export class MintOperationService {
       this.quoteLockKey(mintUrl, method, quoteId),
     );
     try {
-      const quote = await this.quoteLifecycle.getMintQuote(mintUrl, method, quoteId);
+      const quote = await this.deps.quotes.getMintQuote(mintUrl, method, quoteId);
       if (!quote) {
         throw new Error(
           `Cannot claim mint quote ${quoteId}: quote for ${method} at ${mintUrl} was not found`,
         );
       }
-      const siblings = await this.mintOperationRepository.getByQuoteId(mintUrl, method, quoteId);
+      const siblings = await this.deps.operations.getByQuoteId(mintUrl, method, quoteId);
       const assessment = this.assessQuoteClaimability(quote, siblings);
       const claimable = assessment.claimAmount ?? Amount.zero();
       if (assessment.status === 'complete') {
@@ -797,12 +566,8 @@ export class MintOperationService {
       const remaining = claimable.subtract(selectedAmount);
       if (autoClaimRemaining && !remaining.isZero()) {
         const refreshedQuote =
-          (await this.quoteLifecycle.getMintQuote(mintUrl, method, quoteId)) ?? quote;
-        const refreshedSiblings = await this.mintOperationRepository.getByQuoteId(
-          mintUrl,
-          method,
-          quoteId,
-        );
+          (await this.deps.quotes.getMintQuote(mintUrl, method, quoteId)) ?? quote;
+        const refreshedSiblings = await this.deps.operations.getByQuoteId(mintUrl, method, quoteId);
         const currentAssessment = this.assessQuoteClaimability(refreshedQuote, refreshedSiblings);
         if (currentAssessment.status === 'claimable' && currentAssessment.claimAmount) {
           const autoClaimAmount = remaining.lessThan(currentAssessment.claimAmount)
@@ -823,12 +588,12 @@ export class MintOperationService {
   }
 
   async claimPendingMintQuotes(options: ClaimMintQuoteOptions = {}): Promise<MintOperation[]> {
-    const quotes = await this.quoteLifecycle.getPendingMintQuotes();
+    const quotes = await this.deps.quotes.getPendingMintQuotes();
     const claimed: MintOperation[] = [];
 
     for (const quote of quotes) {
-      if (!(await this.mintService.isTrustedMint(quote.mintUrl))) {
-        this.logger?.debug('Skipping pending mint quote for untrusted mint', {
+      if (!(await this.deps.remote.isTrusted(quote.mintUrl))) {
+        this.deps.logger?.debug('Skipping pending mint quote for untrusted mint', {
           mintUrl: quote.mintUrl,
           method: quote.method,
         });
@@ -849,12 +614,12 @@ export class MintOperationService {
     quoteId: string,
     options: { requestedAmount?: Amount; targetOperationId?: string } = {},
   ): Promise<MintQuoteClaimabilityAssessment | undefined> {
-    const quote = await this.quoteLifecycle.getMintQuote(mintUrl, method, quoteId);
+    const quote = await this.deps.quotes.getMintQuote(mintUrl, method, quoteId);
     if (!quote) {
       return undefined;
     }
 
-    const siblings = await this.mintOperationRepository.getByQuoteId(mintUrl, method, quoteId);
+    const siblings = await this.deps.operations.getByQuoteId(mintUrl, method, quoteId);
     return this.assessQuoteClaimability(quote, siblings, options);
   }
 
@@ -866,7 +631,7 @@ export class MintOperationService {
       this.quoteLockKey(operation.mintUrl, operation.method, operation.quoteId),
     );
     try {
-      const current = await this.mintOperationRepository.getById(operation.id);
+      const current = await this.deps.operations.getById(operation.id);
       if (!current || current.state !== 'pending') {
         if (current) return current;
         throw new Error(`Operation ${operation.id} not found`);
@@ -874,13 +639,10 @@ export class MintOperationService {
 
       const pending = current as PendingMintOperation;
       const quote =
-        (await this.quoteLifecycle.getMintQuote(
-          pending.mintUrl,
-          pending.method,
-          pending.quoteId,
-        )) ?? initialQuote;
+        (await this.deps.quotes.getMintQuote(pending.mintUrl, pending.method, pending.quoteId)) ??
+        initialQuote;
 
-      const siblings = await this.mintOperationRepository.getByQuoteId(
+      const siblings = await this.deps.operations.getByQuoteId(
         pending.mintUrl,
         pending.method,
         pending.quoteId,
@@ -893,7 +655,7 @@ export class MintOperationService {
         throw new Error(`Mint quote ${pending.quoteId} has invalid claimability accounting`);
       }
       if (assessment.status === 'waiting') {
-        this.logger?.info('Mint quote is not sufficiently funded for operation', {
+        this.deps.logger?.info('Mint quote is not sufficiently funded for operation', {
           operationId: pending.id,
           mintUrl: pending.mintUrl,
           quoteId: pending.quoteId,
@@ -913,15 +675,7 @@ export class MintOperationService {
     quote: MintQuote,
     amount: Amount,
   ): Promise<PendingMintOperation> {
-    const initOperation = await this.createInitOperation(
-      quote.mintUrl,
-      { amount, unit: quote.unit },
-      quote.method,
-      {},
-      { quoteId: quote.quoteId },
-    );
-
-    return this.prepareInitOperation(initOperation.id);
+    return this.prepare(quote, amount);
   }
 
   private assessQuoteClaimability(
@@ -929,7 +683,7 @@ export class MintOperationService {
     siblings: MintOperation[],
     options: { requestedAmount?: Amount; targetOperationId?: string } = {},
   ): MintQuoteClaimabilityAssessment {
-    const localFacts = this.getLocalClaimabilityFacts(siblings, options.targetOperationId);
+    const localFacts = mintLocalClaimabilityFacts(siblings, options.targetOperationId);
 
     return assessMintQuoteClaimability(quote, {
       ...localFacts,
@@ -937,237 +691,89 @@ export class MintOperationService {
     });
   }
 
-  private getLocalClaimabilityFacts(
-    siblings: MintOperation[],
-    targetOperationId?: string,
-  ): { finalizedAmount: Amount; reservedAmount: Amount } {
-    const finalizedAmount = siblings.reduce(
-      (total, operation) => (operation.state === 'finalized' ? total.add(operation.amount) : total),
-      Amount.zero(),
-    );
-    const locallyReserved = siblings.reduce((total, operation) => {
-      if (operation.state !== 'executing' || operation.id === targetOperationId) {
-        return total;
-      }
-
-      return total.add(operation.amount);
-    }, Amount.zero());
-
-    return {
-      finalizedAmount,
-      reservedAmount: locallyReserved,
-    };
-  }
-
   private quoteLockKey(mintUrl: string, method: MintMethod, quoteId: string): string {
     return `${mintUrl}::${method}::${quoteId}`;
   }
 
   async getInFlightOperations(): Promise<MintOperation[]> {
-    return this.mintOperationRepository.getPending();
+    return this.deps.operations.getPending();
   }
 
   private async recoverInitOperation(op: InitMintOperation): Promise<void> {
     const releaseLock = await this.acquireOperationLock(op.id);
     try {
-      const current = await this.mintOperationRepository.getById(op.id);
+      const current = await this.deps.operations.getById(op.id);
       if (!current || current.state !== 'init') {
         return;
       }
 
-      await this.mintOperationRepository.delete(op.id);
-      this.logger?.info('Cleaned up failed mint init operation', { operationId: op.id });
+      await this.deps.transactions.deleteInit(op.id);
+      this.deps.logger?.info('Cleaned up failed mint init operation', { operationId: op.id });
     } finally {
       releaseLock();
     }
   }
 
   async getPendingOperations(): Promise<PendingMintOperation[]> {
-    const ops = await this.mintOperationRepository.getByState('pending');
+    const ops = await this.deps.operations.getByState('pending');
     return ops.filter((op): op is PendingMintOperation => op.state === 'pending');
-  }
-
-  private async tryRecoverInitOperation(op: InitMintOperation): Promise<void> {
-    try {
-      await this.recoverInitOperation(op);
-      this.logger?.info('Recovered mint init operation after failure', { operationId: op.id });
-    } catch (recoveryError) {
-      this.logger?.warn('Failed to recover mint init operation, will retry on startup', {
-        operationId: op.id,
-        error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
-      });
-    }
   }
 
   private async tryRecoverExecutingOperation(op: ExecutingMintOperation): Promise<void> {
     try {
       await this.recoverExecutingOperation(op, { skipLock: true });
-      this.logger?.info('Recovered executing mint operation after failure', {
+      this.deps.logger?.info('Recovered executing mint operation after failure', {
         operationId: op.id,
       });
     } catch (recoveryError) {
-      this.logger?.warn('Failed to recover executing mint operation, will retry on startup', {
+      this.deps.logger?.warn('Failed to recover executing mint operation, will retry on startup', {
         operationId: op.id,
         error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
       });
     }
   }
 
-  private async ensureOutputsSaved(
-    op: ExecutingMintOperation,
-    proofsFromExecute?: Proof[],
-  ): Promise<boolean> {
-    if (await this.hasSavedOutputs(op)) {
-      return true;
+  private async settleIssuedOperation(
+    operation: ExecutingMintOperation,
+    candidates: Proof[],
+    outcome: SettleMintInput['outcome'],
+  ): Promise<MintOperation> {
+    let proofs = candidates;
+    if (!(await this.hasSavedOutputs(operation))) {
+      const secrets = new Set(candidates.map((proof) => proof.secret));
+      if (!getOutputProofSecrets(operation).every((secret) => secrets.has(secret))) {
+        proofs = [...proofs, ...(await this.deps.remote.restoreOutputs(operation))];
+      }
     }
-
-    if (proofsFromExecute && proofsFromExecute.length > 0) {
-      await this.proofService.saveProofs(
-        op.mintUrl,
-        mapProofToCoreProof(op.mintUrl, 'ready', proofsFromExecute, {
-          unit: op.unit,
-          createdByOperationId: op.id,
-        }),
-      );
-    }
-
-    if (await this.hasSavedOutputs(op)) {
-      return true;
-    }
-
-    await this.proofService.recoverProofsFromOutputData(op.mintUrl, op.outputData, {
-      unit: op.unit,
-      createdByOperationId: op.id,
+    const committed = await this.deps.transactions.settle({
+      operation,
+      proofs,
+      outcome,
+      timestamp: Date.now(),
     });
-
-    return this.hasSavedOutputs(op);
+    await this.publish(committed);
+    return committed.operation;
   }
 
-  private async finalizeIssuedOperation(
-    op: ExecutingMintOperation,
-    error?: string,
-  ): Promise<FinalizedMintOperation> {
-    const current = await this.mintOperationRepository.getById(op.id);
-    if (!current) {
-      throw new Error(`Operation ${op.id} not found`);
-    }
-
-    if (current.state === 'finalized') {
-      return current as FinalizedMintOperation;
-    }
-
-    if (current.state !== 'executing') {
-      throw new Error(`Cannot finalize operation ${op.id} in state ${current.state}`);
-    }
-
-    if (current.method === 'bolt11') {
-      await this.quoteLifecycle.recordMintQuoteObservation(
-        current as PendingOrLaterOperation,
-        'ISSUED',
-        Date.now(),
-      );
-    }
-
-    const finalized: FinalizedMintOperation = {
-      ...(current as PendingOrLaterOperation),
-      state: 'finalized',
-      updatedAt: Date.now(),
-      error,
-    };
-
-    await this.mintOperationRepository.update(finalized);
-
-    await this.eventBus.emit('mint-op:finalized', {
-      mintUrl: finalized.mintUrl,
-      operationId: finalized.id,
-      operation: finalized,
+  private async failOperation(operation: ExecutingMintOperation, error: string) {
+    const timestamp = Date.now();
+    const committed = await this.deps.transactions.fail({
+      operation,
+      failure: { reason: error, observedAt: timestamp },
+      timestamp,
     });
-
-    this.logger?.info('Mint operation finalized', {
-      operationId: finalized.id,
-      mintUrl: finalized.mintUrl,
-      quoteId: finalized.quoteId,
-    });
-
-    return finalized;
+    await this.publish(committed);
+    return committed.operation;
   }
 
-  private async failOperation(
-    op: ExecutingMintOperation,
-    error: string,
-  ): Promise<FailedMintOperation> {
-    const current = await this.mintOperationRepository.getById(op.id);
-    if (!current) {
-      throw new Error(`Operation ${op.id} not found`);
-    }
-
-    if (current.state === 'failed') {
-      return current as FailedMintOperation;
-    }
-
-    if (current.state === 'finalized') {
-      throw new Error(`Cannot fail operation ${op.id} in state ${current.state}`);
-    }
-
-    if (current.state !== 'executing') {
-      throw new Error(`Cannot fail operation ${op.id} in state ${current.state}`);
-    }
-
-    const failed: FailedMintOperation = {
-      ...(current as PendingOrLaterOperation),
-      state: 'failed',
-      updatedAt: Date.now(),
+  private async transitionToPending(operation: ExecutingMintOperation, error?: string) {
+    const committed = await this.deps.transactions.returnToPending({
+      operation,
       error,
-      terminalFailure: {
-        reason: error,
-        observedAt: Date.now(),
-      },
-    };
-
-    await this.mintOperationRepository.update(failed);
-
-    await this.eventBus.emit('mint-op:failed', {
-      mintUrl: failed.mintUrl,
-      operationId: failed.id,
-      operation: failed,
+      timestamp: Date.now(),
     });
-
-    this.logger?.info('Mint operation failed during recovery', {
-      operationId: failed.id,
-      mintUrl: failed.mintUrl,
-      quoteId: failed.quoteId,
-      error,
-    });
-
-    return failed;
-  }
-
-  private async transitionToPending(
-    op: ExecutingMintOperation,
-    error?: string,
-  ): Promise<PendingMintOperation> {
-    const pending: PendingMintOperation = {
-      ...op,
-      state: 'pending',
-      updatedAt: Date.now(),
-      error,
-    };
-
-    await this.mintOperationRepository.update(pending);
-    await this.eventBus.emit('mint-op:pending', {
-      mintUrl: op.mintUrl,
-      operationId: op.id,
-      operation: pending,
-    });
-
-    this.logger?.info('Mint operation moved to pending', {
-      operationId: op.id,
-      mintUrl: op.mintUrl,
-      quoteId: op.quoteId,
-      error,
-    });
-
-    return pending;
+    await this.publish(committed);
+    return committed.operation;
   }
 
   async observePendingOperation(operationId: string): Promise<PendingMintCheckResult> {
@@ -1179,21 +785,29 @@ export class MintOperationService {
         }'`,
       );
     }
-    const handler = this.handlerProvider.get(op.method);
-
-    const observation = await handler.checkPending({
-      operation: op as PendingMintOperation,
-      mintAdapter: this.mintAdapter,
-      logger: this.logger,
-    });
+    const observation = await this.deps.remote.observePending(op);
 
     let canonicalQuote: MintQuote | undefined;
     if (observation.quoteSnapshot) {
-      canonicalQuote = await this.quoteLifecycle.recordMintQuoteSnapshot(
-        op.mintUrl,
-        op.method,
-        observation.quoteSnapshot,
-      );
+      const snapshot = observation.quoteSnapshot;
+      const incoming =
+        op.method === 'bolt11'
+          ? mintQuoteObservationFromBolt11Response(
+              op.mintUrl,
+              snapshot as MintMethodQuoteSnapshot<'bolt11'>,
+            )
+          : op.method === 'bolt12'
+            ? mintQuoteObservationFromBolt12Response(
+                op.mintUrl,
+                snapshot as MintMethodQuoteSnapshot<'bolt12'>,
+              )
+            : mintQuoteObservationFromOnchainResponse(
+                op.mintUrl,
+                snapshot as MintMethodQuoteSnapshot<'onchain'>,
+              );
+      const committed = await this.deps.transactions.observeQuote(incoming);
+      canonicalQuote = committed.quote;
+      await this.publishQuote(committed);
     }
 
     let result: PendingMintCheckResult;
@@ -1208,11 +822,7 @@ export class MintOperationService {
       if (!canonicalQuote) {
         throw new Error(`Pending mint observation for operation ${op.id} has no quote snapshot`);
       }
-      const siblings = await this.mintOperationRepository.getByQuoteId(
-        op.mintUrl,
-        op.method,
-        op.quoteId,
-      );
+      const siblings = await this.deps.operations.getByQuoteId(op.mintUrl, op.method, op.quoteId);
       const assessment = this.assessQuoteClaimability(canonicalQuote, siblings, {
         requestedAmount: op.amount,
         targetOperationId: op.id,
@@ -1260,52 +870,18 @@ export class MintOperationService {
   private async failPendingOperation(
     op: PendingMintOperation,
     terminalFailure: FailedMintOperation['terminalFailure'],
-  ): Promise<FailedMintOperation> {
+  ): Promise<MintOperation> {
     if (!terminalFailure) {
       throw new Error(`Cannot fail pending operation ${op.id} without terminal failure details`);
     }
 
-    const current = await this.mintOperationRepository.getById(op.id);
-    if (!current) {
-      throw new Error(`Operation ${op.id} not found`);
-    }
-
-    if (current.state === 'failed') {
-      return current as FailedMintOperation;
-    }
-
-    if (current.state === 'finalized') {
-      throw new Error(`Cannot fail operation ${op.id} in state ${current.state}`);
-    }
-
-    if (current.state !== 'pending') {
-      throw new Error(`Cannot fail operation ${op.id} in state ${current.state}`);
-    }
-
-    const failed: FailedMintOperation = {
-      ...(current as PendingOrLaterOperation),
-      state: 'failed',
-      updatedAt: Date.now(),
-      error: terminalFailure.reason,
-      terminalFailure,
-    };
-
-    await this.mintOperationRepository.update(failed);
-
-    await this.eventBus.emit('mint-op:failed', {
-      mintUrl: failed.mintUrl,
-      operationId: failed.id,
-      operation: failed,
+    const committed = await this.deps.transactions.fail({
+      operation: op,
+      failure: terminalFailure,
+      timestamp: Date.now(),
     });
-
-    this.logger?.info('Mint operation failed while pending', {
-      operationId: failed.id,
-      mintUrl: failed.mintUrl,
-      quoteId: failed.quoteId,
-      error: terminalFailure.reason,
-    });
-
-    return failed;
+    await this.publish(committed);
+    return committed.operation;
   }
 
   private async hasSavedOutputs(op: PendingOrLaterOperation): Promise<boolean> {
@@ -1319,12 +895,58 @@ export class MintOperationService {
     }
 
     for (const secret of outputSecrets) {
-      const proof = await this.proofRepository.getProofBySecret(op.mintUrl, secret);
+      const proof = await this.deps.proofs.getProofBySecret(op.mintUrl, secret);
       if (!proof) {
         return false;
       }
     }
 
     return true;
+  }
+
+  private async emit<E extends keyof CoreEvents>(event: E, payload: CoreEvents[E]) {
+    try {
+      await this.deps.events.emit(event, payload);
+    } catch (error) {
+      this.deps.logger?.warn('Mint event listener failed after commit', { event, error });
+    }
+  }
+
+  private async publishQuote(commit: MintQuoteCommit) {
+    if (!commit.changed) return;
+    const { quote } = commit;
+    await this.emit('mint-quote:updated', {
+      mintUrl: quote.mintUrl,
+      method: quote.method,
+      quoteId: quote.quoteId,
+      quote,
+    });
+  }
+
+  private async publish(commit: MintCommit) {
+    const { operation, proofs } = commit;
+    for (const keysetId of new Set(proofs.map((proof) => proof.id)))
+      await this.emit('proofs:saved', {
+        mintUrl: operation.mintUrl,
+        keysetId,
+        proofs: proofs.filter((proof) => proof.id === keysetId),
+      });
+    if (commit.quote) await this.publishQuote(commit.quote);
+    if (!commit.changed || operation.state === 'init') return;
+    const payload = { mintUrl: operation.mintUrl, operationId: operation.id };
+    switch (operation.state) {
+      case 'pending':
+        await this.emit('mint-op:pending', { ...payload, operation });
+        break;
+      case 'executing':
+        await this.emit('mint-op:executing', { ...payload, operation });
+        break;
+      case 'finalized':
+        await this.emit('mint-op:finalized', { ...payload, operation });
+        break;
+      case 'failed':
+        await this.emit('mint-op:failed', { ...payload, operation });
+        break;
+    }
   }
 }

--- a/packages/core/operations/mint/MintOperationService.ts
+++ b/packages/core/operations/mint/MintOperationService.ts
@@ -1,3 +1,5 @@
+import type { MintQueries } from '../../mints/MintMetadata.ts';
+import type { MintService } from '../../services/MintService.ts';
 import { Amount, type Proof } from '@cashu/cashu-ts';
 import type { MintCommit, MintQuoteCommit, SettleMintInput } from './MintCommands.ts';
 import { mintLocalClaimabilityFacts } from './MintLocalClaimability.ts';
@@ -55,6 +57,9 @@ export interface ClaimMintQuoteOptions {
 }
 
 export interface MintOperationDependencies {
+  mintQueries: Pick<MintQueries, 'isTrustedMint'>;
+  mintMetadataRefresh: Pick<MintService, 'refreshAndCommitIfStale'>;
+  loadSeed(): Promise<Uint8Array>;
   operations: MintOperationQueries;
   proofs: MintProofQueries;
   quotes: MintQuoteQueries;
@@ -104,7 +109,7 @@ export class MintOperationService {
     const quote = await this.deps.quotes.requireMintQuoteRefForPrepare(quoteRef);
     const amount = Amount.from(requestedAmount);
     if (amount.isZero()) throw new ProofValidationError('Amount must be a positive number');
-    if (!(await this.deps.remote.isTrusted(quote.mintUrl)))
+    if (!(await this.deps.mintQueries.isTrustedMint(quote.mintUrl)))
       throw new UnknownMintError(`Mint ${quote.mintUrl} is not trusted`);
     const fixedAmount = getMintQuoteAmount(quote);
     if (fixedAmount && !fixedAmount.equals(amount)) {
@@ -128,7 +133,9 @@ export class MintOperationService {
         { amount, unit: quote.unit },
         { quoteId: quote.quoteId },
       );
-      const input = await this.deps.remote.prepare(operation, quote);
+      const metadata = await this.deps.mintMetadataRefresh.refreshAndCommitIfStale(quote.mintUrl);
+      const seed = await this.deps.loadSeed();
+      const input = await this.deps.remote.prepare(operation, quote, metadata, seed);
       const prepared = await this.deps.transactions.prepare(input);
       await this.emit('counter:updated', prepared.counter);
       await this.publish({ operation: prepared.operation, changed: true, proofs: [] });
@@ -205,10 +212,13 @@ export class MintOperationService {
           }'`,
         );
       }
-      if (!(await this.deps.remote.isTrusted(operation.mintUrl))) {
+      if (!(await this.deps.mintQueries.isTrustedMint(operation.mintUrl))) {
         throw new UnknownMintError(`Mint ${operation.mintUrl} is not trusted`);
       }
 
+      const metadata = await this.deps.mintMetadataRefresh.refreshAndCommitIfStale(
+        operation.mintUrl,
+      );
       const authorized = await this.deps.transactions.authorize({
         operationId,
         timestamp: Date.now(),
@@ -219,7 +229,7 @@ export class MintOperationService {
       const executing = authorized.operation;
 
       try {
-        const result = await this.deps.remote.execute(executing);
+        const result = await this.deps.remote.execute(executing, metadata);
 
         switch (result.status) {
           case 'ISSUED': {
@@ -323,7 +333,7 @@ export class MintOperationService {
       const pendingOps = await this.deps.operations.getByState('pending');
       for (const op of pendingOps) {
         try {
-          if (await this.deps.remote.isTrusted(op.mintUrl)) {
+          if (await this.deps.mintQueries.isTrustedMint(op.mintUrl)) {
             await this.checkPendingOperation(op.id);
             pendingCount++;
           } else {
@@ -402,7 +412,7 @@ export class MintOperationService {
         return;
       }
 
-      if (!(await this.deps.remote.isTrusted(executing.mintUrl))) {
+      if (!(await this.deps.mintQueries.isTrustedMint(executing.mintUrl))) {
         this.deps.logger?.warn(
           'Mint is not trusted, skipping recovery of executing mint operation',
           {
@@ -419,9 +429,13 @@ export class MintOperationService {
         executing.method,
         executing.quoteId,
       );
+      const metadata = await this.deps.mintMetadataRefresh.refreshAndCommitIfStale(
+        executing.mintUrl,
+      );
       const result = await this.deps.remote.recoverExecuting(
         executing,
         mintLocalClaimabilityFacts(siblings, executing.id),
+        metadata,
       );
 
       switch (result.status) {
@@ -592,7 +606,7 @@ export class MintOperationService {
     const claimed: MintOperation[] = [];
 
     for (const quote of quotes) {
-      if (!(await this.deps.remote.isTrusted(quote.mintUrl))) {
+      if (!(await this.deps.mintQueries.isTrustedMint(quote.mintUrl))) {
         this.deps.logger?.debug('Skipping pending mint quote for untrusted mint', {
           mintUrl: quote.mintUrl,
           method: quote.method,
@@ -742,7 +756,10 @@ export class MintOperationService {
     if (!(await this.hasSavedOutputs(operation))) {
       const secrets = new Set(candidates.map((proof) => proof.secret));
       if (!getOutputProofSecrets(operation).every((secret) => secrets.has(secret))) {
-        proofs = [...proofs, ...(await this.deps.remote.restoreOutputs(operation))];
+        const metadata = await this.deps.mintMetadataRefresh.refreshAndCommitIfStale(
+          operation.mintUrl,
+        );
+        proofs = [...proofs, ...(await this.deps.remote.restoreOutputs(operation, metadata))];
       }
     }
     const committed = await this.deps.transactions.settle({

--- a/packages/core/operations/mint/MintRemote.ts
+++ b/packages/core/operations/mint/MintRemote.ts
@@ -1,0 +1,27 @@
+import type { Amount, Proof } from '@cashu/cashu-ts';
+import type { MintQuote } from '../../models/MintQuote.ts';
+import type { PrepareMintInput } from './MintCommands.ts';
+import type {
+  MintExecutionResult,
+  PendingMintObservationResult,
+  RecoverExecutingResult,
+} from './MintMethodHandler.ts';
+import type {
+  ExecutingMintOperation,
+  InitMintOperation,
+  PendingMintOperation,
+  PendingOrLaterOperation,
+} from './MintOperation.ts';
+
+/** Method-specific preflight and remote effects; none of these methods persists Mint state. */
+export interface MintRemote {
+  isTrusted(mintUrl: string): Promise<boolean>;
+  prepare(operation: InitMintOperation, quote: MintQuote): Promise<PrepareMintInput>;
+  execute(operation: ExecutingMintOperation): Promise<MintExecutionResult>;
+  recoverExecuting(
+    operation: ExecutingMintOperation,
+    localClaimabilityFacts: { finalizedAmount: Amount; reservedAmount: Amount },
+  ): Promise<RecoverExecutingResult>;
+  observePending(operation: PendingMintOperation): Promise<PendingMintObservationResult>;
+  restoreOutputs(operation: PendingOrLaterOperation): Promise<Proof[]>;
+}

--- a/packages/core/operations/mint/MintRemote.ts
+++ b/packages/core/operations/mint/MintRemote.ts
@@ -1,3 +1,4 @@
+import type { MintMetadata } from '../../mints/MintMetadata.ts';
 import type { Amount, Proof } from '@cashu/cashu-ts';
 import type { MintQuote } from '../../models/MintQuote.ts';
 import type { PrepareMintInput } from './MintCommands.ts';
@@ -15,13 +16,18 @@ import type {
 
 /** Method-specific preflight and remote effects; none of these methods persists Mint state. */
 export interface MintRemote {
-  isTrusted(mintUrl: string): Promise<boolean>;
-  prepare(operation: InitMintOperation, quote: MintQuote): Promise<PrepareMintInput>;
-  execute(operation: ExecutingMintOperation): Promise<MintExecutionResult>;
+  prepare(
+    operation: InitMintOperation,
+    quote: MintQuote,
+    metadata: MintMetadata,
+    seed: Uint8Array,
+  ): Promise<PrepareMintInput>;
+  execute(operation: ExecutingMintOperation, metadata: MintMetadata): Promise<MintExecutionResult>;
   recoverExecuting(
     operation: ExecutingMintOperation,
     localClaimabilityFacts: { finalizedAmount: Amount; reservedAmount: Amount },
+    metadata: MintMetadata,
   ): Promise<RecoverExecutingResult>;
   observePending(operation: PendingMintOperation): Promise<PendingMintObservationResult>;
-  restoreOutputs(operation: PendingOrLaterOperation): Promise<Proof[]>;
+  restoreOutputs(operation: PendingOrLaterOperation, metadata: MintMetadata): Promise<Proof[]>;
 }

--- a/packages/core/proofs/KeysetSelection.ts
+++ b/packages/core/proofs/KeysetSelection.ts
@@ -1,0 +1,20 @@
+import { KeyChain, type KeyChainCache } from '@cashu/cashu-ts';
+import type { Keyset } from '@core/models/Keyset.ts';
+
+/** The same fee and selection model is used during preflight and authoritative reservation. */
+export function createKeyChain(
+  mintUrl: string,
+  unit: string,
+  keysets: readonly Keyset[],
+): KeyChain {
+  return KeyChain.fromCache(mintUrl, unit, {
+    mintUrl,
+    keysets: keysets.map((keyset) => ({
+      id: keyset.id,
+      unit: keyset.unit,
+      active: keyset.active,
+      input_fee_ppk: keyset.feePpk,
+      keys: keyset.keypairs,
+    })),
+  } satisfies KeyChainCache);
+}

--- a/packages/core/queries/MintOperationQueries.ts
+++ b/packages/core/queries/MintOperationQueries.ts
@@ -1,0 +1,24 @@
+import type { MintQuote } from '../models/MintQuote.ts';
+import type { MintQuoteRef } from '../models/QuoteIdentity.ts';
+import type { MintMethod } from '../operations/mint/MintMethodHandler.ts';
+import type { MintOperation, MintOperationState } from '../operations/mint/MintOperation.ts';
+import type { CoreProof } from '../types.ts';
+
+export interface MintOperationQueries {
+  getById(id: string): Promise<MintOperation | null>;
+  getByState(state: MintOperationState): Promise<MintOperation[]>;
+  getPending(): Promise<MintOperation[]>;
+  getByMintUrl(mintUrl: string): Promise<MintOperation[]>;
+  getByQuoteId(mintUrl: string, method: string, quoteId: string): Promise<MintOperation[]>;
+}
+
+export interface MintProofQueries {
+  getProofBySecret(mintUrl: string, secret: string): Promise<CoreProof | null>;
+}
+
+/** Read-only access to canonical quotes. Import and observation are separate mutations. */
+export interface MintQuoteQueries {
+  requireMintQuoteRefForPrepare(ref: MintQuoteRef): Promise<MintQuote>;
+  getMintQuote(mintUrl: string, method: MintMethod, quoteId: string): Promise<MintQuote | null>;
+  getPendingMintQuotes(): Promise<MintQuote[]>;
+}

--- a/packages/core/repositories/index.ts
+++ b/packages/core/repositories/index.ts
@@ -283,10 +283,10 @@ export interface AuthSessionRepository {
 }
 
 export interface MintOperationRepository {
-  /** Create a new mint operation */
+  /** Create a mint operation, preserving caller-owned timestamps at millisecond precision. */
   create(operation: MintOperation): Promise<void>;
 
-  /** Update an existing mint operation */
+  /** Persist the supplied state and timestamps; do not replace updatedAt with adapter-local time. */
   update(operation: MintOperation): Promise<void>;
 
   /** Get a mint operation by ID */

--- a/packages/core/repositories/memory/MemoryMintOperationRepository.ts
+++ b/packages/core/repositories/memory/MemoryMintOperationRepository.ts
@@ -20,7 +20,7 @@ export class MemoryMintOperationRepository implements MintOperationRepository {
     if (!this.operations.has(operation.id)) {
       throw new Error(`MintOperation with id ${operation.id} not found`);
     }
-    this.operations.set(operation.id, { ...operation, updatedAt: Date.now() });
+    this.operations.set(operation.id, { ...operation });
   }
 
   async getById(id: string): Promise<MintOperation | null> {

--- a/packages/core/services/MintService.ts
+++ b/packages/core/services/MintService.ts
@@ -1,4 +1,16 @@
+import {
+  getMethodUnitCapability,
+  assertMethodUnitCapability,
+  type MethodUnitCapability,
+} from '../mints/MintCapabilities.ts';
 import { Amount, isBlsKeyset, type AmountLike } from '@cashu/cashu-ts';
+import {
+  MINT_REFRESH_TTL_S,
+  type MintMetadata,
+  type MintQueries,
+} from '@core/mints/MintMetadata.ts';
+import type { MintMetadataRemote } from '@core/mints/MintMetadataRemote.ts';
+import type { MintMetadataTransactions } from '@core/transactions/mints/MintMetadataTransactions.ts';
 import {
   KeysetSyncError,
   MintFetchError,
@@ -15,8 +27,6 @@ import type { MintInfo } from '../types';
 import type { Logger } from '../logging/Logger.ts';
 import { normalizeMintUrl } from '../utils';
 import { DEFAULT_UNIT, normalizeUnit, normalizeUnitAmount, type UnitAmount } from '../amounts.ts';
-
-const MINT_REFRESH_TTL_S = 60 * 5;
 
 function excludeBlsKeysets<T extends { id: string }>(keysets: T[]): T[] {
   // TODO: Admit BLS keysets after every proof-state lookup uses curve-aware Y derivation.
@@ -48,18 +58,7 @@ function supportsNut29MintQuoteCheckFromInfo(mintInfo: MintInfo, method: string)
   );
 }
 
-export interface MethodUnitCapability {
-  supported: boolean;
-  disabled: boolean;
-  nut: 4 | 5;
-  method: string;
-  unit: string;
-  minAmount?: Amount | null;
-  maxAmount?: Amount | null;
-  options?: unknown;
-  legacySatAllowed?: boolean;
-  reason?: string;
-}
+export type { MethodUnitCapability } from '../mints/MintCapabilities.ts';
 
 /** Operation side for Payment Method Capability discovery. */
 export type PaymentMethodCapabilityOperationKind = 'mint' | 'melt';
@@ -116,6 +115,13 @@ type NutSupportSettings = {
 
 export type TopLevelNutCapability = 11 | 20;
 
+/** Explicit dependencies of the independently committed metadata refresh action. */
+export interface MintMetadataRefreshDependencies {
+  queries: MintQueries;
+  remote: MintMetadataRemote;
+  transactions: MintMetadataTransactions;
+}
+
 export class MintService {
   private readonly mintRepo: MintRepository;
   private readonly keysetRepo: KeysetRepository;
@@ -127,6 +133,7 @@ export class MintService {
     mintRepo: MintRepository,
     keysetRepo: KeysetRepository,
     mintAdapter: MintAdapter,
+    private readonly metadata: MintMetadataRefreshDependencies,
     logger?: Logger,
     eventBus?: EventBus<CoreEvents>,
   ) {
@@ -212,33 +219,41 @@ export class MintService {
     return await this.mintRepo.isTrustedMint(normalizeMintUrl(mintUrl));
   }
 
-  async ensureUpdatedMint(mintUrl: string): Promise<{ mint: Mint; keysets: Keyset[] }> {
+  /**
+   * May fetch remotely and independently commit metadata, even if the caller later fails.
+   * Fresh metadata needs no transaction. Returns after commit and attempted event publication;
+   * listener failures are logged and cannot turn an already committed refresh into a failure.
+   * Call only outside a Wallet transaction; runtime nesting rejection is not yet universal.
+   */
+  async refreshAndCommitIfStale(mintUrl: string): Promise<MintMetadata> {
     mintUrl = normalizeMintUrl(mintUrl);
-    let mint = await this.mintRepo.getMintByUrl(mintUrl).catch(() => null);
+    const cached = await this.metadata.queries.getMetadata(mintUrl);
+    if (cached && cached.mint.updatedAt >= Math.floor(Date.now() / 1000) - MINT_REFRESH_TTL_S)
+      return cached;
+    const observation = await this.metadata.remote.fetchMintMetadata(
+      mintUrl,
+      cached?.keysets ?? [],
+    );
+    const refreshed = await this.metadata.transactions.applyObservation(observation);
+    await this.publishCommittedEvent('mint:metadata-refreshed', { mintUrl });
+    await this.publishCommittedEvent('mint:updated', refreshed);
+    return refreshed;
+  }
 
-    if (!mint) {
-      // Mint doesn't exist, create it as untrusted
-      const now = Math.floor(Date.now() / 1000);
-      mint = {
-        mintUrl,
-        name: mintUrl,
-        mintInfo: {} as MintInfo,
-        trusted: false,
-        createdAt: now,
-        updatedAt: 0,
-      };
+  private async publishCommittedEvent<E extends 'mint:metadata-refreshed' | 'mint:updated'>(
+    event: E,
+    payload: CoreEvents[E],
+  ): Promise<void> {
+    try {
+      await this.eventBus?.emit(event, payload, { throwOnError: true });
+    } catch (error) {
+      this.logger?.error('Failed to publish committed mint metadata event', { event, error });
     }
+  }
 
-    const now = Math.floor(Date.now() / 1000);
-    if (mint.updatedAt < now - MINT_REFRESH_TTL_S) {
-      this.logger?.debug('Refreshing stale mint', { mintUrl });
-      const updated = await this.updateMint(mint);
-      await this.eventBus?.emit('mint:updated', updated);
-      return updated;
-    }
-
-    const keysets = excludeBlsKeysets(await this.keysetRepo.getKeysetsByMintUrl(mint.mintUrl));
-    return { mint, keysets };
+  /** Compatibility wrapper; new internal callers use the explicitly committing action. */
+  async ensureUpdatedMint(mintUrl: string): Promise<{ mint: Mint; keysets: Keyset[] }> {
+    return this.refreshAndCommitIfStale(mintUrl);
   }
 
   async deleteMint(mintUrl: string): Promise<void> {
@@ -349,63 +364,12 @@ export class MintService {
     unit: string,
   ): Promise<MethodUnitCapability> {
     this.assertMethodCapabilityNut(nut);
-    const normalizedMintUrl = normalizeMintUrl(mintUrl);
-    const normalizedUnit = normalizeUnit(unit, { defaultUnit: DEFAULT_UNIT });
-    const mintInfo = await this.getMintInfo(normalizedMintUrl);
-    const settings = this.getNutMethodSettings(mintInfo, nut);
-    const nutName = this.formatNut(nut);
-
-    if (settings?.disabled === true) {
-      return {
-        supported: false,
-        disabled: true,
-        nut,
-        method,
-        unit: normalizedUnit,
-        reason: `${nutName} is disabled`,
-      };
-    }
-
-    if (!settings || !Array.isArray(settings.methods)) {
-      return {
-        supported: false,
-        disabled: false,
-        nut,
-        method,
-        unit: normalizedUnit,
-        reason: `${nutName} method metadata is missing`,
-      };
-    }
-
-    const matchingMethod = settings.methods.find((entry) => {
-      try {
-        return entry.method === method && normalizeUnit(entry.unit) === normalizedUnit;
-      } catch {
-        return false;
-      }
-    });
-
-    if (!matchingMethod) {
-      return {
-        supported: false,
-        disabled: false,
-        nut,
-        method,
-        unit: normalizedUnit,
-        reason: `${nutName} method ${method} does not support unit ${normalizedUnit}`,
-      };
-    }
-
-    return {
-      supported: true,
-      disabled: false,
+    return getMethodUnitCapability(
+      await this.getMintInfo(normalizeMintUrl(mintUrl)),
       nut,
       method,
-      unit: normalizedUnit,
-      minAmount: this.parseOptionalAmount(matchingMethod.min_amount),
-      maxAmount: this.parseOptionalAmount(matchingMethod.max_amount),
-      options: matchingMethod.options,
-    };
+      unit,
+    );
   }
 
   async listPaymentMethodCapabilities(
@@ -456,36 +420,8 @@ export class MintService {
     method: string,
     scope: string | UnitAmount,
   ): Promise<void> {
-    let unit: string;
-    let requestedAmount: Amount | undefined;
-    if (typeof scope === 'string') {
-      unit = scope;
-    } else {
-      const intent = normalizeUnitAmount(scope);
-      unit = intent.unit;
-      requestedAmount = intent.amount;
-    }
-    const capability = await this.getMintMethodUnitCapability(mintUrl, nut, method, unit);
-    if (!capability.supported) {
-      throw new ProofValidationError(
-        capability.reason ??
-          `${this.formatNut(nut)} method ${method} does not support unit ${capability.unit}`,
-      );
-    }
-
-    if (requestedAmount === undefined) return;
-
-    const amountRequirement = `${this.formatNut(nut)} method ${method} unit ${capability.unit}`;
-    if (capability.minAmount && requestedAmount.lessThan(capability.minAmount)) {
-      throw new ProofValidationError(
-        `${amountRequirement} requires amount >= ${capability.minAmount}`,
-      );
-    }
-    if (capability.maxAmount && requestedAmount.greaterThan(capability.maxAmount)) {
-      throw new ProofValidationError(
-        `${amountRequirement} requires amount <= ${capability.maxAmount}`,
-      );
-    }
+    this.assertMethodCapabilityNut(nut);
+    assertMethodUnitCapability(await this.getMintInfo(mintUrl), nut, method, scope);
   }
 
   async getAllMints(): Promise<Mint[]> {

--- a/packages/core/test/fixtures/MintMetadata.ts
+++ b/packages/core/test/fixtures/MintMetadata.ts
@@ -1,0 +1,25 @@
+import { deriveKeysetId } from '@cashu/cashu-ts';
+import type { MintInfo } from '../../types.ts';
+
+export const testMintInfo: MintInfo = {
+  name: 'Test Mint',
+  version: '1.0.0',
+  pubkey: 'test-pubkey',
+  contact: [],
+  nuts: {
+    '4': { methods: [], disabled: false },
+    '5': { methods: [], disabled: false },
+    '11': { supported: true },
+  },
+};
+
+export const testMintKeypairs = {
+  '1': '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+  '2': '02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+  '4': '02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9',
+  '8': '03774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb',
+};
+
+export function testMintKeysetId(unit = 'sat') {
+  return deriveKeysetId(testMintKeypairs, { unit });
+}

--- a/packages/core/test/fixtures/MintMetadataRefresh.ts
+++ b/packages/core/test/fixtures/MintMetadataRefresh.ts
@@ -1,0 +1,48 @@
+import { mock } from 'bun:test';
+import { MintService } from '../../services/MintService.ts';
+import type { MintAdapter } from '../../infra/MintAdapter.ts';
+import type { MintMetadataRemote } from '../../mints/MintMetadataRemote.ts';
+import { StoredMintQueries } from '../../mints/MintMetadata.ts';
+import { CoreMintMetadataTransactions } from '../../transactions/mints/MintMetadataTransactions.ts';
+import { RepositoryCoreTransactionRunner } from '../../transactions/CoreTransaction.ts';
+import type { Repositories } from '../../repositories/index.ts';
+import { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+
+export function createMintMetadataRemoteDouble() {
+  return {
+    fetchMintMetadata: mock<MintMetadataRemote['fetchMintMetadata']>(async () => {
+      throw new Error('Unexpected mint metadata refresh');
+    }),
+  };
+}
+
+export function createMintMetadataRefreshDependencies(
+  repositories: Repositories,
+  remote: MintMetadataRemote = createMintMetadataRemoteDouble(),
+) {
+  return {
+    queries: new StoredMintQueries(repositories.mintRepository, repositories.keysetRepository),
+    remote,
+    transactions: new CoreMintMetadataTransactions(
+      new RepositoryCoreTransactionRunner(repositories),
+    ),
+  };
+}
+
+/** Exercise the real shared action; legacy MintService methods are outside this fixture's scope. */
+export function createMintServiceForMetadata(
+  repositories: Repositories,
+  remote: MintMetadataRemote = createMintMetadataRemoteDouble(),
+  events = new EventBus<CoreEvents>(),
+) {
+  const unusedAdapter = {} as MintAdapter;
+  return new MintService(
+    repositories.mintRepository,
+    repositories.keysetRepository,
+    unusedAdapter,
+    createMintMetadataRefreshDependencies(repositories, remote),
+    undefined,
+    events,
+  );
+}

--- a/packages/core/test/unit/CashuMintMetadataRemote.test.ts
+++ b/packages/core/test/unit/CashuMintMetadataRemote.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { CashuMintMetadataRemote } from '../../infra/CashuMintMetadataRemote.ts';
+import { KeysetSyncError, MintFetchError } from '../../models/Error.ts';
+import { testMintInfo, testMintKeypairs, testMintKeysetId } from '../fixtures/MintMetadata.ts';
+
+const mintUrl = 'https://mint.test';
+const keyset = { id: testMintKeysetId(), unit: 'sat', active: true, input_fee_ppk: 2 };
+function environment() {
+  const adapter = {
+    fetchMintInfo: mock(async () => testMintInfo),
+    fetchKeysets: mock(async () => ({ keysets: [keyset] })),
+    fetchKeysForId: mock(async () => testMintKeypairs),
+  };
+  return { adapter, remote: new CashuMintMetadataRemote(adapter) };
+}
+
+describe('CashuMintMetadataRemote', () => {
+  it('reuses immutable known keys and fetches missing keys', async () => {
+    const { adapter, remote } = environment();
+    const known = { mintUrl, ...keyset, feePpk: 0, updatedAt: 0, keypairs: testMintKeypairs };
+    const result = await remote.fetchMintMetadata(mintUrl, [known]);
+    expect(result.mintInfo).toEqual(testMintInfo);
+    expect(result.keysets[0]?.keypairs).toEqual(testMintKeypairs);
+    expect(result.keysets[0]?.feePpk).toBe(2);
+    expect(adapter.fetchKeysForId).not.toHaveBeenCalled();
+    await remote.fetchMintMetadata(mintUrl, []);
+    expect(adapter.fetchKeysForId).toHaveBeenCalledWith(mintUrl, keyset.id);
+  });
+
+  it('excludes unsupported BLS keysets before fetching keys', async () => {
+    const { adapter, remote } = environment();
+    adapter.fetchKeysets.mockResolvedValue({ keysets: [{ ...keyset, id: '0200000000000000' }] });
+    expect((await remote.fetchMintMetadata(mintUrl, [])).keysets).toEqual([]);
+    expect(adapter.fetchKeysForId).not.toHaveBeenCalled();
+  });
+
+  it('preserves domain errors for failed metadata or key fetches', async () => {
+    const { adapter, remote } = environment();
+    adapter.fetchMintInfo.mockRejectedValueOnce(new Error('offline'));
+    await expect(remote.fetchMintMetadata(mintUrl, [])).rejects.toBeInstanceOf(MintFetchError);
+    adapter.fetchKeysets.mockRejectedValueOnce(new Error('offline'));
+    await expect(remote.fetchMintMetadata(mintUrl, [])).rejects.toBeInstanceOf(MintFetchError);
+    adapter.fetchKeysForId.mockRejectedValueOnce(new Error('offline'));
+    await expect(remote.fetchMintMetadata(mintUrl, [])).rejects.toBeInstanceOf(KeysetSyncError);
+  });
+});

--- a/packages/core/test/unit/CoreTransaction.test.ts
+++ b/packages/core/test/unit/CoreTransaction.test.ts
@@ -1,3 +1,4 @@
+import { RepositoryMintCommands } from '../../transactions/scoped/mint/ScopedMintCommands.ts';
 import { describe, expect, it } from 'bun:test';
 import { RepositoryTransactionConflictError } from '../../repositories/RepositoryTransactionError.ts';
 import type { RepositoryTransactionScope } from '../../repositories/index.ts';
@@ -108,6 +109,7 @@ describe('RepositoryCoreTransactionRunner', () => {
         boundRepositories = scope;
         return Object.freeze({
           keypairs: new RepositoryKeypairCommands(scope.keyRingRepository),
+          mints: new RepositoryMintCommands(scope),
         });
       },
     );
@@ -258,7 +260,7 @@ describe('RepositoryCoreTransactionRunner', () => {
             scope.counterRepository.setCounter('https://mint.test', 'keyset', 7),
           ]);
         };
-        return { keypairs };
+        return { keypairs, mints: new RepositoryMintCommands(scope) };
       });
       const result = runner
         .run((scope) => scope.keypairs.importP2pk(importedKey('slow')))
@@ -358,7 +360,10 @@ describe('RepositoryCoreTransactionRunner', () => {
       let persistKey!: RepositoryTransactionScope['keyRingRepository']['setPersistedKeyPair'];
       const runner = new RepositoryCoreTransactionRunner(repositories, (scope) => {
         capturedRepositories = scope;
-        return { keypairs: new RepositoryKeypairCommands(scope.keyRingRepository) };
+        return {
+          keypairs: new RepositoryKeypairCommands(scope.keyRingRepository),
+          mints: new RepositoryMintCommands(scope),
+        };
       });
       const result = runner.run(async (scope) => {
         capturedTransaction = scope;

--- a/packages/core/test/unit/CoreTransaction.test.ts
+++ b/packages/core/test/unit/CoreTransaction.test.ts
@@ -7,7 +7,7 @@ import type { CoreTransaction } from '../../transactions/CoreTransaction.ts';
 import { CoreKeyRingTransactions } from '../../transactions/keypairs/KeyRingTransactions.ts';
 import { KeypairDerivation } from '../../keypairs/KeypairDerivation.ts';
 import { RepositoryKeypairCommands } from '../../transactions/scoped/keypairs/ScopedKeypairCommands.ts';
-import { RepositoryMintCommands } from '../../transactions/scoped/mint/ScopedMintCommands.ts';
+import { createCoreTransactionModuleFactory } from '../../transactions/CoreTransaction.ts';
 import { overrideTransactions } from '../overrideTransactions.ts';
 
 function gate() {
@@ -108,8 +108,7 @@ describe('RepositoryCoreTransactionRunner', () => {
       (scope) => {
         boundRepositories = scope;
         return Object.freeze({
-          keypairs: new RepositoryKeypairCommands(scope.keyRingRepository),
-          mints: new RepositoryMintCommands(scope),
+          ...createCoreTransactionModuleFactory()(scope),
         });
       },
     );
@@ -260,7 +259,7 @@ describe('RepositoryCoreTransactionRunner', () => {
             scope.counterRepository.setCounter('https://mint.test', 'keyset', 7),
           ]);
         };
-        return { keypairs, mints: new RepositoryMintCommands(scope) };
+        return { ...createCoreTransactionModuleFactory()(scope), keypairs };
       });
       const result = runner
         .run((scope) => scope.keypairs.importP2pk(importedKey('slow')))
@@ -361,8 +360,7 @@ describe('RepositoryCoreTransactionRunner', () => {
       const runner = new RepositoryCoreTransactionRunner(repositories, (scope) => {
         capturedRepositories = scope;
         return {
-          keypairs: new RepositoryKeypairCommands(scope.keyRingRepository),
-          mints: new RepositoryMintCommands(scope),
+          ...createCoreTransactionModuleFactory()(scope),
         };
       });
       const result = runner.run(async (scope) => {

--- a/packages/core/test/unit/CoreTransaction.test.ts
+++ b/packages/core/test/unit/CoreTransaction.test.ts
@@ -1,4 +1,3 @@
-import { RepositoryMintCommands } from '../../transactions/scoped/mint/ScopedMintCommands.ts';
 import { describe, expect, it } from 'bun:test';
 import { RepositoryTransactionConflictError } from '../../repositories/RepositoryTransactionError.ts';
 import type { RepositoryTransactionScope } from '../../repositories/index.ts';
@@ -8,6 +7,7 @@ import type { CoreTransaction } from '../../transactions/CoreTransaction.ts';
 import { CoreKeyRingTransactions } from '../../transactions/keypairs/KeyRingTransactions.ts';
 import { KeypairDerivation } from '../../keypairs/KeypairDerivation.ts';
 import { RepositoryKeypairCommands } from '../../transactions/scoped/keypairs/ScopedKeypairCommands.ts';
+import { RepositoryMintCommands } from '../../transactions/scoped/mint/ScopedMintCommands.ts';
 import { overrideTransactions } from '../overrideTransactions.ts';
 
 function gate() {

--- a/packages/core/test/unit/MintApi.test.ts
+++ b/packages/core/test/unit/MintApi.test.ts
@@ -1,5 +1,8 @@
 import { Amount } from '@cashu/cashu-ts';
 import { describe, expect, it, mock } from 'bun:test';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { CashuMintMetadataRemote } from '../../infra/CashuMintMetadataRemote.ts';
+import { createMintMetadataRefreshDependencies } from '../fixtures/MintMetadataRefresh.ts';
 
 import { MintApi } from '../../api/MintApi';
 import { ProofValidationError } from '../../models/Error';
@@ -10,8 +13,6 @@ import {
   type PaymentMethodCapability,
   type PaymentMethodCapabilityCheck,
 } from '../../services/MintService';
-import { MemoryKeysetRepository } from '../../repositories/memory/MemoryKeysetRepository';
-import { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository';
 import type { Mint } from '../../models/Mint';
 import type { MintAdapter } from '../../infra/MintAdapter';
 import type { MintInfo } from '../../types';
@@ -39,14 +40,20 @@ describe('MintApi payment method capabilities', () => {
     }) as unknown as MintInfo;
 
   const createApi = async (mintInfo: MintInfo, updatedAt = now) => {
-    const mintRepo = new MemoryMintRepository();
-    const keysetRepo = new MemoryKeysetRepository();
+    const repositories = new MemoryRepositories();
+    const mintRepo = repositories.mintRepository;
+    const keysetRepo = repositories.keysetRepository;
     const adapter = {
       fetchMintInfo: mock(async () => mintInfo),
       fetchKeysets: mock(async () => ({ keysets })),
       fetchKeysForId: mock(async () => ({ '1': 'key-1' })),
     } as unknown as MintAdapter;
-    const service = new MintService(mintRepo, keysetRepo, adapter);
+    const service = new MintService(
+      mintRepo,
+      keysetRepo,
+      adapter,
+      createMintMetadataRefreshDependencies(repositories, new CashuMintMetadataRemote(adapter)),
+    );
     await mintRepo.addOrUpdateMint({
       mintUrl,
       name: mintUrl,

--- a/packages/core/test/unit/MintBolt11Handler.test.ts
+++ b/packages/core/test/unit/MintBolt11Handler.test.ts
@@ -106,14 +106,6 @@ describe('MintBolt11Handler', () => {
 
   const buildPrepareContext = (): PrepareContext<'bolt11'> => ({
     operation,
-    wallet,
-    mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
-    logger,
   });
 
   const buildCreateQuoteContext = (): CreateMintQuoteContext<'bolt11'> => ({
@@ -121,11 +113,7 @@ describe('MintBolt11Handler', () => {
     createQuoteData: { amount: { amount: Amount.from(10), unit: 'sat' } },
     wallet,
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
     mintService,
-    eventBus,
     logger,
   });
 
@@ -151,27 +139,22 @@ describe('MintBolt11Handler', () => {
       updatedAt: Date.now(),
     },
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
     logger,
   });
 
   const buildRecoverContext = (): RecoverExecutingContext<'bolt11'> => ({
     operation: executingOperation,
     wallet,
+    restoreOutputs: () =>
+      proofService.recoverProofsFromOutputData(mintUrl, outputData, {
+        unit: 'sat',
+        persistRecoveredProofs: false,
+      }),
     localClaimabilityFacts: {
       finalizedAmount: Amount.zero(),
       reservedAmount: Amount.zero(),
     },
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
     logger,
   });
 
@@ -181,11 +164,6 @@ describe('MintBolt11Handler', () => {
     operation: operationOverride,
     wallet,
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
     logger,
   });
 
@@ -430,7 +408,7 @@ describe('MintBolt11Handler', () => {
         operation: { ...executingOperation, pubkey: quotePubkey },
       });
 
-      expect(result).toEqual({ status: 'FINALIZED' });
+      expect(result).toMatchObject({ status: 'FINALIZED', proofs: expect.any(Array) });
       const call = (wallet.mintProofsBolt11 as Mock<any>).mock.calls[0];
       expect(call?.[2]).toEqual({ privkey: bytesToHex(quoteSecretKey) });
       const customOutputs = call?.[3] as
@@ -440,7 +418,7 @@ describe('MintBolt11Handler', () => {
         'B_out_1',
         'B_out_2',
       ]);
-      expect(proofService.saveProofs).toHaveBeenCalledTimes(1);
+      expect(proofService.saveProofs).not.toHaveBeenCalled();
     });
 
     it('keeps NUT-20 ownership contradictions pending for ambiguity-preserving recovery', async () => {

--- a/packages/core/test/unit/MintBolt12Handler.test.ts
+++ b/packages/core/test/unit/MintBolt12Handler.test.ts
@@ -89,25 +89,12 @@ describe('MintBolt12Handler', () => {
     overrides: Partial<PrepareContext<'bolt12'>> = {},
   ): PrepareContext<'bolt12'> => ({
     operation,
-    wallet,
-    mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
-    logger,
     ...overrides,
   });
 
   const buildFetchRemoteQuoteContext = (): FetchRemoteMintQuoteContext<'bolt12'> => ({
     quote: mintQuoteFromBolt12Response(mintUrl, quote()),
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
     logger,
   });
 
@@ -132,6 +119,9 @@ describe('MintBolt12Handler', () => {
     (mintAdapter.checkMintQuote as Mock<any>).mockImplementation(async () => remoteQuote);
     return {
       ...buildPrepareContext(),
+      wallet,
+      mintAdapter,
+      logger,
       operation: {
         ...operation,
         state: 'executing',
@@ -152,6 +142,11 @@ describe('MintBolt12Handler', () => {
     },
   ): RecoverExecutingContext<'bolt12'> => ({
     ...buildExecuteContext(remoteQuote),
+    restoreOutputs: () =>
+      proofService.recoverProofsFromOutputData(mintUrl, outputData, {
+        unit: 'sat',
+        persistRecoveredProofs: false,
+      }),
     localClaimabilityFacts,
   });
 
@@ -183,6 +178,10 @@ describe('MintBolt12Handler', () => {
   it('creates a fixed-amount quote with a fresh keypair', async () => {
     const result = await handler.createQuote({
       ...buildPrepareContext(),
+      wallet,
+      mintAdapter,
+      mintService,
+      logger,
       mintUrl,
       createQuoteData: {
         unit: 'sat',
@@ -224,6 +223,10 @@ describe('MintBolt12Handler', () => {
     const error = await handler
       .createQuote({
         ...buildPrepareContext(),
+        wallet,
+        mintAdapter,
+        mintService,
+        logger,
         mintUrl,
         createQuoteData: {
           unit: 'sat',
@@ -244,6 +247,10 @@ describe('MintBolt12Handler', () => {
     await expect(
       handler.createQuote({
         ...buildPrepareContext(),
+        wallet,
+        mintAdapter,
+        mintService,
+        logger,
         mintUrl,
         createQuoteData: {
           unit: 'sat',
@@ -261,6 +268,10 @@ describe('MintBolt12Handler', () => {
     await expect(
       handler.createQuote({
         ...buildPrepareContext(),
+        wallet,
+        mintAdapter,
+        mintService,
+        logger,
         mintUrl,
         createQuoteData: {
           unit: 'sat',
@@ -277,6 +288,10 @@ describe('MintBolt12Handler', () => {
 
     const result = await handler.createQuote({
       ...buildPrepareContext(),
+      wallet,
+      mintAdapter,
+      mintService,
+      logger,
       mintUrl,
       createQuoteData: {
         unit: 'sat',
@@ -507,9 +522,9 @@ describe('MintBolt12Handler', () => {
 
     const result = await handler.recoverExecuting(buildRecoverContext(expiredQuote));
 
-    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(result).toMatchObject({ status: 'FINALIZED', proofs: expect.any(Array) });
     expect(wallet.mintProofsBolt12).toHaveBeenCalled();
-    expect(proofService.saveProofs).toHaveBeenCalled();
+    expect(proofService.saveProofs).not.toHaveBeenCalled();
   });
 
   it('fails recovery when the mint rejects BOLT12 issuance with quote expired', async () => {

--- a/packages/core/test/unit/MintMetadata.test.ts
+++ b/packages/core/test/unit/MintMetadata.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import { StoredMintQueries } from '../../mints/MintMetadata.ts';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { RepositoryCoreTransactionRunner } from '../../transactions/CoreTransaction.ts';
+import { CoreMintMetadataTransactions } from '../../transactions/mints/MintMetadataTransactions.ts';
+import { overrideTransactions } from '../overrideTransactions.ts';
+import { testMintInfo, testMintKeypairs, testMintKeysetId } from '../fixtures/MintMetadata.ts';
+
+const mintUrl = 'https://mint.test';
+const original = {
+  mintUrl,
+  name: 'Test Mint',
+  trusted: true,
+  mintInfo: testMintInfo,
+  createdAt: 1,
+  updatedAt: 10,
+};
+const keyset = {
+  mintUrl,
+  id: testMintKeysetId(),
+  unit: 'sat',
+  keypairs: testMintKeypairs,
+  active: true,
+  feePpk: 0,
+};
+const observation = {
+  mintUrl,
+  mintInfo: { ...testMintInfo, name: 'Refreshed' },
+  keysets: [{ ...keyset, active: false }],
+  observedAt: 20,
+};
+
+describe('Mint metadata queries and transactions', () => {
+  it('returns missing or stale stored metadata without opening a transaction or refreshing it', async () => {
+    const repositories = new MemoryRepositories();
+    const queries = new StoredMintQueries(
+      repositories.mintRepository,
+      repositories.keysetRepository,
+    );
+    expect(await queries.getMetadata(mintUrl)).toBeNull();
+    expect(await repositories.mintRepository.getAllMints()).toEqual([]);
+    await repositories.mintRepository.addNewMint(original);
+    await repositories.keysetRepository.addKeyset(keyset);
+    const result = await queries.getMetadata(`${mintUrl}/`);
+    expect(result?.mint.updatedAt).toBe(10);
+    expect(result?.keysets[0]?.active).toBe(true);
+    expect(await queries.isTrustedMint(`${mintUrl}/`)).toBe(true);
+  });
+
+  it('preserves current trust when applying metadata fetched before a trust change', async () => {
+    const repositories = new MemoryRepositories();
+    await repositories.mintRepository.addNewMint({ ...original, trusted: false });
+    await repositories.keysetRepository.addKeyset(keyset);
+    const transactions = new CoreMintMetadataTransactions(
+      new RepositoryCoreTransactionRunner(repositories),
+    );
+    const result = await transactions.applyObservation(observation);
+    expect(result.mint.trusted).toBe(false);
+    expect(result.mint.mintInfo.name).toBe('Refreshed');
+    expect(result.keysets[0]?.active).toBe(false);
+  });
+
+  it('rolls back keyset refreshes if the mint snapshot cannot be persisted', async () => {
+    const repositories = new MemoryRepositories();
+    await repositories.mintRepository.addNewMint(original);
+    await repositories.keysetRepository.addKeyset(keyset);
+    const controlled = overrideTransactions(repositories, (fn) =>
+      repositories.withTransaction((scope) => {
+        scope.mintRepository.addOrUpdateMint = async () => {
+          throw new Error('metadata write failed');
+        };
+        return fn(scope);
+      }),
+    );
+    const transactions = new CoreMintMetadataTransactions(
+      new RepositoryCoreTransactionRunner(controlled),
+    );
+    await expect(transactions.applyObservation(observation)).rejects.toThrow(
+      'metadata write failed',
+    );
+    expect((await repositories.mintRepository.getMintByUrl(mintUrl)).updatedAt).toBe(10);
+    expect((await repositories.keysetRepository.getKeysetById(mintUrl, keyset.id))?.active).toBe(
+      true,
+    );
+  });
+});

--- a/packages/core/test/unit/MintMetadataRefresh.test.ts
+++ b/packages/core/test/unit/MintMetadataRefresh.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+import type { RepositoryTransactionScope } from '../../repositories/index.ts';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { overrideTransactions } from '../overrideTransactions.ts';
+import {
+  createMintMetadataRemoteDouble,
+  createMintServiceForMetadata,
+} from '../fixtures/MintMetadataRefresh.ts';
+import { testMintInfo, testMintKeypairs, testMintKeysetId } from '../fixtures/MintMetadata.ts';
+
+const mintUrl = 'https://mint.test';
+const keyset = {
+  mintUrl,
+  id: testMintKeysetId(),
+  unit: 'sat',
+  keypairs: testMintKeypairs,
+  active: true,
+  feePpk: 0,
+};
+
+async function environment() {
+  const repositories = new MemoryRepositories();
+  await repositories.mintRepository.addNewMint({
+    mintUrl,
+    name: 'Test',
+    trusted: true,
+    mintInfo: testMintInfo,
+    createdAt: 1,
+    updatedAt: 0,
+  });
+  await repositories.keysetRepository.addKeyset(keyset);
+  const events = new EventBus<CoreEvents>();
+  const remote = createMintMetadataRemoteDouble();
+  let transactionOpen = false;
+  const withTransaction = mock(() => {});
+  const controlled = overrideTransactions(
+    repositories,
+    <T>(work: (scope: RepositoryTransactionScope) => Promise<T>) => {
+      withTransaction();
+      return repositories.withTransaction(async (scope) => {
+        transactionOpen = true;
+        try {
+          return await work(scope);
+        } finally {
+          transactionOpen = false;
+        }
+      });
+    },
+  );
+  const service = createMintServiceForMetadata(controlled, remote, events);
+  remote.fetchMintMetadata.mockImplementation(async () => {
+    expect(transactionOpen).toBe(false);
+    return {
+      mintUrl,
+      mintInfo: { ...testMintInfo, name: 'Refreshed' },
+      keysets: [{ ...keyset, active: false }],
+      observedAt: Math.floor(Date.now() / 1000),
+    };
+  });
+  return {
+    repositories,
+    events,
+    remote,
+    withTransaction,
+    service,
+    isTransactionOpen: () => transactionOpen,
+  };
+}
+
+describe('MintService.refreshAndCommitIfStale', () => {
+  it('returns fresh metadata without a fetch, transaction, or events through either entry point', async () => {
+    const { repositories, events, remote, withTransaction, service } = await environment();
+    const mint = await repositories.mintRepository.getMintByUrl(mintUrl);
+    await repositories.mintRepository.updateMint({
+      ...mint,
+      updatedAt: Math.floor(Date.now() / 1000),
+    });
+    const published = mock(() => {});
+    events.on('mint:updated', published);
+    const result = await service.refreshAndCommitIfStale(`${mintUrl}/`);
+    expect(result.mint.mintUrl).toBe(mintUrl);
+    expect(await service.ensureUpdatedMint(mintUrl)).toEqual(result);
+    expect(remote.fetchMintMetadata).not.toHaveBeenCalled();
+    expect(withTransaction).not.toHaveBeenCalled();
+    expect(published).not.toHaveBeenCalled();
+  });
+
+  it('commits stale metadata once and publishes the committed snapshot outside the transaction', async () => {
+    const { repositories, events, remote, withTransaction, service, isTransactionOpen } =
+      await environment();
+    const published: string[] = [];
+    events.on('mint:metadata-refreshed', async () => {
+      expect(isTransactionOpen()).toBe(false);
+      expect((await repositories.mintRepository.getMintByUrl(mintUrl)).mintInfo.name).toBe(
+        'Refreshed',
+      );
+      published.push('refreshed');
+    });
+    events.on('mint:updated', async (metadata) => {
+      expect(isTransactionOpen()).toBe(false);
+      expect(metadata.keysets[0]?.active).toBe(false);
+      expect(metadata.mint.trusted).toBe(true);
+      published.push('updated');
+    });
+    const result = await service.refreshAndCommitIfStale(`${mintUrl}/`);
+    expect(result.mint.mintInfo.name).toBe('Refreshed');
+    expect(remote.fetchMintMetadata).toHaveBeenCalledWith(mintUrl, [
+      expect.objectContaining(keyset),
+    ]);
+    expect(withTransaction).toHaveBeenCalledTimes(1);
+    expect(published).toEqual(['refreshed', 'updated']);
+    await service.ensureUpdatedMint(mintUrl);
+    expect(withTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open a transaction or publish success when fetching fails', async () => {
+    const { repositories, events, remote, withTransaction, service } = await environment();
+    remote.fetchMintMetadata.mockRejectedValue(new Error('fetch failed'));
+    const published = mock(() => {});
+    events.on('mint:metadata-refreshed', published);
+    events.on('mint:updated', published);
+    await expect(service.refreshAndCommitIfStale(mintUrl)).rejects.toThrow('fetch failed');
+    expect(withTransaction).not.toHaveBeenCalled();
+    expect(published).not.toHaveBeenCalled();
+    expect((await repositories.mintRepository.getMintByUrl(mintUrl)).updatedAt).toBe(0);
+  });
+
+  it('rolls back all metadata and emits no success events when persistence fails', async () => {
+    const { repositories, remote, events } = await environment();
+    const controlled = overrideTransactions(repositories, (work) =>
+      repositories.withTransaction(async (scope) => {
+        scope.mintRepository.addOrUpdateMint = async () => {
+          throw new Error('write failed');
+        };
+        return work(scope);
+      }),
+    );
+    const service = createMintServiceForMetadata(controlled, remote, events);
+    const published = mock(() => {});
+    events.on('mint:metadata-refreshed', published);
+    events.on('mint:updated', published);
+    await expect(service.refreshAndCommitIfStale(mintUrl)).rejects.toThrow('write failed');
+    expect((await repositories.mintRepository.getMintByUrl(mintUrl)).updatedAt).toBe(0);
+    expect((await repositories.keysetRepository.getKeysetById(mintUrl, keyset.id))?.active).toBe(
+      true,
+    );
+    expect(published).not.toHaveBeenCalled();
+  });
+
+  it('retains a committed refresh and attempts the next event after a listener failure', async () => {
+    const { repositories, events, service } = await environment();
+    events.on('mint:metadata-refreshed', () => {
+      throw new Error('listener failed');
+    });
+    const updated = mock(() => {});
+    events.on('mint:updated', updated);
+    const result = await service.refreshAndCommitIfStale(mintUrl);
+    expect(result.mint.mintInfo.name).toBe('Refreshed');
+    expect((await repositories.mintRepository.getMintByUrl(mintUrl)).updatedAt).toBeGreaterThan(0);
+    expect(updated).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates unknown metadata atomically as untrusted', async () => {
+    const { repositories, remote, service } = await environment();
+    await repositories.mintRepository.deleteMint(mintUrl);
+    const result = await service.refreshAndCommitIfStale(mintUrl);
+    expect(result.mint.trusted).toBe(false);
+    expect(remote.fetchMintMetadata).toHaveBeenCalledWith(mintUrl, []);
+    expect((await repositories.mintRepository.getMintByUrl(mintUrl)).trusted).toBe(false);
+  });
+});

--- a/packages/core/test/unit/MintOnchainHandler.test.ts
+++ b/packages/core/test/unit/MintOnchainHandler.test.ts
@@ -71,11 +71,7 @@ describe('MintOnchainHandler', () => {
     createQuoteData: { unit: 'sat' },
     wallet,
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
     mintService,
-    eventBus,
     logger,
   });
 
@@ -100,11 +96,6 @@ describe('MintOnchainHandler', () => {
       updatedAt: Date.now(),
     },
     mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
     logger,
   });
 
@@ -121,14 +112,6 @@ describe('MintOnchainHandler', () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     } satisfies InitMintOperation<'onchain'>,
-    wallet,
-    mintAdapter,
-    proofService,
-    proofRepository,
-    walletService,
-    mintService,
-    eventBus,
-    logger,
   });
 
   const buildExecutingOperation = (): ExecutingMintOperation<'onchain'> => ({
@@ -148,7 +131,15 @@ describe('MintOnchainHandler', () => {
     },
   ): RecoverExecutingContext<'onchain'> => ({
     ...buildPrepareContext(),
+    wallet,
+    mintAdapter,
+    logger,
     operation: buildExecutingOperation(),
+    restoreOutputs: () =>
+      proofService.recoverProofsFromOutputData(mintUrl, buildExecutingOperation().outputData, {
+        unit: 'sat',
+        persistRecoveredProofs: false,
+      }),
     localClaimabilityFacts,
   });
 
@@ -271,25 +262,18 @@ describe('MintOnchainHandler', () => {
     expect(result.amountIssued.equals(Amount.from(8))).toBe(true);
   });
 
-  it('prepares deterministic outputs without requiring available quote balance', async () => {
+  it('prepares quote metadata without requiring available quote balance', async () => {
     const result = await handler.prepare({
       ...buildPrepareContext(),
       importedQuote: { ...remoteQuote, amount_paid: Amount.zero(), amount_issued: Amount.zero() },
     });
 
     expect(keyRingService.getMintQuoteKeyPair).toHaveBeenCalledWith(pubkey);
-    expect(proofService.createOutputsAndIncrementCounters).toHaveBeenCalledWith(
-      mintUrl,
-      {
-        keep: { amount: Amount.from(10), unit: 'sat' },
-        send: { amount: Amount.zero(), unit: 'sat' },
-      },
-      {},
-    );
+    expect(proofService.createOutputsAndIncrementCounters).not.toHaveBeenCalled();
     expect(result.state).toBe('pending');
     expect(result.quoteId).toBe(quoteId);
     expect(result.pubkey).toBe(pubkey);
-    expect(deserializeOutputData(result.outputData).keep).toHaveLength(1);
+    expect(result).not.toHaveProperty('outputData');
   });
 
   it('fails onchain preparation when the quote key is missing', async () => {
@@ -310,8 +294,12 @@ describe('MintOnchainHandler', () => {
     });
     const context: ExecuteContext<'onchain'> = {
       ...buildPrepareContext(),
+      wallet,
+      mintAdapter,
+      logger,
       operation: {
         ...pending,
+        outputData: buildExecutingOperation().outputData,
         state: 'executing',
       },
     };
@@ -325,7 +313,7 @@ describe('MintOnchainHandler', () => {
       remoteQuote,
       ''.padEnd(64, '0'),
       undefined,
-      { type: 'custom', data: deserializeOutputData(pending.outputData).keep },
+      { type: 'custom', data: deserializeOutputData(buildExecutingOperation().outputData).keep },
     );
   });
 
@@ -343,7 +331,14 @@ describe('MintOnchainHandler', () => {
     await expect(
       handler.execute({
         ...buildPrepareContext(),
-        operation: { ...pending, state: 'executing' },
+        wallet,
+        mintAdapter,
+        logger,
+        operation: {
+          ...pending,
+          outputData: buildExecutingOperation().outputData,
+          state: 'executing',
+        },
       }),
     ).rejects.toThrow(`Onchain mint quote ${quoteId} is not claimable: invalid`);
 
@@ -363,7 +358,14 @@ describe('MintOnchainHandler', () => {
 
     const result = await handler.execute({
       ...buildPrepareContext(),
-      operation: { ...pending, state: 'executing' },
+      wallet,
+      mintAdapter,
+      logger,
+      operation: {
+        ...pending,
+        outputData: buildExecutingOperation().outputData,
+        state: 'executing',
+      },
     });
 
     expect(result.status).toBe('ISSUED');
@@ -382,7 +384,7 @@ describe('MintOnchainHandler', () => {
 
     const result = await handler.recoverExecuting(buildRecoverContext());
 
-    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(result).toMatchObject({ status: 'FINALIZED', proofs: expect.any(Array) });
     expect(proofService.recoverProofsFromOutputData).toHaveBeenCalled();
     expect(wallet.mintProofsOnchain).not.toHaveBeenCalled();
   });
@@ -390,7 +392,7 @@ describe('MintOnchainHandler', () => {
   it('retries onchain minting from persisted output data when the quote is still available', async () => {
     const result = await handler.recoverExecuting(buildRecoverContext());
 
-    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(result).toMatchObject({ status: 'FINALIZED', proofs: expect.any(Array) });
     expect(proofService.recoverProofsFromOutputData).toHaveBeenCalled();
     expect(wallet.mintProofsOnchain).toHaveBeenCalledWith(
       Amount.from(10),
@@ -399,7 +401,7 @@ describe('MintOnchainHandler', () => {
       undefined,
       { type: 'custom', data: [output] },
     );
-    expect(proofService.saveProofs).toHaveBeenCalled();
+    expect(proofService.saveProofs).not.toHaveBeenCalled();
   });
 
   it('returns pending during recovery when output restore is empty and balance is unavailable', async () => {
@@ -444,7 +446,7 @@ describe('MintOnchainHandler', () => {
 
     const result = await handler.recoverExecuting(buildRecoverContext());
 
-    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(result).toMatchObject({ status: 'FINALIZED', proofs: expect.any(Array) });
     expect(proofService.recoverProofsFromOutputData).toHaveBeenCalledTimes(2);
   });
 
@@ -456,9 +458,9 @@ describe('MintOnchainHandler', () => {
 
     const result = await handler.recoverExecuting(buildRecoverContext());
 
-    expect(result).toEqual({ status: 'FINALIZED' });
+    expect(result).toMatchObject({ status: 'FINALIZED', proofs: expect.any(Array) });
     expect(wallet.mintProofsOnchain).toHaveBeenCalled();
-    expect(proofService.saveProofs).toHaveBeenCalled();
+    expect(proofService.saveProofs).not.toHaveBeenCalled();
   });
 
   it('fails recovery when the mint rejects onchain issuance with quote expired', async () => {

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -1,3 +1,9 @@
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { RepositoryCoreTransactionRunner } from '../../transactions/CoreTransaction.ts';
+import { CoreMintTransactions } from '../../transactions/mint/MintTransactions.ts';
+import { overrideTransactions } from '../overrideTransactions.ts';
+import { mintQuoteToMethodSnapshot } from '../../models/MintQuote.ts';
+import type { MintRemote } from '../../operations/mint/MintRemote.ts';
 import { Amount } from '@cashu/cashu-ts';
 import { describe, it, beforeEach, expect, mock, type Mock } from 'bun:test';
 import {
@@ -44,7 +50,7 @@ import type { WalletService } from '../../services/WalletService';
 import type { ProofService } from '../../services/ProofService';
 import type { MintAdapter } from '../../infra/MintAdapter';
 import type { Logger } from '../../logging/Logger';
-import { serializeOutputData } from '../../utils';
+import { serializeOutputData, deserializeOutputData } from '../../utils';
 import type { CoreProof } from '../../types';
 import { MintQuoteValidationError, QuoteIdentityConflictError } from '../../models/Error';
 
@@ -53,6 +59,9 @@ describe('MintOperationService', () => {
   const quoteId = 'quote-1';
   const keysetId = 'keyset-1';
 
+  let repositories: MemoryRepositories;
+  let remote: MintRemote;
+  let rejectPreparation: boolean;
   let operationRepo: MemoryMintOperationRepository;
   let quoteRepo: MemoryMintQuoteRepository;
   let proofRepo: MemoryProofRepository;
@@ -99,6 +108,17 @@ describe('MintOperationService', () => {
         ),
       ],
       send: [],
+    });
+
+  const proofsForOperation = (operation: PendingMintOperation | ExecutingMintOperation): Proof[] =>
+    deserializeOutputData(operation.outputData).keep.map((output) => {
+      const secret = new TextDecoder().decode(output.secret);
+      return {
+        id: output.blindedMessage.id,
+        amount: output.blindedMessage.amount,
+        secret,
+        C: `C_${secret}`,
+      };
     });
 
   const toCoreProof = (secret: string, operationId: string): CoreProof => ({
@@ -205,7 +225,7 @@ describe('MintOperationService', () => {
       execute: mock(async ({ operation }: any): Promise<MintExecutionResult> => {
         lastExecutedAmount = operation.amount;
         executedAmounts.push(operation.amount.toString());
-        return { status: 'ISSUED', proofs: [makeProof(operation.id)] };
+        return { status: 'ISSUED', proofs: proofsForOperation(operation) };
       }),
       fetchRemoteQuote: mock(async ({ quote }) => {
         issued = issued.add(lastExecutedAmount);
@@ -261,9 +281,26 @@ describe('MintOperationService', () => {
   });
 
   beforeEach(async () => {
-    operationRepo = new MemoryMintOperationRepository();
-    quoteRepo = new MemoryMintQuoteRepository();
-    proofRepo = new MemoryProofRepository();
+    repositories = new MemoryRepositories();
+    await repositories.init();
+    rejectPreparation = false;
+    operationRepo = repositories.mintOperationRepository as MemoryMintOperationRepository;
+    quoteRepo = repositories.mintQuoteRepository as MemoryMintQuoteRepository;
+    proofRepo = repositories.proofRepository as MemoryProofRepository;
+    await repositories.mintRepository.addOrUpdateMint({
+      mintUrl,
+      name: 'Test mint',
+      mintInfo: {
+        name: 'Fixture',
+        pubkey: '',
+        version: 'test/1',
+        contact: [],
+        nuts: { '4': { methods: [], disabled: false }, '5': { methods: [], disabled: false } },
+      },
+      trusted: true,
+      createdAt: 1,
+      updatedAt: 1,
+    });
     eventBus = new EventBus<CoreEvents>();
     logger = {
       error: mock(() => {}),
@@ -272,9 +309,22 @@ describe('MintOperationService', () => {
       debug: mock(() => {}),
     };
 
-    const mockPrepare = mock(async ({ operation }: { operation: InitMintOperation<'bolt11'> }) => {
-      return makePendingOp(operation.id) as PendingMintOperation<'bolt11'>;
-    });
+    const mockPrepare = mock(
+      async ({
+        operation,
+        importedQuote,
+      }: {
+        operation: InitMintOperation<'bolt11'>;
+        importedQuote?: MintMethodQuoteSnapshot<'bolt11'>;
+      }) => {
+        return {
+          ...makePendingOp(operation.id),
+          ...operation,
+          state: 'pending',
+          request: importedQuote!.request,
+        } as PendingMintOperation<'bolt11'>;
+      },
+    );
 
     const mockExecute = mock(async (): Promise<MintExecutionResult> => {
       return { status: 'ISSUED', proofs: [makeProof('out-1')] };
@@ -340,7 +390,6 @@ describe('MintOperationService', () => {
         if (!options?.createdByOperationId) {
           return [];
         }
-        await proofRepo.saveProofs(mintUrl, [toCoreProof('out-1', options.createdByOperationId)]);
         return [makeProof('out-1')];
       }),
     } as unknown as ProofService;
@@ -390,17 +439,86 @@ describe('MintOperationService', () => {
       logger,
     });
 
-    service = new MintOperationService(
-      handlerProvider,
-      operationRepo,
-      quoteLifecycle,
-      proofRepo,
-      proofService,
-      mintService,
-      walletService,
-      mintAdapter,
-      eventBus,
+    remote = {
+      isTrusted: (url) => mintService.isTrustedMint(url),
+      prepare: async (operation, quote) => {
+        const selectedHandler = handlerProvider.get(operation.method);
+        await selectedHandler.validateQuoteForPrepare?.(quote);
+        await mintService.assertMethodUnitSupported(
+          operation.mintUrl,
+          4,
+          operation.method,
+          operation.method === 'onchain'
+            ? operation.unit
+            : { amount: operation.amount, unit: operation.unit },
+        );
+        await walletService.getWalletWithActiveKeysetId(operation.mintUrl, operation.unit);
+        const prepared = await selectedHandler.prepare({
+          operation,
+          importedQuote: mintQuoteToMethodSnapshot(quote),
+        });
+        // The old method fixtures provide a deterministic plan. Allocation is now owned by the gateway.
+        const plan = (prepared as PendingMintOperation).outputData;
+        return { operation: prepared, keysetId, derive: () => plan };
+      },
+      execute: async (operation) => {
+        const { wallet } = await walletService.getWalletWithActiveKeysetId(
+          operation.mintUrl,
+          operation.unit,
+        );
+        return handlerProvider
+          .get(operation.method)
+          .execute({ operation, wallet, mintAdapter, logger });
+      },
+      recoverExecuting: async (operation, localClaimabilityFacts) => {
+        const { wallet } = await walletService.getWalletWithActiveKeysetId(
+          operation.mintUrl,
+          operation.unit,
+        );
+        return handlerProvider.get(operation.method).recoverExecuting({
+          operation,
+          wallet,
+          mintAdapter,
+          logger,
+          localClaimabilityFacts,
+          restoreOutputs: () => remote.restoreOutputs(operation),
+        });
+      },
+      observePending: (operation) =>
+        handlerProvider.get(operation.method).checkPending({ operation, mintAdapter, logger }),
+      restoreOutputs: (operation) =>
+        proofService.recoverProofsFromOutputData(operation.mintUrl, operation.outputData, {
+          unit: operation.unit,
+          createdByOperationId: operation.id,
+          persistRecoveredProofs: false,
+        }),
+    };
+    const runner = new RepositoryCoreTransactionRunner(
+      overrideTransactions(repositories, (work) =>
+        repositories.withTransaction((scope) =>
+          work({
+            ...scope,
+            mintOperationRepository: rejectPreparation
+              ? {
+                  ...scope.mintOperationRepository,
+                  create: async () => {
+                    throw new Error('pending persistence failed');
+                  },
+                }
+              : scope.mintOperationRepository,
+          }),
+        ),
+      ),
     );
+    service = new MintOperationService({
+      operations: operationRepo,
+      proofs: proofRepo,
+      quotes: quoteLifecycle,
+      remote,
+      transactions: new CoreMintTransactions(runner),
+      events: eventBus,
+      logger,
+    });
   });
 
   it('prepare persists a pending operation and emits mint-op:pending', async () => {
@@ -561,7 +679,7 @@ describe('MintOperationService', () => {
         request: importedQuote.request,
         expiry: importedQuote.expiry,
         pubkey: importedQuote.pubkey,
-        outputData: makeSerializedOutputData(operation.id),
+        outputData: makeSerializedOutputData(operation.id, operation.amount),
       })),
     } as unknown as MintMethodHandler<'onchain'>;
     (handlerProvider.get as Mock<any>).mockImplementation(() => onchainHandler);
@@ -576,7 +694,7 @@ describe('MintOperationService', () => {
     expect(new Set(operations.map((operation) => operation.id)).size).toBe(2);
   });
 
-  it('prepare cleans init operations but keeps consumed counters when onchain persistence fails', async () => {
+  it('prepare rolls back operation and counter allocation when onchain persistence fails', async () => {
     const onchainQuoteId = 'onchain-quote-1';
     const consumedCounters: string[] = [];
     await persistOnchainQuote(onchainQuoteId);
@@ -592,14 +710,12 @@ describe('MintOperationService', () => {
           request: importedQuote.request,
           expiry: importedQuote.expiry,
           pubkey: importedQuote.pubkey,
-          outputData: makeSerializedOutputData(operation.id),
+          outputData: makeSerializedOutputData(operation.id, operation.amount),
         };
       }),
     } as unknown as MintMethodHandler<'onchain'>;
     (handlerProvider.get as Mock<any>).mockImplementation(() => onchainHandler);
-    operationRepo.update = mock(async () => {
-      throw new Error('pending persistence failed');
-    }) as typeof operationRepo.update;
+    rejectPreparation = true;
 
     await expect(
       service.prepare({ mintUrl, method: 'onchain', quoteId: onchainQuoteId }, Amount.from(10)),
@@ -607,6 +723,7 @@ describe('MintOperationService', () => {
 
     expect(consumedCounters).toHaveLength(1);
     expect(await operationRepo.getAll()).toHaveLength(0);
+    expect(await repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
   });
 
   it('createQuote persists a canonical quote without creating operation output data', async () => {
@@ -1519,6 +1636,7 @@ describe('MintOperationService', () => {
           ...makePendingOp(operation.id),
           quoteId: importedQuote.quote,
           amount: importedQuote.amount,
+          outputData: makeSerializedOutputData('out-1', importedQuote.amount),
           request: importedQuote.request,
           expiry: importedQuote.expiry,
         };
@@ -1711,6 +1829,7 @@ describe('MintOperationService', () => {
         ...makePendingOp(operation.id),
         quoteId: importedQuote.quote,
         amount: importedQuote.amount,
+        outputData: makeSerializedOutputData('out-1', importedQuote.amount),
         request: importedQuote.request,
         expiry: importedQuote.expiry,
       }),
@@ -1936,7 +2055,10 @@ describe('MintOperationService', () => {
     await persistQuote();
     const executing = makeExecutingOp('orphaned-executing');
     await operationRepo.create(executing);
-    (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({ status: 'FINALIZED' });
+    (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({
+      status: 'FINALIZED',
+      proofs: [],
+    });
 
     const result = await service.execute(executing.id);
 
@@ -1987,10 +2109,11 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-underfunded';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.from(4), issued: Amount.zero() });
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-underfunded'),
+      ...makePendingOp('onchain-underfunded', 'onchain-underfunded'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(10),
+      outputData: makeSerializedOutputData('onchain-underfunded', Amount.from(10)),
     };
     await operationRepo.create(pendingOp);
 
@@ -2006,11 +2129,12 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-funded';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.from(10), issued: Amount.zero() });
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-funded'),
+      ...makePendingOp('onchain-funded', 'onchain-funded'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
+      outputData: makeSerializedOutputData('onchain-funded', Amount.from(5)),
     };
     await operationRepo.create(pendingOp);
 
@@ -2019,7 +2143,7 @@ describe('MintOperationService', () => {
       execute: mock(
         async (): Promise<MintExecutionResult> => ({
           status: 'ISSUED',
-          proofs: [makeProof('out-1')],
+          proofs: proofsForOperation(pendingOp),
         }),
       ),
       fetchRemoteQuote: mock(async ({ quote }) =>
@@ -2060,11 +2184,12 @@ describe('MintOperationService', () => {
       pubkey: '02'.padEnd(66, '1'),
     });
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-reserved-pending'),
+      ...makePendingOp('onchain-reserved-pending', 'onchain-reserved-pending'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
+      outputData: makeSerializedOutputData('onchain-reserved-pending', Amount.from(5)),
     };
     await operationRepo.create(pendingOp);
 
@@ -2089,11 +2214,12 @@ describe('MintOperationService', () => {
     };
     await operationRepo.create(finalized);
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-local-issued-pending'),
+      ...makePendingOp('onchain-local-issued-pending', 'onchain-local-issued-pending'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
+      outputData: makeSerializedOutputData('onchain-local-issued-pending', Amount.from(5)),
     };
     await operationRepo.create(pendingOp);
 
@@ -2102,7 +2228,7 @@ describe('MintOperationService', () => {
       execute: mock(
         async (): Promise<MintExecutionResult> => ({
           status: 'ISSUED',
-          proofs: [makeProof('out-1')],
+          proofs: proofsForOperation(pendingOp),
         }),
       ),
     } as unknown as MintMethodHandler<'onchain'>;
@@ -2122,20 +2248,22 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-prefix';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.from(10), issued: Amount.zero() });
     const first: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-prefix-a'),
+      ...makePendingOp('onchain-prefix-a', 'onchain-prefix-a'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(7),
       pubkey: '02'.padEnd(66, '1'),
       createdAt: 1,
+      outputData: makeSerializedOutputData('onchain-prefix-a', Amount.from(7)),
     };
     const second: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-prefix-b'),
+      ...makePendingOp('onchain-prefix-b', 'onchain-prefix-b'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
       createdAt: 2,
+      outputData: makeSerializedOutputData('onchain-prefix-b', Amount.from(5)),
     };
     await operationRepo.create(first);
     await operationRepo.create(second);
@@ -2145,7 +2273,7 @@ describe('MintOperationService', () => {
       execute: mock(
         async ({ operation }: any): Promise<MintExecutionResult> => ({
           status: 'ISSUED',
-          proofs: [makeProof(operation.id)],
+          proofs: proofsForOperation(operation),
         }),
       ),
       fetchRemoteQuote: mock(async ({ quote }) =>
@@ -2177,20 +2305,22 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-duplicate';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.from(10), issued: Amount.zero() });
     const first: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-duplicate-a'),
+      ...makePendingOp('onchain-duplicate-a', 'onchain-duplicate-a'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(7),
       pubkey: '02'.padEnd(66, '1'),
       createdAt: 1,
+      outputData: makeSerializedOutputData('onchain-duplicate-a', Amount.from(7)),
     };
     const second: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-duplicate-b'),
+      ...makePendingOp('onchain-duplicate-b', 'onchain-duplicate-b'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
       createdAt: 2,
+      outputData: makeSerializedOutputData('onchain-duplicate-b', Amount.from(5)),
     };
     await operationRepo.create(first);
     await operationRepo.create(second);
@@ -2200,7 +2330,7 @@ describe('MintOperationService', () => {
       execute: mock(
         async ({ operation }: any): Promise<MintExecutionResult> => ({
           status: 'ISSUED',
-          proofs: [makeProof(operation.id)],
+          proofs: proofsForOperation(operation),
         }),
       ),
       fetchRemoteQuote: mock(async ({ quote }) =>
@@ -2235,20 +2365,22 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-partials';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.from(10), issued: Amount.zero() });
     const first: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-partial-a'),
+      ...makePendingOp('onchain-partial-a', 'onchain-partial-a'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(7),
       pubkey: '02'.padEnd(66, '1'),
       createdAt: 1,
+      outputData: makeSerializedOutputData('onchain-partial-a', Amount.from(7)),
     };
     const second: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-partial-b'),
+      ...makePendingOp('onchain-partial-b', 'onchain-partial-b'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
       createdAt: 2,
+      outputData: makeSerializedOutputData('onchain-partial-b', Amount.from(5)),
     };
     await operationRepo.create(first);
     await operationRepo.create(second);
@@ -2260,7 +2392,7 @@ describe('MintOperationService', () => {
       execute: mock(
         async ({ operation }: any): Promise<MintExecutionResult> => ({
           status: 'ISSUED',
-          proofs: [makeProof(operation.id)],
+          proofs: proofsForOperation(operation),
         }),
       ),
       fetchRemoteQuote: mock(async ({ quote }) => {
@@ -2380,27 +2512,30 @@ describe('MintOperationService', () => {
       expiry: Math.floor(Date.now() / 1000) - 1,
     });
     const finalized: FinalizedMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-expired-finalized'),
+      ...makePendingOp('onchain-expired-finalized', 'onchain-expired-finalized'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(7),
       pubkey: '02'.padEnd(66, '1'),
       state: 'finalized',
+      outputData: makeSerializedOutputData('onchain-expired-finalized', Amount.from(7)),
     };
     const reserved: ExecutingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-expired-reserved'),
+      ...makePendingOp('onchain-expired-reserved', 'onchain-expired-reserved'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(5),
       pubkey: '02'.padEnd(66, '1'),
       state: 'executing',
+      outputData: makeSerializedOutputData('onchain-expired-reserved', Amount.from(5)),
     };
     const pending: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-expired-pending'),
+      ...makePendingOp('onchain-expired-pending', 'onchain-expired-pending'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       amount: Amount.from(8),
       pubkey: '02'.padEnd(66, '1'),
+      outputData: makeSerializedOutputData('onchain-expired-pending', Amount.from(8)),
     };
     await operationRepo.create(finalized);
     await operationRepo.create(reserved);
@@ -2456,7 +2591,7 @@ describe('MintOperationService', () => {
       pubkey: '02'.padEnd(66, '1'),
     };
     const pending: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-recover-pending'),
+      ...makePendingOp('onchain-recover-pending', 'onchain-recover-pending'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       pubkey: '02'.padEnd(66, '1'),
@@ -2467,7 +2602,7 @@ describe('MintOperationService', () => {
     const onchainHandler = {
       ...handler,
       recoverExecuting: mock(
-        async (): Promise<RecoverExecutingResult> => ({ status: 'FINALIZED' }),
+        async (): Promise<RecoverExecutingResult> => ({ status: 'FINALIZED', proofs: [] }),
       ),
       fetchRemoteQuote: mock(async ({ quote }) =>
         mintQuoteFromOnchainResponse(quote.mintUrl, {
@@ -2503,7 +2638,7 @@ describe('MintOperationService', () => {
     const onchainHandler = {
       ...handler,
       recoverExecuting: mock(
-        async (): Promise<RecoverExecutingResult> => ({ status: 'FINALIZED' }),
+        async (): Promise<RecoverExecutingResult> => ({ status: 'FINALIZED', proofs: [] }),
       ),
       fetchRemoteQuote: mock(async () => {
         throw new Error('mint offline');
@@ -2521,7 +2656,10 @@ describe('MintOperationService', () => {
     const op = makeExecutingOp('exec-1');
     await operationRepo.create(op);
 
-    (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({ status: 'FINALIZED' });
+    (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({
+      status: 'FINALIZED',
+      proofs: [],
+    });
 
     await service.recoverExecutingOperation(op);
 
@@ -2549,7 +2687,10 @@ describe('MintOperationService', () => {
     const op = makeExecutingOp('exec-3');
     await operationRepo.create(op);
 
-    (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({ status: 'FINALIZED' });
+    (handler.recoverExecuting as Mock<any>).mockResolvedValueOnce({
+      status: 'FINALIZED',
+      proofs: [],
+    });
     (proofService.recoverProofsFromOutputData as Mock<any>).mockResolvedValueOnce([]);
 
     await service.recoverExecutingOperation(op);
@@ -2862,10 +3003,11 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-pending-check';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.zero(), issued: Amount.zero() });
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-pending-check'),
+      ...makePendingOp('onchain-pending-check', 'onchain-pending-check'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       pubkey: '02'.padEnd(66, '1'),
+      outputData: makeSerializedOutputData('onchain-recover-pending', Amount.from(10)),
     };
     await operationRepo.create(pendingOp);
 
@@ -2897,7 +3039,7 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-quote-stale-check';
     await persistOnchainQuote(onchainQuoteId, { paid: Amount.from(10), issued: Amount.from(8) });
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-stale-check'),
+      ...makePendingOp('onchain-stale-check', 'onchain-stale-check'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       pubkey: '02'.padEnd(66, '1'),
@@ -2936,7 +3078,7 @@ describe('MintOperationService', () => {
       remoteUpdatedAt: 20,
     });
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('onchain-conflicting-check'),
+      ...makePendingOp('onchain-conflicting-check', 'onchain-conflicting-check'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       request: 'bc1qtest',
@@ -3077,7 +3219,7 @@ describe('MintOperationService', () => {
     const onchainQuoteId = 'onchain-legacy-state';
     await persistOnchainQuote(onchainQuoteId);
     const pendingOp: PendingMintOperation<'onchain'> = {
-      ...makePendingOp('pending-onchain-legacy-state'),
+      ...makePendingOp('pending-onchain-legacy-state', 'pending-onchain-legacy-state'),
       method: 'onchain',
       quoteId: onchainQuoteId,
       request: 'bc1qtest',
@@ -3110,6 +3252,7 @@ describe('MintOperationService', () => {
       ...makePendingOp('pending-concurrent-compatibility-observation'),
       request: 'lnbc1old',
       expiry: initialExpiry,
+      outputData: makeSerializedOutputData('onchain-stale-check', Amount.from(10)),
     };
     const newerAtPersist = createDeferred();
     const releaseNewerPersist = createDeferred();

--- a/packages/core/test/unit/MintOperationService.test.ts
+++ b/packages/core/test/unit/MintOperationService.test.ts
@@ -1,3 +1,7 @@
+import { createCoreTransactionModuleFactory } from '../../transactions/CoreTransaction.ts';
+import { StoredMintQueries } from '../../mints/MintMetadata.ts';
+import { makeOutputDataCreator } from '../fixtures/OutputDataCreator.ts';
+import type { SerializedOutputData } from '../../utils.ts';
 import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
 import { RepositoryCoreTransactionRunner } from '../../transactions/CoreTransaction.ts';
 import { CoreMintTransactions } from '../../transactions/mint/MintTransactions.ts';
@@ -439,8 +443,8 @@ describe('MintOperationService', () => {
       logger,
     });
 
+    const plans = new WeakMap<Uint8Array, SerializedOutputData>();
     remote = {
-      isTrusted: (url) => mintService.isTrustedMint(url),
       prepare: async (operation, quote) => {
         const selectedHandler = handlerProvider.get(operation.method);
         await selectedHandler.validateQuoteForPrepare?.(quote);
@@ -459,7 +463,21 @@ describe('MintOperationService', () => {
         });
         // The old method fixtures provide a deterministic plan. Allocation is now owned by the gateway.
         const plan = (prepared as PendingMintOperation).outputData;
-        return { operation: prepared, keysetId, derive: () => plan };
+        const seed = new Uint8Array(64);
+        plans.set(seed, plan);
+        await repositories.keysetRepository.addKeyset({
+          mintUrl: operation.mintUrl,
+          id: keysetId,
+          unit: operation.unit,
+          active: true,
+          keypairs: {},
+          feePpk: 0,
+        });
+        return {
+          operation: prepared,
+          activeKeys: { id: keysetId, unit: operation.unit, keys: {} },
+          seed,
+        };
       },
       execute: async (operation) => {
         const { wallet } = await walletService.getWalletWithActiveKeysetId(
@@ -470,7 +488,7 @@ describe('MintOperationService', () => {
           .get(operation.method)
           .execute({ operation, wallet, mintAdapter, logger });
       },
-      recoverExecuting: async (operation, localClaimabilityFacts) => {
+      recoverExecuting: async (operation, localClaimabilityFacts, metadata) => {
         const { wallet } = await walletService.getWalletWithActiveKeysetId(
           operation.mintUrl,
           operation.unit,
@@ -481,7 +499,7 @@ describe('MintOperationService', () => {
           mintAdapter,
           logger,
           localClaimabilityFacts,
-          restoreOutputs: () => remote.restoreOutputs(operation),
+          restoreOutputs: () => remote.restoreOutputs(operation, metadata),
         });
       },
       observePending: (operation) =>
@@ -509,8 +527,22 @@ describe('MintOperationService', () => {
           }),
         ),
       ),
+      createCoreTransactionModuleFactory(
+        makeOutputDataCreator({
+          createDeterministicData: (_amount, seed) => deserializeOutputData(plans.get(seed)!).keep,
+        }),
+      ),
     );
     service = new MintOperationService({
+      mintQueries: { isTrustedMint: (url) => mintService.isTrustedMint(url) },
+      mintMetadataRefresh: {
+        refreshAndCommitIfStale: async (url) =>
+          (await new StoredMintQueries(
+            repositories.mintRepository,
+            repositories.keysetRepository,
+          ).getMetadata(url))!,
+      },
+      loadSeed: async () => new Uint8Array(64),
       operations: operationRepo,
       proofs: proofRepo,
       quotes: quoteLifecycle,

--- a/packages/core/test/unit/MintService.test.ts
+++ b/packages/core/test/unit/MintService.test.ts
@@ -1,9 +1,12 @@
 import { Amount } from '@cashu/cashu-ts';
 import { describe, it, beforeEach, expect, mock } from 'bun:test';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { CashuMintMetadataRemote } from '../../infra/CashuMintMetadataRemote.ts';
+import { createMintMetadataRefreshDependencies } from '../fixtures/MintMetadataRefresh.ts';
 import { MintService } from '../../services/MintService';
 import { ProofValidationError } from '../../models/Error';
-import { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository';
-import { MemoryKeysetRepository } from '../../repositories/memory/MemoryKeysetRepository';
+import type { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository';
+import type { MemoryKeysetRepository } from '../../repositories/memory/MemoryKeysetRepository';
 import { EventBus } from '../../events/EventBus';
 import type { CoreEvents } from '../../events/types';
 import type { Mint } from '../../models/Mint';
@@ -51,8 +54,9 @@ describe('MintService', () => {
   };
 
   beforeEach(() => {
-    mintRepo = new MemoryMintRepository();
-    keysetRepo = new MemoryKeysetRepository();
+    const repositories = new MemoryRepositories();
+    mintRepo = repositories.mintRepository as MemoryMintRepository;
+    keysetRepo = repositories.keysetRepository as MemoryKeysetRepository;
     eventBus = new EventBus<CoreEvents>();
 
     // Create mock MintAdapter
@@ -65,7 +69,14 @@ describe('MintService', () => {
       checkProofStates: mock(() => Promise.resolve([])),
     } as unknown as MintAdapter;
 
-    service = new MintService(mintRepo, keysetRepo, mockAdapter, undefined, eventBus);
+    service = new MintService(
+      mintRepo,
+      keysetRepo,
+      mockAdapter,
+      createMintMetadataRefreshDependencies(repositories, new CashuMintMetadataRemote(mockAdapter)),
+      undefined,
+      eventBus,
+    );
   });
 
   describe('trust management', () => {

--- a/packages/core/test/unit/MintTransactions.test.ts
+++ b/packages/core/test/unit/MintTransactions.test.ts
@@ -1,3 +1,8 @@
+import { createMintServiceForMetadata } from '../fixtures/MintMetadataRefresh.ts';
+import { testMintKeypairs, testMintKeysetId } from '../fixtures/MintMetadata.ts';
+import { StoredMintQueries } from '../../mints/MintMetadata.ts';
+import { createCoreTransactionModuleFactory } from '../../transactions/CoreTransaction.ts';
+import { MintWalletFactory } from '../../infra/mint/MintWallet.ts';
 import {
   Amount,
   Mint,
@@ -37,7 +42,7 @@ import { overrideTransactions } from '../overrideTransactions.ts';
 import { makeOutputDataCreator } from '../fixtures/OutputDataCreator.ts';
 
 const mintUrl = 'https://mint.test';
-const keysetId = 'keyset';
+const keysetId = testMintKeysetId();
 const timestamp = 1_700_000_000_123;
 
 async function fixture(repositories: Repositories, method: 'bolt11' | 'onchain' = 'bolt11') {
@@ -51,10 +56,43 @@ async function fixture(repositories: Repositories, method: 'bolt11' | 'onchain' 
       pubkey: '',
       version: 'test/1',
       contact: [],
-      nuts: { '4': { methods: [], disabled: false }, '5': { methods: [], disabled: false } },
+      nuts: {
+        '4': {
+          methods: [
+            {
+              method: 'bolt11',
+              unit: 'sat',
+              method_name: null,
+              min_amount: null,
+              max_amount: null,
+            },
+          ],
+          disabled: false,
+        },
+        '5': { methods: [], disabled: false },
+      },
     },
     createdAt: timestamp,
     updatedAt: timestamp,
+  });
+  await repositories.keysetRepository.addKeyset({
+    mintUrl,
+    id: keysetId,
+    unit: 'sat',
+    active: true,
+    feePpk: 0,
+    keypairs: testMintKeypairs,
+  });
+  const creator = makeOutputDataCreator({
+    createDeterministicData: (_amount, _seed, counter) =>
+      [8, 2].map(
+        (amount, index) =>
+          new OutputData(
+            { id: keysetId, amount: Amount.from(amount), B_: `B_${counter + index}` },
+            1n,
+            new TextEncoder().encode(`secret_${counter + index}`),
+          ),
+      ),
   });
   const common = {
     quote: 'quote',
@@ -91,21 +129,13 @@ async function fixture(repositories: Repositories, method: 'bolt11' | 'onchain' 
       createdAt: timestamp,
       updatedAt: timestamp,
     },
-    keysetId,
-    derive: (counter) =>
-      serializeOutputData({
-        keep: [8, 2].map(
-          (amount, index) =>
-            new OutputData(
-              { id: keysetId, amount: Amount.from(amount), B_: `B_${counter + index}` },
-              1n,
-              new TextEncoder().encode(`secret_${counter + index}`),
-            ),
-        ),
-        send: [],
-      }),
+    activeKeys: { id: keysetId, unit: 'sat', keys: { ...testMintKeypairs } },
+    seed: new Uint8Array(64),
   });
-  const runner = new RepositoryCoreTransactionRunner(repositories);
+  const runner = new RepositoryCoreTransactionRunner(
+    repositories,
+    createCoreTransactionModuleFactory(creator),
+  );
   const transactions = new CoreMintTransactions(runner);
   async function authorize(id = 'mint') {
     await transactions.prepare(input(id));
@@ -121,7 +151,7 @@ async function fixture(repositories: Repositories, method: 'bolt11' | 'onchain' 
       C: `C_${output.blindedMessage.B_}`,
     }));
   }
-  return { repositories, quote, input, runner, transactions, authorize, proofs };
+  return { repositories, quote, input, runner, transactions, authorize, proofs, creator };
 }
 
 const adapters = [
@@ -246,6 +276,36 @@ for (const adapter of adapters)
         db.close();
       }
     });
+
+    it.each(['deactivated', 'unit changed', 'keys replaced'] as const)(
+      'rejects allocation when the selected keyset is %s before commit',
+      async (change) => {
+        const db = adapter.create();
+        try {
+          const f = await fixture(db.repositories);
+          const input = f.input();
+          await f.repositories.keysetRepository.deleteKeyset(mintUrl, keysetId);
+          await f.repositories.keysetRepository.addKeyset({
+            mintUrl,
+            id: keysetId,
+            unit: change === 'unit changed' ? 'usd' : 'sat',
+            active: change !== 'deactivated',
+            feePpk: 0,
+            keypairs:
+              change === 'keys replaced'
+                ? { ...testMintKeypairs, '1': testMintKeypairs['2'] }
+                : testMintKeypairs,
+          });
+          await expect(f.transactions.prepare(input)).rejects.toThrow('changed after preflight');
+          expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+          expect(
+            await f.repositories.mintOperationRepository.getById(input.operation.id),
+          ).toBeNull();
+        } finally {
+          db.close();
+        }
+      },
+    );
 
     it('atomically settles proofs, legacy BOLT11 accounting, and finalized operation state', async () => {
       const db = adapter.create();
@@ -405,7 +465,12 @@ describe('Mint transaction orchestration', () => {
         expect(inTransaction).toBe(true);
         expect(Amount.from(amount).equals(Amount.from(10))).toBe(true);
         expect(providedSeed).toBe(seed);
-        return deserializeOutputData(f.input().derive(counter)).keep;
+        return f.creator.createDeterministicData(
+          amount,
+          providedSeed,
+          counter,
+          f.input().activeKeys,
+        );
       },
     );
     const handler = new MintBolt11Handler({
@@ -416,32 +481,26 @@ describe('Mint transaction orchestration', () => {
     });
     const remote = new HandlerMintRemote(
       new MintHandlerProvider({ bolt11: handler }),
-      {
-        getWalletWithActiveKeysetId: async () => {
-          expect(inTransaction).toBe(false);
-          return {
-            wallet: new Wallet(new Mint(mintUrl)),
-            keysetId,
-            unit: 'sat',
-            keyset: { id: keysetId, unit: 'sat', active: true, input_fee_ppk: 0 },
-            keys: { id: keysetId, unit: 'sat', keys: {} },
-          };
+      new MintWalletFactory(
+        { getAuthProvider: () => undefined },
+        {
+          getRequestFn: () => async () => {
+            throw new Error('Unexpected mint request');
+          },
         },
-      },
-      {
-        isTrustedMint: async () => true,
-        assertMethodUnitSupported: async () => {
-          expect(inTransaction).toBe(false);
-        },
-      },
+      ),
       {} as MintAdapter,
-      getSeed,
-      async () => {
-        throw new Error('Unexpected Restore');
-      },
-      makeOutputDataCreator({ createDeterministicData: derive }),
     );
-    const prepared = await remote.prepare({ ...f.input().operation, state: 'init' }, f.quote);
+    const metadata = (await new StoredMintQueries(
+      f.repositories.mintRepository,
+      f.repositories.keysetRepository,
+    ).getMetadata(mintUrl))!;
+    const prepared = await remote.prepare(
+      { ...f.input().operation, state: 'init' },
+      f.quote,
+      metadata,
+      await getSeed(),
+    );
     expect(derive).not.toHaveBeenCalled();
     expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
     await f.repositories.counterRepository.setCounter(mintUrl, keysetId, 7);
@@ -454,16 +513,132 @@ describe('Mint transaction orchestration', () => {
       }
     });
     const result = await new CoreMintTransactions(
-      new RepositoryCoreTransactionRunner(controlled),
+      new RepositoryCoreTransactionRunner(
+        controlled,
+        createCoreTransactionModuleFactory(
+          makeOutputDataCreator({ createDeterministicData: derive }),
+        ),
+      ),
     ).prepare(prepared);
     expect(result.counter.counter).toBe(9);
     expect(derive).toHaveBeenCalledTimes(1);
     expect(getSeed).toHaveBeenCalledTimes(1);
   });
 
+  it('retains the independently committed metadata refresh when Mint preparation rolls back', async () => {
+    const f = await fixture(new MemoryRepositories());
+    const mint = await f.repositories.mintRepository.getMintByUrl(mintUrl);
+    await f.repositories.mintRepository.updateMint({ ...mint, updatedAt: 0 });
+    let inTransaction = false;
+    const controlled = overrideTransactions(f.repositories, (work) =>
+      f.repositories.withTransaction(async (scope) => {
+        inTransaction = true;
+        const operations = new Proxy(scope.mintOperationRepository, {
+          get(target, property) {
+            if (property === 'create')
+              return async () => {
+                throw new Error('operation write failed');
+              };
+            const value = Reflect.get(target, property, target);
+            return typeof value === 'function' ? value.bind(target) : value;
+          },
+        });
+        try {
+          return await work({ ...scope, mintOperationRepository: operations });
+        } finally {
+          inTransaction = false;
+        }
+      }),
+    );
+    const events = new EventBus<CoreEvents>();
+    const refreshed = mock(async () => {
+      expect(inTransaction).toBe(false);
+      expect((await f.repositories.mintRepository.getMintByUrl(mintUrl)).mintInfo.name).toBe(
+        'Refreshed',
+      );
+    });
+    events.on('mint:updated', refreshed);
+    const pending = mock(() => {});
+    events.on('mint-op:pending', pending);
+    const fetchMintMetadata = mock(async () => {
+      expect(inTransaction).toBe(false);
+      return {
+        mintUrl,
+        mintInfo: { ...mint.mintInfo, name: 'Refreshed' },
+        keysets: [
+          {
+            mintUrl,
+            id: keysetId,
+            unit: 'sat',
+            active: true,
+            keypairs: testMintKeypairs,
+            feePpk: 0,
+          },
+        ],
+        observedAt: Math.floor(Date.now() / 1000),
+      };
+    });
+    const refresh = createMintServiceForMetadata(controlled, { fetchMintMetadata }, events);
+    const handler = new MintBolt11Handler({
+      getMintQuoteKeyPair: async () => null,
+      generateMintQuoteKeyPair: async () => {
+        throw new Error('Unexpected key allocation');
+      },
+    });
+    const remote = new HandlerMintRemote(
+      new MintHandlerProvider({ bolt11: handler }),
+      new MintWalletFactory(
+        { getAuthProvider: () => undefined },
+        {
+          getRequestFn: () => async () => {
+            throw new Error('Unexpected mint request');
+          },
+        },
+      ),
+      {} as MintAdapter,
+    );
+    const service = new MintOperationService({
+      mintQueries: new StoredMintQueries(
+        f.repositories.mintRepository,
+        f.repositories.keysetRepository,
+      ),
+      mintMetadataRefresh: refresh,
+      loadSeed: async () => {
+        expect(inTransaction).toBe(false);
+        return new Uint8Array(64);
+      },
+      operations: f.repositories.mintOperationRepository,
+      proofs: f.repositories.proofRepository,
+      quotes: {
+        requireMintQuoteRefForPrepare: async () => f.quote,
+        getMintQuote: async () => f.quote,
+        getPendingMintQuotes: async () => [],
+      },
+      remote,
+      events,
+      transactions: new CoreMintTransactions(
+        new RepositoryCoreTransactionRunner(
+          controlled,
+          createCoreTransactionModuleFactory(f.creator),
+        ),
+      ),
+    });
+    await expect(
+      service.prepare({ mintUrl, method: 'bolt11', quoteId: f.quote.quoteId }, Amount.from(10)),
+    ).rejects.toThrow('operation write failed');
+    expect(fetchMintMetadata).toHaveBeenCalledTimes(1);
+    expect(refreshed).toHaveBeenCalledTimes(1);
+    expect(pending).not.toHaveBeenCalled();
+    expect((await f.repositories.mintRepository.getMintByUrl(mintUrl)).mintInfo.name).toBe(
+      'Refreshed',
+    );
+    expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+    expect(await f.repositories.mintOperationRepository.getByMintUrl(mintUrl)).toEqual([]);
+  });
+
   it('keeps derivation inputs stable across rollback and bounded conflict retries', async () => {
     const f = await fixture(new MemoryRepositories());
-    const derive = mock(f.input().derive);
+    const derive = mock(f.creator.createDeterministicData);
     let conflict = true;
     const controlled = overrideTransactions(f.repositories, (work) =>
       f.repositories.withTransaction(async (scope) => {
@@ -475,9 +650,20 @@ describe('Mint transaction orchestration', () => {
         return result;
       }),
     );
-    const transactions = new CoreMintTransactions(new RepositoryCoreTransactionRunner(controlled));
-    const committed = await transactions.prepare({ ...f.input(), derive });
-    expect(derive.mock.calls).toEqual([[0], [0]]);
+    const transactions = new CoreMintTransactions(
+      new RepositoryCoreTransactionRunner(
+        controlled,
+        createCoreTransactionModuleFactory(
+          makeOutputDataCreator({ createDeterministicData: derive }),
+        ),
+      ),
+    );
+    const input = f.input();
+    const committed = await transactions.prepare(input);
+    expect(derive.mock.calls).toEqual([
+      [input.operation.amount, input.seed, 0, input.activeKeys],
+      [input.operation.amount, input.seed, 0, input.activeKeys],
+    ]);
     expect(committed.operation.createdAt).toBe(timestamp);
     expect(committed.operation.updatedAt).toBe(timestamp);
     expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toMatchObject({
@@ -511,7 +697,6 @@ describe('Mint transaction orchestration', () => {
       return { status: 'ISSUED' as const, proofs: f.proofs(operation) };
     });
     const remote: MintRemote = {
-      isTrusted: async () => true,
       prepare: async () => {
         throw new Error('unexpected preparation');
       },
@@ -527,6 +712,15 @@ describe('Mint transaction orchestration', () => {
       },
     };
     const service = new MintOperationService({
+      mintQueries: { isTrustedMint: async () => true },
+      mintMetadataRefresh: {
+        refreshAndCommitIfStale: async () =>
+          (await new StoredMintQueries(
+            f.repositories.mintRepository,
+            f.repositories.keysetRepository,
+          ).getMetadata(mintUrl))!,
+      },
+      loadSeed: async () => new Uint8Array(64),
       operations: f.repositories.mintOperationRepository,
       proofs: f.repositories.proofRepository,
       remote,

--- a/packages/core/test/unit/MintTransactions.test.ts
+++ b/packages/core/test/unit/MintTransactions.test.ts
@@ -1,0 +1,548 @@
+import {
+  Amount,
+  Mint,
+  OutputData,
+  Wallet,
+  type Proof,
+  type OutputDataCreator,
+} from '@cashu/cashu-ts';
+import { Database } from 'bun:sqlite';
+import { describe, expect, it, mock } from 'bun:test';
+import { EventBus } from '../../events/EventBus.ts';
+import type { CoreEvents } from '../../events/types.ts';
+import { MintBolt11Handler } from '../../infra/handlers/mint/MintBolt11Handler.ts';
+import { MintHandlerProvider } from '../../infra/handlers/mint/MintHandlerProvider.ts';
+import { HandlerMintRemote } from '../../infra/mint/HandlerMintRemote.ts';
+import type { MintAdapter } from '../../infra/MintAdapter.ts';
+import { KeypairDerivation } from '../../keypairs/KeypairDerivation.ts';
+import {
+  mintQuoteFromBolt11Response,
+  mintQuoteFromOnchainResponse,
+} from '../../models/MintQuote.ts';
+import type { PrepareMintInput } from '../../operations/mint/MintCommands.ts';
+import { MintOperationService } from '../../operations/mint/MintOperationService.ts';
+import type { MintRemote } from '../../operations/mint/MintRemote.ts';
+import type { Repositories, RepositoryTransactionScope } from '../../repositories/index.ts';
+import { RepositoryTransactionConflictError } from '../../repositories/RepositoryTransactionError.ts';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import {
+  RepositoryCoreTransactionRunner,
+  type CoreTransaction,
+} from '../../transactions/CoreTransaction.ts';
+import { CoreMintTransactions } from '../../transactions/mint/MintTransactions.ts';
+import { deserializeOutputData, serializeOutputData } from '../../utils.ts';
+import { SqlStorageRepositories } from '../../../sql-storage/src/repositories.ts';
+import { SqliteDb } from '../../../sqlite-bun/src/db.ts';
+import { overrideTransactions } from '../overrideTransactions.ts';
+import { makeOutputDataCreator } from '../fixtures/OutputDataCreator.ts';
+
+const mintUrl = 'https://mint.test';
+const keysetId = 'keyset';
+const timestamp = 1_700_000_000_123;
+
+async function fixture(repositories: Repositories, method: 'bolt11' | 'onchain' = 'bolt11') {
+  await repositories.init();
+  await repositories.mintRepository.addOrUpdateMint({
+    mintUrl,
+    name: 'Mint transaction fixture',
+    trusted: true,
+    mintInfo: {
+      name: 'Fixture',
+      pubkey: '',
+      version: 'test/1',
+      contact: [],
+      nuts: { '4': { methods: [], disabled: false }, '5': { methods: [], disabled: false } },
+    },
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  const common = {
+    quote: 'quote',
+    request: 'request',
+    unit: 'sat',
+    expiry: 1,
+    amount_paid: Amount.from(10),
+    amount_issued: Amount.zero(),
+    updated_at: null,
+  };
+  const quote =
+    method === 'bolt11'
+      ? mintQuoteFromBolt11Response(mintUrl, {
+          ...common,
+          method,
+          amount: Amount.from(10),
+          state: 'PAID',
+        })
+      : mintQuoteFromOnchainResponse(mintUrl, { ...common, method, pubkey: 'owned-key' });
+  await repositories.mintQuoteRepository.upsertMintQuote(quote);
+  const input = (id = 'mint'): PrepareMintInput => ({
+    operation: {
+      id,
+      mintUrl,
+      method,
+      methodData: {},
+      state: 'pending',
+      quoteId: quote.quoteId,
+      request: quote.request,
+      amount: Amount.from(10),
+      unit: 'sat',
+      pubkey: quote.pubkey,
+      expiry: quote.expiry,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    keysetId,
+    derive: (counter) =>
+      serializeOutputData({
+        keep: [8, 2].map(
+          (amount, index) =>
+            new OutputData(
+              { id: keysetId, amount: Amount.from(amount), B_: `B_${counter + index}` },
+              1n,
+              new TextEncoder().encode(`secret_${counter + index}`),
+            ),
+        ),
+        send: [],
+      }),
+  });
+  const runner = new RepositoryCoreTransactionRunner(repositories);
+  const transactions = new CoreMintTransactions(runner);
+  async function authorize(id = 'mint') {
+    await transactions.prepare(input(id));
+    const committed = await transactions.authorize({ operationId: id, timestamp });
+    if (committed.operation.state !== 'executing') throw new Error('Fixture was not authorized');
+    return committed.operation;
+  }
+  function proofs(operation: Awaited<ReturnType<typeof authorize>>): Proof[] {
+    return deserializeOutputData(operation.outputData).keep.map((output) => ({
+      id: output.blindedMessage.id,
+      amount: output.blindedMessage.amount,
+      secret: new TextDecoder().decode(output.secret),
+      C: `C_${output.blindedMessage.B_}`,
+    }));
+  }
+  return { repositories, quote, input, runner, transactions, authorize, proofs };
+}
+
+const adapters = [
+  { name: 'memory', create: () => ({ repositories: new MemoryRepositories(), close() {} }) },
+  {
+    name: 'sqlite',
+    create: () => {
+      const database = new Database(':memory:');
+      return {
+        repositories: new SqlStorageRepositories({ database: new SqliteDb({ database }) }),
+        close: () => database.close(),
+      };
+    },
+  },
+];
+
+for (const adapter of adapters)
+  describe(`Mint transaction migration (${adapter.name})`, () => {
+    it('commits output allocation and pending state with a composed keypair allocation', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const keyInput = await new KeypairDerivation(async () => new Uint8Array(64)).prepare(
+          'nut20_mint_quote',
+        );
+        const pending = await f.runner.run(async (scope) => {
+          await scope.keypairs.allocate(keyInput);
+          return scope.mints.prepare(f.input());
+        });
+        expect(pending.counter.counter).toBe(2);
+        expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toMatchObject({
+          counter: 2,
+        });
+        expect(await f.repositories.mintOperationRepository.getById('mint')).toEqual(
+          pending.operation,
+        );
+        expect(
+          await f.repositories.keyRingRepository.getAllPersistedKeyPairs('nut20_mint_quote'),
+        ).toHaveLength(1);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('rolls back every allocation even when a caller catches a scoped Mint failure', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const keyInput = await new KeypairDerivation(async () => new Uint8Array(64)).prepare(
+          'nut20_mint_quote',
+        );
+        await expect(
+          f.runner.run(async (scope) => {
+            await scope.keypairs.allocate(keyInput);
+            await scope.mints.prepare(f.input());
+            await scope.mints.prepare(f.input('duplicate')).catch(() => {});
+          }),
+        ).rejects.toThrow('already tracked');
+        expect(await f.repositories.mintOperationRepository.getByMintUrl(mintUrl)).toEqual([]);
+        expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+        expect(
+          await f.repositories.keyRingRepository.getAllPersistedKeyPairs('nut20_mint_quote'),
+        ).toEqual([]);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('rejects Mint commands captured from a closed scope', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        let captured!: CoreTransaction['mints'];
+        await f.runner.run(async (scope) => {
+          captured = scope.mints;
+        });
+        await expect(captured.prepare(f.input())).rejects.toThrow();
+        expect(await f.repositories.mintOperationRepository.getByMintUrl(mintUrl)).toEqual([]);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('serializes sibling authorization against the current quote reservation', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories, 'onchain');
+        await Promise.all([
+          f.transactions.prepare(f.input('first')),
+          f.transactions.prepare(f.input('second')),
+        ]);
+        const commits = await Promise.all([
+          f.transactions.authorize({ operationId: 'first', timestamp }),
+          f.transactions.authorize({ operationId: 'second', timestamp }),
+        ]);
+        expect(commits.filter((commit) => commit.changed)).toHaveLength(1);
+        expect(await f.repositories.mintOperationRepository.getByState('executing')).toHaveLength(
+          1,
+        );
+        expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toMatchObject({
+          counter: 4,
+        });
+      } finally {
+        db.close();
+      }
+    });
+
+    it('rechecks trust before authorizing an already prepared operation', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        await f.transactions.prepare(f.input());
+        const mint = (await f.repositories.mintRepository.getMintByUrl(mintUrl))!;
+        await f.repositories.mintRepository.addOrUpdateMint({ ...mint, trusted: false });
+        await expect(f.transactions.authorize({ operationId: 'mint', timestamp })).rejects.toThrow(
+          'not trusted',
+        );
+        expect(await f.repositories.mintOperationRepository.getById('mint')).toMatchObject({
+          state: 'pending',
+        });
+      } finally {
+        db.close();
+      }
+    });
+
+    it('atomically settles proofs, legacy BOLT11 accounting, and finalized operation state', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const operation = await f.authorize();
+        const settled = await f.transactions.settle({
+          operation,
+          proofs: f.proofs(operation),
+          outcome: 'issued',
+          timestamp,
+        });
+        expect(settled.operation.state).toBe('finalized');
+        expect(await f.repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(2);
+        expect(
+          (
+            await f.repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote')
+          )?.amountIssued.toString(),
+        ).toBe('10');
+        expect(await f.repositories.mintOperationRepository.getById('mint')).toEqual(
+          settled.operation,
+        );
+        // Milliseconds are persisted losslessly, so same-millisecond transitions remain distinguishable.
+        expect(settled.operation.updatedAt).toBe(operation.updatedAt + 1);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('rolls proofs and quote accounting back when final operation persistence fails', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const operation = await f.authorize();
+        const controlled = overrideTransactions(f.repositories, (work) =>
+          f.repositories.withTransaction((scope) => {
+            const operations = scope.mintOperationRepository;
+            const rejecting = new Proxy(operations, {
+              get(target, property) {
+                if (property === 'update')
+                  return async () => {
+                    throw new Error('finalization failed');
+                  };
+                const value = Reflect.get(target, property);
+                return typeof value === 'function' ? value.bind(target) : value;
+              },
+            });
+            return work({ ...scope, mintOperationRepository: rejecting });
+          }),
+        );
+        const transactions = new CoreMintTransactions(
+          new RepositoryCoreTransactionRunner(controlled),
+        );
+        await expect(
+          transactions.settle({
+            operation,
+            proofs: f.proofs(operation),
+            outcome: 'issued',
+            timestamp,
+          }),
+        ).rejects.toThrow('finalization failed');
+        expect(await f.repositories.proofRepository.getReadyProofs(mintUrl)).toEqual([]);
+        expect(
+          (
+            await f.repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote')
+          )?.amountIssued.isZero(),
+        ).toBe(true);
+        expect(await f.repositories.mintOperationRepository.getById('mint')).toEqual(operation);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('ignores stale negative results after the operation is authorized again', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const first = await f.authorize();
+        await f.transactions.returnToPending({ operation: first, timestamp });
+        const second = await f.transactions.authorize({ operationId: first.id, timestamp });
+        const stale = await f.transactions.fail({
+          operation: first,
+          failure: { reason: 'late rejection', observedAt: timestamp },
+          timestamp,
+        });
+        expect(stale.changed).toBe(false);
+        expect(stale.operation).toEqual(second.operation);
+        expect(await f.repositories.mintOperationRepository.getById(first.id)).toEqual(
+          second.operation,
+        );
+      } finally {
+        db.close();
+      }
+    });
+
+    it('retains late issuance proofs after recovery returns the operation to pending', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const operation = await f.authorize();
+        const pending = await f.transactions.returnToPending({ operation, timestamp });
+        const settled = await f.transactions.settle({
+          operation,
+          proofs: f.proofs(operation),
+          outcome: 'issued',
+          timestamp,
+        });
+        expect(settled.operation).toEqual(pending.operation);
+        expect(settled.changed).toBe(false);
+        expect(settled.proofs).toHaveLength(2);
+        expect(await f.repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(2);
+        const duplicate = await f.transactions.settle({
+          operation,
+          proofs: f.proofs(operation),
+          outcome: 'issued',
+          timestamp,
+        });
+        expect(duplicate.proofs).toEqual([]);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('retains legacy already-issued completion without recovered proofs', async () => {
+      const db = adapter.create();
+      try {
+        const f = await fixture(db.repositories);
+        const operation = await f.authorize();
+        const settled = await f.transactions.settle({
+          operation,
+          proofs: [],
+          outcome: 'already-issued',
+          timestamp,
+        });
+        expect(settled.operation).toMatchObject({
+          state: 'finalized',
+          error: expect.stringContaining('no proofs could be restored'),
+        });
+        expect(await f.repositories.proofRepository.getReadyProofs(mintUrl)).toEqual([]);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+describe('Mint transaction orchestration', () => {
+  it('performs method preflight before allocating from the transaction-current counter', async () => {
+    const f = await fixture(new MemoryRepositories());
+    let inTransaction = false;
+    const seed = new Uint8Array(64);
+    const getSeed = mock(async () => {
+      expect(inTransaction).toBe(false);
+      return seed;
+    });
+    const derive = mock<OutputDataCreator['createDeterministicData']>(
+      (amount, providedSeed, counter) => {
+        expect(inTransaction).toBe(true);
+        expect(Amount.from(amount).equals(Amount.from(10))).toBe(true);
+        expect(providedSeed).toBe(seed);
+        return deserializeOutputData(f.input().derive(counter)).keep;
+      },
+    );
+    const handler = new MintBolt11Handler({
+      getMintQuoteKeyPair: async () => null,
+      generateMintQuoteKeyPair: async () => {
+        throw new Error('Unexpected key allocation');
+      },
+    });
+    const remote = new HandlerMintRemote(
+      new MintHandlerProvider({ bolt11: handler }),
+      {
+        getWalletWithActiveKeysetId: async () => {
+          expect(inTransaction).toBe(false);
+          return {
+            wallet: new Wallet(new Mint(mintUrl)),
+            keysetId,
+            unit: 'sat',
+            keyset: { id: keysetId, unit: 'sat', active: true, input_fee_ppk: 0 },
+            keys: { id: keysetId, unit: 'sat', keys: {} },
+          };
+        },
+      },
+      {
+        isTrustedMint: async () => true,
+        assertMethodUnitSupported: async () => {
+          expect(inTransaction).toBe(false);
+        },
+      },
+      {} as MintAdapter,
+      getSeed,
+      async () => {
+        throw new Error('Unexpected Restore');
+      },
+      makeOutputDataCreator({ createDeterministicData: derive }),
+    );
+    const prepared = await remote.prepare({ ...f.input().operation, state: 'init' }, f.quote);
+    expect(derive).not.toHaveBeenCalled();
+    expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toBeNull();
+    await f.repositories.counterRepository.setCounter(mintUrl, keysetId, 7);
+    const controlled = overrideTransactions(f.repositories, async (work) => {
+      inTransaction = true;
+      try {
+        return await f.repositories.withTransaction(work);
+      } finally {
+        inTransaction = false;
+      }
+    });
+    const result = await new CoreMintTransactions(
+      new RepositoryCoreTransactionRunner(controlled),
+    ).prepare(prepared);
+    expect(result.counter.counter).toBe(9);
+    expect(derive).toHaveBeenCalledTimes(1);
+    expect(getSeed).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps derivation inputs stable across rollback and bounded conflict retries', async () => {
+    const f = await fixture(new MemoryRepositories());
+    const derive = mock(f.input().derive);
+    let conflict = true;
+    const controlled = overrideTransactions(f.repositories, (work) =>
+      f.repositories.withTransaction(async (scope) => {
+        const result = await work(scope);
+        if (conflict) {
+          conflict = false;
+          throw new RepositoryTransactionConflictError('retry allocation');
+        }
+        return result;
+      }),
+    );
+    const transactions = new CoreMintTransactions(new RepositoryCoreTransactionRunner(controlled));
+    const committed = await transactions.prepare({ ...f.input(), derive });
+    expect(derive.mock.calls).toEqual([[0], [0]]);
+    expect(committed.operation.createdAt).toBe(timestamp);
+    expect(committed.operation.updatedAt).toBe(timestamp);
+    expect(await f.repositories.counterRepository.getCounter(mintUrl, keysetId)).toMatchObject({
+      counter: 2,
+    });
+  });
+
+  it('runs remote effects and live listeners outside transactions and cannot replay on listener failure', async () => {
+    const f = await fixture(new MemoryRepositories());
+    let inTransaction = false;
+    const controlled = overrideTransactions(f.repositories, async (work) => {
+      inTransaction = true;
+      try {
+        return await f.repositories.withTransaction(work);
+      } finally {
+        inTransaction = false;
+      }
+    });
+    const events = new EventBus<CoreEvents>({ throwOnError: true });
+    const listener = mock(async () => {
+      expect(inTransaction).toBe(false);
+      expect(await f.repositories.proofRepository.getReadyProofs(mintUrl)).toHaveLength(2);
+      throw new Error('listener failed');
+    });
+    events.on('proofs:saved', listener);
+    const execute = mock(async (operation: Parameters<MintRemote['execute']>[0]) => {
+      expect(inTransaction).toBe(false);
+      expect(await f.repositories.mintOperationRepository.getById(operation.id)).toMatchObject({
+        state: 'executing',
+      });
+      return { status: 'ISSUED' as const, proofs: f.proofs(operation) };
+    });
+    const remote: MintRemote = {
+      isTrusted: async () => true,
+      prepare: async () => {
+        throw new Error('unexpected preparation');
+      },
+      execute,
+      recoverExecuting: async () => {
+        throw new Error('unexpected replay');
+      },
+      observePending: async () => {
+        throw new Error('unexpected observation');
+      },
+      restoreOutputs: async () => {
+        throw new Error('unexpected Restore');
+      },
+    };
+    const service = new MintOperationService({
+      operations: f.repositories.mintOperationRepository,
+      proofs: f.repositories.proofRepository,
+      remote,
+      events,
+      transactions: new CoreMintTransactions(new RepositoryCoreTransactionRunner(controlled)),
+      quotes: {
+        getMintQuote: () =>
+          f.repositories.mintQuoteRepository.getMintQuote(mintUrl, 'bolt11', 'quote'),
+        requireMintQuoteRefForPrepare: async () => f.quote,
+        getPendingMintQuotes: async () => [],
+      },
+    });
+    const pending = await f.transactions.prepare(f.input());
+    expect((await service.execute(pending.operation.id)).state).toBe('finalized');
+    expect((await service.execute(pending.operation.id)).state).toBe('finalized');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/test/unit/QuoteLifecyclePolling.test.ts
+++ b/packages/core/test/unit/QuoteLifecyclePolling.test.ts
@@ -1,5 +1,8 @@
 import { Amount } from '@cashu/cashu-ts';
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { MemoryRepositories } from '../../repositories/memory/MemoryRepositories.ts';
+import { CashuMintMetadataRemote } from '../../infra/CashuMintMetadataRemote.ts';
+import { createMintMetadataRefreshDependencies } from '../fixtures/MintMetadataRefresh.ts';
 import { EventBus } from '../../events/EventBus.ts';
 import type { CoreEvents } from '../../events/types.ts';
 import type { MintAdapter } from '../../infra/MintAdapter.ts';
@@ -22,9 +25,8 @@ import {
 } from '../normalizedMintQuoteFixtures.ts';
 import type { CompatibleMintQuoteBolt11Response } from '../../operations/mint/MintMethodHandler.ts';
 import type { ProofRepository } from '../../repositories/index.ts';
-import { MemoryKeysetRepository } from '../../repositories/memory/MemoryKeysetRepository.ts';
 import { MemoryMintQuoteRepository } from '../../repositories/memory/MemoryMintQuoteRepository.ts';
-import { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository.ts';
+import type { MemoryMintRepository } from '../../repositories/memory/MemoryMintRepository.ts';
 import { QuoteLifecycle } from '../../quotes/QuoteLifecycle.ts';
 import { MintService } from '../../services/MintService.ts';
 import type { ProofService } from '../../services/ProofService.ts';
@@ -68,7 +70,8 @@ describe('QuoteLifecycle mint quote polling', () => {
       ),
     } as unknown as MintAdapter;
 
-    mintRepository = new MemoryMintRepository();
+    const repositories = new MemoryRepositories();
+    mintRepository = repositories.mintRepository as MemoryMintRepository;
     await mintRepository.addOrUpdateMint({
       mintUrl,
       name: 'test mint',
@@ -91,8 +94,9 @@ describe('QuoteLifecycle mint quote polling', () => {
     });
     mintService = new MintService(
       mintRepository,
-      new MemoryKeysetRepository(),
+      repositories.keysetRepository,
       mintAdapter,
+      createMintMetadataRefreshDependencies(repositories, new CashuMintMetadataRemote(mintAdapter)),
       undefined,
       eventBus,
     );

--- a/packages/core/transactions/CoreTransaction.ts
+++ b/packages/core/transactions/CoreTransaction.ts
@@ -4,11 +4,11 @@ import {
   RepositoryKeypairCommands,
   type ScopedKeypairCommands,
 } from './scoped/keypairs/ScopedKeypairCommands.ts';
-import { TransactionLifetime } from './scoped/TransactionLifetime.ts';
 import {
   RepositoryMintCommands,
   type ScopedMintCommands,
 } from './scoped/mint/ScopedMintCommands.ts';
+import { TransactionLifetime } from './scoped/TransactionLifetime.ts';
 
 /**
  * Scoped commands sharing one adapter transaction attempt. Await mutations sequentially unless

--- a/packages/core/transactions/CoreTransaction.ts
+++ b/packages/core/transactions/CoreTransaction.ts
@@ -5,6 +5,10 @@ import {
   type ScopedKeypairCommands,
 } from './scoped/keypairs/ScopedKeypairCommands.ts';
 import { TransactionLifetime } from './scoped/TransactionLifetime.ts';
+import {
+  RepositoryMintCommands,
+  type ScopedMintCommands,
+} from './scoped/mint/ScopedMintCommands.ts';
 
 /**
  * Scoped commands sharing one adapter transaction attempt. Await mutations sequentially unless
@@ -12,6 +16,7 @@ import { TransactionLifetime } from './scoped/TransactionLifetime.ts';
  */
 export interface CoreTransaction {
   readonly keypairs: ScopedKeypairCommands;
+  readonly mints: ScopedMintCommands;
 }
 
 export interface CoreTransactionRunner {
@@ -23,6 +28,7 @@ type TransactionModuleFactory = (repositories: RepositoryTransactionScope) => Co
 function createTransactionModules(repositories: RepositoryTransactionScope): CoreTransaction {
   return {
     keypairs: new RepositoryKeypairCommands(repositories.keyRingRepository),
+    mints: new RepositoryMintCommands(repositories),
   };
 }
 

--- a/packages/core/transactions/CoreTransaction.ts
+++ b/packages/core/transactions/CoreTransaction.ts
@@ -1,3 +1,4 @@
+import { OutputData, type OutputDataCreator } from '@cashu/cashu-ts';
 import type { Repositories, RepositoryTransactionScope } from '@core/repositories';
 import { RepositoryTransactionConflictError } from '@core/repositories';
 import {
@@ -8,6 +9,14 @@ import {
   RepositoryMintCommands,
   type ScopedMintCommands,
 } from './scoped/mint/ScopedMintCommands.ts';
+import {
+  RepositoryMintMetadataCommands,
+  type ScopedMintMetadataCommands,
+} from './scoped/mints/ScopedMintMetadataCommands.ts';
+import {
+  RepositoryOutputCommands,
+  type ScopedOutputCommands,
+} from './scoped/outputs/ScopedOutputCommands.ts';
 import { TransactionLifetime } from './scoped/TransactionLifetime.ts';
 
 /**
@@ -15,6 +24,8 @@ import { TransactionLifetime } from './scoped/TransactionLifetime.ts';
  * their independence is established; lifetime tracking does not serialize conflicting work.
  */
 export interface CoreTransaction {
+  readonly mintMetadata: ScopedMintMetadataCommands;
+  readonly outputs: ScopedOutputCommands;
   readonly keypairs: ScopedKeypairCommands;
   readonly mints: ScopedMintCommands;
 }
@@ -25,10 +36,24 @@ export interface CoreTransactionRunner {
 
 type TransactionModuleFactory = (repositories: RepositoryTransactionScope) => CoreTransaction;
 
-function createTransactionModules(repositories: RepositoryTransactionScope): CoreTransaction {
-  return {
-    keypairs: new RepositoryKeypairCommands(repositories.keyRingRepository),
-    mints: new RepositoryMintCommands(repositories),
+export function createCoreTransactionModuleFactory(
+  outputDataCreator: OutputDataCreator = OutputData,
+): TransactionModuleFactory {
+  return (repositories) => {
+    const outputs = new RepositoryOutputCommands(
+      repositories.counterRepository,
+      repositories.keysetRepository,
+      outputDataCreator,
+    );
+    return {
+      mintMetadata: new RepositoryMintMetadataCommands(
+        repositories.mintRepository,
+        repositories.keysetRepository,
+      ),
+      outputs,
+      keypairs: new RepositoryKeypairCommands(repositories.keyRingRepository),
+      mints: new RepositoryMintCommands(repositories, outputs),
+    };
   };
 }
 
@@ -38,7 +63,7 @@ const MAX_TRANSACTION_ATTEMPTS = 3;
 export class RepositoryCoreTransactionRunner implements CoreTransactionRunner {
   constructor(
     private readonly repositories: Repositories,
-    private readonly createModules: TransactionModuleFactory = createTransactionModules,
+    private readonly createModules: TransactionModuleFactory = createCoreTransactionModuleFactory(),
   ) {}
 
   async run<T>(work: (transaction: CoreTransaction) => Promise<T>): Promise<T> {

--- a/packages/core/transactions/mint/MintTransactions.ts
+++ b/packages/core/transactions/mint/MintTransactions.ts
@@ -1,0 +1,45 @@
+import type { MintQuote } from '../../models/MintQuote.ts';
+import type {
+  AuthorizeMintInput,
+  FailMintInput,
+  MintCommands,
+  PrepareMintInput,
+  ReturnMintToPendingInput,
+  SettleMintInput,
+} from '../../operations/mint/MintCommands.ts';
+import type { CoreTransactionRunner } from '../CoreTransaction.ts';
+
+/** Every method owns one transaction and resolves only after its writes commit. */
+export interface MintTransactions extends MintCommands {}
+
+export class CoreMintTransactions implements MintTransactions {
+  constructor(private readonly runner: CoreTransactionRunner) {}
+
+  prepare(input: PrepareMintInput) {
+    return this.runner.run((transaction) => transaction.mints.prepare(input));
+  }
+
+  authorize(input: AuthorizeMintInput) {
+    return this.runner.run((transaction) => transaction.mints.authorize(input));
+  }
+
+  settle(input: SettleMintInput) {
+    return this.runner.run((transaction) => transaction.mints.settle(input));
+  }
+
+  returnToPending(input: ReturnMintToPendingInput) {
+    return this.runner.run((transaction) => transaction.mints.returnToPending(input));
+  }
+
+  fail(input: FailMintInput) {
+    return this.runner.run((transaction) => transaction.mints.fail(input));
+  }
+
+  observeQuote(quote: MintQuote) {
+    return this.runner.run((transaction) => transaction.mints.observeQuote(quote));
+  }
+
+  deleteInit(operationId: string) {
+    return this.runner.run((transaction) => transaction.mints.deleteInit(operationId));
+  }
+}

--- a/packages/core/transactions/mints/MintMetadataTransactions.ts
+++ b/packages/core/transactions/mints/MintMetadataTransactions.ts
@@ -1,0 +1,14 @@
+import type { MintMetadata, MintMetadataObservation } from '@core/mints/MintMetadata.ts';
+import type { CoreTransactionRunner } from '../CoreTransaction.ts';
+
+export interface MintMetadataTransactions {
+  applyObservation(observation: MintMetadataObservation): Promise<MintMetadata>;
+}
+
+export class CoreMintMetadataTransactions implements MintMetadataTransactions {
+  constructor(private readonly runner: CoreTransactionRunner) {}
+
+  applyObservation(observation: MintMetadataObservation): Promise<MintMetadata> {
+    return this.runner.run((transaction) => transaction.mintMetadata.applyObservation(observation));
+  }
+}

--- a/packages/core/transactions/scoped/mint/ScopedMintCommands.ts
+++ b/packages/core/transactions/scoped/mint/ScopedMintCommands.ts
@@ -1,3 +1,4 @@
+import type { ScopedOutputCommands } from '../outputs/ScopedOutputCommands.ts';
 import { Amount } from '@cashu/cashu-ts';
 import { ProofValidationError, UnknownMintError } from '../../../models/Error.ts';
 import {
@@ -33,7 +34,10 @@ export type ScopedMintCommands = MintCommands;
 
 /** Existing Mint lifecycle mutations, using only repositories from one runner-owned scope. */
 export class RepositoryMintCommands implements ScopedMintCommands {
-  constructor(private readonly scope: RepositoryTransactionScope) {}
+  constructor(
+    private readonly scope: RepositoryTransactionScope,
+    private readonly outputs: ScopedOutputCommands,
+  ) {}
 
   private async requireOperation(id: string) {
     const operation = await this.scope.mintOperationRepository.getById(id);
@@ -54,7 +58,8 @@ export class RepositoryMintCommands implements ScopedMintCommands {
   }
 
   async prepare(input: PrepareMintInput): Promise<PreparedMintCommit> {
-    const { operation, keysetId } = input;
+    const { operation, activeKeys, seed } = input;
+    const keysetId = activeKeys.id;
     const quote = await this.scope.mintQuoteRepository.getMintQuote(
       operation.mintUrl,
       operation.method,
@@ -88,9 +93,15 @@ export class RepositoryMintCommands implements ScopedMintCommands {
           `Mint quote ${quote.quoteId} is already tracked by operation ${siblings[0]!.id} in state ${siblings[0]!.state}`,
         );
     }
-    const counter =
-      (await this.scope.counterRepository.getCounter(operation.mintUrl, keysetId))?.counter ?? 0;
-    const outputData = input.derive(counter);
+    const allocated = await this.outputs.allocate({
+      mintUrl: operation.mintUrl,
+      unit: operation.unit,
+      activeKeys,
+      seed,
+      keepAmount: operation.amount,
+      sendAmount: Amount.zero(),
+    });
+    const { outputData } = allocated;
     if (
       !outputData.keep.length ||
       outputData.send.length ||
@@ -103,15 +114,11 @@ export class RepositoryMintCommands implements ScopedMintCommands {
       new Set(outputData.keep.map((output) => output.secret)).size !== outputData.keep.length
     )
       throw new ProofValidationError('Invalid Mint output allocation');
-    const nextCounter = counter + outputData.keep.length;
-    if (!Number.isSafeInteger(nextCounter))
-      throw new ProofValidationError('Mint output counter exhausted');
     const pending: PendingMintOperation = { ...operation, outputData };
-    await this.scope.counterRepository.setCounter(operation.mintUrl, keysetId, nextCounter);
     await this.scope.mintOperationRepository.create(pending);
     return {
       operation: pending,
-      counter: { mintUrl: operation.mintUrl, keysetId, counter: nextCounter },
+      counter: allocated.counter!,
     };
   }
 

--- a/packages/core/transactions/scoped/mint/ScopedMintCommands.ts
+++ b/packages/core/transactions/scoped/mint/ScopedMintCommands.ts
@@ -1,0 +1,308 @@
+import { Amount } from '@cashu/cashu-ts';
+import { ProofValidationError, UnknownMintError } from '../../../models/Error.ts';
+import {
+  applyBolt11MintQuoteStateFallback,
+  getMintQuoteAmount,
+  type MintQuote,
+} from '../../../models/MintQuote.ts';
+import { assessMintQuoteClaimability } from '../../../models/MintQuoteClaimability.ts';
+import type {
+  AuthorizeMintInput,
+  FailMintInput,
+  MintCommands,
+  MintCommit,
+  MintQuoteCommit,
+  PreparedMintCommit,
+  PrepareMintInput,
+  ReturnMintToPendingInput,
+  SettleMintInput,
+} from '../../../operations/mint/MintCommands.ts';
+import { mintLocalClaimabilityFacts } from '../../../operations/mint/MintLocalClaimability.ts';
+import {
+  getOutputProofSecrets,
+  type MintOperation,
+  type PendingMintOperation,
+  type PendingOrLaterOperation,
+} from '../../../operations/mint/MintOperation.ts';
+import { resolveMintQuoteObservation } from '../../../quotes/MintQuoteObservation.ts';
+import type { RepositoryTransactionScope } from '../../../repositories/index.ts';
+import type { CoreProof } from '../../../types.ts';
+import { deserializeOutputData, mapProofToCoreProof } from '../../../utils.ts';
+
+export type ScopedMintCommands = MintCommands;
+
+/** Existing Mint lifecycle mutations, using only repositories from one runner-owned scope. */
+export class RepositoryMintCommands implements ScopedMintCommands {
+  constructor(private readonly scope: RepositoryTransactionScope) {}
+
+  private async requireOperation(id: string) {
+    const operation = await this.scope.mintOperationRepository.getById(id);
+    if (!operation) throw new Error(`Operation ${id} not found`);
+    return operation;
+  }
+
+  private unchanged(operation: MintOperation): MintCommit {
+    return { operation, changed: false, proofs: [] };
+  }
+
+  private matches(current: MintOperation, expected: PendingOrLaterOperation) {
+    return current.state === expected.state && current.updatedAt === expected.updatedAt;
+  }
+
+  private nextTimestamp(operation: MintOperation, timestamp: number) {
+    return Math.max(timestamp, operation.updatedAt + 1);
+  }
+
+  async prepare(input: PrepareMintInput): Promise<PreparedMintCommit> {
+    const { operation, keysetId } = input;
+    const quote = await this.scope.mintQuoteRepository.getMintQuote(
+      operation.mintUrl,
+      operation.method,
+      operation.quoteId,
+    );
+    if (!quote) throw new Error(`Mint quote ${operation.quoteId} was not found`);
+    if (!(await this.scope.mintRepository.isTrustedMint(operation.mintUrl)))
+      throw new UnknownMintError(`Mint ${operation.mintUrl} is not trusted`);
+    if (operation.amount.isZero())
+      throw new ProofValidationError('Amount must be a positive number');
+    if (
+      quote.request !== operation.request ||
+      quote.unit !== operation.unit ||
+      quote.pubkey !== operation.pubkey
+    )
+      throw new Error('Mint quote changed during preparation');
+    const assessment = assessMintQuoteClaimability(quote);
+    if (assessment.status === 'complete' || assessment.status === 'invalid')
+      throw new Error(`Cannot prepare mint quote ${quote.quoteId}: quote is ${assessment.status}`);
+    const fixedAmount = getMintQuoteAmount(quote);
+    if (fixedAmount) {
+      if (!fixedAmount.equals(operation.amount))
+        throw new Error(`Mint quote ${quote.quoteId} amount does not match requested amount`);
+      const siblings = await this.scope.mintOperationRepository.getByQuoteId(
+        quote.mintUrl,
+        quote.method,
+        quote.quoteId,
+      );
+      if (siblings.length)
+        throw new Error(
+          `Mint quote ${quote.quoteId} is already tracked by operation ${siblings[0]!.id} in state ${siblings[0]!.state}`,
+        );
+    }
+    const counter =
+      (await this.scope.counterRepository.getCounter(operation.mintUrl, keysetId))?.counter ?? 0;
+    const outputData = input.derive(counter);
+    if (
+      !outputData.keep.length ||
+      outputData.send.length ||
+      !Amount.sum(outputData.keep.map((output) => output.blindedMessage.amount)).equals(
+        operation.amount,
+      ) ||
+      outputData.keep.some((output) => output.blindedMessage.id !== keysetId) ||
+      new Set(outputData.keep.map((output) => output.blindedMessage.B_)).size !==
+        outputData.keep.length ||
+      new Set(outputData.keep.map((output) => output.secret)).size !== outputData.keep.length
+    )
+      throw new ProofValidationError('Invalid Mint output allocation');
+    const nextCounter = counter + outputData.keep.length;
+    if (!Number.isSafeInteger(nextCounter))
+      throw new ProofValidationError('Mint output counter exhausted');
+    const pending: PendingMintOperation = { ...operation, outputData };
+    await this.scope.counterRepository.setCounter(operation.mintUrl, keysetId, nextCounter);
+    await this.scope.mintOperationRepository.create(pending);
+    return {
+      operation: pending,
+      counter: { mintUrl: operation.mintUrl, keysetId, counter: nextCounter },
+    };
+  }
+
+  async authorize(input: AuthorizeMintInput): Promise<MintCommit> {
+    const operation = await this.requireOperation(input.operationId);
+    if (operation.state !== 'pending') return this.unchanged(operation);
+    if (!(await this.scope.mintRepository.isTrustedMint(operation.mintUrl)))
+      throw new UnknownMintError(`Mint ${operation.mintUrl} is not trusted`);
+    const quote = await this.scope.mintQuoteRepository.getMintQuote(
+      operation.mintUrl,
+      operation.method,
+      operation.quoteId,
+    );
+    if (quote) {
+      const siblings = await this.scope.mintOperationRepository.getByQuoteId(
+        operation.mintUrl,
+        operation.method,
+        operation.quoteId,
+      );
+      const assessment = assessMintQuoteClaimability(quote, {
+        ...mintLocalClaimabilityFacts(siblings, operation.id),
+        requestedAmount: operation.amount,
+      });
+      if (assessment.status === 'invalid')
+        throw new Error(`Mint quote ${operation.quoteId} has invalid claimability accounting`);
+      if (assessment.status === 'waiting') return this.unchanged(operation);
+    }
+    const executing = {
+      ...operation,
+      state: 'executing' as const,
+      updatedAt: this.nextTimestamp(operation, input.timestamp),
+      error: undefined,
+    };
+    await this.scope.mintOperationRepository.update(executing);
+    return { operation: executing, changed: true, proofs: [] };
+  }
+
+  async settle(input: SettleMintInput): Promise<MintCommit> {
+    const operation = await this.requireOperation(input.operation.id);
+    if (operation.state === 'init') return this.unchanged(operation);
+    const outputs = deserializeOutputData(operation.outputData);
+    const expected = [...outputs.keep, ...outputs.send];
+    const proofs: CoreProof[] = [];
+    for (const proof of input.proofs) {
+      if (
+        !expected.some(
+          (output) =>
+            new TextDecoder().decode(output.secret) === proof.secret &&
+            output.blindedMessage.id === proof.id &&
+            output.blindedMessage.amount.equals(proof.amount),
+        )
+      )
+        throw new ProofValidationError('Mint proof does not match persisted outputs');
+      const existing = await this.scope.proofRepository.getProofBySecret(
+        operation.mintUrl,
+        proof.secret,
+      );
+      if (existing) {
+        if (
+          existing.id !== proof.id ||
+          existing.C !== proof.C ||
+          existing.unit !== operation.unit ||
+          !existing.amount.equals(proof.amount) ||
+          (existing.createdByOperationId && existing.createdByOperationId !== operation.id)
+        )
+          throw new ProofValidationError('Mint proof ownership conflict');
+        continue;
+      }
+      if (!proofs.some((candidate) => candidate.secret === proof.secret))
+        proofs.push(
+          ...mapProofToCoreProof(operation.mintUrl, 'ready', [proof], {
+            unit: operation.unit,
+            createdByOperationId: operation.id,
+          }),
+        );
+    }
+    await this.scope.proofRepository.saveProofs(operation.mintUrl, proofs);
+    // Positive proofs survive a concurrent recovery transition; stale lifecycle conclusions do not.
+    if (operation.state !== 'executing' || !this.matches(operation, input.operation))
+      return { operation, changed: false, proofs };
+    const secrets = getOutputProofSecrets(operation);
+    let complete = secrets.length > 0;
+    for (const secret of secrets) {
+      if (!(await this.scope.proofRepository.getProofBySecret(operation.mintUrl, secret)))
+        complete = false;
+    }
+    // Keep the legacy distinction: an already-issued BOLT11 quote can finalize without proofs.
+    // The dependent reconciliation change replaces this quote-wide conclusion with exact evidence.
+    if (!complete && input.outcome === 'issued') return { operation, changed: false, proofs };
+    const finalized = complete || input.outcome === 'already-issued';
+    let quote: MintQuoteCommit | undefined;
+    if (finalized && operation.method === 'bolt11') {
+      const existing =
+        (await this.scope.mintQuoteRepository.getMintQuote(
+          operation.mintUrl,
+          'bolt11',
+          operation.quoteId,
+        )) ?? this.legacyQuote(operation);
+      if (existing.method !== 'bolt11') throw new Error('Mint quote method conflict');
+      quote = await this.observeQuote(
+        applyBolt11MintQuoteStateFallback(existing, 'ISSUED', input.timestamp),
+      );
+    }
+    const updated = {
+      ...operation,
+      state: finalized ? ('finalized' as const) : ('pending' as const),
+      updatedAt: this.nextTimestamp(operation, input.timestamp),
+      error: complete
+        ? undefined
+        : `Recovered issued quote ${operation.quoteId} but no proofs could be restored`,
+    };
+    await this.scope.mintOperationRepository.update(updated);
+    return { operation: updated, changed: true, proofs, quote };
+  }
+
+  private legacyQuote(operation: PendingOrLaterOperation): MintQuote<'bolt11'> {
+    return {
+      mintUrl: operation.mintUrl,
+      method: 'bolt11',
+      quoteId: operation.quoteId,
+      quote: operation.quoteId,
+      request: operation.request,
+      unit: operation.unit,
+      amount: operation.amount,
+      expiry: operation.expiry,
+      pubkey: operation.pubkey,
+      state: 'UNPAID',
+      reusable: false,
+      amountPaid: Amount.zero(),
+      amountIssued: Amount.zero(),
+      remoteUpdatedAt: null,
+      quoteData: { amount: operation.amount },
+      createdAt: operation.createdAt,
+      updatedAt: operation.updatedAt,
+    };
+  }
+
+  async returnToPending(input: ReturnMintToPendingInput): Promise<MintCommit> {
+    const operation = await this.requireOperation(input.operation.id);
+    if (operation.state !== 'executing' || !this.matches(operation, input.operation))
+      return this.unchanged(operation);
+    const pending = {
+      ...operation,
+      state: 'pending' as const,
+      updatedAt: this.nextTimestamp(operation, input.timestamp),
+      error: input.error,
+    };
+    await this.scope.mintOperationRepository.update(pending);
+    return { operation: pending, changed: true, proofs: [] };
+  }
+
+  async fail(input: FailMintInput): Promise<MintCommit> {
+    const operation = await this.requireOperation(input.operation.id);
+    if (
+      (operation.state !== 'pending' && operation.state !== 'executing') ||
+      !this.matches(operation, input.operation)
+    )
+      return this.unchanged(operation);
+    const failed = {
+      ...operation,
+      state: 'failed' as const,
+      updatedAt: this.nextTimestamp(operation, input.timestamp),
+      error: input.failure.reason,
+      terminalFailure: input.failure,
+    };
+    await this.scope.mintOperationRepository.update(failed);
+    return { operation: failed, changed: true, proofs: [] };
+  }
+
+  async observeQuote(incoming: MintQuote): Promise<MintQuoteCommit> {
+    const existing = await this.scope.mintQuoteRepository.getMintQuote(
+      incoming.mintUrl,
+      incoming.method,
+      incoming.quoteId,
+    );
+    const resolution = resolveMintQuoteObservation(existing, incoming);
+    if (!resolution.disposition.startsWith('accepted-'))
+      return { quote: resolution.resolvedQuote, changed: false };
+    await this.scope.mintQuoteRepository.upsertMintQuote(resolution.resolvedQuote);
+    return {
+      quote: (await this.scope.mintQuoteRepository.getMintQuote(
+        incoming.mintUrl,
+        incoming.method,
+        incoming.quoteId,
+      ))!,
+      changed: resolution.disposition === 'accepted-meaningful-change',
+    };
+  }
+
+  async deleteInit(operationId: string): Promise<void> {
+    const operation = await this.scope.mintOperationRepository.getById(operationId);
+    if (operation?.state === 'init') await this.scope.mintOperationRepository.delete(operationId);
+  }
+}

--- a/packages/core/transactions/scoped/mints/ScopedMintMetadataCommands.ts
+++ b/packages/core/transactions/scoped/mints/ScopedMintMetadataCommands.ts
@@ -1,0 +1,57 @@
+import { UnknownMintError } from '@core/models/Error.ts';
+import { isBlsKeyset } from '@cashu/cashu-ts';
+import type { MintMetadata, MintMetadataObservation } from '@core/mints/MintMetadata.ts';
+import type { MintRepository, KeysetRepository } from '@core/repositories';
+
+export interface ScopedMintMetadataCommands {
+  assertTrusted(mintUrl: string): Promise<void>;
+  applyObservation(observation: MintMetadataObservation): Promise<MintMetadata>;
+}
+
+/** Cache persistence shared by owning transactions; remote metadata cannot change mint trust. */
+export class RepositoryMintMetadataCommands implements ScopedMintMetadataCommands {
+  constructor(
+    private readonly mints: MintRepository,
+    private readonly keysets: KeysetRepository,
+  ) {}
+
+  async assertTrusted(mintUrl: string): Promise<void> {
+    if (!(await this.mints.isTrustedMint(mintUrl)))
+      throw new UnknownMintError(`Mint ${mintUrl} is not trusted`);
+  }
+
+  async applyObservation(observation: MintMetadataObservation): Promise<MintMetadata> {
+    const current = (await this.mints.getAllMints()).find(
+      (mint) => mint.mintUrl === observation.mintUrl,
+    );
+    if (current && current.updatedAt > observation.observedAt) {
+      return {
+        mint: current,
+        keysets: (await this.keysets.getKeysetsByMintUrl(current.mintUrl)).filter(
+          (keyset) => !isBlsKeyset(keyset.id),
+        ),
+      };
+    }
+    for (const keyset of observation.keysets) {
+      const existing = await this.keysets.getKeysetById(observation.mintUrl, keyset.id);
+      if (existing) {
+        await this.keysets.updateKeyset(keyset);
+      } else {
+        await this.keysets.addKeyset(keyset);
+      }
+    }
+    const mint = {
+      ...(current ?? {
+        mintUrl: observation.mintUrl,
+        name: observation.mintUrl,
+        trusted: false,
+        createdAt: observation.observedAt,
+      }),
+      mintInfo: observation.mintInfo,
+      updatedAt: observation.observedAt,
+    };
+    await this.mints.addOrUpdateMint(mint);
+    const keysets = await this.keysets.getKeysetsByMintUrl(mint.mintUrl);
+    return { mint, keysets: keysets.filter((keyset) => !isBlsKeyset(keyset.id)) };
+  }
+}

--- a/packages/core/transactions/scoped/outputs/ScopedOutputCommands.ts
+++ b/packages/core/transactions/scoped/outputs/ScopedOutputCommands.ts
@@ -1,0 +1,92 @@
+import {
+  OutputData,
+  type Amount,
+  type MintKeys,
+  type OutputDataCreator,
+  type OutputDataLike,
+} from '@cashu/cashu-ts';
+import { normalizeUnit } from '@core/amounts.ts';
+import type { Counter } from '@core/models/Counter.ts';
+import { ProofValidationError } from '@core/models/Error.ts';
+import type { CounterRepository, KeysetRepository } from '@core/repositories';
+import { serializeOutputData, type SerializedOutputData } from '@core/utils.ts';
+
+export interface AllocateOutputsInput {
+  mintUrl: string;
+  unit: string;
+  activeKeys: MintKeys;
+  seed: Uint8Array;
+  keepAmount: Amount;
+  sendAmount: Amount;
+  fixedSendOutputs?: readonly OutputDataLike[];
+}
+
+export interface AllocatedOutputs {
+  outputData: SerializedOutputData;
+  counter?: Counter;
+}
+
+export interface ScopedOutputCommands {
+  assertActiveKeys(mintUrl: string, unit: string, activeKeys: MintKeys): Promise<void>;
+  /** The caller must persist the returned output plan in this same transaction. */
+  allocate(input: AllocateOutputsInput): Promise<AllocatedOutputs>;
+}
+
+/** Shared deterministic Output Allocation. Only the owning transition may commit its plan. */
+export class RepositoryOutputCommands implements ScopedOutputCommands {
+  constructor(
+    private readonly counters: CounterRepository,
+    private readonly keysets: KeysetRepository,
+    private readonly creator: OutputDataCreator = OutputData,
+  ) {}
+
+  async assertActiveKeys(mintUrl: string, unit: string, activeKeys: MintKeys): Promise<void> {
+    const keyset = await this.keysets.getKeysetById(mintUrl, activeKeys.id);
+    if (
+      !keyset ||
+      !keyset.active ||
+      normalizeUnit(keyset.unit) !== normalizeUnit(unit) ||
+      normalizeUnit(activeKeys.unit) !== normalizeUnit(unit) ||
+      JSON.stringify(Object.entries(keyset.keypairs).sort()) !==
+        JSON.stringify(Object.entries(activeKeys.keys).sort())
+    ) {
+      throw new ProofValidationError(`Active keyset ${activeKeys.id} changed after preflight`);
+    }
+  }
+
+  async allocate(input: AllocateOutputsInput): Promise<AllocatedOutputs> {
+    await this.assertActiveKeys(input.mintUrl, input.unit, input.activeKeys);
+    const current =
+      (await this.counters.getCounter(input.mintUrl, input.activeKeys.id))?.counter ?? 0;
+    const keep = input.keepAmount.isZero()
+      ? []
+      : this.creator.createDeterministicData(
+          input.keepAmount,
+          input.seed,
+          current,
+          input.activeKeys,
+        );
+    const send = input.fixedSendOutputs
+      ? [...input.fixedSendOutputs]
+      : input.sendAmount.isZero()
+        ? []
+        : this.creator.createDeterministicData(
+            input.sendAmount,
+            input.seed,
+            current + keep.length,
+            input.activeKeys,
+          );
+    if (input.fixedSendOutputs && send.length === 0) {
+      throw new ProofValidationError('Method preflight did not produce output data');
+    }
+    const positions = keep.length + (input.fixedSendOutputs ? 0 : send.length);
+    const next = current + positions;
+    if (!Number.isSafeInteger(next)) throw new ProofValidationError('Output counter exhausted');
+    const counter =
+      positions > 0
+        ? { mintUrl: input.mintUrl, keysetId: input.activeKeys.id, counter: next }
+        : undefined;
+    if (counter) await this.counters.setCounter(counter.mintUrl, counter.keysetId, counter.counter);
+    return { outputData: serializeOutputData({ keep, send }), counter };
+  }
+}

--- a/packages/indexeddb/src/repositories/MintOperationRepository.ts
+++ b/packages/indexeddb/src/repositories/MintOperationRepository.ts
@@ -1,7 +1,6 @@
 import type { MintOperationRepository } from '@cashu/coco-core/adapter';
 import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core/adapter';
 import type { IdbDb, MintOperationRow } from '../lib/db.ts';
-import { getUnixTimeSeconds } from '../lib/db.ts';
 
 type MintOperation = NonNullable<Awaited<ReturnType<MintOperationRepository['getById']>>>;
 type MintOperationState = Parameters<MintOperationRepository['getByState']>[0];
@@ -35,8 +34,8 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     mintUrl: row.mintUrl,
     method: row.method as MintOperation['method'],
     methodData: JSON.parse(row.methodDataJson) as MintMethodData,
-    createdAt: row.createdAt * 1000,
-    updatedAt: row.updatedAt * 1000,
+    createdAt: Math.round(row.createdAt * 1000),
+    updatedAt: Math.round(row.updatedAt * 1000),
     error: row.error ?? undefined,
     ...(row.terminalFailureJson
       ? { terminalFailure: JSON.parse(row.terminalFailureJson) as MintOperationFailure }
@@ -70,8 +69,8 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
 };
 
 const operationToRow = (operation: MintOperation): MintOperationRow => {
-  const createdAtSeconds = Math.floor(operation.createdAt / 1000);
-  const updatedAtSeconds = Math.floor(operation.updatedAt / 1000);
+  const createdAtSeconds = operation.createdAt / 1000;
+  const updatedAtSeconds = operation.updatedAt / 1000;
   const methodDataJson = stringifyJson(operation.methodData);
 
   if (operation.state === 'init') {
@@ -145,7 +144,6 @@ export class IdbMintOperationRepository implements MintOperationRepository {
       }
 
       const row = operationToRow(operation);
-      row.updatedAt = getUnixTimeSeconds();
       await table.put(row);
     });
   }

--- a/packages/sql-storage/src/repositories/MintOperationRepository.ts
+++ b/packages/sql-storage/src/repositories/MintOperationRepository.ts
@@ -1,7 +1,6 @@
 import type { MintOperationRepository } from '@cashu/coco-core/adapter';
 import { deserializeAmount, serializeAmount, stringifyJson } from '@cashu/coco-core/adapter';
 import type { SqlDatabase, SqlValue } from '../index.ts';
-import { getUnixTimeSeconds } from '../utils.ts';
 
 type MintOperation = NonNullable<Awaited<ReturnType<MintOperationRepository['getById']>>>;
 type MintOperationState = Parameters<MintOperationRepository['getByState']>[0];
@@ -57,8 +56,8 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
     mintUrl: row.mintUrl,
     method: row.method,
     methodData: JSON.parse(row.methodDataJson) as MintMethodData,
-    createdAt: row.createdAt * 1000,
-    updatedAt: row.updatedAt * 1000,
+    createdAt: Math.round(row.createdAt * 1000),
+    updatedAt: Math.round(row.updatedAt * 1000),
     error: row.error ?? undefined,
     ...(row.terminalFailureJson
       ? { terminalFailure: JSON.parse(row.terminalFailureJson) as MintOperationFailure }
@@ -92,8 +91,8 @@ const rowToOperation = (row: MintOperationRow): MintOperation => {
 };
 
 const operationToParams = (operation: MintOperation): SqlValue[] => {
-  const createdAtSeconds = Math.floor(operation.createdAt / 1000);
-  const updatedAtSeconds = Math.floor(operation.updatedAt / 1000);
+  const createdAtSeconds = operation.createdAt / 1000;
+  const updatedAtSeconds = operation.updatedAt / 1000;
   const methodDataJson = stringifyJson(operation.methodData);
 
   if (operation.state === 'init') {
@@ -175,7 +174,7 @@ export class SqliteMintOperationRepository implements MintOperationRepository {
       throw new Error(`MintOperation with id ${operation.id} not found`);
     }
 
-    const updatedAtSeconds = getUnixTimeSeconds();
+    const updatedAtSeconds = operation.updatedAt / 1000;
 
     if (operation.state === 'init') {
       await this.db.run(


### PR DESCRIPTION
Standalone Mint currently spreads counter allocation, operation writes, and proof settlement across independent repository calls. This PR moves those local mutations into the shared domain transaction runner while preserving the existing method-specific issuance and recovery policy.

**Part 1 of the split from #481. Review and merge this PR first.** #481 targets this branch and contains exact-evidence reconciliation and recovery storage.

## Changes

- Commit deterministic Output Allocation with the pending operation; commit issued proofs, legacy BOLT11 accounting, and completion together.
- Recheck quote identity, mint trust, sibling reservations, and selected keyset activity/unit/key material inside the owning transaction. Fence stale negative transitions while retaining matching late issuance proofs.
- Reuse the metadata action, gateway, transport, scoped Output Allocation, keyset selection, and Restore helper established in #463. The shared pieces are included here so this PR stands on master without the Send migration.
- Make metadata refresh an explicit, independently committed prerequisite through `refreshAndCommitIfStale()`. Mint preparation and remote effects consume snapshots; the adapter has no WalletService, MintService, or ProofService dependency. Capability validation shares pure snapshot logic with MintService.
- Preserve caller-owned millisecond timestamps across memory, SQL, and IndexedDB. Keep network work outside transactions and publish committed events afterward.

## Compatibility

Includes `.changeset/mint-transaction-migration.md`: major core change for custom Mint handler/context and MintService construction, plus adapter and contract patches. Manager and public MintOps APIs retain their interfaces. Existing timestamp columns and old rows remain supported; no recovery schema is added here. Exact-output reconciliation, accounting baselines, held receipts, and conservative no-replay recovery belong to #481.

A metadata refresh commits independently and survives later Mint preparation failure. Existing mint add, forced-update, trust, and delete paths are not all migrated by this PR. The independent-action contract and ADR-0011 match #463.

## Verification

- Workspace build and typecheck passed.
- Core unit and shared SQL tests: 1,761 passed.
- Bun SQLite and Expo harness contracts: 154 passed combined; Node SQLite: 75 passed; Chromium IndexedDB: 76 passed.
- Reproduced stale-keyset acceptance before the fix on memory and SQLite. Regression cases now reject deactivated, wrong-unit, and replaced keys before allocation commits.
- Manager-level adapter cases verify atomic preparation and rejection when keysets change during seed preflight. Metadata tests cover atomic failure, independent commits surviving later rollback, cached reads, and listener failures.
- Standards and behavior reviews confirmed both previously reported architecture gaps are resolved. Formatting and `git diff --check` passed.

Live-mint integration was not run because `MINT_URL` is unset. Browser coverage is Chromium; Expo coverage uses the repository driver harness.
